### PR TITLE
feat: use /api/v1/search/city in OpenClimate API

### DIFF
--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -658,7 +658,7 @@ export const openclimateAPI = createApi({
   }),
   endpoints: (builder) => ({
     getOCCity: builder.query<any, string>({
-      query: (q) => `/api/v1/search/actor?q=${q}`,
+      query: (q) => `/api/v1/search/city?q=${q}`,
       transformResponse: (response: any) => {
         return response.data.filter((item: any) => item.type === "city");
       },


### PR DESCRIPTION
Use the /api/v1/search/city endpoint for getting cities. This is faster, more accurate, and sorts the output by population (descending).

To test, go to the onboarding and search for a new city.