### PR TITLE
ON-3073 sector percentages fix for basic+

### DIFF
--- a/app/src/backend/ResultsService.ts
+++ b/app/src/backend/ResultsService.ts
@@ -133,7 +133,7 @@ async function fetchTotalEmissionsBulk(
   return Object.entries(grouped).map(([inventoryId, records]) => {
     const emissions = records.map(({ co2eq, sector_name }) => ({
       sectorName: sector_name,
-      co2eq: bigIntToDecimal(co2eq),
+      co2eq: bigIntToDecimal(co2eq || 0),
     }));
 
     const sumOfEmissions = emissions.reduce(
@@ -188,7 +188,7 @@ async function fetchTopEmissionsBulk(
       .slice(0, 3)
       .map(({ co2eq, sector_name, subsector_name, scope_name }) => ({
         inventoryId,
-        co2eq: bigIntToDecimal(co2eq),
+        co2eq: bigIntToDecimal(co2eq || 0),
         sectorName: sector_name,
         subsectorName: subsector_name,
         scopeName: scope_name,
@@ -250,7 +250,7 @@ async function fetchActivitiesBulk(
       activitiesByInventory[inventoryId][sectorName] = filteredActivities.map(
         (record) => ({
           ...record,
-          co2eq: bigIntToDecimal(record.co2eq),
+          co2eq: bigIntToDecimal(record.co2eq || 0),
         }),
       );
     });
@@ -456,12 +456,12 @@ async function calculateThirdPartyEmissionsByScope(
     }
 
     const co2eq = value.co2eq ?? 0n;
-    const totalEmissions = bigIntToDecimal(co2eq);
+    const totalEmissions = bigIntToDecimal(co2eq || 0);
 
     return {
       activityTitle: "mixed-activities",
       scopes: {
-        [scopeName]: bigIntToDecimal(co2eq),
+        [scopeName]: bigIntToDecimal(co2eq || 0),
       },
       totalEmissions,
       percentage: 100,
@@ -519,10 +519,14 @@ const groupActivities = (
     "subsectorName",
   );
 
+  console.log(groupedBySubsector);
+
   return mapValues(groupedBySubsector, (subsectorActivities) => {
     const groupedByActivity = groupBy(subsectorActivities, (e) =>
       toKebabCase(e.activityTitle),
     );
+
+    console.log(groupedByActivity);
 
     return mapValues(groupedByActivity, (activityGroup) => {
       const groupedByUnit = groupBy(activityGroup, "activityUnits");

--- a/app/src/models/InventoryValue.ts
+++ b/app/src/models/InventoryValue.ts
@@ -28,7 +28,8 @@ export interface InventoryValueAttributes {
   subSectorId?: string;
   subCategoryId?: string;
   inventoryId?: string;
-  datasourceId?: string | null;
+  /** @deprecated moved to ActivityValue */
+  datasourceId?: string | null; // TODO remove
   created?: Date;
   lastUpdated?: Date;
 }

--- a/app/src/models/InventoryValue.ts
+++ b/app/src/models/InventoryValue.ts
@@ -29,7 +29,7 @@ export interface InventoryValueAttributes {
   subCategoryId?: string;
   inventoryId?: string;
   /** @deprecated moved to ActivityValue */
-  datasourceId?: string | null; // TODO remove
+  datasourceId?: string; // TODO remove
   created?: Date;
   lastUpdated?: Date;
 }


### PR DESCRIPTION
Now that scope 3 has been added to basic+ this pr includes changes to accommodate that

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor the calculation of subcategory counts for sectors to accurately account for inventory types, and mark the `datasourceId` field in the `InventoryValue` model as deprecated.

### Why are these changes being made?
The previous implementation of subcategory counting did not properly consider the specific scopes applicable to an inventory type, which could lead to incorrect sector percentages for GPC_BASIC_PLUS. The refactoring ensures that only applicable subcategories are counted based on inventory type, thus improving accuracy. Additionally, `datasourceId` has been moved to `ActivityValue`, and the field in the `InventoryValue` model is marked deprecated for eventual removal, reflecting data model changes for better organization.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->