### PR TITLE
[ON-2881] fix deletion of cities with invites

### DIFF
--- a/app/migrations/20241211143647-cityInvite_delete_cascade.cjs
+++ b/app/migrations/20241211143647-cityInvite_delete_cascade.cjs
@@ -1,0 +1,33 @@
+"use strict";
+
+const sql_up = `
+    alter table "CityInvite"
+    drop constraint "CityInvite_city_id_fkey";
+
+    ALTER TABLE "CityInvite"
+        ADD CONSTRAINT "CityInvite_city_id_fkey"
+            FOREIGN KEY (city_id)
+                REFERENCES "City" (city_id)
+                ON UPDATE CASCADE
+                ON DELETE CASCADE;
+`;
+
+const sql_down = `
+    ALTER TABLE "CityInvite" DROP CONSTRAINT "CityInvite_city_id_fkey";
+
+    ALTER TABLE "CityInvite"
+        ADD CONSTRAINT "CityInvite_city_id_fkey"
+            FOREIGN KEY (city_id)
+                REFERENCES "City" (city_id)
+    ;
+`;
+/** @type {import("sequelize-cli").Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(sql_up);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(sql_down);
+  },
+};


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement cascading delete for the "CityInvite" table by updating the foreign key constraint to allow invites to be automatically deleted when a city is removed.

### Why are these changes being made?

To ensure referential integrity and prevent orphaned records in the "CityInvite" table when a city is deleted, which resolves issues where invites remained without an associated city. This migration adjusts the foreign key constraint to cascade deletions, providing a cleaner and more automated maintenance process.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->