### PR TITLE
fix: years and margins in onboarding UI

### DIFF
--- a/app/src/app/[lng]/onboarding/done/[cityId]/page.tsx
+++ b/app/src/app/[lng]/onboarding/done/[cityId]/page.tsx
@@ -15,7 +15,7 @@ export default function OnboardingDone({ params: { lng } }: { params: { lng: str
   const year = '2023';
 
   return (
-    <div className="pt-[148px] w-[1024px] max-w-full mx-auto px-4 flex flex-col items-center">
+    <div className="pt-[148px] w-[1024px] max-w-full mx-auto px-4 pb-12 flex flex-col items-center">
       <Image src="/assets/check-circle.svg" width={64} height={64} alt="Checkmark" />
       <Heading size="xl" mt={12} mb={20}>
         <Trans t={t}>done-heading</Trans>

--- a/app/src/app/[lng]/onboarding/layout.tsx
+++ b/app/src/app/[lng]/onboarding/layout.tsx
@@ -12,7 +12,7 @@ export default function AuthLayout({
   return (
     <main className="h-screen flex flex-col">
       <NavigationBar lng={lng} />
-      <div className="w-full h-full bg-city bg-left-bottom bg-no-repeat">
+      <div className="w-full h-full bg-city bg-left-bottom bg-no-repeat px-8">
         {children}
       </div>
     </main>

--- a/app/src/app/[lng]/onboarding/setup/page.tsx
+++ b/app/src/app/[lng]/onboarding/setup/page.tsx
@@ -153,7 +153,7 @@ export default function OnboardingSetup({ params: { lng } }: { params: { lng: st
 
   return (
     <>
-      <div className="pt-[64px] w-[1090px] max-w-full mx-auto px-8">
+      <div className="pt-16 w-[1090px] max-w-full mx-auto">
         <Button
           variant="ghost"
           leftIcon={<ArrowBackIcon boxSize={6} />}
@@ -169,7 +169,7 @@ export default function OnboardingSetup({ params: { lng } }: { params: { lng: st
             />
           </div>
         </div>
-        <div className="flex flex-col md:flex-row md:space-x-12 md:space-y-0 space-y-12 align-top mb-24 mt-[112px]">
+        <div className="flex flex-col md:flex-row md:space-x-12 md:space-y-0 space-y-12 align-top mb-24 mt-[112px] pb-16">
           {activeStep === 0 && <SetupStep errors={errors} register={register} t={t} />}
           {activeStep === 1 && <ConfirmStep cityName={getValues('city')} t={t} />}
         </div>

--- a/app/src/app/[lng]/onboarding/setup/page.tsx
+++ b/app/src/app/[lng]/onboarding/setup/page.tsx
@@ -19,7 +19,8 @@ type Inputs = {
 }
 
 function SetupStep({ errors, register, t }: { errors: FieldErrors<Inputs>, register: UseFormRegister<Inputs>, t: TFunction }) {
-  const years = Array.from({ length: 10 }, (_x, i) => 2020 + i);
+  const currentYear = new Date().getFullYear();
+  const years = Array.from({ length: 7 }, (_x, i) => currentYear - i);
   return (
     <>
       <div>

--- a/app/tailwind.config.cjs
+++ b/app/tailwind.config.cjs
@@ -1,7 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
     './src/stories/**/*.{js,ts,jsx,tsx,mdx}'


### PR DESCRIPTION
- Implements feedback from https://openearth.atlassian.net/browse/ON-626?focusedCommentId=11834
- Bottom margins on OnboardingSetup and OnboardingDone pages to have full page scrollable on smaller (less high) screens
- Make displayed years depend on current year and show last 7 years including current one (which is up for discussion)