### PR TITLE
On 2569 change initialize thread

### DIFF
--- a/app/src/app/api/v0/assistants/threads/[inventory]/retrieve/route.ts
+++ b/app/src/app/api/v0/assistants/threads/[inventory]/retrieve/route.ts
@@ -1,0 +1,22 @@
+import { apiHandler } from "@/util/api";
+import { setupOpenAI } from "@/util/openai";
+import { NextResponse } from "next/server";
+
+export const POST = apiHandler(async (req) => {
+  try {
+    const input = await req.json();
+
+    const threadId = input.threadId;
+
+    const openai = setupOpenAI();
+    const thread = await openai.beta.threads.retrieve(threadId);
+
+    return NextResponse.json({ thread: thread });
+  } catch (error) {
+    console.error("Error retrieving thread:", error);
+    return NextResponse.json(
+      { error: "Failed to retrieve thread." },
+      { status: 500 },
+    );
+  }
+});

--- a/app/src/app/api/v0/assistants/threads/messages/route.ts
+++ b/app/src/app/api/v0/assistants/threads/messages/route.ts
@@ -1,28 +1,8 @@
 import { apiHandler } from "@/util/api";
 import { setupOpenAI } from "@/util/openai";
-// import { AssistantStream } from "openai/lib/AssistantStream";
 import { NextResponse } from "next/server";
 
 const assistantId = process.env.OPENAI_ASSISTANT_ID as string;
-
-// Helper function for debugging
-// const handleReadableStream = (stream: AssistantStream): AssistantStream => {
-//   stream.on("textCreated", () => console.log("Created"));
-//   stream.on("textDelta", async (delta) => {
-//     // Make sure token has annotation value
-//     if (delta.annotations !== undefined && delta.annotations.length > 0) {
-//       // console.log(delta.value);
-//       // console.log(delta.annotations);
-//       // @ts-ignore
-//       const file_id = delta.annotations[0].file_citation.file_id;
-
-//       const citedFile = await openai.files.retrieve(file_id);
-//       console.log(citedFile.filename);
-//     }
-//   });
-
-//   return stream;
-// };
 
 // Send a new message to a thread
 export const POST = apiHandler(async (req) => {

--- a/app/src/components/ChatBot/chat-bot.tsx
+++ b/app/src/components/ChatBot/chat-bot.tsx
@@ -103,7 +103,6 @@ export default function ChatBot({
         inventoryId: inventoryId,
         content: t("initial-message"),
       }).unwrap();
-      console.log("Thread initialized with ID:", result);
 
       // Set the threadIdRef which gets set synchronously
       threadIdRef.current = result;

--- a/app/src/components/ChatBot/chat-bot.tsx
+++ b/app/src/components/ChatBot/chat-bot.tsx
@@ -96,7 +96,14 @@ export default function ChatBot({
     scrollToBottom();
   }, [messages]);
 
-  // Took function out of useEffect
+  // Create function here to store the threadIdRef in an database
+  const storeThreadId = async (threadId: string) => {
+    // Store the threadId in the database
+    console.log("Storing threadId in database", threadId);
+
+    // Implement logic here to store the threadId in the database
+  };
+
   const initializeThread = async () => {
     try {
       const result = await createThreadId({


### PR DESCRIPTION
I moved the initialization of the thread (communication with openAI assistant API) from rendering the chat component to sending a message. 
Now the initial answer will take slightly longer, but we do not create a lot of empty threads each time it gets rendered. 