### PR TITLE
feat(ON-809): add EDGAR tables to ccglobal API database

### DIFF
--- a/global-api/migrations/versions/64eb87bae0a3_add_edgar_tables.py
+++ b/global-api/migrations/versions/64eb87bae0a3_add_edgar_tables.py
@@ -1,0 +1,57 @@
+"""add-EDGAR-tables
+
+Revision ID: 64eb87bae0a3
+Revises: bd6c5bbd6eb4
+Create Date: 2023-09-18 12:25:22.687198
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import text
+
+# revision identifiers, used by Alembic.
+revision: str = '64eb87bae0a3'
+down_revision: Union[str, None] = 'bd6c5bbd6eb4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table('edgar_grid',
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column('lat_center', sa.Float, nullable=False),
+        sa.Column('lon_center', sa.Float, nullable=False),
+        sa.Column('geometry', sa.String, nullable=False),
+        sa.Column('area', sa.Float, nullable=False),
+        sa.Column("created_date", sa.DateTime(), nullable=False),
+        sa.Column("modified_date", sa.DateTime(), server_default=text('CURRENT_TIMESTAMP'))
+    )
+
+    op.create_table('edgar_data',
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column('year', sa.Integer, nullable=False),
+        sa.Column('reference_number', sa.String, nullable=False),
+        sa.Column("gas", sa.String(), nullable=False),
+        sa.Column("emissions_quantity", sa.Integer(), nullable=False),
+        sa.Column("emissions_quantity_units", sa.String(), nullable=False),
+        sa.Column('grid_id', sa.Integer, sa.ForeignKey('edgar_grid.id'), nullable=False),
+        sa.Column("created_date", sa.DateTime(), nullable=False),
+        sa.Column("modified_date", sa.DateTime(), server_default=text('CURRENT_TIMESTAMP'))
+    )
+
+    op.create_table('edgar_city_data',
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column('locode', sa.String, nullable=False),
+        sa.Column('fraction_in_city', sa.Float, nullable=False),
+        sa.Column('grid_id', sa.Integer, sa.ForeignKey('edgar_grid.id'), nullable=False),
+        sa.Column("created_date", sa.DateTime(), nullable=False),
+        sa.Column("modified_date", sa.DateTime(), server_default=text('CURRENT_TIMESTAMP'))
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('edgar_city_data')
+    op.drop_table('edgar_data')
+    op.drop_table('edgar_grid')

--- a/global-api/migrations/versions/64eb87bae0a3_add_edgar_tables.py
+++ b/global-api/migrations/versions/64eb87bae0a3_add_edgar_tables.py
@@ -20,7 +20,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     op.create_table('edgar_grid',
-        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column('id', sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
         sa.Column('lat_center', sa.Float, nullable=False),
         sa.Column('lon_center', sa.Float, nullable=False),
         sa.Column('geometry', sa.String, nullable=False),
@@ -30,22 +30,22 @@ def upgrade() -> None:
     )
 
     op.create_table('edgar_data',
-        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column('id', sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
         sa.Column('year', sa.Integer, nullable=False),
         sa.Column('reference_number', sa.String, nullable=False),
         sa.Column("gas", sa.String(), nullable=False),
         sa.Column("emissions_quantity", sa.Integer(), nullable=False),
         sa.Column("emissions_quantity_units", sa.String(), nullable=False),
-        sa.Column('grid_id', sa.Integer, sa.ForeignKey('edgar_grid.id'), nullable=False),
+        sa.Column('grid_id', sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey('edgar_grid.id'), nullable=False),
         sa.Column("created_date", sa.DateTime(), nullable=False),
         sa.Column("modified_date", sa.DateTime(), server_default=text('CURRENT_TIMESTAMP'))
     )
 
     op.create_table('edgar_city_data',
-        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column('id', sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
         sa.Column('locode', sa.String, nullable=False),
         sa.Column('fraction_in_city', sa.Float, nullable=False),
-        sa.Column('grid_id', sa.Integer, sa.ForeignKey('edgar_grid.id'), nullable=False),
+        sa.Column('grid_id', sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey('edgar_grid.id'), nullable=False),
         sa.Column("created_date", sa.DateTime(), nullable=False),
         sa.Column("modified_date", sa.DateTime(), server_default=text('CURRENT_TIMESTAMP'))
     )

--- a/global-api/migrations/versions/64eb87bae0a3_add_edgar_tables.py
+++ b/global-api/migrations/versions/64eb87bae0a3_add_edgar_tables.py
@@ -26,7 +26,9 @@ def upgrade() -> None:
         sa.Column("lon_center", sa.Float, nullable=False),
         sa.Column("geometry", sa.String, nullable=False),
         sa.Column("area", sa.Float, nullable=False),
-        sa.Column("created_date", sa.DateTime(), server_default=text("CURRENT_TIMESTAMP")),
+        sa.Column(
+            "created_date", sa.DateTime(), server_default=text("CURRENT_TIMESTAMP")
+        ),
         sa.Column(
             "modified_date", sa.DateTime(), server_default=text("CURRENT_TIMESTAMP")
         ),
@@ -46,7 +48,9 @@ def upgrade() -> None:
             sa.ForeignKey("GridCellEdgar.id"),
             nullable=False,
         ),
-        sa.Column("created_date", sa.DateTime(),server_default=text("CURRENT_TIMESTAMP")),
+        sa.Column(
+            "created_date", sa.DateTime(), server_default=text("CURRENT_TIMESTAMP")
+        ),
         sa.Column(
             "modified_date", sa.DateTime(), server_default=text("CURRENT_TIMESTAMP")
         ),
@@ -63,7 +67,9 @@ def upgrade() -> None:
             sa.ForeignKey("GridCellEdgar.id"),
             nullable=False,
         ),
-        sa.Column("created_date", sa.DateTime(), server_default=text("CURRENT_TIMESTAMP")),
+        sa.Column(
+            "created_date", sa.DateTime(), server_default=text("CURRENT_TIMESTAMP")
+        ),
         sa.Column(
             "modified_date", sa.DateTime(), server_default=text("CURRENT_TIMESTAMP")
         ),

--- a/global-api/migrations/versions/64eb87bae0a3_add_edgar_tables.py
+++ b/global-api/migrations/versions/64eb87bae0a3_add_edgar_tables.py
@@ -12,46 +12,65 @@ import sqlalchemy as sa
 from sqlalchemy.sql import text
 
 # revision identifiers, used by Alembic.
-revision: str = '64eb87bae0a3'
-down_revision: Union[str, None] = 'bd6c5bbd6eb4'
+revision: str = "64eb87bae0a3"
+down_revision: Union[str, None] = "bd6c5bbd6eb4"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.create_table('GridCellEdgar',
-        sa.Column('id', sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
-        sa.Column('lat_center', sa.Float, nullable=False),
-        sa.Column('lon_center', sa.Float, nullable=False),
-        sa.Column('geometry', sa.String, nullable=False),
-        sa.Column('area', sa.Float, nullable=False),
+    op.create_table(
+        "GridCellEdgar",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("lat_center", sa.Float, nullable=False),
+        sa.Column("lon_center", sa.Float, nullable=False),
+        sa.Column("geometry", sa.String, nullable=False),
+        sa.Column("area", sa.Float, nullable=False),
         sa.Column("created_date", sa.DateTime(), nullable=False),
-        sa.Column("modified_date", sa.DateTime(), server_default=text('CURRENT_TIMESTAMP'))
+        sa.Column(
+            "modified_date", sa.DateTime(), server_default=text("CURRENT_TIMESTAMP")
+        ),
     )
 
-    op.create_table('GridCellEmissionsEdgar',
-        sa.Column('id', sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
-        sa.Column('year', sa.Integer, nullable=False),
-        sa.Column('reference_number', sa.String, nullable=False),
+    op.create_table(
+        "GridCellEmissionsEdgar",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("year", sa.Integer, nullable=False),
+        sa.Column("reference_number", sa.String, nullable=False),
         sa.Column("gas", sa.String(), nullable=False),
         sa.Column("emissions_quantity", sa.Float(), nullable=False),
         sa.Column("emissions_quantity_units", sa.String(), nullable=False),
-        sa.Column('cell_id', sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey('GridCellEdgar.id'), nullable=False),
+        sa.Column(
+            "cell_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("GridCellEdgar.id"),
+            nullable=False,
+        ),
         sa.Column("created_date", sa.DateTime(), nullable=False),
-        sa.Column("modified_date", sa.DateTime(), server_default=text('CURRENT_TIMESTAMP'))
+        sa.Column(
+            "modified_date", sa.DateTime(), server_default=text("CURRENT_TIMESTAMP")
+        ),
     )
 
-    op.create_table('CityCellOverlapEdgar',
-        sa.Column('id', sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
-        sa.Column('locode', sa.String, nullable=False),
-        sa.Column('fraction_in_city', sa.Float, nullable=False),
-        sa.Column('cell_id', sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey('GridCellEdgar.id'), nullable=False),
+    op.create_table(
+        "CityCellOverlapEdgar",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("locode", sa.String, nullable=False),
+        sa.Column("fraction_in_city", sa.Float, nullable=False),
+        sa.Column(
+            "cell_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("GridCellEdgar.id"),
+            nullable=False,
+        ),
         sa.Column("created_date", sa.DateTime(), nullable=False),
-        sa.Column("modified_date", sa.DateTime(), server_default=text('CURRENT_TIMESTAMP'))
+        sa.Column(
+            "modified_date", sa.DateTime(), server_default=text("CURRENT_TIMESTAMP")
+        ),
     )
 
 
 def downgrade() -> None:
-    op.drop_table('CityCellOverlapEdgar')
-    op.drop_table('GridCellEmissionsEdgar')
-    op.drop_table('GridCellEdgar')
+    op.drop_table("CityCellOverlapEdgar")
+    op.drop_table("GridCellEmissionsEdgar")
+    op.drop_table("GridCellEdgar")

--- a/global-api/migrations/versions/64eb87bae0a3_add_edgar_tables.py
+++ b/global-api/migrations/versions/64eb87bae0a3_add_edgar_tables.py
@@ -34,7 +34,7 @@ def upgrade() -> None:
         sa.Column('year', sa.Integer, nullable=False),
         sa.Column('reference_number', sa.String, nullable=False),
         sa.Column("gas", sa.String(), nullable=False),
-        sa.Column("emissions_quantity", sa.Integer(), nullable=False),
+        sa.Column("emissions_quantity", sa.Float(), nullable=False),
         sa.Column("emissions_quantity_units", sa.String(), nullable=False),
         sa.Column('grid_id', sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey('edgar_grid.id'), nullable=False),
         sa.Column("created_date", sa.DateTime(), nullable=False),

--- a/global-api/migrations/versions/64eb87bae0a3_add_edgar_tables.py
+++ b/global-api/migrations/versions/64eb87bae0a3_add_edgar_tables.py
@@ -19,7 +19,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.create_table('edgar_grid',
+    op.create_table('GridCellEdgar',
         sa.Column('id', sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
         sa.Column('lat_center', sa.Float, nullable=False),
         sa.Column('lon_center', sa.Float, nullable=False),
@@ -29,29 +29,29 @@ def upgrade() -> None:
         sa.Column("modified_date", sa.DateTime(), server_default=text('CURRENT_TIMESTAMP'))
     )
 
-    op.create_table('edgar_data',
+    op.create_table('GridCellEmissionsEdgar',
         sa.Column('id', sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
         sa.Column('year', sa.Integer, nullable=False),
         sa.Column('reference_number', sa.String, nullable=False),
         sa.Column("gas", sa.String(), nullable=False),
         sa.Column("emissions_quantity", sa.Float(), nullable=False),
         sa.Column("emissions_quantity_units", sa.String(), nullable=False),
-        sa.Column('grid_id', sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey('edgar_grid.id'), nullable=False),
+        sa.Column('cell_id', sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey('GridCellEdgar.id'), nullable=False),
         sa.Column("created_date", sa.DateTime(), nullable=False),
         sa.Column("modified_date", sa.DateTime(), server_default=text('CURRENT_TIMESTAMP'))
     )
 
-    op.create_table('edgar_city_data',
+    op.create_table('CityCellOverlapEdgar',
         sa.Column('id', sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
         sa.Column('locode', sa.String, nullable=False),
         sa.Column('fraction_in_city', sa.Float, nullable=False),
-        sa.Column('grid_id', sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey('edgar_grid.id'), nullable=False),
+        sa.Column('cell_id', sa.dialects.postgresql.UUID(as_uuid=True), sa.ForeignKey('GridCellEdgar.id'), nullable=False),
         sa.Column("created_date", sa.DateTime(), nullable=False),
         sa.Column("modified_date", sa.DateTime(), server_default=text('CURRENT_TIMESTAMP'))
     )
 
 
 def downgrade() -> None:
-    op.drop_table('edgar_city_data')
-    op.drop_table('edgar_data')
-    op.drop_table('edgar_grid')
+    op.drop_table('CityCellOverlapEdgar')
+    op.drop_table('GridCellEmissionsEdgar')
+    op.drop_table('GridCellEdgar')

--- a/global-api/migrations/versions/64eb87bae0a3_add_edgar_tables.py
+++ b/global-api/migrations/versions/64eb87bae0a3_add_edgar_tables.py
@@ -26,7 +26,7 @@ def upgrade() -> None:
         sa.Column("lon_center", sa.Float, nullable=False),
         sa.Column("geometry", sa.String, nullable=False),
         sa.Column("area", sa.Float, nullable=False),
-        sa.Column("created_date", sa.DateTime(), nullable=False),
+        sa.Column("created_date", sa.DateTime(), server_default=text("CURRENT_TIMESTAMP")),
         sa.Column(
             "modified_date", sa.DateTime(), server_default=text("CURRENT_TIMESTAMP")
         ),
@@ -46,7 +46,7 @@ def upgrade() -> None:
             sa.ForeignKey("GridCellEdgar.id"),
             nullable=False,
         ),
-        sa.Column("created_date", sa.DateTime(), nullable=False),
+        sa.Column("created_date", sa.DateTime(),server_default=text("CURRENT_TIMESTAMP")),
         sa.Column(
             "modified_date", sa.DateTime(), server_default=text("CURRENT_TIMESTAMP")
         ),
@@ -63,7 +63,7 @@ def upgrade() -> None:
             sa.ForeignKey("GridCellEdgar.id"),
             nullable=False,
         ),
-        sa.Column("created_date", sa.DateTime(), nullable=False),
+        sa.Column("created_date", sa.DateTime(), server_default=text("CURRENT_TIMESTAMP")),
         sa.Column(
             "modified_date", sa.DateTime(), server_default=text("CURRENT_TIMESTAMP")
         ),


### PR DESCRIPTION
this adds three tables to the ccglobal API Database. I named them to be specifically used for [EDGAR data](https://edgar.jrc.ec.europa.eu/dataset_ghg70#p3), but they may generalizable. This PR adds three tables:
- `edgar_grid`: this contains relevant grid information (centroid, polygon in WKT, and area)
- `edgar_data`: this contains the emissions data for each gas. The corresponding GPC reference number is included and there is a FK to `edgar_grid`
- `edgar_city_data`: this contains the fraction of each grid cell that is within each locode. Only grid cells where the fraction is >0 will be included.

`edgar_data` contains all the raw data, so this could be used for custom boundaries. While `edgar_city_data` contains the fractions of grid cells within the locode geometries we got from OSM. 