### PR TITLE
Add default inventory storage

### DIFF
--- a/app/migrations/20231024111822-user-default-inventory.cjs
+++ b/app/migrations/20231024111822-user-default-inventory.cjs
@@ -1,0 +1,32 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.addColumn(
+        "User",
+        "default_city_locode",
+        Sequelize.CHAR,
+        { transaction },
+      );
+      await queryInterface.addColumn(
+        "User",
+        "default_inventory_year",
+        Sequelize.INTEGER,
+        { transaction },
+      );
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.removeColumn("User", "default_city_locode", {
+        transaction,
+      });
+      await queryInterface.removeColumn("User", "default_inventory_year", {
+        transaction,
+      });
+    });
+  },
+};

--- a/app/migrations/20231024111822-user-default-inventory.cjs
+++ b/app/migrations/20231024111822-user-default-inventory.cjs
@@ -7,7 +7,7 @@ module.exports = {
       await queryInterface.addColumn(
         "User",
         "default_city_locode",
-        Sequelize.CHAR,
+        Sequelize.STRING,
         { transaction },
       );
       await queryInterface.addColumn(

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -39,7 +39,7 @@
         "i18next-resources-to-backend": "^1.1.4",
         "jsonwebtoken": "^9.0.2",
         "leaflet": "^1.9.4",
-        "next": "13.4.19",
+        "next": "13.5.6",
         "next-auth": "^4.23.2",
         "nodemailer": "^6.9.5",
         "pg": "^8.11.3",
@@ -4488,9 +4488,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.19.tgz",
-      "integrity": "sha512-FsAT5x0jF2kkhNkKkukhsyYOrRqtSxrEhfliniIq0bwWbuXLgyt3Gv0Ml+b91XwjwArmuP7NxCiGd++GGKdNMQ=="
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.6.tgz",
+      "integrity": "sha512-Yac/bV5sBGkkEXmAX5FWPS9Mmo2rthrOPRQQNfycJPkjUAUclomCPH7QFVCDQ4Mp2k2K1SSM6m0zrxYrOwtFQw=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "13.4.16",
@@ -4520,9 +4520,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.19.tgz",
-      "integrity": "sha512-vv1qrjXeGbuF2mOkhkdxMDtv9np7W4mcBtaDnHU+yJG+bBwa6rYsYSCI/9Xm5+TuF5SbZbrWO6G1NfTh1TMjvQ==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.6.tgz",
+      "integrity": "sha512-5nvXMzKtZfvcu4BhtV0KH1oGv4XEW+B+jOfmBdpFI3C7FrB/MfujRpWYSBBO64+qbW8pkZiSyQv9eiwnn5VIQA==",
       "cpu": [
         "arm64"
       ],
@@ -4535,9 +4535,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.19.tgz",
-      "integrity": "sha512-jyzO6wwYhx6F+7gD8ddZfuqO4TtpJdw3wyOduR4fxTUCm3aLw7YmHGYNjS0xRSYGAkLpBkH1E0RcelyId6lNsw==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.6.tgz",
+      "integrity": "sha512-6cgBfxg98oOCSr4BckWjLLgiVwlL3vlLj8hXg2b+nDgm4bC/qVXXLfpLB9FHdoDu4057hzywbxKvmYGmi7yUzA==",
       "cpu": [
         "x64"
       ],
@@ -4550,9 +4550,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.19.tgz",
-      "integrity": "sha512-vdlnIlaAEh6H+G6HrKZB9c2zJKnpPVKnA6LBwjwT2BTjxI7e0Hx30+FoWCgi50e+YO49p6oPOtesP9mXDRiiUg==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.6.tgz",
+      "integrity": "sha512-txagBbj1e1w47YQjcKgSU4rRVQ7uF29YpnlHV5xuVUsgCUf2FmyfJ3CPjZUvpIeXCJAoMCFAoGnbtX86BK7+sg==",
       "cpu": [
         "arm64"
       ],
@@ -4565,9 +4565,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.19.tgz",
-      "integrity": "sha512-aU0HkH2XPgxqrbNRBFb3si9Ahu/CpaR5RPmN2s9GiM9qJCiBBlZtRTiEca+DC+xRPyCThTtWYgxjWHgU7ZkyvA==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.6.tgz",
+      "integrity": "sha512-cGd+H8amifT86ZldVJtAKDxUqeFyLWW+v2NlBULnLAdWsiuuN8TuhVBt8ZNpCqcAuoruoSWynvMWixTFcroq+Q==",
       "cpu": [
         "arm64"
       ],
@@ -4580,9 +4580,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.19.tgz",
-      "integrity": "sha512-htwOEagMa/CXNykFFeAHHvMJeqZfNQEoQvHfsA4wgg5QqGNqD5soeCer4oGlCol6NGUxknrQO6VEustcv+Md+g==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.6.tgz",
+      "integrity": "sha512-Mc2b4xiIWKXIhBy2NBTwOxGD3nHLmq4keFk+d4/WL5fMsB8XdJRdtUlL87SqVCTSaf1BRuQQf1HvXZcy+rq3Nw==",
       "cpu": [
         "x64"
       ],
@@ -4595,9 +4595,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.19.tgz",
-      "integrity": "sha512-4Gj4vvtbK1JH8ApWTT214b3GwUh9EKKQjY41hH/t+u55Knxi/0wesMzwQRhppK6Ddalhu0TEttbiJ+wRcoEj5Q==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.6.tgz",
+      "integrity": "sha512-CFHvP9Qz98NruJiUnCe61O6GveKKHpJLloXbDSWRhqhkJdZD2zU5hG+gtVJR//tyW897izuHpM6Gtf6+sNgJPQ==",
       "cpu": [
         "x64"
       ],
@@ -4610,9 +4610,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.19.tgz",
-      "integrity": "sha512-bUfDevQK4NsIAHXs3/JNgnvEY+LRyneDN788W2NYiRIIzmILjba7LaQTfihuFawZDhRtkYCv3JDC3B4TwnmRJw==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.6.tgz",
+      "integrity": "sha512-aFv1ejfkbS7PUa1qVPwzDHjQWQtknzAZWGTKYIAaS4NMtBlk3VyA6AYn593pqNanlicewqyl2jUhQAaFV/qXsg==",
       "cpu": [
         "arm64"
       ],
@@ -4625,9 +4625,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.19.tgz",
-      "integrity": "sha512-Y5kikILFAr81LYIFaw6j/NrOtmiM4Sf3GtOc0pn50ez2GCkr+oejYuKGcwAwq3jiTKuzF6OF4iT2INPoxRycEA==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.6.tgz",
+      "integrity": "sha512-XqqpHgEIlBHvzwG8sp/JXMFkLAfGLqkbVsyN+/Ih1mR8INb6YCc2x/Mbwi6hsAgUnqQztz8cvEbHJUbSl7RHDg==",
       "cpu": [
         "ia32"
       ],
@@ -4640,9 +4640,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.19.tgz",
-      "integrity": "sha512-YzA78jBDXMYiINdPdJJwGgPNT3YqBNNGhsthsDoWHL9p24tEJn9ViQf/ZqTbwSpX/RrkPupLfuuTH2sf73JBAw==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.6.tgz",
+      "integrity": "sha512-Cqfe1YmOS7k+5mGu92nl5ULkzpKuxJrP3+4AEuPmrpFZ3BHxTY3TnHmU1On3bFmFFs6FbTcdF58CCUProGpIGQ==",
       "cpu": [
         "x64"
       ],
@@ -10370,9 +10370,9 @@
       "dev": true
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
-      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+      "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -19526,35 +19526,34 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/next": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.4.19.tgz",
-      "integrity": "sha512-HuPSzzAbJ1T4BD8e0bs6B9C1kWQ6gv8ykZoRWs5AQoiIuqbGHHdQO7Ljuvg05Q0Z24E2ABozHe6FxDvI6HfyAw==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.5.6.tgz",
+      "integrity": "sha512-Y2wTcTbO4WwEsVb4A8VSnOsG1I9ok+h74q0ZdxkwM3EODqrs4pasq7O0iUxbcS9VtWMicG7f3+HAj0r1+NtKSw==",
       "dependencies": {
-        "@next/env": "13.4.19",
-        "@swc/helpers": "0.5.1",
+        "@next/env": "13.5.6",
+        "@swc/helpers": "0.5.2",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
-        "postcss": "8.4.14",
+        "postcss": "8.4.31",
         "styled-jsx": "5.1.1",
-        "watchpack": "2.4.0",
-        "zod": "3.21.4"
+        "watchpack": "2.4.0"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=16.8.0"
+        "node": ">=16.14.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.4.19",
-        "@next/swc-darwin-x64": "13.4.19",
-        "@next/swc-linux-arm64-gnu": "13.4.19",
-        "@next/swc-linux-arm64-musl": "13.4.19",
-        "@next/swc-linux-x64-gnu": "13.4.19",
-        "@next/swc-linux-x64-musl": "13.4.19",
-        "@next/swc-win32-arm64-msvc": "13.4.19",
-        "@next/swc-win32-ia32-msvc": "13.4.19",
-        "@next/swc-win32-x64-msvc": "13.4.19"
+        "@next/swc-darwin-arm64": "13.5.6",
+        "@next/swc-darwin-x64": "13.5.6",
+        "@next/swc-linux-arm64-gnu": "13.5.6",
+        "@next/swc-linux-arm64-musl": "13.5.6",
+        "@next/swc-linux-x64-gnu": "13.5.6",
+        "@next/swc-linux-x64-musl": "13.5.6",
+        "@next/swc-win32-arm64-msvc": "13.5.6",
+        "@next/swc-win32-ia32-msvc": "13.5.6",
+        "@next/swc-win32-x64-msvc": "13.5.6"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -19610,37 +19609,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.4",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/next/node_modules/zod": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     },
     "node_modules/no-case": {
       "version": "3.0.4",

--- a/app/package.json
+++ b/app/package.json
@@ -55,7 +55,7 @@
     "i18next-resources-to-backend": "^1.1.4",
     "jsonwebtoken": "^9.0.2",
     "leaflet": "^1.9.4",
-    "next": "13.4.19",
+    "next": "13.5.6",
     "next-auth": "^4.23.2",
     "nodemailer": "^6.9.5",
     "pg": "^8.11.3",

--- a/app/src/app/[lng]/page.tsx
+++ b/app/src/app/[lng]/page.tsx
@@ -57,6 +57,8 @@ export default function Home({ params: { lng } }: { params: { lng: string } }) {
   const router = useRouter();
 
   // query API data
+  // TODO maybe rework this logic into one RTK query:
+  // https://redux-toolkit.js.org/rtk-query/usage/customizing-queries#performing-multiple-requests-with-a-single-query
   let locode: string | null = null;
   let year: number | null = null;
   const { data: userInfo, isLoading: isUserInfoLoading } =

--- a/app/src/app/[lng]/page.tsx
+++ b/app/src/app/[lng]/page.tsx
@@ -6,7 +6,6 @@ import { SegmentedProgress } from "@/components/SegmentedProgress";
 import { CircleIcon } from "@/components/icons";
 import { NavigationBar } from "@/components/navigation-bar";
 import { useTranslation } from "@/i18n/client";
-import { Trans } from "react-i18next/TransWithoutContext";
 import { api } from "@/services/api";
 import { formatPercent } from "@/util/helpers";
 import { InfoOutlineIcon } from "@chakra-ui/icons";
@@ -30,6 +29,8 @@ import {
 } from "@chakra-ui/react";
 import dynamic from "next/dynamic";
 import NextLink from "next/link";
+import { useRouter } from "next/navigation";
+import { Trans } from "react-i18next/TransWithoutContext";
 import { FiDownload } from "react-icons/fi";
 import {
   MdArrowOutward,
@@ -51,18 +52,35 @@ const CITY_INTENTORY_YEAR = "DE_BER";
 const CityMap = dynamic(() => import("@/components/CityMap"), { ssr: false });
 
 export default function Home({ params: { lng } }: { params: { lng: string } }) {
-  const toast = useToast();
-
   const { t } = useTranslation(lng, "dashboard");
+  const toast = useToast();
+  const router = useRouter();
 
   // query API data
-  // TODO get these from user record
-  const locode = "XX_INVENTORY_CITY";
-  const year = 3000;
+  let locode: string | null = null;
+  let year: number | null = null;
+  const { data: userInfo, isLoading: isUserInfoLoading } =
+    api.useGetUserInfoQuery();
+  if (!isUserInfoLoading && userInfo) {
+    locode = userInfo.defaultCityLocode;
+    year = userInfo.defaultInventoryYear;
+
+    // if the user doesn't have a default city/ year, redirect to onboarding page
+    if (!locode || !year) {
+      router.push("/onboarding");
+    }
+  }
   const { data: inventory, isLoading: isInventoryLoading } =
-    api.useGetInventoryQuery({ locode, year });
+    api.useGetInventoryQuery(
+      { locode: locode!, year: year! },
+      { skip: !locode || !year },
+    );
   const { data: inventoryProgress, isLoading: isInventoryProgressLoading } =
-    api.useGetInventoryProgressQuery({ locode, year });
+    api.useGetInventoryProgressQuery(
+      { locode: locode!, year: year! },
+      { skip: !locode || !year },
+    );
+
   let totalProgress = 0,
     thirdPartyProgress = 0,
     uploadedProgress = 0;
@@ -472,7 +490,7 @@ export default function Home({ params: { lng } }: { params: { lng: string } }) {
               >
                 <Trans t={t}>sectors-required-from-inventory</Trans>
               </Text>
-              {isInventoryProgressLoading ? (
+              {isUserInfoLoading || isInventoryProgressLoading ? (
                 <Center>
                   <Spinner size="lg" />
                 </Center>

--- a/app/src/app/[lng]/page.tsx
+++ b/app/src/app/[lng]/page.tsx
@@ -30,6 +30,7 @@ import {
 import dynamic from "next/dynamic";
 import NextLink from "next/link";
 import { useRouter } from "next/navigation";
+import { CircleFlag } from "react-circle-flags";
 import { Trans } from "react-i18next/TransWithoutContext";
 import { FiDownload } from "react-icons/fi";
 import {
@@ -216,21 +217,29 @@ export default function Home({ params: { lng } }: { params: { lng: string } }) {
                   <Trans t={t}>welcome-back</Trans>,
                 </Text>
                 <Box className="flex items-center gap-4 w-[644px] h-[104px]">
-                  <Avatar
-                    className="h-[32px] w-[32px]"
-                    name="Argentina"
-                    src="https://upload.wikimedia.org/wikipedia/commons/1/1a/Flag_of_Argentina.svg"
-                  />
-                  <Heading
-                    fontSize="display.md"
-                    color="base.light"
-                    fontWeight="semibold"
-                    lineHeight="52"
-                    className="flex"
-                  >
-                    {inventory?.city?.name}
-                    Ciudad Autónoma de Buenos Aires
-                  </Heading>
+                  {inventory?.city ? (
+                    <>
+                      <CircleFlag
+                        countryCode={inventory.city.locode
+                          .substring(0, 2)
+                          .toLowerCase()}
+                        width={32}
+                      />
+                      <Heading
+                        fontSize="display.md"
+                        color="base.light"
+                        fontWeight="semibold"
+                        lineHeight="52"
+                        className="flex"
+                      >
+                        {inventory?.city?.name}
+                      </Heading>
+                    </>
+                  ) : (
+                    (isUserInfoLoading || isInventoryLoading) && (
+                      <Spinner size="lg" color="white" />
+                    )
+                  )}
                 </Box>
                 <Box className="flex gap-8 mt-[24px]">
                   <Box className="flex align-baseline gap-3">

--- a/app/src/app/api/v0/city/[city]/inventory/[year]/route.ts
+++ b/app/src/app/api/v0/city/[city]/inventory/[year]/route.ts
@@ -30,11 +30,11 @@ export const GET = apiHandler(
 
     const inventory = await db.models.Inventory.findOne({
       where: { cityId: city.cityId, year: params.year },
+      include: [{ model: db.models.City, as: "city" }],
     });
     if (!inventory) {
       throw new createHttpError.NotFound("Inventory not found");
     }
-    inventory.city = city;
 
     return NextResponse.json({ data: inventory });
   },

--- a/app/src/app/api/v0/city/route.ts
+++ b/app/src/app/api/v0/city/route.ts
@@ -12,13 +12,15 @@ export const POST = apiHandler(
     context: { session?: Session; params: Record<string, string> },
   ) => {
     const body = createCityRequest.parse(await req.json());
-    if (!context.session)
+    if (!context.session) {
       throw new createHttpError.Unauthorized("Unauthorized");
+    }
+
     const city = await db.models.City.create({
       cityId: randomUUID(),
       ...body,
     });
-    city.addUser("7b730ed9-5c7a-4758-a658-c31673700cc9");
+    await city.addUser(context.session.user.id);
     return NextResponse.json({ data: city });
   },
 );

--- a/app/src/app/api/v0/user/route.ts
+++ b/app/src/app/api/v0/user/route.ts
@@ -1,0 +1,30 @@
+import { db } from "@/models";
+import { apiHandler } from "@/util/api";
+import createHttpError from "http-errors";
+import { Session } from "next-auth";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+const updateUserRequest = z.object({
+  defaultCityLocode: z.string().min(2),
+  defaultInventoryYear: z.number().gt(0),
+});
+
+export const PATCH = apiHandler(
+  async (
+    req: Request,
+    context: { session?: Session; params: Record<string, string> },
+  ) => {
+    const body = updateUserRequest.parse(await req.json());
+    if (!context.session) {
+      throw new createHttpError.Unauthorized("Unauthorized");
+    }
+
+    const user = await db.models.User.update(body, {
+      where: {
+        userId: context.session.user.id,
+      },
+    });
+    return NextResponse.json({ success: true });
+  },
+);

--- a/app/src/components/CityMap.tsx
+++ b/app/src/components/CityMap.tsx
@@ -10,7 +10,7 @@ import { FC, useEffect } from "react";
 import { GeoJSON, MapContainer, TileLayer, useMap } from "react-leaflet";
 
 export interface CityMapProps {
-  locode: string;
+  locode: string | null;
   width: number;
   height: number;
 }
@@ -33,7 +33,9 @@ function BoundingBoxFocus({ boundingBox }: { boundingBox?: number[] }) {
 }
 
 export const CityMap: FC<CityMapProps> = ({ locode, width, height }) => {
-  const { data, isLoading } = api.useGetCityBoundaryQuery(locode);
+  const { data, isLoading } = api.useGetCityBoundaryQuery(locode!, {
+    skip: !locode,
+  });
   let boundingBox: number[] | undefined = [34, -37, 35, -38];
   if (data) {
     boundingBox = geoJSONBoundingBox(data);

--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -1,12 +1,49 @@
-import { NextAuthOptions } from "next-auth";
-import Credentials from "next-auth/providers/credentials";
-import bcrypt from "bcrypt";
-import { User } from "@/models/User";
 import { db } from "@/models";
+import { User } from "@/models/User";
+import bcrypt from "bcrypt";
+import { DefaultSession, NextAuthOptions, getServerSession } from "next-auth";
+import {
+  CredentialInput,
+  CredentialsConfig,
+} from "next-auth/providers/credentials";
 
 export enum Roles {
   User = "user",
   Admin = "admin",
+}
+
+// extracted from next-auth/providers/credentials
+// added here since the node test runner/ tsx wouldn't properly import ESM modules
+// error was: Credentials is not a function
+type UserCredentialsConfig<C extends Record<string, CredentialInput>> = Partial<
+  Omit<CredentialsConfig<C>, "options">
+> &
+  Pick<CredentialsConfig<C>, "authorize" | "credentials">;
+
+export default function Credentials<
+  C extends Record<string, CredentialInput> = Record<string, CredentialInput>,
+>(options: UserCredentialsConfig<C>): CredentialsConfig<C> {
+  return {
+    id: "credentials",
+    name: "Credentials",
+    type: "credentials",
+    credentials: {} as any,
+    authorize: () => null,
+    options,
+  };
+}
+
+export type AppSession = DefaultSession & {
+  user: {
+    id: string;
+    role: string;
+  };
+}
+
+export class Auth {
+  static async getServerSession(): Promise<AppSession | null> {
+    return await getServerSession(authOptions);
+  }
 }
 
 export const authOptions: NextAuthOptions = {
@@ -81,3 +118,4 @@ export const authOptions: NextAuthOptions = {
     },
   },
 };
+;

--- a/app/src/models/User.ts
+++ b/app/src/models/User.ts
@@ -10,6 +10,8 @@ export interface UserAttributes {
   email?: string;
   passwordHash?: string;
   role?: string;
+  defaultCityLocode?: string;
+  defaultInventoryYear?: number;
   created?: Date;
   lastUpdated?: Date;
   organizationId?: string;
@@ -24,6 +26,8 @@ export type UserOptionalAttributes =
   | "email"
   | "passwordHash"
   | "role"
+  | "defaultCityLocode"
+  | "defaultInventoryYear"
   | "created"
   | "lastUpdated"
   | "organizationId";
@@ -43,6 +47,8 @@ export class User
   email?: string;
   passwordHash?: string;
   role?: string;
+  defaultCityLocode?: string;
+  defaultInventoryYear?: number;
   created?: Date;
   lastUpdated?: Date;
   organizationId?: string;
@@ -108,6 +114,16 @@ export class User
         role: {
           type: DataTypes.TEXT,
           allowNull: true,
+        },
+        defaultCityLocode: {
+          type: DataTypes.STRING(255),
+          allowNull: true,
+          field: "default_city_locode",
+        },
+        defaultInventoryYear: {
+          type: DataTypes.INTEGER,
+          allowNull: true,
+          field: "default_inventory_year",
         },
         organizationId: {
           type: DataTypes.UUID,

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -49,7 +49,7 @@ export const api = createApi({
     ),
     addInventory: builder.mutation<
       InventoryAttributes,
-      { locode: string; year: number }
+      { locode: string; year: number; inventoryName: string }
     >({
       query: (data) => ({
         url: `/city/${data.locode}/inventory`,

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -67,7 +67,7 @@ export const api = createApi({
         body: data,
       }),
     }),
-    getUserInfo: builder.query<UserInfoResponse, {}>({
+    getUserInfo: builder.query<UserInfoResponse, void>({
       query: () => "/user",
       transformResponse: (response: { data: UserInfoResponse }) =>
         response.data,

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -1,4 +1,8 @@
-import type { CityAttributes, InventoryAttributes } from "@/models/init-models";
+import {
+  UserAttributes,
+  type CityAttributes,
+  type InventoryAttributes,
+} from "@/models/init-models";
 import type {
   InventoryProgressResponse,
   InventoryResponse,
@@ -33,10 +37,32 @@ export const api = createApi({
       transformResponse: (response: { data: InventoryProgressResponse }) =>
         response.data,
     }),
-    addCity: builder.mutation<CityAttributes, {}>({
+    addCity: builder.mutation<CityAttributes, { name: string; locode: string }>(
+      {
+        query: (data) => ({
+          url: `/city`,
+          method: "POST",
+          body: data,
+        }),
+      },
+    ),
+    addInventory: builder.mutation<
+      InventoryAttributes,
+      { locode: string; year: number }
+    >({
       query: (data) => ({
-        url: `/city`,
+        url: `/city/${data.locode}/inventory`,
         method: "POST",
+        body: data,
+      }),
+    }),
+    setUserInfo: builder.mutation<
+      UserAttributes,
+      { defaultCityLocode: string; defaultInventoryYear: number }
+    >({
+      query: (data) => ({
+        url: `/user`,
+        method: "PATCH",
         body: data,
       }),
     }),
@@ -59,5 +85,10 @@ export const openclimateAPI = createApi({
 });
 
 // hooks are automatically generated
-export const { useGetCityQuery, useAddCityMutation } = api;
+export const {
+  useGetCityQuery,
+  useAddCityMutation,
+  useAddInventoryMutation,
+  useSetUserInfoMutation,
+} = api;
 export const { useGetOCCityQuery } = openclimateAPI;

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -6,6 +6,7 @@ import {
 import type {
   InventoryProgressResponse,
   InventoryResponse,
+  UserInfoResponse,
 } from "@/util/types";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
@@ -61,10 +62,15 @@ export const api = createApi({
       { defaultCityLocode: string; defaultInventoryYear: number }
     >({
       query: (data) => ({
-        url: `/user`,
+        url: "/user",
         method: "PATCH",
         body: data,
       }),
+    }),
+    getUserInfo: builder.query<UserInfoResponse, {}>({
+      query: () => "/user",
+      transformResponse: (response: { data: UserInfoResponse }) =>
+        response.data,
     }),
   }),
 });

--- a/app/src/util/api.ts
+++ b/app/src/util/api.ts
@@ -1,8 +1,7 @@
+import { Auth } from "@/lib/auth";
 import createHttpError from "http-errors";
 import { NextRequest, NextResponse } from "next/server";
 import { ZodError } from "zod";
-import { getServerSession } from "next-auth/next";
-import { authOptions } from "@/lib/auth";
 
 import { db } from "@/models";
 import { ValidationError } from "sequelize";
@@ -22,7 +21,7 @@ export function apiHandler(handler: NextHandler) {
         await db.initialize();
       }
 
-      const session = await getServerSession(authOptions);
+      const session = await Auth.getServerSession();
       const context = {
         ...props,
         session,

--- a/app/src/util/types.d.ts
+++ b/app/src/util/types.d.ts
@@ -20,6 +20,8 @@ interface InventoryProgressResponse {
 }
 
 interface UserInfoResponse {
+  userId: string;
+  name: string;
   defaultCityLocode: string | null;
   defaultInventoryYear: number | null;
 }

--- a/app/src/util/types.d.ts
+++ b/app/src/util/types.d.ts
@@ -19,6 +19,11 @@ interface InventoryProgressResponse {
   sectorProgress: SectorProgress[];
 }
 
+interface UserInfoResponse {
+  defaultCityLocode: string | null;
+  defaultInventoryYear: number | null;
+}
+
 declare module "next-auth" {
   interface Session {
     user: {

--- a/app/tests/api/city.test.ts
+++ b/app/tests/api/city.test.ts
@@ -9,7 +9,7 @@ import { CreateCityRequest } from "@/util/validation";
 import env from "@next/env";
 import assert from "node:assert";
 import { after, before, describe, it } from "node:test";
-import { createRequest } from "../helpers";
+import { createRequest, setupTests } from "../helpers";
 
 const city: CreateCityRequest = {
   locode: "XX_CITY",
@@ -37,8 +37,7 @@ const invalidCity = {
 
 describe("City API", () => {
   before(async () => {
-    const projectDir = process.cwd();
-    env.loadEnvConfig(projectDir);
+    setupTests();
     await db.initialize();
     await db.models.City.destroy({ where: { locode: city.locode } });
   });

--- a/app/tests/api/inventory.test.ts
+++ b/app/tests/api/inventory.test.ts
@@ -7,12 +7,11 @@ import { GET as calculateProgress } from "@/app/api/v0/city/[city]/inventory/[ye
 import { POST as createInventory } from "@/app/api/v0/city/[city]/inventory/route";
 import { db } from "@/models";
 import { CreateInventoryRequest } from "@/util/validation";
-import env from "@next/env";
 import assert from "node:assert";
 import { randomUUID } from "node:crypto";
 import { after, before, beforeEach, describe, it } from "node:test";
 import { Op } from "sequelize";
-import { createRequest } from "../helpers";
+import { createRequest, setupTests } from "../helpers";
 import { SubSectorAttributes } from "@/models/SubSector";
 import { City } from "@/models/City";
 
@@ -39,8 +38,7 @@ const invalidInventory = {
 describe("Inventory API", () => {
   let city: City;
   before(async () => {
-    const projectDir = process.cwd();
-    env.loadEnvConfig(projectDir);
+    setupTests();
     await db.initialize();
     // this also deletes all Sector/SubSectorValue instances associated with it (cascade)
     await db.models.Inventory.destroy({

--- a/app/tests/api/sector.test.ts
+++ b/app/tests/api/sector.test.ts
@@ -6,12 +6,11 @@ import {
 } from "@/app/api/v0/city/[city]/inventory/[year]/sector/[sector]/route";
 import { db } from "@/models";
 import { CreateSectorRequest } from "@/util/validation";
-import env from "@next/env";
 import assert from "node:assert";
 import { randomUUID } from "node:crypto";
 import { after, before, beforeEach, describe, it } from "node:test";
 
-import { createRequest } from "../helpers";
+import { createRequest, setupTests } from "../helpers";
 
 import { Sector } from "@/models/Sector";
 
@@ -35,8 +34,7 @@ const invalidSector = {
 describe("Sector API", () => {
   let sector: Sector;
   before(async () => {
-    const projectDir = process.cwd();
-    env.loadEnvConfig(projectDir);
+    setupTests();
     await db.initialize();
     await db.models.Sector.destroy({
       where: {

--- a/app/tests/api/subsector.test.ts
+++ b/app/tests/api/subsector.test.ts
@@ -7,12 +7,11 @@ import {
 
 import { db } from "@/models";
 import { CreateSubSectorRequest } from "@/util/validation";
-import env from "@next/env";
 import assert from "node:assert";
 import { randomUUID } from "node:crypto";
 import { after, before, beforeEach, describe, it } from "node:test";
 
-import { createRequest } from "../helpers";
+import { createRequest, setupTests } from "../helpers";
 
 import { SubSector } from "@/models/SubSector";
 import { Sector } from "@/models/Sector";
@@ -30,11 +29,6 @@ const subsector1: CreateSubSectorRequest = {
   sectorId,
 };
 
-const subsector2: CreateSubSectorRequest = {
-  subsectorName: "Test Sector 2",
-  sectorId: randomUUID(),
-};
-
 const invalidSubSector = {
   subsectorName: 0,
   sectorId: "INVALID_XX",
@@ -44,8 +38,7 @@ describe("Sub Sector API", () => {
   let subsector: SubSector;
   let sector: Sector;
   before(async () => {
-    const projectDir = process.cwd();
-    env.loadEnvConfig(projectDir);
+    setupTests();
     await db.initialize();
     await db.models.SubSector.destroy({
       where: {

--- a/app/tests/api/user.test.ts
+++ b/app/tests/api/user.test.ts
@@ -15,6 +15,16 @@ const userUpdate = {
   defaultInventoryYear: 3000,
 };
 
+const invalidUserUpdate1 = {
+  defaultCityLocode: "XX_USER_TEST2",
+  defaultInventoryYear: -1,
+};
+
+const invalidUserUpdate2 = {
+  defaultCityLocode: "X",
+  defaultInventoryYear: 1,
+};
+
 describe("User API", () => {
   before(async () => {
     setupTests();
@@ -42,6 +52,24 @@ describe("User API", () => {
   });
 
   it("should not update a user with invalid data", async () => {
-    // TODO
+    const req = mockRequest(invalidUserUpdate1);
+    const res = await updateUser(req, { params: {} });
+    assert.equal(res.status, 400);
+    const user = await db.models.User.findOne({
+      where: { userId: userData.userId },
+    });
+    assert.ok(user != null);
+    assert.notEqual(user.defaultCityLocode, invalidUserUpdate1.defaultCityLocode);
+    assert.notEqual(user.defaultInventoryYear, invalidUserUpdate1.defaultInventoryYear);
+
+    const req2 = mockRequest(invalidUserUpdate2);
+    const res2 = await updateUser(req2, { params: {} });
+    assert.equal(res2.status, 400);
+    const user2 = await db.models.User.findOne({
+      where: { userId: userData.userId },
+    });
+    assert.ok(user2 != null);
+    assert.notEqual(user2.defaultCityLocode, invalidUserUpdate2.defaultCityLocode);
+    assert.notEqual(user2.defaultInventoryYear, invalidUserUpdate2.defaultInventoryYear);
   });
 });

--- a/app/tests/api/user.test.ts
+++ b/app/tests/api/user.test.ts
@@ -1,0 +1,50 @@
+import { PATCH as updateUser } from "@/app/api/v0/user/route";
+import { db } from "@/models";
+import env from "@next/env";
+import assert from "node:assert";
+import { after, before, describe, it } from "node:test";
+import { mockRequest } from "../helpers";
+import { UserAttributes } from "@/models/User";
+import { randomUUID } from "node:crypto";
+
+const userData: UserAttributes = {
+  userId: randomUUID(),
+  name: "TEST_USER_USER",
+};
+
+const userUpdate = {
+  defaultCityLocode: "XX_USER_TEST",
+  defaultInventoryYear: 3000,
+};
+
+describe("User API", () => {
+  before(async () => {
+    const projectDir = process.cwd();
+    env.loadEnvConfig(projectDir);
+    await db.initialize();
+    await db.models.User.destroy({ where: { name: userData.name } });
+    await db.models.User.create(userData);
+  });
+
+  after(async () => {
+    if (db.sequelize) await db.sequelize.close();
+  });
+
+  it("should update a user", async () => {
+    const req = mockRequest(userUpdate);
+    const res = await updateUser(req, { params: {} });
+    assert.equal(res.status, 200);
+    const { data } = await res.json();
+    assert.equal(data.success, true);
+    const user = await db.models.User.findOne({
+      where: { userId: userData.userId },
+    });
+    assert.ok(user != null);
+    assert.equal(user.defaultCityLocode, userUpdate.defaultCityLocode);
+    assert.equal(user.defaultInventoryYear, userUpdate.defaultInventoryYear);
+  });
+
+  it("should not update a user with invalid data", async () => {
+    // TODO
+  });
+});

--- a/app/tests/api/user.test.ts
+++ b/app/tests/api/user.test.ts
@@ -1,11 +1,12 @@
 import { PATCH as updateUser } from "@/app/api/v0/user/route";
 import { db } from "@/models";
+import { UserAttributes } from "@/models/User";
 import env from "@next/env";
 import assert from "node:assert";
-import { after, before, describe, it } from "node:test";
-import { mockRequest } from "../helpers";
-import { UserAttributes } from "@/models/User";
 import { randomUUID } from "node:crypto";
+import { after, before, describe, it, mock } from "node:test";
+import { mockRequest } from "../helpers";
+import { AppSession, Auth } from "@/lib/auth";
 
 const userData: UserAttributes = {
   userId: randomUUID(),
@@ -24,6 +25,21 @@ describe("User API", () => {
     await db.initialize();
     await db.models.User.destroy({ where: { name: userData.name } });
     await db.models.User.create(userData);
+
+    mock.method(Auth, "getServerSession", (): AppSession => {
+      const expires = new Date();
+      expires.setDate(expires.getDate() + 1);
+      return {
+        user: {
+          id: randomUUID(),
+          name: "Test User",
+          email: "test@example.com",
+          image: null,
+          role: "user",
+        },
+        expires: expires.toISOString(),
+      };
+    });
   });
 
   after(async () => {
@@ -34,8 +50,6 @@ describe("User API", () => {
     const req = mockRequest(userUpdate);
     const res = await updateUser(req, { params: {} });
     assert.equal(res.status, 200);
-    const { data } = await res.json();
-    assert.equal(data.success, true);
     const user = await db.models.User.findOne({
       where: { userId: userData.userId },
     });

--- a/app/tests/helpers.ts
+++ b/app/tests/helpers.ts
@@ -1,8 +1,16 @@
 import { NextRequest } from "next/server";
 import { mock } from "node:test";
 
+const mockUrl = "http://localhost:3000/api/v0";
+
 export function createRequest(url: string, body?: any) {
   const request = new NextRequest(new URL(url));
+  request.json = mock.fn(() => Promise.resolve(body));
+  return request;
+}
+
+export function mockRequest(body?: any) {
+  const request = new NextRequest(new URL(mockUrl));
   request.json = mock.fn(() => Promise.resolve(body));
   return request;
 }

--- a/app/tests/helpers.ts
+++ b/app/tests/helpers.ts
@@ -1,4 +1,7 @@
+import { AppSession, Auth } from "@/lib/auth";
+import env from "@next/env";
 import { NextRequest } from "next/server";
+import { randomUUID } from "node:crypto";
 import { mock } from "node:test";
 
 const mockUrl = "http://localhost:3000/api/v0";
@@ -13,4 +16,27 @@ export function mockRequest(body?: any) {
   const request = new NextRequest(new URL(mockUrl));
   request.json = mock.fn(() => Promise.resolve(body));
   return request;
+}
+
+export const testUserID = "beb9634a-b68c-4c1b-a20b-2ab0ced5e3c2";
+
+export function setupTests() {
+  const projectDir = process.cwd();
+  env.loadEnvConfig(projectDir);
+
+  // mock getServerSession from NextAuth, since NextJS headers() isn't available outside of the server context (needs async storage)
+  mock.method(Auth, "getServerSession", (): AppSession => {
+    const expires = new Date();
+    expires.setDate(expires.getDate() + 1);
+    return {
+      user: {
+        id: testUserID,
+        name: "Test User",
+        email: "test@example.com",
+        image: null,
+        role: "user",
+      },
+      expires: expires.toISOString(),
+    };
+  });
 }


### PR DESCRIPTION
- Store `defaultCityLocode` and `defaultInventoryYear` in `User` model
- Save this information when creating a new inventory during onboarding
- Load it on dashboard
- Show city name and country flag on dashboard heading
- Fix TypeScript ESModule related errors in tests (couldn't import Credentials in auth.ts)
- Mock useServerSession in tests since headers()/ async storage isn't available without a server
- Add better error handling to onboarding setup page (with toast popups)
- Ignore city unique error on onboarding setup, since we can just create the inventory then
- Actually create an inventory, not just a city on onboarding setup page
- Redirect to onboarding when a user doesn't have a defaultCityLocode/ defaultInventoryYear assigned yet