### PR TITLE
Change env vars ca

### DIFF
--- a/.github/workflows/web-develop.yml
+++ b/.github/workflows/web-develop.yml
@@ -138,7 +138,8 @@ jobs:
             NEXTAUTH_SECRET=${{secrets.NEXTAUTH_SECRET}} \
             RESET_TOKEN_SECRET=${{secrets.RESET_TOKEN_SECRET}} \
             VERIFICATION_TOKEN_SECRET=${{secrets.VERIFICATION_TOKEN_SECRET}} \
-            OPENAI_API_KEY=${{secrets.OPENAI_API_KEY}} \
+            OPENAI_API_KEY=${{secrets.OPENAI_API_KEY_DEV}} \
+            "OPENAI_ASSISTANT_ID=asst_saoKNCVqCX7adTMoLqPxPHvB" \
             HUGGINGFACE_API_KEY=${{secrets.HUGGINGFACE_API_KEY}} \
             "ADMIN_EMAILS=${{secrets.ADMIN_EMAILS}}" \
             "ADMIN_NAMES=${{secrets.ADMIN_NAMES}}" \

--- a/.github/workflows/web-tag.yml
+++ b/.github/workflows/web-tag.yml
@@ -135,9 +135,12 @@ jobs:
             SMTP_USER=${{secrets.SMTP_USER}} \
             SMTP_PASSWORD=${{secrets.SMTP_PASSWORD}} \
             NEXTAUTH_SECRET=${{secrets.NEXTAUTH_SECRET}} \
-            RESET_TOKEN_SECRET=${{secrets.RESET_TOKEN_SECRET}} \ VERIFICATION_TOKEN_SECRET=${{secrets.VERIFICATION_TOKEN_SECRET}} \
-            OPENAI_API_KEY=${{secrets.OPENAI_API_KEY}} \
-            HUGGINGFACE_API_KEY=${{secrets.HUGGINGFACE_API_KEY}} \ "ADMIN_EMAILS=${{secrets.ADMIN_EMAILS}}" \
+            RESET_TOKEN_SECRET=${{secrets.RESET_TOKEN_SECRET}} \ 
+            VERIFICATION_TOKEN_SECRET=${{secrets.VERIFICATION_TOKEN_SECRET}} \
+            OPENAI_API_KEY=${{secrets.OPENAI_API_KEY_PROD}} \
+            "OPENAI_ASSISTANT_ID=asst_FCZ1wta3NElIFXCxDO1KME9I" \
+            HUGGINGFACE_API_KEY=${{secrets.HUGGINGFACE_API_KEY}} \ 
+            "ADMIN_EMAILS=${{secrets.ADMIN_EMAILS}}" \
             "ADMIN_NAMES=${{secrets.ADMIN_NAMES}}" \
             "DEFAULT_ADMIN_EMAIL=${{secrets.DEFAULT_ADMIN_EMAIL}}" \
             "DEFAULT_ADMIN_PASSWORD=${{secrets.DEFAULT_ADMIN_PASSWORD}}" \

--- a/.github/workflows/web-test.yml
+++ b/.github/workflows/web-test.yml
@@ -125,7 +125,8 @@ jobs:
             NEXTAUTH_SECRET=${{secrets.NEXTAUTH_SECRET}} \
             RESET_TOKEN_SECRET=${{secrets.RESET_TOKEN_SECRET}} \
             VERIFICATION_TOKEN_SECRET=${{secrets.VERIFICATION_TOKEN_SECRET}} \
-            OPENAI_API_KEY=${{secrets.OPENAI_API_KEY}} \
+            OPENAI_API_KEY=${{secrets.OPENAI_API_KEY_TEST}} \
+            "OPENAI_ASSISTANT_ID=asst_4if8qn6W8Vlxwbf2cuyH8OFU" \
             HUGGINGFACE_API_KEY=${{secrets.HUGGINGFACE_API_KEY}} \
             "ADMIN_EMAILS=${{secrets.ADMIN_EMAILS}}" \
             "ADMIN_NAMES=${{secrets.ADMIN_NAMES}}" \

--- a/k8s/cc-web-deploy.yml
+++ b/k8s/cc-web-deploy.yml
@@ -54,8 +54,6 @@ spec:
               value: "openai"
             - name: OPEN_AI_MODEL
               value: "gpt-4o-mini"
-            - name: OPENAI_ASSISTANT_ID
-              value: "asst_saoKNCVqCX7adTMoLqPxPHvB"
           resources:
             limits:
               memory: "1024Mi"

--- a/k8s/test/cc-test-web-deploy.yml
+++ b/k8s/test/cc-test-web-deploy.yml
@@ -54,8 +54,6 @@ spec:
               value: "openai"
             - name: OPEN_AI_MODEL
               value: "gpt-4o-mini"
-            - name: OPENAI_ASSISTANT_ID
-              value: "asst_saoKNCVqCX7adTMoLqPxPHvB"
           resources:
             limits:
               memory: "1024Mi"


### PR DESCRIPTION
Added a separate API Key to each of the three envs dev, test, prod to have more control and insights about usage.
Added a separate assistant ID to each of the three envs dev, test, prod to be able to change assistants in different systems without affecting the other systems.

Before merging, the new API KEYs have to be set in Github secrets!