### PR TITLE
feat: add area to city boundaries and own endpoint

### DIFF
--- a/global-api/requirements.txt
+++ b/global-api/requirements.txt
@@ -27,3 +27,4 @@ openpyxl==3.1.*
 pytest==8.1.1
 pytest-cov==4.1.0
 httpx==0.27.0
+pyproj==3.6.*


### PR DESCRIPTION
Add `area` to the boundaries endpoint, so you can get the area when you fetch boundaries.

Also added a dedicated area endpoint, in case you want the area without all the extra data from the boundaries.

area is in km^2.