### PR TITLE
[ON-2853] restore scope 3 for basic+

### DIFF
--- a/app/src/util/constants.ts
+++ b/app/src/util/constants.ts
@@ -63,7 +63,7 @@ export const SECTORS: ISector[] = [
     icon: TbBuildingCommunity,
     inventoryTypes: {
       [InventoryTypeEnum.GPC_BASIC]: { scopes: [1, 2] },
-      [InventoryTypeEnum.GPC_BASIC_PLUS]: { scopes: [1, 2] }, // [ON-2853] restore scope 3
+      [InventoryTypeEnum.GPC_BASIC_PLUS]: { scopes: [1, 2, 3] },
     },
     testId: "stationary-energy-sector-card",
   },
@@ -75,7 +75,7 @@ export const SECTORS: ISector[] = [
     icon: BsTruck,
     inventoryTypes: {
       [InventoryTypeEnum.GPC_BASIC]: { scopes: [1, 2] },
-      [InventoryTypeEnum.GPC_BASIC_PLUS]: { scopes: [1, 2] }, // [ON-2853] restore scope 3
+      [InventoryTypeEnum.GPC_BASIC_PLUS]: { scopes: [1, 2, 3] },
     },
     testId: "transportation-sector-card",
   },


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Restore scope 3 in the inventory types for `GPC_BASIC_PLUS` within the constants file.

### Why are these changes being made?

The omission of scope 3 for `GPC_BASIC_PLUS` was identified as a regression issue needing rectification. This change reinstates the correct scope categories to align with the intended functionality and ensure comprehensive emissions tracking for `GPC_BASIC_PLUS`.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->