### PR TITLE
fix(ui): wrong scale label being displayed for data sources on SourceDrawer

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/[step]/SourceDrawer.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/SourceDrawer.tsx
@@ -209,10 +209,7 @@ export function SourceDrawer({
                 <Tag bgColor="brand.secondary" border={0}>
                   <TagLeftIcon as={ScaleIcon} boxSize={6} color="base.light" />
                   <TagLabel color="base.light">
-                    {t("scale")}:{" "}
-                    {source.accessType === "global-api"
-                      ? t("city")
-                      : t("country")}
+                    {t("scale")}: {t(source.spatialResolution || "unknown")}
                   </TagLabel>
                 </Tag>
 


### PR DESCRIPTION
Was displaying "country" for all of them instead of "city" for the non-downscaled sources