### PR TITLE
Add source references to data sources imported in catalogue-sync.ts

### DIFF
--- a/app/scripts/catalogue-sync.ts
+++ b/app/scripts/catalogue-sync.ts
@@ -4,8 +4,6 @@ import env from "@next/env";
 import { randomUUID } from "node:crypto";
 import { logger } from "@/services/logger";
 
-const GLOBAL_API_URL = process.env.GLOBAL_API_URL || "http://api.citycatalyst.io";
-
 interface Source {
   datasource_id: string;
   name: string;
@@ -83,9 +81,7 @@ async function syncDataCatalogue() {
   // convert to unix timestamp in ms
   const lastUpdate = lastUpdateData.last_update * 1000;
 
-  console.log(
-    `Last update: DB - ${previousUpdate}, API - ${lastUpdate}`,
-  );
+  console.log(`Last update: DB - ${previousUpdate}, API - ${lastUpdate}`);
   if (lastUpdate <= previousUpdate) {
     console.warn("Already on the newest data catalogue version, exiting.");
     await db.sequelize?.close();
@@ -117,6 +113,11 @@ async function syncDataCatalogue() {
     source.last_updated = new Date(source.modified_date!);
     delete source.created_date;
     delete source.modified_date;
+
+    if (!source.notes) {
+      // publisher_id is still a name at this stage
+      source.notes = `Third-party data from ${source.name} by ${source.publisher_id}. For more details see ${source.url}.`;
+    }
 
     if (source.geographical_location === "global") {
       source.geographical_location = "EARTH";

--- a/app/scripts/catalogue-sync.ts
+++ b/app/scripts/catalogue-sync.ts
@@ -116,7 +116,7 @@ async function syncDataCatalogue() {
 
     if (!source.notes) {
       // publisher_id is still a name at this stage
-      source.notes = `Third-party data from ${source.name} by ${source.publisher_id}. For more details see ${source.url}.`;
+      source.notes = `${source.name} by ${source.publisher_id}. For more details see ${source.url}`;
     }
 
     if (source.geographical_location === "global") {


### PR DESCRIPTION
- Adds "<SOURCE NAME> by <PUBLISHER>. For more details see <SOURCE WEBSITE>." as the fallback for the `notes` field in `DataSource` when none is present. This way the scope this source is applied to has "completed" as the tag on it when manually editing it after connecting the source.

This is how the manual edit of third party data looks with this PR:
![image](https://github.com/Open-Earth-Foundation/CityCatalyst/assets/93539/a41255c0-7b70-4f31-9b63-b659fb464268)
