### PR TITLE
fix(ui): adds translation for new password label

### DIFF
--- a/app/src/app/[lng]/auth/update-password/page.tsx
+++ b/app/src/app/[lng]/auth/update-password/page.tsx
@@ -73,7 +73,7 @@ export default function UpdatePassword({
         <PasswordInput
           register={register}
           error={errors.password}
-          name="New Password"
+          name={t("new-password")}
           t={t}
         >
           <FormHelperText>

--- a/app/src/i18n/locales/en/auth.json
+++ b/app/src/i18n/locales/en/auth.json
@@ -54,6 +54,7 @@
 
   "update-password-heading": "Update your Password",
   "update-password-details": "Update your password. This is the one that you will use from now on.",
+  "new-password": "New Password",
   "reset-button": "Reset Password",
 
   "password-min-length": "Password must be at least 8 characters long.",

--- a/app/src/i18n/locales/es/auth.json
+++ b/app/src/i18n/locales/es/auth.json
@@ -35,6 +35,7 @@
 
   "forgot-password-heading": "¿Olvidaste tu contraseña?",
   "forgot-password-details": "Ingresa la dirección de correo electrónico que utilizaste cuando te registraste y te enviaremos instrucciones para restablecer tu contraseña.",
+  "new-password": "Nueva contraseña",
   "reset-password": "Restablecer contraseña",
   "cancel": "Cancelar",
 

--- a/app/src/i18n/locales/pt/auth.json
+++ b/app/src/i18n/locales/pt/auth.json
@@ -35,6 +35,7 @@
 
   "forgot-password-heading": "Esqueceu a Senha?",
   "forgot-password-details": "Insira o endereço de e-mail que você usou ao se registrar e enviaremos instruções para redefinir sua senha.",
+  "new-password": "Nova Senha",
   "reset-password": "Redefinir Senha",
   "cancel": "Cancelar",
 


### PR DESCRIPTION
Changes
- Adds translation string to update password - new password label
- Also adds translations for en, es, pt

![image](https://github.com/user-attachments/assets/6e00f3fb-a53a-4cd8-8d89-337c5c022962)
