### PR TITLE
fix: translations for password rules; closes ON-3007

### DIFF
--- a/app/src/i18n/locales/es/auth.json
+++ b/app/src/i18n/locales/es/auth.json
@@ -55,5 +55,9 @@
 
   "update-password-heading": "Actualiza tu Contraseña",
   "update-password-details": "Actualiza tu contraseña. Esta es la que usarás a partir de ahora.",
-  "reset-button": "Restablecer contraseña"
+  "reset-button": "Restablecer contraseña",
+  "password-min-length-check": "Al menos {{length}} caracteres",
+  "password-upper-case-check": "Al menos una letra mayúscula",
+  "password-lower-case-check": "Al menos una letra minúscula",
+  "password-number-check": "Al menos un número"
 }

--- a/app/src/i18n/locales/pt/auth.json
+++ b/app/src/i18n/locales/pt/auth.json
@@ -55,5 +55,9 @@
 
   "update-password-heading": "Atualize sua Senha",
   "update-password-details": "Atualize sua senha. Esta é a que você usará a partir de agora.",
-  "reset-button": "Redefinir Senha"
+  "reset-button": "Redefinir Senha",
+  "password-min-length-check": "Pelo menos {{length}} caracteres",
+  "password-upper-case-check": "Pelo menos uma letra maiúscula",
+  "password-lower-case-check": "Pelo menos uma letra minúscula",
+  "password-number-check": "Pelo menos um número"
 }


### PR DESCRIPTION
This fixes a problem with untranslated prompts in the password reset UI.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add translations for password rule checks in Spanish and Portuguese localization files.

### Why are these changes being made?

These changes ensure that users receive password rule instructions in their preferred language, enhancing user understanding and experience. This update addresses the missing translations for password complexity requirements which are crucial for guiding users during password creation or updates.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->