### PR TITLE
fix: change publisher_name to name in Publisher table

### DIFF
--- a/emissions_factors/data_processed/EFDB_US/Publisher.csv
+++ b/emissions_factors/data_processed/EFDB_US/Publisher.csv
@@ -1,2 +1,2 @@
-publisher_id,publisher_name,URL
+publisher_id,name,URL
 5be81e5d-1d8a-45b5-9ad8-389f699afb04,IPCC,https://www.ipcc.ch/

--- a/emissions_factors/scripts/EFDB_US.py
+++ b/emissions_factors/scripts/EFDB_US.py
@@ -146,7 +146,7 @@ if __name__ == "__main__":
     # =================================================================
     publisher_data = {
         "publisher_id": uuid_generate_v4(),
-        "publisher_name": "IPCC",
+        "name": "IPCC",
         "URL": "https://www.ipcc.ch/",
     }
 


### PR DESCRIPTION
fixes a typo. changes `publisher_name` to `name` in the `Publisher` table. 

The  [lucid chart](https://lucid.app/lucidchart/7a94c7ce-1b2c-49ec-863b-a2e928ca119f/edit?invitationId=inv_1de91863-7a10-460b-bcfe-3a93f970252d&referringApp=slack&page=0_0#) listed the column as `publisher_name`, I have updated the diagram so it now agrees with the database. 