### PR TITLE
feat(ON-774): add new migration to CC EmissionsFactor

### DIFF
--- a/app/migrations/20230906193347-modify-EmissionsFactor.cjs
+++ b/app/migrations/20230906193347-modify-EmissionsFactor.cjs
@@ -1,0 +1,52 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      -- GPC reference number the EF corresponds to (ex. I.1.2)
+      ALTER TABLE "EmissionsFactor"
+      ADD COLUMN "gpc_refno" varchar(255);
+
+      -- chemical formula of the gas (ex. CH4)
+      ALTER TABLE "EmissionsFactor"
+      ADD COLUMN "gas" varchar(255);
+
+      -- (optional) region the EF is appliable for (ex. US-NY)
+      ALTER TABLE "EmissionsFactor"
+      ADD COLUMN "region" varchar(255);
+
+      -- (optional) time frame the EF is appliable for (ex. 2010)
+      ALTER TABLE "EmissionsFactor"
+      ADD COLUMN "time_frame" varchar(255);
+
+      -- (optional) reference or citation for the EF
+      ALTER TABLE "EmissionsFactor"
+      ADD COLUMN "reference" varchar(255);
+    `);
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      -- (optional) reference or citation for the EF
+      ALTER TABLE "EmissionsFactor"
+      DROP COLUMN "reference" varchar(255);
+
+      -- (optional) time frame the EF is appliable for (ex. 2010)
+      ALTER TABLE "EmissionsFactor"
+      DROP COLUMN "time_frame" varchar(255);
+
+      -- (optional) region the EF is appliable for (ex. US-NY)
+      ALTER TABLE "EmissionsFactor"
+      DROP COLUMN "region" varchar(255);
+
+      -- chemical formula of the gas (ex. CH4)
+      ALTER TABLE "EmissionsFactor"
+      DROP COLUMN "gas" varchar(255);
+
+      -- GPC reference number the EF corresponds to (ex. I.1.2)
+      ALTER TABLE "EmissionsFactor"
+      DROP COLUMN "gpc_refno" varchar(255);
+    `);
+  }
+};

--- a/app/migrations/20230906193347-modify-EmissionsFactor.cjs
+++ b/app/migrations/20230906193347-modify-EmissionsFactor.cjs
@@ -6,23 +6,23 @@ module.exports = {
     await queryInterface.sequelize.query(`
       -- GPC reference number the EF corresponds to (ex. I.1.2)
       ALTER TABLE "EmissionsFactor"
-      ADD COLUMN "gpc_refno" varchar(255);
+      ADD COLUMN "gpc_refno" varchar(20);
 
       -- chemical formula of the gas (ex. CH4)
       ALTER TABLE "EmissionsFactor"
-      ADD COLUMN "gas" varchar(255);
+      ADD COLUMN "gas" varchar(20);
 
       -- (optional) region the EF is appliable for (ex. US-NY)
       ALTER TABLE "EmissionsFactor"
-      ADD COLUMN "region" varchar(255);
+      ADD COLUMN "region" varchar(10);
 
       -- (optional) time frame the EF is appliable for (ex. 2010)
       ALTER TABLE "EmissionsFactor"
-      ADD COLUMN "time_frame" varchar(255);
+      ADD COLUMN "year" integer;
 
       -- (optional) reference or citation for the EF
       ALTER TABLE "EmissionsFactor"
-      ADD COLUMN "reference" varchar(255);
+      ADD COLUMN "reference" text;
     `);
   },
 
@@ -30,23 +30,23 @@ module.exports = {
     await queryInterface.sequelize.query(`
       -- (optional) reference or citation for the EF
       ALTER TABLE "EmissionsFactor"
-      DROP COLUMN "reference" varchar(255);
+      DROP COLUMN "reference" text;
 
       -- (optional) time frame the EF is appliable for (ex. 2010)
       ALTER TABLE "EmissionsFactor"
-      DROP COLUMN "time_frame" varchar(255);
+      DROP COLUMN "year" integer;
 
       -- (optional) region the EF is appliable for (ex. US-NY)
       ALTER TABLE "EmissionsFactor"
-      DROP COLUMN "region" varchar(255);
+      DROP COLUMN "region" varchar(10);
 
       -- chemical formula of the gas (ex. CH4)
       ALTER TABLE "EmissionsFactor"
-      DROP COLUMN "gas" varchar(255);
+      DROP COLUMN "gas" varchar(20);
 
       -- GPC reference number the EF corresponds to (ex. I.1.2)
       ALTER TABLE "EmissionsFactor"
-      DROP COLUMN "gpc_refno" varchar(255);
+      DROP COLUMN "gpc_refno" varchar(20);
     `);
   }
 };


### PR DESCRIPTION
This adds the following columns to the `EmissionsFactor` table:
-  `gpc_refno`: GPC reference number
- `gas`: chemical formula of the gas
- `region`: region code the EF is applicable for (eg. CA) [optional]
- `time_frame`: time frame the EF is applicable for (eg 2010)  [optional]
- `reference`: reference for the EF [optional] 

This should be enough to uniquely define the emissions factor. Please let me know if any changes are necessary.