### PR TITLE
fix: add ON DELETE CASCADE to foreign key of GasValue

### DIFF
--- a/app/migrations/20241210173228-gasvalue-activityvalue-on-delete-cascade.cjs
+++ b/app/migrations/20241210173228-gasvalue-activityvalue-on-delete-cascade.cjs
@@ -1,0 +1,36 @@
+
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+
+  async up(queryInterface, Sequelize) {
+    await queryInterface.removeConstraint('GasValue', 'FK_GasValue_activity_value_id');
+    await queryInterface.addConstraint('GasValue', {
+      fields: ['activity_value_id'],
+      type: 'foreign key',
+      name: 'FK_GasValue_activity_value_id',
+      references: {
+        table: 'ActivityValue',
+        field: 'id'
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeConstraint('GasValue', 'FK_GasValue_activity_value_id');
+    await queryInterface.addConstraint('GasValue', {
+      fields: ['activity_value_id'],
+      type: 'foreign key',
+      name: 'FK_GasValue_activity_value_id',
+      references: {
+        table: 'ActivityValue',
+        field: 'id'
+      },
+      onDelete: 'NO ACTION',
+      onUpdate: 'NO ACTION'
+    });
+  }
+};


### PR DESCRIPTION
We have an error in the deletion of ActivityValue entries because of the foreign key to GasValue.

This migration adds an ON DELETE CASCADE and ON UPDATE CASCADE to the foreign key.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add ON DELETE CASCADE action to the foreign key constraint on the `activity_value_id` column of the `GasValue` table in the database migration script.

### Why are these changes being made?

These changes ensure that when a related record in the `ActivityValue` table is deleted, the corresponding entries in the `GasValue` table will automatically be removed, maintaining referential integrity and preventing orphaned records. This decision mitigates potential data inconsistencies and adheres to best practices in relational database management.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->