### PR TITLE
fix(db): not being able to disconnect source because of incorrect foreign key constraints

### DIFF
--- a/app/migrations/20240408115847-inventory-value-cascade.cjs
+++ b/app/migrations/20240408115847-inventory-value-cascade.cjs
@@ -1,0 +1,22 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    return queryInterface.sequelize.query(`
+      BEGIN;
+      ALTER TABLE "GasValue" DROP CONSTRAINT "GasValue_emissions_factor_id_fkey";
+      ALTER TABLE "GasValue" DROP CONSTRAINT "GasValue_inventory_value_id_fkey";
+      COMMIT;
+    `);
+  },
+
+  async down(queryInterface) {
+    return queryInterface.sequelize.query(`
+      BEGIN;
+      ALTER TABLE "GasValue" ADD CONSTRAINT "GasValue_emissions_factor_id_fkey" FOREIGN KEY (emissions_factor_id) REFERENCES "EmissionsFactor"(id);
+      ALTER TABLE "GasValue" ADD CONSTRAINT "GasValue_inventory_value_id_fkey" FOREIGN KEY (inventory_value_id) REFERENCES "InventoryValue"(id);
+      COMMIT;
+    `);
+  },
+};


### PR DESCRIPTION
There were two foreign key constraints for both emissions_factor_id and inventory_value_id on the GasValue table. I've removed the one that didn't have `on update cascade on delete cascade` properties as this was making it impossible to delete an InventoryValue without manually deleting all of its GasValues first.