### PR TITLE
ON-840: add EDGAR endpoint to global API

### DIFF
--- a/global-api/main.py
+++ b/global-api/main.py
@@ -9,6 +9,7 @@ from utils.helpers import get_or_create_log_file
 from routes.health import api_router as health_check_route
 from routes.city_locode_endpoint import api_router as city_locode_route
 from routes.city_boundaries_endpoint import api_router as city_boundaries_route
+from routes.city_locode_endpoint_edgar import api_router as edgar_city_locode_route
 
 """
 Logger instance initialized and configured
@@ -82,6 +83,11 @@ app.include_router(
 app.include_router(
     city_boundaries_route,
     tags=["Climate Trace"],
+)
+
+app.include_router(
+    edgar_city_locode_route,
+    tags=["EDGAR"],
 )
 
 """

--- a/global-api/routes/city_locode_endpoint_edgar.py
+++ b/global-api/routes/city_locode_endpoint_edgar.py
@@ -22,7 +22,7 @@ def db_query(locode, year, reference_number):
         query = text(
             """
             SELECT
-                cco.grid_id,
+                cco.cell_id,
                 cg.area,
                 cco.fraction_in_city,
                 gce.emissions_quantity,
@@ -32,9 +32,9 @@ def db_query(locode, year, reference_number):
             FROM
                 "CityCellOverlapEdgar" cco
             JOIN
-                "GridCellEdgar" cg ON ecd.grid_id = cg.id
+                "GridCellEdgar" cg ON cco.cell_id = cg.id
             JOIN
-                "GridCellEmissionsEdgar" gce ON ecd.grid_id = gce.grid_id
+                "GridCellEmissionsEdgar" gce ON cco.cell_id = gce.cell_id
             WHERE cco.locode = :locode
             AND gce.reference_number = :reference_number
             AND gce.year = :year;"""
@@ -59,7 +59,7 @@ def get_emissions_by_city_and_year(locode: str, year: int, gpcReferenceNumber: s
         .groupby("gas")
         .sum("emissions_total")
         .astype({"emissions_total": int})
-        .loc[:,['emissions_total']]
+        .loc[:, ["emissions_total"]]
         .squeeze()
     )
 

--- a/global-api/routes/city_locode_endpoint_edgar.py
+++ b/global-api/routes/city_locode_endpoint_edgar.py
@@ -47,7 +47,7 @@ def db_query(locode, year, reference_number):
 
 
 @api_router.get("/edgar/city/{locode}/{year}/{gpcReferenceNumber}")
-def get_emissions_by_city_and_year(locode: str, year: int, gpcReferenceNumber: float):
+def get_emissions_by_city_and_year(locode: str, year: int, gpcReferenceNumber: str):
     records = db_query(locode, year, gpcReferenceNumber)
     series = (
         pd.DataFrame(records)
@@ -59,6 +59,7 @@ def get_emissions_by_city_and_year(locode: str, year: int, gpcReferenceNumber: f
         .groupby("gas")
         .sum("emissions_total")
         .astype({"emissions_total": int})
+        .loc[:,['emissions_total']]
         .squeeze()
     )
 

--- a/global-api/routes/city_locode_endpoint_edgar.py
+++ b/global-api/routes/city_locode_endpoint_edgar.py
@@ -79,4 +79,4 @@ def get_emissions_by_city_and_year(locode: str, year: int, gpcReferenceNumber: s
         }
     }
 
-    return {"totals": totals}
+    return totals

--- a/global-api/routes/city_locode_endpoint_edgar.py
+++ b/global-api/routes/city_locode_endpoint_edgar.py
@@ -1,0 +1,81 @@
+from fastapi import APIRouter
+from sqlalchemy import text
+import pandas as pd
+from db.database import SessionLocal
+
+api_router = APIRouter(prefix="/api/v0")
+
+# AR6 GWP
+ch4_GWP_100yr = 29.8
+ch4_GWP_20yr = 82.5
+n2o_GWP_100yr = 273
+n2o_GWP_20yr = 273
+
+# GPC quality classification
+gpc_quality_data = "TBD"
+gpc_quality_EF = "TBD"
+
+
+# Extract the data by locode, year and sector/subsector
+def db_query(locode, year, reference_number):
+    with SessionLocal() as session:
+        query = text(
+            """
+            SELECT
+                ecd.grid_id,
+                eg.area,
+                ecd.fraction_in_city,
+                ed.emissions_quantity,
+                ed.gas,
+                ed.year,
+                ed.reference_number
+            FROM
+                edgar_city_data ecd
+            JOIN
+                edgar_grid eg ON ecd.grid_id = eg.id
+            JOIN
+                edgar_data ed ON ecd.grid_id = ed.grid_id
+            WHERE ecd.locode = :locode
+            AND ed.reference_number = :reference_number
+            AND ed.year = :year;"""
+        )
+
+        params = {"locode": locode, "year": year, "reference_number": reference_number}
+        result = session.execute(query, params).fetchall()
+
+    return result
+
+
+@api_router.get("/edgar/city/{locode}/{year}/{gpcReferenceNumber}")
+def get_emissions_by_city_and_year(locode: str, year: int, gpcReferenceNumber: float):
+    records = db_query(locode, year, gpcReferenceNumber)
+    series = (
+        pd.DataFrame(records)
+        .assign(
+            emissions_total=lambda row: row["area"]
+            * row["fraction_in_city"]
+            * row["emissions_quantity"]
+        )
+        .groupby("gas")
+        .sum("emissions_total")
+        .astype({"emissions_total": int})
+        .squeeze()
+    )
+
+    totals = {
+        "totals": {
+            "emissions": {
+                "co2_mass": str(series.get("CO2", 0)),
+                "co2_co2eq": str(series.get("CO2", 0)),
+                "ch4_mass": str(series.get("CH4", 0)),
+                "ch4_co2eq_100yr": str(series.get("CH4", 0) * ch4_GWP_100yr),
+                "ch4_co2eq_20yr": str(series.get("CH4", 0) * ch4_GWP_20yr),
+                "n2o_mass": str(series.get("N2O", 0)),
+                "n2o_co2eq_100yr": str(series.get("N2O", 0) * n2o_GWP_100yr),
+                "n2o_co2eq_20yr": str(series.get("N2O", 0) * n2o_GWP_20yr),
+                "gpc_quality": str(gpc_quality_data),
+            }
+        }
+    }
+
+    return {"totals": totals}

--- a/global-api/routes/city_locode_endpoint_edgar.py
+++ b/global-api/routes/city_locode_endpoint_edgar.py
@@ -22,22 +22,22 @@ def db_query(locode, year, reference_number):
         query = text(
             """
             SELECT
-                ecd.grid_id,
-                eg.area,
-                ecd.fraction_in_city,
-                ed.emissions_quantity,
-                ed.gas,
-                ed.year,
-                ed.reference_number
+                cco.grid_id,
+                cg.area,
+                cco.fraction_in_city,
+                gce.emissions_quantity,
+                gce.gas,
+                gce.year,
+                gce.reference_number
             FROM
-                edgar_city_data ecd
+                "CityCellOverlapEdgar" cco
             JOIN
-                edgar_grid eg ON ecd.grid_id = eg.id
+                "GridCellEdgar" cg ON ecd.grid_id = cg.id
             JOIN
-                edgar_data ed ON ecd.grid_id = ed.grid_id
-            WHERE ecd.locode = :locode
-            AND ed.reference_number = :reference_number
-            AND ed.year = :year;"""
+                "GridCellEmissionsEdgar" gce ON ecd.grid_id = gce.grid_id
+            WHERE cco.locode = :locode
+            AND gce.reference_number = :reference_number
+            AND gce.year = :year;"""
         )
 
         params = {"locode": locode, "year": year, "reference_number": reference_number}


### PR DESCRIPTION
this PR adds a get endpoint to the global API.

This was tested locally. 

`http://localhost:8000/api/v0/edgar/city/US NYC/2021/II.1.1`

returns:
```json
{
  "totals": {
    "totals": {
      "emissions": {
        "co2_mass": "266468760",
        "co2_co2eq": "266468760",
        "ch4_mass": "21810",
        "ch4_co2eq_100yr": "649938.0",
        "ch4_co2eq_20yr": "1799325.0",
        "n2o_mass": "11951",
        "n2o_co2eq_100yr": "3262623",
        "n2o_co2eq_20yr": "3262623",
        "gpc_quality": "TBD"
      }
    }
  }
}
```