### PR TITLE
Feature/on 2136

### DIFF
--- a/app/src/components/ChatBot/chat-bot.tsx
+++ b/app/src/components/ChatBot/chat-bot.tsx
@@ -277,7 +277,7 @@ export default function ChatBot({
     const runId = event.data.id;
     const toolCalls = event.data.required_action.submit_tool_outputs.tool_calls;
 
-    const timeoutDuration = 1000; // Adjust the timeout duration as needed
+    const timeoutDuration = 60000; // Adjust the timeout duration as needed
 
     const createFallbackOutputs = (toolCalls: any) => {
       return toolCalls.map((toolCall: any) => ({


### PR DESCRIPTION
added a timeout function to `handleRequiresAction` that returns a default tooloutput in case there are issues connecting to the internal apis.