### PR TITLE
Fix saving on add data screen

### DIFF
--- a/app/migrations/20231206143948-SubSectorValue-unique.cjs
+++ b/app/migrations/20231206143948-SubSectorValue-unique.cjs
@@ -1,0 +1,30 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.bulkDelete("SubSectorValue", {}, { transaction });
+      await queryInterface.addIndex(
+        "SubSectorValue",
+        ["inventory_id", "subsector_id"],
+        {
+          name: "ID_SubSectorValue_inventory_id_subsector_id",
+          indicesType: "UNIQUE",
+          unique: true,
+          transaction,
+        },
+      );
+    });
+  },
+
+  async down(queryInterface) {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.removeIndex(
+        "SubSectorValue",
+        "ID_SubSectorValue_inventory_id_subsector_id",
+        { transaction },
+      );
+    });
+  },
+};

--- a/app/src/app/[lng]/data/[step]/SubsectorDrawer.tsx
+++ b/app/src/app/[lng]/data/[step]/SubsectorDrawer.tsx
@@ -1,6 +1,6 @@
 import { RadioButton } from "@/components/radio-button";
 import { api } from "@/services/api";
-import { resolve } from "@/util/helpers";
+import { resolve, resolvePromisesSequentially } from "@/util/helpers";
 import type {
   SubCategoryValueWithSource,
   SubSectorValueResponse,
@@ -209,7 +209,7 @@ export function SubsectorDrawer({
           unavailableExplanation: "",
         },
       });
-      const results = await Promise.all(
+      const results = await resolvePromisesSequentially(
         Object.keys(data.subcategoryData).map((subcategoryId) => {
           const value = data.subcategoryData[subcategoryId];
           let subCategoryValue: SubCategoryValueData = {

--- a/app/src/app/[lng]/data/[step]/page.tsx
+++ b/app/src/app/[lng]/data/[step]/page.tsx
@@ -297,23 +297,6 @@ export default function AddDataSteps({
         setNewlyConnectedDataSourceIds(
           newlyConnectedDataSourceIds.concat(response.successful),
         );
-        setSteps(
-          steps.map((step, i) => {
-            if (i !== activeStep) {
-              return step;
-            }
-            if (step.totalSubSectors === 0) {
-              console.error(
-                "Step has no totalSubSectors value, can't increase progress!",
-              );
-              return step;
-            }
-            const newProgress =
-              step.connectedProgress + 1.0 / step.totalSubSectors;
-            step.connectedProgress = Math.min(newProgress, 1.0);
-            return step;
-          }),
-        );
         onSourceDrawerClose();
       }
     } catch (error: any) {

--- a/app/src/app/api/v0/city/[city]/inventory/[year]/progress/route.ts
+++ b/app/src/app/api/v0/city/[city]/inventory/[year]/progress/route.ts
@@ -88,8 +88,7 @@ export const GET = apiHandler(
             const sourceType = subSectorValue.dataSource.sourceType;
             if (sourceType === "user") {
               acc.uploaded++;
-            } else if (sourceType === "third_party" || !sourceType) {
-              // TODO remove empty case (!sourceType condition) once data catalogue is updated
+            } else if (sourceType === "third_party") {
               acc.thirdParty++;
             } else {
               console.error(

--- a/app/src/app/api/v0/inventory/[inventory]/subcategory/[subcategory]/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/subcategory/[subcategory]/route.ts
@@ -39,6 +39,7 @@ export const PATCH = apiHandler(async (req: NextRequest, { params }) => {
       {
         model: db.models.SubSector,
         as: "subsector",
+        required: true,
         include: [
           {
             model: db.models.SubCategory,

--- a/app/src/util/helpers.ts
+++ b/app/src/util/helpers.ts
@@ -4,7 +4,6 @@
  * @param obj: object to be searched
  * @param separator: key separator for path (. by default)
  */
-
 export function resolve(
   path: string | string[],
   obj: Record<string, any>,
@@ -21,4 +20,13 @@ export function formatPercent(percent: number) {
 export function getCurrentVersion(): string {
   const version = process.env.APP_VERSION!;
   return version;
+}
+
+export async function resolvePromisesSequentially(promises: Promise<any>[]) {
+  const results = [];
+  for (const promise of promises) {
+    results.push(await promise);
+  }
+
+  return results;
 }

--- a/app/tests/api/subsector.test.ts
+++ b/app/tests/api/subsector.test.ts
@@ -82,7 +82,7 @@ describe("Sub Sector API", () => {
 
   beforeEach(async () => {
     await db.models.SubSectorValue.destroy({
-      where: { subsectorValueId },
+      where: { subsectorId: subSector.subsectorId },
     });
 
     await db.models.SectorValue.destroy({


### PR DESCRIPTION
- Adds unique constraint (and index) on SubSectorValue table for `(inventory_id, subsector_id)` to prevent multiple values being saved for a single inventory
- Fixes race condition for API requests during add data form saving by saving the SubCategoryValue instances one after another (for now, there can be a batch endpoint later)
- This deletes all current SubSectorValue entries to prevent issues during the migration. Do I need to delete the SubCategoryValues as well so we don't have left-over data in the DB? Or is it fine since these tables will be removed once we refactor our DB structure?
- Removes manual progress increment when connecting data sources, since inventory progress is now automatically reloaded