### PR TITLE
Gather total country emissions during onboarding and add to Inventory table

### DIFF
--- a/app/migrations/20241001024448-inventory-total-country-emissions.cjs
+++ b/app/migrations/20241001024448-inventory-total-country-emissions.cjs
@@ -1,0 +1,19 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn(
+      'Inventory',
+      'total_country_emissions',
+      {
+        type: Sequelize.BIGINT,
+        allowNull: true
+      }
+    );
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('Inventory', 'total_country_emissions');
+  }
+};

--- a/app/src/app/[lng]/onboarding/setup/page.tsx
+++ b/app/src/app/[lng]/onboarding/setup/page.tsx
@@ -74,6 +74,7 @@ type Inputs = {
   regionPopulationYear: number;
   countryPopulation: number;
   countryPopulationYear: number;
+  totalCountryEmissions: number;
 };
 
 type PopulationEntry = {
@@ -170,6 +171,7 @@ function SetupStep({
     setValue("regionYear", null);
     setValue("countryPopulation", null);
     setValue("countryYear", null);
+    setValue("totalCountryEmissions", null);
   }, [locode, setValue]);
 
   const { data: cityData } = useGetOCCityDataQuery(locode!, {
@@ -232,6 +234,14 @@ function SetupStep({
       }
       setValue("countryPopulation", population.population);
       setValue("countryPopulationYear", population.year);
+      const keys = Object.keys(countryData.emissions)
+      const id = keys.find(id => id.startsWith('UNFCCC'))
+      if (id) {
+        const emissionsData = countryData.emissions[id].data
+        const emissions =
+        emissionsData.find((e: any) => e.year === year)?.total_emissions
+        setValue("totalCountryEmissions", emissions)
+      }
     }
   }, [countryData, year, setValue]);
 
@@ -767,6 +777,7 @@ export default function OnboardingSetup({
         cityId: city?.cityId!,
         year: data.year,
         inventoryName: `${data.name} - ${data.year}`,
+        totalCountryEmissions: getValues("totalCountryEmissions"),
       }).unwrap();
       await setUserInfo({
         cityId: city?.cityId!,

--- a/app/src/app/[lng]/onboarding/setup/page.tsx
+++ b/app/src/app/[lng]/onboarding/setup/page.tsx
@@ -4,7 +4,7 @@ import RecentSearches from "@/components/recent-searches";
 import WizardSteps from "@/components/wizard-steps";
 import { set } from "@/features/city/openclimateCitySlice";
 import { useTranslation } from "@/i18n/client";
-import { useAppDispatch, useAppSelector } from "@/lib/hooks";
+import { useAppDispatch } from "@/lib/hooks";
 import type { CityAttributes } from "@/models/City";
 import {
   api,
@@ -81,6 +81,11 @@ type PopulationEntry = {
   year: number;
   population: number;
   datasource_id: string;
+};
+
+type CountryEmissionsEntry = {
+  year: number;
+  total_emissions: number;
 };
 
 type OnboardingData = {
@@ -234,13 +239,19 @@ function SetupStep({
       }
       setValue("countryPopulation", population.population);
       setValue("countryPopulationYear", population.year);
-      const keys = Object.keys(countryData.emissions)
-      const id = keys.find(id => id.startsWith('UNFCCC'))
-      if (id) {
-        const emissionsData = countryData.emissions[id].data
-        const emissions =
-        emissionsData.find((e: any) => e.year === year)?.total_emissions
-        setValue("totalCountryEmissions", emissions)
+      const keys = Object.keys(countryData.emissions);
+      const sourceId = keys.find((id) => id.startsWith("UNFCCC"));
+
+      if (sourceId) {
+        const emissionsData: CountryEmissionsEntry[] =
+          countryData.emissions[sourceId].data;
+        const emissions = emissionsData.find(
+          (e) => e.year === year,
+        )?.total_emissions;
+        if (emissions == null) {
+          console.error("Failed to find country emissions for ", year);
+        }
+        setValue("totalCountryEmissions", emissions);
       }
     }
   }, [countryData, year, setValue]);

--- a/app/src/models/Inventory.ts
+++ b/app/src/models/Inventory.ts
@@ -10,6 +10,7 @@ export interface InventoryAttributes {
   year?: number;
   totalEmissions?: number;
   cityId?: string;
+  totalCountryEmissions?: number;
 }
 
 export type InventoryPk = "inventoryId";
@@ -18,7 +19,8 @@ export type InventoryOptionalAttributes =
   | "inventoryName"
   | "year"
   | "totalEmissions"
-  | "cityId";
+  | "cityId"
+  | "totalCountryEmissions";
 export type InventoryCreationAttributes = Optional<
   InventoryAttributes,
   InventoryOptionalAttributes
@@ -33,6 +35,7 @@ export class Inventory
   year?: number;
   totalEmissions?: number;
   cityId?: string;
+  totalCountryEmissions?: number;
 
   // Inventory belongsTo City via cityId
   city!: City;
@@ -116,6 +119,11 @@ export class Inventory
             key: "city_id",
           },
           field: "city_id",
+        },
+        totalCountryEmissions: {
+          type: DataTypes.BIGINT,
+          allowNull: true,
+          field: "total_country_emissions",
         },
       },
       {

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -97,7 +97,12 @@ export const api = createApi({
     }),
     addInventory: builder.mutation<
       InventoryAttributes,
-      { cityId: string; year: number; inventoryName: string }
+      {
+        cityId: string;
+        year: number;
+        inventoryName: string;
+        totalCountryEmissions: number
+      }
     >({
       query: (data) => ({
         url: `/city/${data.cityId}/inventory`,

--- a/app/src/util/validation.ts
+++ b/app/src/util/validation.ts
@@ -32,6 +32,7 @@ export const createInventoryRequest = z.object({
   inventoryName: z.string().min(1),
   year: z.number().int().min(2000),
   totalEmissions: z.number().int().optional(),
+  totalCountryEmissions: z.number().int().optional(),
 });
 export type CreateInventoryRequest = z.infer<typeof createInventoryRequest>;
 


### PR DESCRIPTION
This PR adds an attribute to inventories for total country emissions.

During onboarding, it also gets the value of the country emissions for the given year, and saves it with the inventory.