### PR TITLE
fix(ui): replace portugal flag icon with brazil flag

### DIFF
--- a/app/src/components/navigation-bar.tsx
+++ b/app/src/components/navigation-bar.tsx
@@ -134,7 +134,11 @@ export function NavigationBar({
               minW="120px"
               leftIcon={
                 <CircleFlag
-                  countryCode={countryFromLanguage(i18next.language)}
+                  countryCode={
+                    countryFromLanguage(i18next.language) === "pt"
+                      ? "br"
+                      : countryFromLanguage(i18next.language)
+                  }
                   width="24"
                 />
               }
@@ -156,7 +160,11 @@ export function NavigationBar({
                   key={language}
                 >
                   <CircleFlag
-                    countryCode={countryFromLanguage(language)}
+                    countryCode={
+                      countryFromLanguage(language) === "pt"
+                        ? "br"
+                        : countryFromLanguage(language)
+                    }
                     width="24"
                     className="mr-4"
                   />


### PR DESCRIPTION
Changes
- Adds logic to resolve and place the portuguese flag icon with brazilian flag for the dropdown
- Adds the same logic for the selected portuguese flag

![image](https://github.com/user-attachments/assets/91b0606d-8dd6-4662-a874-a7f9390046dc)
