### PR TITLE
Allow saving single scopes, fix scope loading, confirm dialog

### DIFF
--- a/app/src/app/[lng]/data/[step]/SubsectorDrawer.tsx
+++ b/app/src/app/[lng]/data/[step]/SubsectorDrawer.tsx
@@ -111,8 +111,8 @@ function extractFormValues(subSectorValue: SubSectorValueResponse): Inputs {
           value.activityValue != null ? "activity-data" : "direct-measure";
         const data: SubcategoryData = {
           methodology,
-          activity: defaultActivityData,
-          direct: defaultDirectMeasureData,
+          activity: {...defaultActivityData},
+          direct: {...defaultDirectMeasureData},
         };
 
         if (methodology === "activity-data") {

--- a/app/src/lib/app-theme.ts
+++ b/app/src/lib/app-theme.ts
@@ -239,6 +239,24 @@ export const appTheme = extendTheme({
             },
           },
         },
+        danger: {
+          bg: "semantic.danger",
+          color: "white",
+          _hover: {
+            bg: "#FF5F5F",
+          },
+          _active: {
+            bg: "#E22D23",
+          },
+          _loading: {
+            bg: "semantic.dangerOverlay",
+            color: "base.light",
+            _hover: {
+              bg: "#E22D23",
+              color: "base.light",
+            },
+          },
+        },
         solidPrimary: {
           ...theme.components.Button.variants?.solid,
           bg: "sentiment.positiveOverlay",


### PR DESCRIPTION
- Allow saving the SubsectorDrawer form if not all scopes have been filled
- Fixes scope loading so they don't all share the same values
- Adds confirmation dialog if you have unsaved data and try to close the SubsectorDrawer:

![image](https://github.com/Open-Earth-Foundation/CityCatalyst/assets/93539/028fd68e-46c4-4764-9ce7-59a646da7c0b)
