### PR TITLE
fix: remove empty inventory string from request [OC-1429]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ global-api/data/**
 
 #Python virtual env
 global-api/env
+
+#Intellij
+/.idea/**

--- a/app/src/app/[lng]/auth/signup/page.tsx
+++ b/app/src/app/[lng]/auth/signup/page.tsx
@@ -23,6 +23,7 @@ import { Trans } from "react-i18next/TransWithoutContext";
 import { logger } from "@/services/logger";
 
 type Inputs = {
+  inventory?: string;
   name: string;
   email: string;
   password: string;
@@ -78,10 +79,14 @@ export default function Signup({
       return;
     }
 
+    if(inventoryId && inventoryId !== '') {
+      data.inventory = inventoryId
+    }
+
     try {
       const res = await fetch("/api/v0/auth/register", {
         method: "POST",
-        body: JSON.stringify({ ...data, inventory: inventoryId }),
+        body: JSON.stringify(data),
         headers: {
           "Content-Type": "application/json",
         },


### PR DESCRIPTION
When no inventoryId was found, we were sending {... inventory: ""} in the request, this triggered an error from zod. Now we only add the inventory key if the field is not null and not an empty string.