### PR TITLE
remove selector since "by-activity" will not be implemented for now

### DIFF
--- a/app/src/app/[lng]/[inventory]/InventoryCalculationTab.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryCalculationTab.tsx
@@ -5,8 +5,21 @@ import { SegmentedProgress } from "@/components/SegmentedProgress";
 import { CircleIcon } from "@/components/icons";
 import { useTranslation } from "@/i18n/client";
 import { formatPercent } from "@/util/helpers";
-import { InventoryProgressResponse, InventoryResponse, SectorProgress } from "@/util/types";
-import { Box, Center, Heading, Spinner, Tag, TagLabel, TagLeftIcon, Text } from "@chakra-ui/react";
+import {
+  InventoryProgressResponse,
+  InventoryResponse,
+  SectorProgress,
+} from "@/util/types";
+import {
+  Box,
+  Center,
+  Heading,
+  Spinner,
+  Tag,
+  TagLabel,
+  TagLeftIcon,
+  Text,
+} from "@chakra-ui/react";
 import { Trans } from "react-i18next/TransWithoutContext";
 import { TabHeader } from "@/app/[lng]/[inventory]/TabHeader";
 import { undefined } from "zod";

--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsWidget.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsWidget.tsx
@@ -10,7 +10,7 @@ import {
   Icon,
   Stack,
   StackDivider,
-  Text
+  Text,
 } from "@chakra-ui/react";
 import { TFunction } from "i18next";
 import { InventoryResponse } from "@/util/types";
@@ -18,11 +18,11 @@ import { Trans } from "react-i18next/TransWithoutContext";
 import { MdArrowOutward } from "react-icons/md";
 
 const EmissionsWidgetCard = ({
-                               icon,
-                               value,
-                               field,
-                               showProgress
-                             }: {
+  icon,
+  value,
+  field,
+  showProgress,
+}: {
   icon: any;
   value?: number | undefined;
   field: any;
@@ -62,9 +62,9 @@ const EmissionsWidgetCard = ({
 };
 
 const EmissionsWidget = ({
-                                  t,
-                                  inventory
-                                }: {
+  t,
+  inventory,
+}: {
   t: Function & TFunction<"translation", undefined>;
   inventory?: InventoryResponse;
 }) => {
@@ -83,7 +83,7 @@ const EmissionsWidget = ({
       ),
       value: inventory?.totalEmissions,
       icon: MdArrowOutward,
-      showProgress: false
+      showProgress: false,
     },
     {
       id: "emissions-per-capita-in-year",
@@ -100,24 +100,24 @@ const EmissionsWidget = ({
           ? inventory?.totalEmissions / inventory?.city.population
           : undefined,
       icon: MdArrowOutward,
-      showProgress: false
+      showProgress: false,
     },
     {
       id: "% of country's emissions",
       field: t("%-of-country's-emissions"),
-      showProgress: true
+      showProgress: true,
       // TODO ON-2212 ON-1383 add value when available
-    }
+    },
   ];
   return (
-    <Box width={"18vw"} >
+    <Box width={"18vw"}>
       <Card padding={0}>
         <CardHeader>
           <Heading size="sm">{t("total-emissions")}</Heading>
         </CardHeader>
 
         <CardBody>
-          <Stack divider={<StackDivider />} >
+          <Stack divider={<StackDivider />}>
             {EmissionsData.map(({ id, field, value, icon, showProgress }) => (
               <EmissionsWidgetCard
                 key={id}

--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/TopEmissionsWidget.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/TopEmissionsWidget.tsx
@@ -12,24 +12,34 @@ import {
   Text,
   Th,
   Thead,
-  Tr
+  Tr,
 } from "@chakra-ui/react";
-import {TFunction} from "i18next";
-import {InventoryResponse, TopEmission} from "@/util/types";
-import {capitalizeFirstLetter, convertKgToTonnes} from "@/util/helpers";
-import {api} from "@/services/api";
-import groupBy from "lodash/groupBy";
-import {SegmentedProgress, SegmentedProgressValues} from "@/components/SegmentedProgress";
+import { TFunction } from "i18next";
+import type {InventoryResponse, SectorEmission, TopEmission} from "@/util/types";
+import { capitalizeFirstLetter, convertKgToTonnes } from "@/util/helpers";
+import { api } from "@/services/api";
+import {
+  SegmentedProgress,
+  SegmentedProgressValues,
+} from "@/components/SegmentedProgress";
 
-const EmissionsTable = ({ topEmissions, t }: { topEmissions: TopEmission[], t: TFunction }) => {
+const EmissionsTable = ({
+  topEmissions,
+  t,
+}: {
+  topEmissions: TopEmission[];
+  t: TFunction;
+}) => {
   return (
     <TableContainer my={4}>
       <Table variant="simple">
         <Thead>
           <Tr>
-            <Th sx={{ "font": "bold", color: "black" }}>{t("subsector")}</Th>
-            <Th sx={{ "font": "bold", color: "black" }}>{t("total-emissions-CO2eq")}</Th>
-            <Th sx={{ "font": "bold", color: "black" }}>{t("%-of-emissions")}</Th>
+            <Th sx={{ font: "bold", color: "black" }}>{t("subsector")}</Th>
+            <Th sx={{ font: "bold", color: "black" }}>
+              {t("total-emissions-CO2eq")}
+            </Th>
+            <Th sx={{ font: "bold", color: "black" }}>{t("%-of-emissions")}</Th>
           </Tr>
         </Thead>
         <Tbody>
@@ -39,12 +49,17 @@ const EmissionsTable = ({ topEmissions, t }: { topEmissions: TopEmission[], t: T
                 <Text
                   fontFamily="heading"
                   className="text-sm leading-5 tracking-[0.5px]"
-                >{emission.subsectorName}</Text>
+                >
+                  {emission.subsectorName}
+                </Text>
                 <Text
                   fontFamily="heading"
                   color="content.tertiary"
                   className="text-xs leading-4 tracking-[0.5px] "
-                  >{capitalizeFirstLetter(t("scope"))} {emission.scopeName} - {emission.sectorName} </Text>
+                >
+                  {capitalizeFirstLetter(t("scope"))} {emission.scopeName} -{" "}
+                  {emission.sectorName}{" "}
+                </Text>
               </Td>
               <Td>{convertKgToTonnes(emission.co2eq)}</Td>
               <Td>{emission.percentage}%</Td>
@@ -56,52 +71,60 @@ const EmissionsTable = ({ topEmissions, t }: { topEmissions: TopEmission[], t: T
   );
 };
 
-
 const TopEmissionsWidget = ({
-                              t,
-                              inventory
-                            }: {
+  t,
+  inventory,
+}: {
   t: Function & TFunction<"translation", undefined>;
   inventory?: InventoryResponse;
 }) => {
-
   const { data: results, isLoading: isTopEmissionsResponseLoading } =
     api.useGetResultsQuery(inventory!.inventoryId!);
 
   function getPercentagesForProgress(): SegmentedProgressValues[] {
-    // @ts-ignore
-    const grouped = (groupBy(results?.totalEmissions.bySector, e => e.sectorName)) as Record<string, [{
-      co2eq: bigint,
-      percentage: number
-    }]>;
-    const out = Object.entries(grouped || {}).map(([name, [{ co2eq, percentage }]]) => {
+    const bySector: SectorEmission[] = results?.totalEmissions.bySector ??  [];
+    return bySector.map(({sectorName, co2eq, percentage}) => {
       return {
-        name,
+        name: sectorName,
         value: co2eq,
         percentage: percentage
       } as SegmentedProgressValues;
     });
-    return out;
 
   }
 
   return (
     <HStack>
-      <Card  marginLeft={"4"} backgroundColor={"white"} p={4}>
-        {isTopEmissionsResponseLoading
-          ? <Center><CircularProgress isIndeterminate /></Center>
-          : <>
+      <Card marginLeft={"4"} backgroundColor={"white"} p={4}>
+        {isTopEmissionsResponseLoading ? (
+          <Center>
+            <CircularProgress isIndeterminate />
+          </Center>
+        ) : (
+          <>
             <Box>
-              <Heading size="sm" my={4}>{t("total-emissions")}</Heading>
+              <Heading size="sm" my={4}>
+                {t("total-emissions")}
+              </Heading>
             </Box>
-            <SegmentedProgress values={getPercentagesForProgress()} total={results!.totalEmissions.total} t={t}
-                               showLabels showHover />
-              <Box>
-                <Heading size="sm" marginTop={10} marginBottom={4}>{t("top-emissions")}</Heading>
-              </Box>
-            <EmissionsTable topEmissions={results!.topEmissions.bySubSector} t={t} />
+            <SegmentedProgress
+              values={getPercentagesForProgress()}
+              total={results!.totalEmissions.total}
+              t={t}
+              showLabels
+              showHover
+            />
+            <Box>
+              <Heading size="sm" marginTop={10} marginBottom={4}>
+                {t("top-emissions")}
+              </Heading>
+            </Box>
+            <EmissionsTable
+              topEmissions={results!.topEmissions.bySubSector}
+              t={t}
+            />
           </>
-        }
+        )}
       </Card>
     </HStack>
   );

--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/TopEmissionsWidget.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/TopEmissionsWidget.tsx
@@ -5,7 +5,6 @@ import {
   CircularProgress,
   Heading,
   HStack,
-  Select,
   Table,
   TableContainer,
   Tbody,
@@ -15,29 +14,12 @@ import {
   Thead,
   Tr
 } from "@chakra-ui/react";
-import { TFunction } from "i18next";
-import { InventoryResponse, TopEmission } from "@/util/types";
-import { capitalizeFirstLetter, convertKgToTonnes } from "@/util/helpers";
-import { api } from "@/services/api";
+import {TFunction} from "i18next";
+import {InventoryResponse, TopEmission} from "@/util/types";
+import {capitalizeFirstLetter, convertKgToTonnes} from "@/util/helpers";
+import {api} from "@/services/api";
 import groupBy from "lodash/groupBy";
-import { SegmentedProgress, SegmentedProgressValues } from "@/components/SegmentedProgress";
-
-const TitleAndSelector = ({ t }: { t: Function }) => {
-  return <HStack justifyContent="space-between">
-    <Box>
-      <Heading size="sm" marginTop={10} marginBottom={4}>{t("top-emissions")}</Heading>
-    </Box>
-    <Select width={"15vw"} my={2}
-    >
-      {["by-sub-sector"].map((grouping) => (
-        <option key={grouping} value={grouping}>
-          {t(grouping)}
-        </option>
-      ))}
-    </Select>
-  </HStack>;
-};
-
+import {SegmentedProgress, SegmentedProgressValues} from "@/components/SegmentedProgress";
 
 const EmissionsTable = ({ topEmissions, t }: { topEmissions: TopEmission[], t: TFunction }) => {
   return (
@@ -114,7 +96,9 @@ const TopEmissionsWidget = ({
             </Box>
             <SegmentedProgress values={getPercentagesForProgress()} total={results!.totalEmissions.total} t={t}
                                showLabels showHover />
-            <TitleAndSelector t={t} />
+              <Box>
+                <Heading size="sm" marginTop={10} marginBottom={4}>{t("top-emissions")}</Heading>
+              </Box>
             <EmissionsTable topEmissions={results!.topEmissions.bySubSector} t={t} />
           </>
         }

--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
@@ -8,14 +8,13 @@ import EmissionsWidget from "@/app/[lng]/[inventory]/InventoryResultTab/Emission
 import TopEmissionsWidget from "@/app/[lng]/[inventory]/InventoryResultTab/TopEmissionsWidget";
 import { BlueSubtitle } from "@/components/blue-subtitle";
 
-
 export default function InventoryResultTab({
-                                             lng,
-                                             inventory,
-                                             isUserInfoLoading,
-                                             isInventoryProgressLoading,
-                                             inventoryProgress
-                                           }: {
+  lng,
+  inventory,
+  isUserInfoLoading,
+  isInventoryProgressLoading,
+  inventoryProgress,
+}: {
   lng: string;
   inventory?: InventoryResponse;
   isUserInfoLoading?: boolean;
@@ -33,14 +32,17 @@ export default function InventoryResultTab({
             title={"tab-emission-inventory-results-title"}
           />
           <BlueSubtitle t={t} text={"overview"} />
-          <Heading fontSize="headline.sm" fontWeight="semibold"
-                   lineHeight="32">{t("Total Emissions in {{year}}", { year: inventory?.year })}</Heading>
+          <Heading fontSize="headline.sm" fontWeight="semibold" lineHeight="32">
+            {t("Total Emissions in {{year}}", { year: inventory?.year })}
+          </Heading>
           <Text
             fontWeight="regular"
             fontSize="body.lg"
             color="interactive.control"
             letterSpacing="wide"
-          >{t("see-your-citys-emissions")}</Text>
+          >
+            {t("see-your-citys-emissions")}
+          </Text>
           <HStack my={4} alignItems={"start"}>
             <EmissionsWidget t={t} inventory={inventory} />
             <TopEmissionsWidget t={t} inventory={inventory} />

--- a/app/src/util/types.d.ts
+++ b/app/src/util/types.d.ts
@@ -144,13 +144,15 @@ interface TopEmission {
   percentage: number;
 }
 
-interface ResultsResponse {
-  totalEmissions: {
-    bySector: {
+interface SectorEmission {
       sectorName: string;
       co2eq: bigint;
       percentage: number;
-    };
+}
+
+interface ResultsResponse {
+  totalEmissions: {
+    bySector: SectorEmission[];
     total: bigint;
   };
   topEmissions: { bySubSector: TopEmission[] };


### PR DESCRIPTION
Since there was only one option ("by-activity") is on hold, I'm removing the selector.

before:
![image](https://github.com/user-attachments/assets/93c74935-a7b9-47b5-b332-9339c0fbc768)

after:
![image](https://github.com/user-attachments/assets/51c68078-9370-4592-a755-359cd125d391)
