### PR TITLE
[ON-2266] fix: hover population year

### DIFF
--- a/app/src/app/[lng]/[inventory]/page.tsx
+++ b/app/src/app/[lng]/[inventory]/page.tsx
@@ -386,7 +386,7 @@ export default function Home({ params: { lng } }: { params: { lng: string } }) {
                                   </Trans>
                                   <br />
                                   {t("population-year", {
-                                    year: inventory.city.populationYear,
+                                    year: population?.year,
                                   })}
                                 </>
                               }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c498251b-c598-4276-9d4b-a5f734b3fb9b)
 show the year on the population hover