### PR TITLE
Inventory Backend v2 - Rise of the ActivityValue

### DIFF
--- a/app/migrations/20240506114511-inventory-v2.cjs
+++ b/app/migrations/20240506114511-inventory-v2.cjs
@@ -10,6 +10,7 @@ module.exports = {
           "id" uuid UNIQUE PRIMARY KEY NOT NULL,
           "activity_data" text,
           "inventory_value_id" uuid,
+          "datasource_id" uuid,
           "metadata" jsonb,
           "created" timestamp,
           "last_updated" timestamp
@@ -23,6 +24,15 @@ module.exports = {
         references: { table: "InventoryValue", field: "id" },
         onDelete: "CASCADE",
         onUpdate: "CASCADE",
+        transaction,
+      });
+      await queryInterface.addConstraint("ActivityValue", {
+        type: "foreign key",
+        name: "FK_ActivityValue_datasource_id",
+        fields: ["datasource_id"],
+        references: { table: "DataSource", field: "datasource_id" },
+        onDelete: "SET NULL",
+        onUpdate: "SET NULL",
         transaction,
       });
 

--- a/app/migrations/20240506114511-inventory-v2.cjs
+++ b/app/migrations/20240506114511-inventory-v2.cjs
@@ -1,0 +1,141 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      // Add table ActivityValue and connect to InventoryValue
+      await queryInterface.sequelize.query(
+        `CREATE TABLE "ActivityValue" (
+          "id" uuid UNIQUE PRIMARY KEY NOT NULL,
+          "activity_data" text,
+          "inventory_value_id" uuid,
+          "metadata" jsonb,
+          "created" timestamp,
+          "last_updated" timestamp
+        );`,
+        { transaction },
+      );
+      await queryInterface.addConstraint("ActivityValue", {
+        type: "foreign key",
+        name: "FK_ActivityValue_inventory_value_id",
+        fields: ["inventory_value_id"],
+        references: { table: "InventoryValue", field: "id" },
+        onDelete: "CASCADE",
+        onUpdate: "CASCADE",
+        transaction,
+      });
+
+      await queryInterface.addColumn(
+        "GasValue",
+        "activity_value_id",
+        Sequelize.UUID,
+        {
+          transaction,
+        },
+      );
+      await queryInterface.addConstraint("GasValue", {
+        type: "foreign key",
+        name: "FK_GasValue_activity_value_id",
+        fields: ["activity_value_id"],
+        references: { table: "ActivityValue", field: "id" },
+        onDelete: "CASCADE",
+        onUpdate: "CASCADE",
+        transaction,
+      });
+
+      // new columns for EmissionsFactor
+      await queryInterface.addColumn(
+        "EmissionsFactor",
+        "metadata",
+        Sequelize.JSONB,
+        { transaction },
+      );
+      await queryInterface.addColumn(
+        "EmissionsFactor",
+        "formula_name",
+        Sequelize.STRING,
+        { transaction },
+      );
+      await queryInterface.addColumn(
+        "EmissionsFactor",
+        "methodology_id",
+        Sequelize.UUID,
+        { transaction },
+      );
+      await queryInterface.addColumn(
+        "EmissionsFactor",
+        "region",
+        Sequelize.CHAR(10),
+        { transaction },
+      );
+      await queryInterface.addColumn(
+        "EmissionsFactor",
+        "year",
+        Sequelize.INTEGER,
+        { transaction },
+      );
+      await queryInterface.addColumn(
+        "EmissionsFactor",
+        "reference",
+        Sequelize.TEXT,
+        { transaction },
+      );
+
+      await queryInterface.addConstraint("EmissionsFactor", {
+        type: "foreign key",
+        name: "FK_EmissionsFactor_methodology_id",
+        fields: ["methodology_id"],
+        references: { table: "Methodology", field: "methodology_id" },
+        onDelete: "SET NULL",
+        onUpdate: "SET NULL",
+        transaction,
+      });
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      // EmissionsFactor
+      await queryInterface.removeConstraint(
+        "EmissionsFactor",
+        "FK_EmissionsFactor_methodology_id",
+        { transaction },
+      );
+      await queryInterface.removeColumn("EmissionsFactor", "reference", {
+        transaction,
+      });
+      await queryInterface.removeColumn("EmissionsFactor", "year", {
+        transaction,
+      });
+      await queryInterface.removeColumn("EmissionsFactor", "region", {
+        transaction,
+      });
+      await queryInterface.removeColumn("EmissionsFactor", "methodology_id", {
+        transaction,
+      });
+      await queryInterface.removeColumn("EmissionsFactor", "formula_name", {
+        transaction,
+      });
+      await queryInterface.removeColumn("EmissionsFactor", "metadata", {
+        transaction,
+      });
+
+      // ActivityValue
+      await queryInterface.removeConstraint(
+        "GasValue",
+        "FK_GasValue_activity_value_id",
+        { transaction },
+      );
+      await queryInterface.removeColumn("GasValue", "activity_value_id", {
+        transaction,
+      });
+      await queryInterface.removeConstraint(
+        "ActivityValue",
+        "FK_ActivityValue_inventory_value_id",
+        { transaction },
+      );
+      await queryInterface.dropTable("ActivityValue");
+    });
+  },
+};

--- a/app/migrations/20240506114511-inventory-v2.cjs
+++ b/app/migrations/20240506114511-inventory-v2.cjs
@@ -63,25 +63,6 @@ module.exports = {
         Sequelize.UUID,
         { transaction },
       );
-      await queryInterface.addColumn(
-        "EmissionsFactor",
-        "region",
-        Sequelize.CHAR(10),
-        { transaction },
-      );
-      await queryInterface.addColumn(
-        "EmissionsFactor",
-        "year",
-        Sequelize.INTEGER,
-        { transaction },
-      );
-      await queryInterface.addColumn(
-        "EmissionsFactor",
-        "reference",
-        Sequelize.TEXT,
-        { transaction },
-      );
-
       await queryInterface.addConstraint("EmissionsFactor", {
         type: "foreign key",
         name: "FK_EmissionsFactor_methodology_id",

--- a/app/scripts/sequelize-auto.sh
+++ b/app/scripts/sequelize-auto.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-npx sequelize-auto -h localhost -d citycatalyst -u citycatalyst --dialect postgres -o src/models -l ts --caseProp c --additional scripts/model-params.json -T SequelizeMeta
-
+shift
+npx sequelize-auto -h localhost -d citycatalyst -u citycatalyst --dialect postgres -o src/models -l ts --caseProp c --additional scripts/model-params.json -T SequelizeMeta "$@"

--- a/app/src/app/api/v0/inventory/[inventory]/activity-value/[id]/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/activity-value/[id]/route.ts
@@ -46,17 +46,17 @@ export const PATCH = apiHandler(async (req, { params, session }) => {
           }
         }
 
-        if (!emissionsFactor) {
+        if (gasValue.emissionsFactor && !emissionsFactor) {
           throw new createHttpError.InternalServerError("Failed to create an emissions factor");
         }
 
         delete gasValue.emissionsFactor;
         const [newGasValue, wasCreated] = await db.models.GasValue.upsert({
+          emissionsFactorId: emissionsFactor?.id ?? undefined,
           ...gasValue,
           id: gasValue.id ?? randomUUID(),
           activityValueId: id,
           inventoryValueId: activityValue?.inventoryValueId,
-          emissionsFactorId: emissionsFactor.id,
         }, { transaction });
       }
       delete body.gasValues;

--- a/app/src/app/api/v0/inventory/[inventory]/activity-value/[id]/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/activity-value/[id]/route.ts
@@ -1,0 +1,40 @@
+import UserService from "@/backend/UserService";
+import { db } from "@/models";
+import { apiHandler } from "@/util/api";
+import { createActivityValueRequest } from "@/util/validation";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+export const PATCH = apiHandler(async (req, { params, session }) => {
+  const id = z.string().uuid().parse(params.id);
+  const body = await createActivityValueRequest.parse(await req.json());
+  // just for access control
+  await UserService.findUserInventory(params.inventory, session);
+
+  const result = await db.models.ActivityValue.update(body, {
+    where: { id },
+  })
+  return NextResponse.json({ "success": true, data: result });
+});
+
+export const DELETE = apiHandler(async (_req, { params, session }) => {
+  const id = z.string().uuid().parse(params.id);
+  // just for access control
+  await UserService.findUserInventory(params.inventory, session);
+
+  const result = await db.models.ActivityValue.destroy({
+    where: { id },
+  });
+  return NextResponse.json({ "success": true, data: result });
+});
+
+export const GET = apiHandler(async (_req, { params, session }) => {
+  const id = z.string().uuid().parse(params.id);
+  // just for access control
+  await UserService.findUserInventory(params.inventory, session);
+
+  const data = await db.models.ActivityValue.findOne({
+    where: { id },
+  });
+  return NextResponse.json({ data });
+});

--- a/app/src/app/api/v0/inventory/[inventory]/activity-value/[id]/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/activity-value/[id]/route.ts
@@ -1,6 +1,9 @@
 import UserService from "@/backend/UserService";
 import { db } from "@/models";
-import { EmissionsFactor, EmissionsFactorAttributes } from "@/models/EmissionsFactor";
+import {
+  EmissionsFactor,
+  EmissionsFactorAttributes,
+} from "@/models/EmissionsFactor";
 import { apiHandler } from "@/util/api";
 import { createActivityValueRequest } from "@/util/validation";
 import createHttpError from "http-errors";
@@ -15,60 +18,111 @@ export const PATCH = apiHandler(async (req, { params, session }) => {
   // just for access control
   await UserService.findUserInventory(params.inventory, session);
 
-  const activityValue = await db.models.ActivityValue.findOne({ where: { id } });
+  const activityValue = await db.models.ActivityValue.findOne({
+    where: { id },
+  });
   if (!activityValue) {
     throw new createHttpError.NotFound(`Activty value with ID ${id} not found`);
   }
+  let datasourceId = activityValue.datasourceId;
 
   await db.sequelize?.transaction(async (transaction): Promise<void> => {
+    const dataSourceParams = body.dataSource;
+    delete body.dataSource;
+    if (activityValue.datasourceId) {
+      const dataSource = await db.models.DataSource.findOne({
+        where: { datasourceId: activityValue.datasourceId },
+        transaction,
+      });
+      if (!dataSource) {
+        throw new createHttpError.NotFound(
+          "Data source for ActivityValue not found",
+        );
+      }
+      Object.assign(dataSource, dataSourceParams);
+      await dataSource?.save({ transaction });
+    } else {
+      const dataSource = await db.models.DataSource.create(
+        {
+          ...dataSourceParams,
+          datasourceId: randomUUID(),
+        },
+        { transaction },
+      );
+      datasourceId = dataSource.datasourceId;
+    }
+
     if (body.gasValues) {
       for (const gasValue of body.gasValues) {
         let emissionsFactor: EmissionsFactor | null = null;
 
         // update emissions factor if already assigned and from this inventory
-        if (gasValue.emissionsFactorId == null && gasValue.emissionsFactor != null) {
+        if (
+          gasValue.emissionsFactorId == null &&
+          gasValue.emissionsFactor != null
+        ) {
           emissionsFactor = await db.models.EmissionsFactor.findOne({
             where: { inventoryId: params.inventory },
-            include: [{ model: db.models.ActivityValue, as: "activityValue", where: { id } }],
-            transaction
+            include: [
+              {
+                model: db.models.ActivityValue,
+                as: "activityValue",
+                where: { id },
+              },
+            ],
+            transaction,
           });
 
           // don't edit emissions factors from other inventories or pre-defined ones (without inventoryId)
-          if (emissionsFactor && emissionsFactor.inventoryId === params.inventory) {
+          if (
+            emissionsFactor &&
+            emissionsFactor.inventoryId === params.inventory
+          ) {
             Object.assign(emissionsFactor, gasValue.emissionsFactor);
             await emissionsFactor.save({ transaction });
           } else {
-            emissionsFactor = await db.models.EmissionsFactor.create({
-              ...gasValue.emissionsFactor,
-              id: randomUUID(),
-              inventoryId: params.inventory,
-            }, { transaction })
+            emissionsFactor = await db.models.EmissionsFactor.create(
+              {
+                ...gasValue.emissionsFactor,
+                id: randomUUID(),
+                inventoryId: params.inventory,
+              },
+              { transaction },
+            );
           }
         }
 
         if (gasValue.emissionsFactor && !emissionsFactor) {
-          throw new createHttpError.InternalServerError("Failed to create an emissions factor");
+          throw new createHttpError.InternalServerError(
+            "Failed to create an emissions factor",
+          );
         }
 
         delete gasValue.emissionsFactor;
-        const [newGasValue, wasCreated] = await db.models.GasValue.upsert({
-          emissionsFactorId: emissionsFactor?.id ?? undefined,
-          ...gasValue,
-          id: gasValue.id ?? randomUUID(),
-          activityValueId: id,
-          inventoryValueId: activityValue?.inventoryValueId,
-        }, { transaction });
+        const [newGasValue, wasCreated] = await db.models.GasValue.upsert(
+          {
+            emissionsFactorId: emissionsFactor?.id ?? undefined,
+            ...gasValue,
+            id: gasValue.id ?? randomUUID(),
+            activityValueId: id,
+            inventoryValueId: activityValue?.inventoryValueId,
+          },
+          { transaction },
+        );
       }
       delete body.gasValues;
     }
 
-    await db.models.ActivityValue.update(body, {
-      transaction,
-      where: { id },
-    });
-  })
+    await db.models.ActivityValue.update(
+      { ...body, datasourceId },
+      {
+        transaction,
+        where: { id },
+      },
+    );
+  });
 
-  return NextResponse.json({ "success": true });
+  return NextResponse.json({ success: true });
 });
 
 export const DELETE = apiHandler(async (_req, { params, session }) => {
@@ -79,7 +133,7 @@ export const DELETE = apiHandler(async (_req, { params, session }) => {
   const result = await db.models.ActivityValue.destroy({
     where: { id },
   });
-  return NextResponse.json({ "success": true, data: result });
+  return NextResponse.json({ success: true, data: result });
 });
 
 export const GET = apiHandler(async (_req, { params, session }) => {

--- a/app/src/app/api/v0/inventory/[inventory]/activity-value/[id]/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/activity-value/[id]/route.ts
@@ -2,19 +2,43 @@ import UserService from "@/backend/UserService";
 import { db } from "@/models";
 import { apiHandler } from "@/util/api";
 import { createActivityValueRequest } from "@/util/validation";
+import createHttpError from "http-errors";
 import { NextResponse } from "next/server";
+import { randomUUID } from "node:crypto";
 import { z } from "zod";
 
 export const PATCH = apiHandler(async (req, { params, session }) => {
   const id = z.string().uuid().parse(params.id);
-  const body = await createActivityValueRequest.parse(await req.json());
+  const body = createActivityValueRequest.parse(await req.json());
+
   // just for access control
   await UserService.findUserInventory(params.inventory, session);
 
-  const result = await db.models.ActivityValue.update(body, {
-    where: { id },
+  const activityValue = await db.models.ActivityValue.findOne({ where: { id } });
+  if (!activityValue) {
+    throw new createHttpError.NotFound(`Activty value with ID ${id} not found`);
+  }
+
+  await db.sequelize?.transaction(async (transaction): Promise<void> => {
+    if (body.gasValues) {
+      for (const gasValue of body.gasValues) {
+        await db.models.GasValue.upsert({
+          ...gasValue,
+          id: gasValue.id ?? randomUUID(),
+          activityValueId: id,
+          inventoryValueId: activityValue?.inventoryValueId
+        }, { transaction });
+      }
+      delete body.gasValues;
+    }
+
+    await db.models.ActivityValue.update(body, {
+      transaction,
+      where: { id },
+    });
   })
-  return NextResponse.json({ "success": true, data: result });
+
+  return NextResponse.json({ "success": true });
 });
 
 export const DELETE = apiHandler(async (_req, { params, session }) => {

--- a/app/src/app/api/v0/inventory/[inventory]/activity-value/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/activity-value/route.ts
@@ -14,49 +14,66 @@ export const POST = apiHandler(async (req, { params, session }) => {
   // just for access control
   await UserService.findUserInventory(params.inventory, session);
 
-  const result = await db.sequelize?.transaction(async (transaction): Promise<ActivityValue> => {
-    const gasValues = body.gasValues;
-    delete body.gasValues;
+  const result = await db.sequelize?.transaction(
+    async (transaction): Promise<ActivityValue> => {
+      const gasValues = body.gasValues;
+      delete body.gasValues;
 
-    const activityValue = await db.models.ActivityValue.create({
-      ...body,
-      id: randomUUID(),
-    }, { transaction });
+      const activityValue = await db.models.ActivityValue.create(
+        {
+          ...body,
+          id: randomUUID(),
+        },
+        { transaction },
+      );
 
-    if (gasValues) {
-      for (const gasValue of gasValues) {
-        let emissionsFactor: EmissionsFactor | null = null;
+      if (gasValues) {
+        for (const gasValue of gasValues) {
+          let emissionsFactor: EmissionsFactor | null = null;
 
-        // update emissions factor if already assigned and from this inventory
-        if (gasValue.emissionsFactorId == null && gasValue.emissionsFactor != null) {
-          emissionsFactor = await db.models.EmissionsFactor.create({
-            ...gasValue.emissionsFactor,
-            id: randomUUID(),
-            inventoryId: params.inventory,
-          }, { transaction })
+          // update emissions factor if already assigned and from this inventory
+          if (
+            gasValue.emissionsFactorId == null &&
+            gasValue.emissionsFactor != null
+          ) {
+            emissionsFactor = await db.models.EmissionsFactor.create(
+              {
+                ...gasValue.emissionsFactor,
+                id: randomUUID(),
+                inventoryId: params.inventory,
+              },
+              { transaction },
+            );
+          }
+
+          if (gasValue.emissionsFactor && !emissionsFactor) {
+            throw new createHttpError.InternalServerError(
+              "Failed to create an emissions factor",
+            );
+          }
+
+          delete gasValue.emissionsFactor;
+          await db.models.GasValue.upsert(
+            {
+              ...gasValue,
+              id: gasValue.id ?? randomUUID(),
+              activityValueId: activityValue.id,
+              inventoryValueId: activityValue?.inventoryValueId,
+            },
+            { transaction },
+          );
         }
-
-        if (gasValue.emissionsFactor && !emissionsFactor) {
-          throw new createHttpError.InternalServerError("Failed to create an emissions factor");
-        }
-
-        delete gasValue.emissionsFactor;
-        await db.models.GasValue.upsert({
-          ...gasValue,
-          id: gasValue.id ?? randomUUID(),
-          activityValueId: activityValue.id,
-          inventoryValueId: activityValue?.inventoryValueId
-        }, { transaction });
       }
-    }
 
-    return activityValue;
-  })
+      return activityValue;
+    },
+  );
 
-  return NextResponse.json({ "success": result != null, data: result });
+  return NextResponse.json({ success: result != null, data: result });
 });
 
 export const GET = apiHandler(async (req, { params, session }) => {
+  // extract and validate query params
   const subCategoryIdsParam = req.nextUrl.searchParams.get("subCategoryIds");
   if (!subCategoryIdsParam || subCategoryIdsParam.length === 0) {
     throw new createHttpError.BadRequest(
@@ -65,7 +82,16 @@ export const GET = apiHandler(async (req, { params, session }) => {
   }
   const subCategoryIds = subCategoryIdsParam.split(",");
 
-  const inventory = await UserService.findUserInventory(params.inventory, session);
+  // optional filter for a specific methodology
+  const methodologyId = req.nextUrl.searchParams.get("methodologyId");
+  if (methodologyId) {
+    z.string().uuid().parse(methodologyId);
+  }
+
+  const inventory = await UserService.findUserInventory(
+    params.inventory,
+    session,
+  );
 
   const activityValues = await db.models.ActivityValue.findAll({
     include: [
@@ -75,7 +101,8 @@ export const GET = apiHandler(async (req, { params, session }) => {
         where: {
           subCategoryId: { [Op.in]: subCategoryIds },
           inventoryId: inventory.inventoryId,
-        }
+          methodologyId: methodologyId ?? undefined,
+        },
       },
       { model: db.models.DataSource, as: "dataSource" },
       {
@@ -98,4 +125,3 @@ export const GET = apiHandler(async (req, { params, session }) => {
 
   return NextResponse.json({ data: activityValues });
 });
-

--- a/app/src/app/api/v0/inventory/[inventory]/activity-value/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/activity-value/route.ts
@@ -1,9 +1,23 @@
 import UserService from "@/backend/UserService";
 import { db } from "@/models";
 import { apiHandler } from "@/util/api";
+import { createActivityValueRequest } from "@/util/validation";
+import { randomUUID } from "crypto";
 import createHttpError from "http-errors";
 import { NextResponse } from "next/server";
 import { Op } from "sequelize";
+
+export const POST = apiHandler(async (req, { params, session }) => {
+  const body = createActivityValueRequest.parse(await req.json());
+  // just for access control
+  await UserService.findUserInventory(params.inventory, session);
+
+  const result = await db.models.ActivityValue.create({
+    ...body,
+    id: randomUUID(),
+  })
+  return NextResponse.json({ "success": true, data: result });
+});
 
 export const GET = apiHandler(async (req, { params, session }) => {
   const subCategoryIdsParam = req.nextUrl.searchParams.get("subCategoryIds");

--- a/app/src/app/api/v0/inventory/[inventory]/activity-value/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/activity-value/route.ts
@@ -19,10 +19,20 @@ export const POST = apiHandler(async (req, { params, session }) => {
     async (transaction): Promise<ActivityValue> => {
       const gasValues = body.gasValues;
       delete body.gasValues;
+      const dataSourceParams = body.dataSource;
+      delete body.dataSource;
 
+      const dataSource = await db.models.DataSource.create(
+        {
+          ...dataSourceParams,
+          datasourceId: randomUUID(),
+        },
+        { transaction },
+      );
       const activityValue = await db.models.ActivityValue.create(
         {
           ...body,
+          datasourceId: dataSource.datasourceId,
           id: randomUUID(),
         },
         { transaction },

--- a/app/src/app/api/v0/inventory/[inventory]/activity-value/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/activity-value/route.ts
@@ -8,6 +8,7 @@ import { randomUUID } from "crypto";
 import createHttpError from "http-errors";
 import { NextResponse } from "next/server";
 import { Op } from "sequelize";
+import { z } from "zod";
 
 export const POST = apiHandler(async (req, { params, session }) => {
   const body = createActivityValueRequest.parse(await req.json());

--- a/app/src/app/api/v0/inventory/[inventory]/activity-value/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/activity-value/route.ts
@@ -1,0 +1,50 @@
+import UserService from "@/backend/UserService";
+import { db } from "@/models";
+import { apiHandler } from "@/util/api";
+import createHttpError from "http-errors";
+import { NextResponse } from "next/server";
+import { Op } from "sequelize";
+
+export const GET = apiHandler(async (req, { params, session }) => {
+  const subCategoryIdsParam = req.nextUrl.searchParams.get("subCategoryIds");
+  if (!subCategoryIdsParam || subCategoryIdsParam.length === 0) {
+    throw new createHttpError.BadRequest(
+      "Query parameter subCategoryIds is required!",
+    );
+  }
+  const subCategoryIds = subCategoryIdsParam.split(",");
+
+  const inventory = await UserService.findUserInventory(params.inventory, session);
+
+  const activityValues = await db.models.ActivityValue.findAll({
+    include: [
+      {
+        model: db.models.InventoryValue,
+        as: "inventoryValue",
+        where: {
+          subCategoryId: { [Op.in]: subCategoryIds },
+          inventoryId: inventory.inventoryId,
+        }
+      },
+      { model: db.models.DataSource, as: "dataSource" },
+      {
+        model: db.models.GasValue,
+        as: "gasValues",
+        include: [
+          {
+            model: db.models.EmissionsFactor,
+            as: "emissionsFactor",
+            include: [{ model: db.models.DataSource, as: "dataSources" }],
+          },
+        ],
+      },
+    ],
+  });
+
+  if (!activityValues) {
+    throw new createHttpError.NotFound("Activity values not found");
+  }
+
+  return NextResponse.json({ data: activityValues });
+});
+

--- a/app/src/app/api/v0/inventory/[inventory]/value/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/value/route.ts
@@ -24,15 +24,17 @@ export const GET = apiHandler(async (req, { params, session }) => {
     include: [
       { model: db.models.DataSource, as: "dataSource" },
       {
-        model: db.models.GasValue,
-        as: "gasValues",
-        include: [
-          {
-            model: db.models.EmissionsFactor,
-            as: "emissionsFactor",
-            include: [{ model: db.models.DataSource, as: "dataSources" }],
-          },
-        ],
+        model: db.models.ActivityValue, as: "activityValues", include: [{
+          model: db.models.GasValue,
+          as: "gasValues",
+          include: [
+            {
+              model: db.models.EmissionsFactor,
+              as: "emissionsFactor",
+              include: [{ model: db.models.DataSource, as: "dataSources" }],
+            },
+          ],
+        }]
       },
     ],
   });
@@ -43,3 +45,4 @@ export const GET = apiHandler(async (req, { params, session }) => {
 
   return NextResponse.json({ data: inventoryValues });
 });
+

--- a/app/src/app/api/v0/user/inventories/route.ts
+++ b/app/src/app/api/v0/user/inventories/route.ts
@@ -1,4 +1,6 @@
 import { db } from "@/models";
+import type { City } from "@/models/City";
+import type { Inventory } from "@/models/Inventory";
 import { apiHandler } from "@/util/api";
 import createHttpError from "http-errors";
 import { NextRequest, NextResponse } from "next/server";
@@ -31,8 +33,8 @@ export const GET = apiHandler(async (_req: NextRequest, context) => {
     throw new createHttpError.NotFound("User not found");
   }
 
-  const data = user.cities.flatMap((city) => {
-    return city.inventories.map((inventory) => {
+  const data = user.cities.flatMap((city: City) => {
+    return city.inventories.map((inventory: Inventory) => {
       return {
         ...inventory.dataValues,
         city: { name: city.name, locode: city.locode },

--- a/app/src/models/ActivityValue.ts
+++ b/app/src/models/ActivityValue.ts
@@ -1,5 +1,6 @@
 import * as Sequelize from 'sequelize';
 import { DataTypes, Model, Optional } from 'sequelize';
+import type { GasValue, GasValueId } from './GasValue';
 import type { InventoryValue, InventoryValueId } from './InventoryValue';
 
 export interface ActivityValueAttributes {
@@ -24,6 +25,18 @@ export class ActivityValue extends Model<ActivityValueAttributes, ActivityValueC
   created?: Date;
   lastUpdated?: Date;
 
+  // ActivityValue hasMany GasValue via activityValueId
+  gasValues!: GasValue[];
+  getGasValues!: Sequelize.HasManyGetAssociationsMixin<GasValue>;
+  setGasValues!: Sequelize.HasManySetAssociationsMixin<GasValue, GasValueId>;
+  addGasValue!: Sequelize.HasManyAddAssociationMixin<GasValue, GasValueId>;
+  addGasValues!: Sequelize.HasManyAddAssociationsMixin<GasValue, GasValueId>;
+  createGasValue!: Sequelize.HasManyCreateAssociationMixin<GasValue>;
+  removeGasValue!: Sequelize.HasManyRemoveAssociationMixin<GasValue, GasValueId>;
+  removeGasValues!: Sequelize.HasManyRemoveAssociationsMixin<GasValue, GasValueId>;
+  hasGasValue!: Sequelize.HasManyHasAssociationMixin<GasValue, GasValueId>;
+  hasGasValues!: Sequelize.HasManyHasAssociationsMixin<GasValue, GasValueId>;
+  countGasValues!: Sequelize.HasManyCountAssociationsMixin;
   // ActivityValue belongsTo InventoryValue via inventoryValueId
   inventoryValue!: InventoryValue;
   getInventoryValue!: Sequelize.BelongsToGetAssociationMixin<InventoryValue>;

--- a/app/src/models/ActivityValue.ts
+++ b/app/src/models/ActivityValue.ts
@@ -1,12 +1,13 @@
-import * as Sequelize from 'sequelize';
-import { DataTypes, Model, Optional } from 'sequelize';
-import type { GasValue, GasValueId } from './GasValue';
-import type { InventoryValue, InventoryValueId } from './InventoryValue';
+import * as Sequelize from "sequelize";
+import { DataTypes, Model, Optional } from "sequelize";
+import type { GasValue, GasValueId } from "./GasValue";
+import type { InventoryValue, InventoryValueId } from "./InventoryValue";
 
 export interface ActivityValueAttributes {
   id: string;
   activityData?: object;
   inventoryValueId?: string;
+  datasourceId?: string;
   metadata?: object;
   created?: Date;
   lastUpdated?: Date;
@@ -14,13 +15,25 @@ export interface ActivityValueAttributes {
 
 export type ActivityValuePk = "id";
 export type ActivityValueId = ActivityValue[ActivityValuePk];
-export type ActivityValueOptionalAttributes = "activityData" | "inventoryValueId" | "metadata" | "created" | "lastUpdated";
-export type ActivityValueCreationAttributes = Optional<ActivityValueAttributes, ActivityValueOptionalAttributes>;
+export type ActivityValueOptionalAttributes =
+  | "activityData"
+  | "inventoryValueId"
+  | "metadata"
+  | "created"
+  | "lastUpdated";
+export type ActivityValueCreationAttributes = Optional<
+  ActivityValueAttributes,
+  ActivityValueOptionalAttributes
+>;
 
-export class ActivityValue extends Model<ActivityValueAttributes, ActivityValueCreationAttributes> implements ActivityValueAttributes {
+export class ActivityValue
+  extends Model<ActivityValueAttributes, ActivityValueCreationAttributes>
+  implements ActivityValueAttributes
+{
   id!: string;
   activityData?: object;
   inventoryValueId?: string;
+  datasourceId?: string;
   metadata?: object;
   created?: Date;
   lastUpdated?: Date;
@@ -32,58 +45,77 @@ export class ActivityValue extends Model<ActivityValueAttributes, ActivityValueC
   addGasValue!: Sequelize.HasManyAddAssociationMixin<GasValue, GasValueId>;
   addGasValues!: Sequelize.HasManyAddAssociationsMixin<GasValue, GasValueId>;
   createGasValue!: Sequelize.HasManyCreateAssociationMixin<GasValue>;
-  removeGasValue!: Sequelize.HasManyRemoveAssociationMixin<GasValue, GasValueId>;
-  removeGasValues!: Sequelize.HasManyRemoveAssociationsMixin<GasValue, GasValueId>;
+  removeGasValue!: Sequelize.HasManyRemoveAssociationMixin<
+    GasValue,
+    GasValueId
+  >;
+  removeGasValues!: Sequelize.HasManyRemoveAssociationsMixin<
+    GasValue,
+    GasValueId
+  >;
   hasGasValue!: Sequelize.HasManyHasAssociationMixin<GasValue, GasValueId>;
   hasGasValues!: Sequelize.HasManyHasAssociationsMixin<GasValue, GasValueId>;
   countGasValues!: Sequelize.HasManyCountAssociationsMixin;
   // ActivityValue belongsTo InventoryValue via inventoryValueId
   inventoryValue!: InventoryValue;
   getInventoryValue!: Sequelize.BelongsToGetAssociationMixin<InventoryValue>;
-  setInventoryValue!: Sequelize.BelongsToSetAssociationMixin<InventoryValue, InventoryValueId>;
+  setInventoryValue!: Sequelize.BelongsToSetAssociationMixin<
+    InventoryValue,
+    InventoryValueId
+  >;
   createInventoryValue!: Sequelize.BelongsToCreateAssociationMixin<InventoryValue>;
 
   static initModel(sequelize: Sequelize.Sequelize): typeof ActivityValue {
-    return ActivityValue.init({
-      id: {
-        type: DataTypes.UUID,
-        allowNull: false,
-        primaryKey: true
-      },
-      activityData: {
-        type: DataTypes.JSONB,
-        allowNull: true,
-        field: 'activity_data'
-      },
-      inventoryValueId: {
-        type: DataTypes.UUID,
-        allowNull: true,
-        references: {
-          model: 'InventoryValue',
-          key: 'id'
+    return ActivityValue.init(
+      {
+        id: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          primaryKey: true,
         },
-        field: 'inventory_value_id'
-      },
-      metadata: {
-        type: DataTypes.JSONB,
-        allowNull: true
-      }
-    }, {
-      sequelize,
-      tableName: 'ActivityValue',
-      schema: 'public',
-      timestamps: true,
-      createdAt: 'created',
-      updatedAt: 'last_updated',
-      indexes: [
-        {
-          name: "ActivityValue_pkey",
-          unique: true,
-          fields: [
-            { name: "id" },
-          ]
+        activityData: {
+          type: DataTypes.JSONB,
+          allowNull: true,
+          field: "activity_data",
         },
-      ]
-    });
+        inventoryValueId: {
+          type: DataTypes.UUID,
+          allowNull: true,
+          references: {
+            model: "InventoryValue",
+            key: "id",
+          },
+          field: "inventory_value_id",
+        },
+        datasourceId: {
+          type: DataTypes.UUID,
+          allowNull: true,
+          references: {
+            model: "DataSource",
+            key: "datasource_id",
+          },
+          field: "datasource_id",
+        },
+        metadata: {
+          type: DataTypes.JSONB,
+          allowNull: true,
+        },
+      },
+      {
+        sequelize,
+        tableName: "ActivityValue",
+        schema: "public",
+        timestamps: true,
+        createdAt: "created",
+        updatedAt: "last_updated",
+        indexes: [
+          {
+            name: "ActivityValue_pkey",
+            unique: true,
+            fields: [{ name: "id" }],
+          },
+        ],
+      },
+    );
   }
 }

--- a/app/src/models/ActivityValue.ts
+++ b/app/src/models/ActivityValue.ts
@@ -1,0 +1,76 @@
+import * as Sequelize from 'sequelize';
+import { DataTypes, Model, Optional } from 'sequelize';
+import type { InventoryValue, InventoryValueId } from './InventoryValue';
+
+export interface ActivityValueAttributes {
+  id: string;
+  activityData?: string;
+  inventoryValueId?: string;
+  metadata?: object;
+  created?: Date;
+  lastUpdated?: Date;
+}
+
+export type ActivityValuePk = "id";
+export type ActivityValueId = ActivityValue[ActivityValuePk];
+export type ActivityValueOptionalAttributes = "activityData" | "inventoryValueId" | "metadata" | "created" | "lastUpdated";
+export type ActivityValueCreationAttributes = Optional<ActivityValueAttributes, ActivityValueOptionalAttributes>;
+
+export class ActivityValue extends Model<ActivityValueAttributes, ActivityValueCreationAttributes> implements ActivityValueAttributes {
+  id!: string;
+  activityData?: string;
+  inventoryValueId?: string;
+  metadata?: object;
+  created?: Date;
+  lastUpdated?: Date;
+
+  // ActivityValue belongsTo InventoryValue via inventoryValueId
+  inventoryValue!: InventoryValue;
+  getInventoryValue!: Sequelize.BelongsToGetAssociationMixin<InventoryValue>;
+  setInventoryValue!: Sequelize.BelongsToSetAssociationMixin<InventoryValue, InventoryValueId>;
+  createInventoryValue!: Sequelize.BelongsToCreateAssociationMixin<InventoryValue>;
+
+  static initModel(sequelize: Sequelize.Sequelize): typeof ActivityValue {
+    return ActivityValue.init({
+    id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      primaryKey: true
+    },
+    activityData: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: 'activity_data'
+    },
+    inventoryValueId: {
+      type: DataTypes.UUID,
+      allowNull: true,
+      references: {
+        model: 'InventoryValue',
+        key: 'id'
+      },
+      field: 'inventory_value_id'
+    },
+    metadata: {
+      type: DataTypes.JSONB,
+      allowNull: true
+    }
+  }, {
+    sequelize,
+    tableName: 'ActivityValue',
+    schema: 'public',
+    timestamps: true,
+    createdAt: 'created',
+    updatedAt: 'last_updated',
+    indexes: [
+      {
+        name: "ActivityValue_pkey",
+        unique: true,
+        fields: [
+          { name: "id" },
+        ]
+      },
+    ]
+  });
+  }
+}

--- a/app/src/models/ActivityValue.ts
+++ b/app/src/models/ActivityValue.ts
@@ -5,7 +5,7 @@ import type { InventoryValue, InventoryValueId } from './InventoryValue';
 
 export interface ActivityValueAttributes {
   id: string;
-  activityData?: string;
+  activityData?: object;
   inventoryValueId?: string;
   metadata?: object;
   created?: Date;
@@ -19,7 +19,7 @@ export type ActivityValueCreationAttributes = Optional<ActivityValueAttributes, 
 
 export class ActivityValue extends Model<ActivityValueAttributes, ActivityValueCreationAttributes> implements ActivityValueAttributes {
   id!: string;
-  activityData?: string;
+  activityData?: object;
   inventoryValueId?: string;
   metadata?: object;
   created?: Date;
@@ -45,45 +45,45 @@ export class ActivityValue extends Model<ActivityValueAttributes, ActivityValueC
 
   static initModel(sequelize: Sequelize.Sequelize): typeof ActivityValue {
     return ActivityValue.init({
-    id: {
-      type: DataTypes.UUID,
-      allowNull: false,
-      primaryKey: true
-    },
-    activityData: {
-      type: DataTypes.TEXT,
-      allowNull: true,
-      field: 'activity_data'
-    },
-    inventoryValueId: {
-      type: DataTypes.UUID,
-      allowNull: true,
-      references: {
-        model: 'InventoryValue',
-        key: 'id'
+      id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        primaryKey: true
       },
-      field: 'inventory_value_id'
-    },
-    metadata: {
-      type: DataTypes.JSONB,
-      allowNull: true
-    }
-  }, {
-    sequelize,
-    tableName: 'ActivityValue',
-    schema: 'public',
-    timestamps: true,
-    createdAt: 'created',
-    updatedAt: 'last_updated',
-    indexes: [
-      {
-        name: "ActivityValue_pkey",
-        unique: true,
-        fields: [
-          { name: "id" },
-        ]
+      activityData: {
+        type: DataTypes.JSONB,
+        allowNull: true,
+        field: 'activity_data'
       },
-    ]
-  });
+      inventoryValueId: {
+        type: DataTypes.UUID,
+        allowNull: true,
+        references: {
+          model: 'InventoryValue',
+          key: 'id'
+        },
+        field: 'inventory_value_id'
+      },
+      metadata: {
+        type: DataTypes.JSONB,
+        allowNull: true
+      }
+    }, {
+      sequelize,
+      tableName: 'ActivityValue',
+      schema: 'public',
+      timestamps: true,
+      createdAt: 'created',
+      updatedAt: 'last_updated',
+      indexes: [
+        {
+          name: "ActivityValue_pkey",
+          unique: true,
+          fields: [
+            { name: "id" },
+          ]
+        },
+      ]
+    });
   }
 }

--- a/app/src/models/GasValue.ts
+++ b/app/src/models/GasValue.ts
@@ -28,8 +28,7 @@ export type GasValueCreationAttributes = Optional<
 
 export class GasValue
   extends Model<GasValueAttributes, GasValueCreationAttributes>
-  implements GasValueAttributes
-{
+  implements GasValueAttributes {
   id!: string;
   inventoryValueId?: string;
   emissionsFactorId?: string;

--- a/app/src/models/GasValue.ts
+++ b/app/src/models/GasValue.ts
@@ -1,7 +1,8 @@
 import * as Sequelize from "sequelize";
 import { DataTypes, Model, Optional } from "sequelize";
-import { InventoryValue, InventoryValueId } from "./InventoryValue";
-import { EmissionsFactor, EmissionsFactorId } from "./EmissionsFactor";
+import type { ActivityValue, ActivityValueId } from "./ActivityValue";
+import type { EmissionsFactor, EmissionsFactorId } from "./EmissionsFactor";
+import type { InventoryValue, InventoryValueId } from "./InventoryValue";
 
 export interface GasValueAttributes {
   id: string;
@@ -9,6 +10,7 @@ export interface GasValueAttributes {
   emissionsFactorId?: string;
   gas?: string;
   gasAmount?: bigint | null;
+  activityValueId?: string;
 }
 
 export type GasValuePk = "id";
@@ -17,7 +19,8 @@ export type GasValueOptionalAttributes =
   | "inventoryValueId"
   | "emissionsFactorId"
   | "gas"
-  | "gasAmount";
+  | "gasAmount"
+  | "activityValueId";
 export type GasValueCreationAttributes = Optional<
   GasValueAttributes,
   GasValueOptionalAttributes
@@ -32,15 +35,16 @@ export class GasValue
   emissionsFactorId?: string;
   gas?: string;
   gasAmount?: bigint | null;
+  activityValueId?: string;
 
-  // GasValue belongsTo InventoryValue via inventoryValueId
-  inventoryValue!: InventoryValue;
-  getInventoryValue!: Sequelize.BelongsToGetAssociationMixin<InventoryValue>;
-  setInventoryValue!: Sequelize.BelongsToSetAssociationMixin<
-    InventoryValue,
-    InventoryValueId
+  // GasValue belongsTo ActivityValue via activityValueId
+  activityValue!: ActivityValue;
+  getActivityValue!: Sequelize.BelongsToGetAssociationMixin<ActivityValue>;
+  setActivityValue!: Sequelize.BelongsToSetAssociationMixin<
+    ActivityValue,
+    ActivityValueId
   >;
-  createInventoryValue!: Sequelize.BelongsToCreateAssociationMixin<InventoryValue>;
+  createActivityValue!: Sequelize.BelongsToCreateAssociationMixin<ActivityValue>;
   // GasValue belongsTo EmissionsFactor via emissionsFactorId
   emissionsFactor!: EmissionsFactor;
   getEmissionsFactor!: Sequelize.BelongsToGetAssociationMixin<EmissionsFactor>;
@@ -49,6 +53,14 @@ export class GasValue
     EmissionsFactorId
   >;
   createEmissionsFactor!: Sequelize.BelongsToCreateAssociationMixin<EmissionsFactor>;
+  // GasValue belongsTo InventoryValue via inventoryValueId
+  inventoryValue!: InventoryValue;
+  getInventoryValue!: Sequelize.BelongsToGetAssociationMixin<InventoryValue>;
+  setInventoryValue!: Sequelize.BelongsToSetAssociationMixin<
+    InventoryValue,
+    InventoryValueId
+  >;
+  createInventoryValue!: Sequelize.BelongsToCreateAssociationMixin<InventoryValue>;
 
   static initModel(sequelize: Sequelize.Sequelize): typeof GasValue {
     return GasValue.init(
@@ -57,16 +69,6 @@ export class GasValue
           type: DataTypes.UUID,
           allowNull: false,
           primaryKey: true,
-          field: "id",
-        },
-        gas: {
-          type: DataTypes.STRING(255),
-          allowNull: true,
-        },
-        gasAmount: {
-          type: DataTypes.BIGINT,
-          allowNull: true,
-          field: "gas_amount",
         },
         inventoryValueId: {
           type: DataTypes.UUID,
@@ -82,9 +84,27 @@ export class GasValue
           allowNull: true,
           references: {
             model: "EmissionsFactor",
-            key: "emissions_factor_id",
+            key: "id",
           },
           field: "emissions_factor_id",
+        },
+        gas: {
+          type: DataTypes.STRING(255),
+          allowNull: true,
+        },
+        gasAmount: {
+          type: DataTypes.BIGINT,
+          allowNull: true,
+          field: "gas_amount",
+        },
+        activityValueId: {
+          type: DataTypes.UUID,
+          allowNull: true,
+          references: {
+            model: "ActivityValue",
+            key: "id",
+          },
+          field: "activity_value_id",
         },
       },
       {
@@ -92,6 +112,8 @@ export class GasValue
         tableName: "GasValue",
         schema: "public",
         timestamps: false,
+        createdAt: "created",
+        updatedAt: "last_updated",
         indexes: [
           {
             name: "GasValue_pkey",

--- a/app/src/models/SubSector.ts
+++ b/app/src/models/SubSector.ts
@@ -1,6 +1,7 @@
 import * as Sequelize from "sequelize";
 import { DataTypes, Model, Optional } from "sequelize";
 import type { DataSource, DataSourceId } from "./DataSource";
+import type { InventoryValue, InventoryValueId } from "./InventoryValue";
 import type { ReportingLevel, ReportingLevelId } from "./ReportingLevel";
 import type { Scope, ScopeId } from "./Scope";
 import type { Sector, SectorId } from "./Sector";
@@ -14,9 +15,10 @@ export interface SubSectorAttributes {
   subsectorId: string;
   subsectorName?: string;
   sectorId?: string;
-  referenceNumber?: string;
   created?: Date;
   lastUpdated?: Date;
+  referenceNumber?: string;
+  scopeId?: string;
 }
 
 export type SubSectorPk = "subsectorId";
@@ -24,9 +26,10 @@ export type SubSectorId = SubSector[SubSectorPk];
 export type SubSectorOptionalAttributes =
   | "subsectorName"
   | "sectorId"
-  | "referenceNumber"
   | "created"
-  | "lastUpdated";
+  | "lastUpdated"
+  | "referenceNumber"
+  | "scopeId";
 export type SubSectorCreationAttributes = Optional<
   SubSectorAttributes,
   SubSectorOptionalAttributes
@@ -39,10 +42,16 @@ export class SubSector
   subsectorId!: string;
   subsectorName?: string;
   sectorId?: string;
-  referenceNumber?: string;
   created?: Date;
   lastUpdated?: Date;
+  referenceNumber?: string;
+  scopeId?: string;
 
+  // SubSector belongsTo Scope via scopeId
+  scope!: Scope;
+  getScope!: Sequelize.BelongsToGetAssociationMixin<Scope>;
+  setScope!: Sequelize.BelongsToSetAssociationMixin<Scope, ScopeId>;
+  createScope!: Sequelize.BelongsToCreateAssociationMixin<Scope>;
   // SubSector belongsTo Sector via sectorId
   sector!: Sector;
   getSector!: Sequelize.BelongsToGetAssociationMixin<Sector>;
@@ -81,6 +90,39 @@ export class SubSector
     DataSourceId
   >;
   countDataSources!: Sequelize.HasManyCountAssociationsMixin;
+  // SubSector hasMany InventoryValue via subSectorId
+  inventoryValues!: InventoryValue[];
+  getInventoryValues!: Sequelize.HasManyGetAssociationsMixin<InventoryValue>;
+  setInventoryValues!: Sequelize.HasManySetAssociationsMixin<
+    InventoryValue,
+    InventoryValueId
+  >;
+  addInventoryValue!: Sequelize.HasManyAddAssociationMixin<
+    InventoryValue,
+    InventoryValueId
+  >;
+  addInventoryValues!: Sequelize.HasManyAddAssociationsMixin<
+    InventoryValue,
+    InventoryValueId
+  >;
+  createInventoryValue!: Sequelize.HasManyCreateAssociationMixin<InventoryValue>;
+  removeInventoryValue!: Sequelize.HasManyRemoveAssociationMixin<
+    InventoryValue,
+    InventoryValueId
+  >;
+  removeInventoryValues!: Sequelize.HasManyRemoveAssociationsMixin<
+    InventoryValue,
+    InventoryValueId
+  >;
+  hasInventoryValue!: Sequelize.HasManyHasAssociationMixin<
+    InventoryValue,
+    InventoryValueId
+  >;
+  hasInventoryValues!: Sequelize.HasManyHasAssociationsMixin<
+    InventoryValue,
+    InventoryValueId
+  >;
+  countInventoryValues!: Sequelize.HasManyCountAssociationsMixin;
   // SubSector belongsToMany ReportingLevel via subsectorId and reportinglevelId
   reportinglevelIdReportingLevelSubSectorReportingLevels!: ReportingLevel[];
   getReportinglevelIdReportingLevelSubSectorReportingLevels!: Sequelize.BelongsToManyGetAssociationsMixin<ReportingLevel>;
@@ -180,14 +222,6 @@ export class SubSector
     SubSectorReportingLevelId
   >;
   countSubSectorReportingLevels!: Sequelize.HasManyCountAssociationsMixin;
-  // SubSector hasOne Scope via scopeId
-  scope!: Scope;
-  getScope!: Sequelize.HasOneGetAssociationMixin<Scope>;
-  setScope!: Sequelize.HasOneSetAssociationMixin<
-    Scope,
-    ScopeId
-  >;
-  createScope!: Sequelize.HasOneCreateAssociationMixin<Scope>;
 
   static initModel(sequelize: Sequelize.Sequelize): typeof SubSector {
     return SubSector.init(
@@ -216,6 +250,15 @@ export class SubSector
           type: DataTypes.STRING(255),
           allowNull: true,
           field: "reference_number",
+        },
+        scopeId: {
+          type: DataTypes.UUID,
+          allowNull: true,
+          references: {
+            model: "Scope",
+            key: "scope_id",
+          },
+          field: "scope_id",
         },
       },
       {

--- a/app/src/models/User.ts
+++ b/app/src/models/User.ts
@@ -1,7 +1,9 @@
 import * as Sequelize from "sequelize";
 import { DataTypes, Model, Optional } from "sequelize";
-import type { City, CityId } from "./City";
+import type { CityInvite, CityInviteId } from "./CityInvite";
+import type { CityUser, CityUserId } from "./CityUser";
 import type { Inventory, InventoryId } from "./Inventory";
+import type { UserFile, UserFileId } from "./UserFile";
 
 export interface UserAttributes {
   userId: string;
@@ -10,10 +12,9 @@ export interface UserAttributes {
   email?: string;
   passwordHash?: string;
   role?: string;
-  defaultInventoryId?: string;
   created?: Date;
   lastUpdated?: Date;
-  organizationId?: string;
+  defaultInventoryId?: string;
 }
 
 export type UserPk = "userId";
@@ -24,10 +25,9 @@ export type UserOptionalAttributes =
   | "email"
   | "passwordHash"
   | "role"
-  | "defaultInventoryId"
   | "created"
   | "lastUpdated"
-  | "organizationId";
+  | "defaultInventoryId";
 export type UserCreationAttributes = Optional<
   UserAttributes,
   UserOptionalAttributes
@@ -43,33 +43,87 @@ export class User
   email?: string;
   passwordHash?: string;
   role?: string;
-  defaultInventoryId?: string;
   created?: Date;
   lastUpdated?: Date;
+  defaultInventoryId?: string;
 
-  // User belongsToMany City via CityId
-  cities!: City[];
-  getCities!: Sequelize.BelongsToManyGetAssociationsMixin<City>;
-  setCities!: Sequelize.BelongsToManySetAssociationsMixin<City, CityId>;
-  addCity!: Sequelize.BelongsToManyAddAssociationMixin<City, CityId>;
-  addCities!: Sequelize.BelongsToManyAddAssociationsMixin<City, CityId>;
-  createCity!: Sequelize.BelongsToManyCreateAssociationMixin<City>;
-  removeCity!: Sequelize.BelongsToManyRemoveAssociationMixin<
-    City,
-    CityId
-  >;
-  removeCities!: Sequelize.BelongsToManyRemoveAssociationsMixin<
-    City,
-    CityId
-  >;
-  hasCity!: Sequelize.BelongsToManyHasAssociationMixin<City, CityId>;
-  hasCities!: Sequelize.BelongsToManyHasAssociationsMixin<City, CityId>;
-  countCities!: Sequelize.BelongsToManyCountAssociationsMixin;
   // User belongsTo Inventory via defaultInventoryId
   defaultInventory!: Inventory;
   getDefaultInventory!: Sequelize.BelongsToGetAssociationMixin<Inventory>;
-  setDefaultInventory!: Sequelize.BelongsToSetAssociationMixin<Inventory, InventoryId>;
+  setDefaultInventory!: Sequelize.BelongsToSetAssociationMixin<
+    Inventory,
+    InventoryId
+  >;
   createDefaultInventory!: Sequelize.BelongsToCreateAssociationMixin<Inventory>;
+  // User hasMany CityInvite via invitingUserId
+  cityInvites!: CityInvite[];
+  getCityInvites!: Sequelize.HasManyGetAssociationsMixin<CityInvite>;
+  setCityInvites!: Sequelize.HasManySetAssociationsMixin<
+    CityInvite,
+    CityInviteId
+  >;
+  addCityInvite!: Sequelize.HasManyAddAssociationMixin<
+    CityInvite,
+    CityInviteId
+  >;
+  addCityInvites!: Sequelize.HasManyAddAssociationsMixin<
+    CityInvite,
+    CityInviteId
+  >;
+  createCityInvite!: Sequelize.HasManyCreateAssociationMixin<CityInvite>;
+  removeCityInvite!: Sequelize.HasManyRemoveAssociationMixin<
+    CityInvite,
+    CityInviteId
+  >;
+  removeCityInvites!: Sequelize.HasManyRemoveAssociationsMixin<
+    CityInvite,
+    CityInviteId
+  >;
+  hasCityInvite!: Sequelize.HasManyHasAssociationMixin<
+    CityInvite,
+    CityInviteId
+  >;
+  hasCityInvites!: Sequelize.HasManyHasAssociationsMixin<
+    CityInvite,
+    CityInviteId
+  >;
+  countCityInvites!: Sequelize.HasManyCountAssociationsMixin;
+  // User hasMany CityUser via userId
+  cityUsers!: CityUser[];
+  getCityUsers!: Sequelize.HasManyGetAssociationsMixin<CityUser>;
+  setCityUsers!: Sequelize.HasManySetAssociationsMixin<CityUser, CityUserId>;
+  addCityUser!: Sequelize.HasManyAddAssociationMixin<CityUser, CityUserId>;
+  addCityUsers!: Sequelize.HasManyAddAssociationsMixin<CityUser, CityUserId>;
+  createCityUser!: Sequelize.HasManyCreateAssociationMixin<CityUser>;
+  removeCityUser!: Sequelize.HasManyRemoveAssociationMixin<
+    CityUser,
+    CityUserId
+  >;
+  removeCityUsers!: Sequelize.HasManyRemoveAssociationsMixin<
+    CityUser,
+    CityUserId
+  >;
+  hasCityUser!: Sequelize.HasManyHasAssociationMixin<CityUser, CityUserId>;
+  hasCityUsers!: Sequelize.HasManyHasAssociationsMixin<CityUser, CityUserId>;
+  countCityUsers!: Sequelize.HasManyCountAssociationsMixin;
+  // User hasMany UserFile via userId
+  userFiles!: UserFile[];
+  getUserFiles!: Sequelize.HasManyGetAssociationsMixin<UserFile>;
+  setUserFiles!: Sequelize.HasManySetAssociationsMixin<UserFile, UserFileId>;
+  addUserFile!: Sequelize.HasManyAddAssociationMixin<UserFile, UserFileId>;
+  addUserFiles!: Sequelize.HasManyAddAssociationsMixin<UserFile, UserFileId>;
+  createUserFile!: Sequelize.HasManyCreateAssociationMixin<UserFile>;
+  removeUserFile!: Sequelize.HasManyRemoveAssociationMixin<
+    UserFile,
+    UserFileId
+  >;
+  removeUserFiles!: Sequelize.HasManyRemoveAssociationsMixin<
+    UserFile,
+    UserFileId
+  >;
+  hasUserFile!: Sequelize.HasManyHasAssociationMixin<UserFile, UserFileId>;
+  hasUserFiles!: Sequelize.HasManyHasAssociationsMixin<UserFile, UserFileId>;
+  countUserFiles!: Sequelize.HasManyCountAssociationsMixin;
 
   static initModel(sequelize: Sequelize.Sequelize): typeof User {
     return User.init(
@@ -106,6 +160,10 @@ export class User
         defaultInventoryId: {
           type: DataTypes.UUID,
           allowNull: true,
+          references: {
+            model: "Inventory",
+            key: "inventory_id",
+          },
           field: "default_inventory_id",
         },
       },

--- a/app/src/models/User.ts
+++ b/app/src/models/User.ts
@@ -4,6 +4,7 @@ import type { CityInvite, CityInviteId } from "./CityInvite";
 import type { CityUser, CityUserId } from "./CityUser";
 import type { Inventory, InventoryId } from "./Inventory";
 import type { UserFile, UserFileId } from "./UserFile";
+import { City, CityId } from "./City";
 
 export interface UserAttributes {
   userId: string;
@@ -35,8 +36,7 @@ export type UserCreationAttributes = Optional<
 
 export class User
   extends Model<UserAttributes, UserCreationAttributes>
-  implements UserAttributes
-{
+  implements UserAttributes {
   userId!: string;
   name?: string;
   pictureUrl?: string;
@@ -124,6 +124,24 @@ export class User
   hasUserFile!: Sequelize.HasManyHasAssociationMixin<UserFile, UserFileId>;
   hasUserFiles!: Sequelize.HasManyHasAssociationsMixin<UserFile, UserFileId>;
   countUserFiles!: Sequelize.HasManyCountAssociationsMixin;
+  // User hasMany City via userId
+  cities!: City[];
+  getCities!: Sequelize.HasManyGetAssociationsMixin<City>;
+  setCities!: Sequelize.HasManySetAssociationsMixin<City, CityId>;
+  addCity!: Sequelize.HasManyAddAssociationMixin<City, CityId>;
+  addCities!: Sequelize.HasManyAddAssociationsMixin<City, CityId>;
+  createCity!: Sequelize.HasManyCreateAssociationMixin<City>;
+  removeCity!: Sequelize.HasManyRemoveAssociationMixin<
+    City,
+    CityId
+  >;
+  removeCities!: Sequelize.HasManyRemoveAssociationsMixin<
+    City,
+    CityId
+  >;
+  hasCity!: Sequelize.HasManyHasAssociationMixin<City, CityId>;
+  hasCities!: Sequelize.HasManyHasAssociationsMixin<City, CityId>;
+  countCities!: Sequelize.HasManyCountAssociationsMixin;
 
   static initModel(sequelize: Sequelize.Sequelize): typeof User {
     return User.init(

--- a/app/src/models/init-models.ts
+++ b/app/src/models/init-models.ts
@@ -1,4 +1,9 @@
 import type { Sequelize } from "sequelize";
+import { ActivityValue as _ActivityValue } from "./ActivityValue";
+import type {
+  ActivityValueAttributes,
+  ActivityValueCreationAttributes,
+} from "./ActivityValue";
 import { ActivityData as _ActivityData } from "./ActivityData";
 import type {
   ActivityDataAttributes,
@@ -128,6 +133,7 @@ import { CityInvite as _CityInvite } from "./CityInvite";
 
 export {
   _ActivityData as ActivityData,
+  _ActivityValue as ActivityValue,
   _Catalogue as Catalogue,
   _City as City,
   _CityUser as CityUser,
@@ -163,6 +169,8 @@ export {
 export type {
   ActivityDataAttributes,
   ActivityDataCreationAttributes,
+  ActivityValueAttributes,
+  ActivityValueCreationAttributes,
   CatalogueAttributes,
   CatalogueCreationAttributes,
   CityAttributes,
@@ -223,6 +231,7 @@ export type {
 
 export function initModels(sequelize: Sequelize) {
   const ActivityData = _ActivityData.initModel(sequelize);
+  const ActivityValue = _ActivityValue.initModel(sequelize);
   const Catalogue = _Catalogue.initModel(sequelize);
   const City = _City.initModel(sequelize);
   const CityUser = _CityUser.initModel(sequelize);
@@ -267,6 +276,38 @@ export function initModels(sequelize: Sequelize) {
     through: DataSourceActivityData,
     foreignKey: "datasourceId",
     otherKey: "activitydataId",
+  });
+  GasValue.belongsTo(ActivityValue, {
+    as: "activityValue",
+    foreignKey: "activityValueId",
+  });
+  ActivityValue.hasMany(GasValue, {
+    as: "gasValues",
+    foreignKey: "activityValueId",
+  });
+  GasValue.belongsTo(EmissionsFactor, {
+    as: "emissionsFactor",
+    foreignKey: "emissionsFactorId",
+  });
+  EmissionsFactor.hasMany(GasValue, {
+    as: "gasValues",
+    foreignKey: "emissionsFactorId",
+  });
+  ActivityValue.belongsTo(InventoryValue, {
+    as: "inventoryValue",
+    foreignKey: "inventoryValueId",
+  });
+  InventoryValue.hasMany(ActivityValue, {
+    as: "activityValues",
+    foreignKey: "inventoryValueId",
+  });
+  GasValue.belongsTo(InventoryValue, {
+    as: "inventoryValue",
+    foreignKey: "inventoryValueId",
+  });
+  InventoryValue.hasMany(GasValue, {
+    as: "gasValues",
+    foreignKey: "inventoryValueId",
   });
   DataSource.belongsToMany(EmissionsFactor, {
     as: "emissionsFactorIdEmissionsFactors",
@@ -632,6 +673,7 @@ export function initModels(sequelize: Sequelize) {
 
   return {
     ActivityData: ActivityData,
+    ActivityValue: ActivityValue,
     Catalogue: Catalogue,
     City: City,
     CityUser: CityUser,

--- a/app/src/models/init-models.ts
+++ b/app/src/models/init-models.ts
@@ -285,28 +285,12 @@ export function initModels(sequelize: Sequelize) {
     as: "gasValues",
     foreignKey: "activityValueId",
   });
-  GasValue.belongsTo(EmissionsFactor, {
-    as: "emissionsFactor",
-    foreignKey: "emissionsFactorId",
-  });
-  EmissionsFactor.hasMany(GasValue, {
-    as: "gasValues",
-    foreignKey: "emissionsFactorId",
-  });
   ActivityValue.belongsTo(InventoryValue, {
     as: "inventoryValue",
     foreignKey: "inventoryValueId",
   });
   InventoryValue.hasMany(ActivityValue, {
     as: "activityValues",
-    foreignKey: "inventoryValueId",
-  });
-  GasValue.belongsTo(InventoryValue, {
-    as: "inventoryValue",
-    foreignKey: "inventoryValueId",
-  });
-  InventoryValue.hasMany(GasValue, {
-    as: "gasValues",
     foreignKey: "inventoryValueId",
   });
   DataSource.belongsToMany(EmissionsFactor, {

--- a/app/src/util/validation.ts
+++ b/app/src/util/validation.ts
@@ -153,17 +153,29 @@ export const createActivityValueRequest = z.object({
   inventoryValueId: z.string().uuid(),
   activityData: z.any().optional(),
   metadata: z.any().optional(),
-  gasValues: z.array(z.object({
-    id: z.string().uuid().optional(),
-    emissionsFactorId: z.string().uuid().optional(),
-    gas: z.string(),
-    gasAmount: z.coerce.bigint().gte(0n).optional(),
-    emissionsFactor: z.object({
-      emissionsPerActivity: z.number().gte(0).optional(),
-      gas: z.string().optional(),
-      units: z.string().optional(),
-      gpcReferenceNumber: z.string().optional(),
-    }).optional(),
-  })).optional()
+  dataSource: z
+    .object({
+      sourceType: z.string(),
+      dataQuality: z.string(),
+      notes: z.string(),
+    })
+    .optional(),
+  gasValues: z
+    .array(
+      z.object({
+        id: z.string().uuid().optional(),
+        emissionsFactorId: z.string().uuid().optional(),
+        gas: z.string(),
+        gasAmount: z.coerce.bigint().gte(0n).optional(),
+        emissionsFactor: z
+          .object({
+            emissionsPerActivity: z.number().gte(0).optional(),
+            gas: z.string().optional(),
+            units: z.string().optional(),
+            gpcReferenceNumber: z.string().optional(),
+          })
+          .optional(),
+      }),
+    )
+    .optional(),
 });
-

--- a/app/src/util/validation.ts
+++ b/app/src/util/validation.ts
@@ -148,3 +148,10 @@ export const createUserInvite = z.object({
 });
 
 export type CreateUserInvite = z.infer<typeof createUserInvite>;
+
+export const createActivityValueRequest = z.object({
+  activityData: z.any(),
+  inventoryValueId: z.string().uuid(),
+  metadata: z.any(),
+});
+

--- a/app/src/util/validation.ts
+++ b/app/src/util/validation.ts
@@ -158,6 +158,12 @@ export const createActivityValueRequest = z.object({
     emissionsFactorId: z.string().uuid().optional(),
     gas: z.string(),
     gasAmount: z.coerce.bigint().gte(0n).optional(),
+    emissionsFactor: z.object({
+      emissionsPerActivity: z.number().gte(0).optional(),
+      gas: z.string().optional(),
+      units: z.string().optional(),
+      gpcReferenceNumber: z.string().optional(),
+    }).optional(),
   })).optional()
 });
 

--- a/app/src/util/validation.ts
+++ b/app/src/util/validation.ts
@@ -150,8 +150,14 @@ export const createUserInvite = z.object({
 export type CreateUserInvite = z.infer<typeof createUserInvite>;
 
 export const createActivityValueRequest = z.object({
-  activityData: z.any(),
   inventoryValueId: z.string().uuid(),
-  metadata: z.any(),
+  activityData: z.any().optional(),
+  metadata: z.any().optional(),
+  gasValues: z.array(z.object({
+    id: z.string().uuid().optional(),
+    emissionsFactorId: z.string().uuid().optional(),
+    gas: z.string(),
+    gasAmount: z.coerce.bigint().gte(0n).optional(),
+  })).optional()
 });
 


### PR DESCRIPTION
Adds the `ActivityValue` table that is located on a new level between `InventoryValue` and `GasValue` now. This allows recording separate data for each activity inside of a SubSector + Scope (InventoryValue), so they can be tracked in compliance with the GPC.

Adds the following API routes:
- POST /api/v0/inventory/[inventoryId]/activity-value
- GET /api/v0/inventory/[inventoryId]/activity-value
- PATCH /api/v0/inventory/[inventoryId]/activity-value/[id]
- GET /api/v0/inventory/[inventoryId]/activity-value/[id]
- DELETE /api/v0/inventory/[inventoryId]/activity-value/[id]

The `id` parameter is `ActivityValue.id` in all of these cases.

Todo:
- [x] Add new routes to documentation once accepted
- [ ] Write unit tests for new routes
- [x] Add DataSource to ActivityValue POST/ PATCH routes
- [x] Add filter parameter for inputMethodologyId to batch GET ActivityValue route
- [ ] Add InputMethodology table
