### PR TITLE
Fix broken data sources section and add debugging tools for filtered out sources

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/[step]/page.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/page.tsx
@@ -108,35 +108,31 @@ function SearchDataSourcesPrompt({
 }) {
   return (
     <Flex align="center" direction="column">
-      <Box p="16px" mb="24px" borderRadius="full" bg="background.neutral">
-        <SearchOffIcon />
-      </Box>
-      <Text
-        fontFamily="heading"
-        fontSize="title.lg"
-        fontWeight="600"
-        color="interactive.control"
+      <Icon
+        as={WorldSearchIcon}
+        boxSize={20}
+        color="interactive.secondary"
+        borderRadius="full"
+        p={4}
+        bgColor="background.neutral"
+        mb={6}
+      />
+      <Button
+        variant="solid"
+        leftIcon={<SearchIcon boxSize={6} />}
+        isLoading={isSearching}
+        isDisabled={isDisabled}
+        loadingText={t("searching")}
+        onClick={onSearchClicked}
+        mb={2}
+        px={6}
+        h={16}
+        py={4}
       >
-        No External Data Sources Available
-      </Text>
-      <Text
-        color="content.tertiary"
-        align="center"
-        size="sm"
-        variant="spaced"
-        w="550px"
-        mt="8px"
-      >
-        <Text>{t("no-external-sources")}</Text>
-        <Text fontWeight="semibold">
-          <Trans t={t} i18nKey="report-any-sources">
-            if you know any,{" "}
-            <Link href="/" color="content.link" textDecor="underline">
-              please report this
-            </Link>{" "}
-            and we&apos;ll prioritize your request.
-          </Trans>
-        </Text>
+        {t("search-available-datasets")}
+      </Button>
+      <Text color="content.tertiary" align="center" size="sm" variant="spaced">
+        {t("wait-for-search")}
       </Text>
     </Flex>
   );

--- a/app/src/app/[lng]/[inventory]/data/[step]/page.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/page.tsx
@@ -7,20 +7,16 @@ import {
   DataAlertIcon,
   DataCheckIcon,
   ExcelFileIcon,
-  SearchOffIcon,
   WorldSearchIcon,
 } from "@/components/icons";
-import WizardSteps from "@/components/wizard-steps";
 import {
   InventoryUserFileAttributes,
-  addFile,
   clear,
   removeFile,
 } from "@/features/city/inventoryDataSlice";
-import { setSubsector, clearSubsector } from "@/features/city/subsectorSlice";
+import { setSubsector } from "@/features/city/subsectorSlice";
 import { useTranslation } from "@/i18n/client";
 import { RootState } from "@/lib/store";
-import { ScopeAttributes } from "@/models/Scope";
 import { api } from "@/services/api";
 import { logger } from "@/services/logger";
 import { bytesToMB, nameToI18NKey } from "@/util/helpers";
@@ -71,7 +67,6 @@ import {
   MdOutlineCheckCircle,
   MdOutlineEdit,
   MdOutlineHomeWork,
-  MdOutlineSkipNext,
   MdRefresh,
 } from "react-icons/md";
 import { useDispatch, useSelector } from "react-redux";
@@ -85,7 +80,6 @@ import type {
 
 import AddFileDataModal from "@/components/Modals/add-file-data-modal";
 import { InventoryValueAttributes } from "@/models/InventoryValue";
-import { UserFileAttributes } from "@/models/UserFile";
 import { motion } from "framer-motion";
 
 function getMailURI(locode?: string, sector?: string, year?: number): string {

--- a/app/src/app/[lng]/[inventory]/data/[step]/page.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/page.tsx
@@ -413,11 +413,7 @@ export default function AddDataSteps({
   }
 
   function onSearchDataSourcesClicked() {
-    if (inventoryProgress) {
-      loadDataSources({ inventoryId: inventoryProgress.inventory.inventoryId });
-    } else {
-      console.error("Inventory progress is still loading!");
-    }
+    loadDataSources({ inventoryId: inventory });
   }
 
   const [selectedSubsector, setSelectedSubsector] =

--- a/app/src/app/[lng]/[inventory]/data/[step]/page.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/page.tsx
@@ -916,7 +916,7 @@ export default function AddDataSteps({
             <Center>
               <WarningIcon boxSize={8} color="semantic.danger" />
             </Center>
-          ) : dataSources && dataSources.length === 0 ? (
+          ) : dataSources && dataSources?.length === 0 ? (
             <NoDataSourcesMessage
               t={t}
               sector={currentStep.referenceNumber}

--- a/app/src/app/[lng]/[inventory]/data/[step]/page.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/page.tsx
@@ -92,12 +92,12 @@ function getMailURI(locode?: string, sector?: string, year?: number): string {
 function SearchDataSourcesPrompt({
   t,
   isSearching,
-  isDisabled,
+  isDisabled = false,
   onSearchClicked,
 }: {
   t: TFunction;
   isSearching: boolean;
-  isDisabled: boolean;
+  isDisabled?: boolean;
   onSearchClicked: () => void;
 }) {
   return (
@@ -899,7 +899,6 @@ export default function AddDataSteps({
             <SearchDataSourcesPrompt
               t={t}
               isSearching={areDataSourcesLoading}
-              isDisabled={!inventoryProgress}
               onSearchClicked={onSearchDataSourcesClicked}
             />
           ) : dataSourcesError ? (

--- a/app/src/app/api/v0/datasource/[inventoryId]/[sectorId]/route.ts
+++ b/app/src/app/api/v0/datasource/[inventoryId]/[sectorId]/route.ts
@@ -5,7 +5,6 @@ import { DataSource } from "@/models/DataSource";
 import { apiHandler } from "@/util/api";
 import createHttpError from "http-errors";
 import { NextRequest, NextResponse } from "next/server";
-import { Op } from "sequelize";
 
 export const GET = apiHandler(async (_req: NextRequest, { params }) => {
   const inventory = await db.models.Inventory.findOne({
@@ -22,10 +21,6 @@ export const GET = apiHandler(async (_req: NextRequest, { params }) => {
       {
         model: DataSource,
         as: "dataSources",
-        where: {
-          startYear: { [Op.lte]: inventory.year },
-          endYear: { [Op.gte]: inventory.year },
-        },
         include: [
           { model: db.models.Scope, as: "scopes" },
           { model: db.models.Publisher, as: "publisher" },
@@ -48,7 +43,7 @@ export const GET = apiHandler(async (_req: NextRequest, { params }) => {
     throw new createHttpError.NotFound("Sector not found");
   }
 
-  const applicableSources = DataSourceService.filterSources(
+  const { applicableSources, removedSources } = DataSourceService.filterSources(
     inventory,
     sector.dataSources,
   );
@@ -69,5 +64,5 @@ export const GET = apiHandler(async (_req: NextRequest, { params }) => {
     )
   ).filter((source) => !!source);
 
-  return NextResponse.json({ data: sourceData });
+  return NextResponse.json({ data: sourceData, removedSources });
 });

--- a/app/src/i18n/locales/en/data.json
+++ b/app/src/i18n/locales/en/data.json
@@ -164,7 +164,7 @@
   "delete-activity": "Delete activity",
   "delete-activities-prompt": "Are you sure you want to <2>permanently delete </2> all activities in the commercial and institutional buildings sub-sector from the city's inventory data?",
   "delete-activity-prompt": "Are you sure you want to <2> permanently delete </2> this activity from the city's inventory data?",
-  
+
   "skip-step-button": "Skip this step",
   "save-continue-button": "Save and Continue",
   "updated-every": "Updated every",
@@ -228,6 +228,7 @@
   "incomplete": "Incomplete",
   "search-available-datasets": "Search for available datasets",
   "searching": "Searching...",
+  "wait-for-search": "Please wait while we search for external data sources that match your inventory needs.",
   "no-external-sources": "It seemes like there are no external sources at this moment.",
   "report-any-sources": "if you know any, <2>please report this</2> and we'll prioritize your request.",
   "unsaved-changes": "Unsaved Changes",


### PR DESCRIPTION
- Fixes the data source section on the add data page always showing "No sources found"
- Removes dependency on inventory progress data from data source search, so you can press the button before the remaining data has loaded (less wait times for users :sparkles:)
- Adds `removedSources` property to all data source routes to make debugging why a certain source was removed easier
- This potentially adds more data and filters by startYear/ endYear of the source in the backend instead of the database, so potentially more data needs to be scanned. In case this is too egregious, we can make it optional and add a "debugging mode" in the frontend. Good enough for now imo though.