### PR TITLE
[ON-3126] hide breakdown by activity

### DIFF
--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/ByScopeView.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/ByScopeView.tsx
@@ -12,12 +12,14 @@ import {
 import { ActivityDataByScope } from "@/util/types";
 import type { TFunction } from "i18next";
 import { convertKgToTonnes } from "@/util/helpers";
+import { InventoryTypeEnum, SECTORS } from "@/util/constants";
 
 interface ByScopeViewProps {
   data: ActivityDataByScope[];
   tData: TFunction;
   tDashboard: TFunction;
   sectorName: string;
+  inventoryType: InventoryTypeEnum;
 }
 
 const ByScopeView: React.FC<ByScopeViewProps> = ({
@@ -25,8 +27,11 @@ const ByScopeView: React.FC<ByScopeViewProps> = ({
   tData,
   tDashboard,
   sectorName,
+  inventoryType,
 }) => {
-  const scopes = sectorName === "waste" ? ["1", "3"] : ["1", "2"];
+  const scopes = SECTORS.find((s) => sectorName === s.name)!.inventoryTypes[
+    inventoryType
+  ].scopes;
   return (
     <ChakraProvider>
       <Box p={4}>

--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
@@ -135,11 +135,11 @@ function SectorTabs({
           const shouldShowTableByActivity =
             !isEmptyInventory &&
             !isResultsLoading &&
+            false && // ON-3126 restore view by activity
             selectedTableView === TableView.BY_ACTIVITY;
           const shouldShowTableByScope =
-            !isEmptyInventory &&
-            !isResultsLoading &&
-            selectedTableView === TableView.BY_SCOPE;
+            !isEmptyInventory && inventory && !isResultsLoading; // &&
+          // selectedTableView === TableView.BY_SCOPE; ON-3126 restore view by activity
           return (
             <TabPanel key={name}>
               {isTopEmissionsResponseLoading ? (
@@ -165,14 +165,14 @@ function SectorTabs({
                     >
                       {t("breakdown-of-sub-sector-emissions")}
                     </Text>
-                    <Box paddingBottom={"12px"}>
-                      <Selector
-                        options={[TableView.BY_ACTIVITY, TableView.BY_SCOPE]}
-                        value={selectedTableView}
-                        onChange={handleViewChange}
-                        t={t}
-                      />
-                    </Box>
+                    {/*<Box paddingBottom={"12px"}>*/}
+                    {/*  <Selector*/}
+                    {/*    options={[TableView.BY_ACTIVITY, TableView.BY_SCOPE]}*/}
+                    {/*    value={selectedTableView}*/}
+                    {/*    onChange={handleViewChange}*/}
+                    {/*    t={t}*/}
+                    {/*  />*/}
+                    {/*</Box>*/} [ON-3126 restore view by activity]
                   </HStack>
                   {isResultsLoading && <CircularProgress isIndeterminate />}
                   {isEmptyInventory && (

--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
@@ -93,7 +93,8 @@ function SectorTabs({
   };
 
   const isEmptyInventory =
-    Object.entries(sectorBreakdown?.byActivity || {}).length === 0;
+    Object.entries(sectorBreakdown?.byActivity || {}).length === 0 &&
+    Object.entries(sectorBreakdown?.byScope || {}).length === 0;
 
   return (
     <Tabs
@@ -194,6 +195,7 @@ function SectorTabs({
                   )}
                   {shouldShowTableByScope && (
                     <ByScopeView
+                      inventoryType={inventory.inventoryType}
                       data={sectorBreakdown!.byScope}
                       tData={tData}
                       tDashboard={t}

--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
@@ -166,14 +166,15 @@ function SectorTabs({
                     >
                       {t("breakdown-of-sub-sector-emissions")}
                     </Text>
-                    {/*<Box paddingBottom={"12px"}>*/}
-                    {/*  <Selector*/}
-                    {/*    options={[TableView.BY_ACTIVITY, TableView.BY_SCOPE]}*/}
-                    {/*    value={selectedTableView}*/}
-                    {/*    onChange={handleViewChange}*/}
-                    {/*    t={t}*/}
-                    {/*  />*/}
-                    {/*</Box>*/} [ON-3126 restore view by activity]
+                    {/*<Box paddingBottom={"12px"}>
+                      <Selector
+                        options={[TableView.BY_ACTIVITY, TableView.BY_SCOPE]}
+                        value={selectedTableView}
+                        onChange={handleViewChange}
+                        t={t}
+                      />
+                    </Box>
+                    {***[ON-3126 restore view by activity]*/}
                   </HStack>
                   {isResultsLoading && <CircularProgress isIndeterminate />}
                   {isEmptyInventory && (

--- a/app/src/backend/ResultsService.ts
+++ b/app/src/backend/ResultsService.ts
@@ -514,7 +514,7 @@ function calculateEmissionsByScope(
   });
 
   // Convert the activities object to an array
-  return Object.values(activities).map(convertEmissionsToStrings);
+  return Object.values(activities);
 }
 
 const groupActivities = (

--- a/app/src/backend/ResultsService.ts
+++ b/app/src/backend/ResultsService.ts
@@ -356,7 +356,7 @@ interface InventoryValuesBySectorByScope {
 
 /** Core Emissions Breakdown Function
  * Simplified version with only data by sector, not by activity. works for data inputted manually and from 3rd parties.
- * [ON-3126] restore byActivity */
+ * [ON-3126] restore byActivity:  bring back changes from commit 9584504412c2da47eeba2a8e3eaaa15c739e05bc*/
 export const getEmissionsBreakdownBatch = async (
   inventoryId: string,
   sectorName: string,

--- a/app/src/backend/ResultsService.ts
+++ b/app/src/backend/ResultsService.ts
@@ -321,7 +321,6 @@ const fetchInventoryValuesBySector = async (
   inventoryId: string,
   sectorName: string,
 ) => {
-  console.log("sectorName", JSON.stringify(sectorName, null, 2)); // TODO NINA
   const rawQuery = `
       SELECT iv.co2eq,
              ss.subsector_name,
@@ -335,7 +334,6 @@ const fetchInventoryValuesBySector = async (
       WHERE iv.inventory_id = (:inventoryId)
         AND LOWER(s.sector_name) = (:sectorName)
   `;
-  console.log("replace", JSON.stringify(sectorName.replace("-", " "), null, 2)); // TODO NINA
   const activitiesRaw: ActivityForSectorBreakdownRecords[] =
     await db.sequelize!.query(rawQuery, {
       replacements: { inventoryId, sectorName: sectorName.replace("-", " ") },
@@ -391,7 +389,6 @@ export const getEmissionsBreakdownBatch = async (
         };
       },
     );
-    console.log("resultsByScope", JSON.stringify(resultsByScope, null, 2)); // TODO NINA
     return { byScope: resultsByScope };
   } catch (error) {
     console.error("Error in getEmissionsBreakdownBatch:", error);
@@ -450,7 +447,7 @@ const getActivityDataValues = (
 const fetch3rdPartyInventoryValues = (inventoryId: string) => {
   const rawQuery = `SELECT iv.id,
                            iv.co2eq,
-                           scope.scope_name,
+                           scope.scope_name
                     FROM "InventoryValue" iv
                              JOIN "Sector" s ON iv.sector_id = s.sector_id
                              JOIN "SubSector" ss ON iv.sub_sector_id = ss.subsector_id

--- a/app/src/backend/ResultsService.ts
+++ b/app/src/backend/ResultsService.ts
@@ -10,7 +10,7 @@ import { bigIntToDecimal } from "@/util/big_int";
 import createHttpError from "http-errors";
 
 function sumBigIntBy(array: any[], fieldName: string): bigint {
-  return array.reduce((sum, item) => sum + item[fieldName], 0n);
+  return array.reduce((sum, item) => sum + BigInt(item[fieldName]), 0n);
 }
 
 function calculatePercentage(co2eq: Decimal, total: Decimal): number {

--- a/app/src/util/types.ts
+++ b/app/src/util/types.ts
@@ -18,13 +18,16 @@ import {
   FailedSourceResult,
   RemovedSourceResult,
 } from "@/backend/DataSourceService";
+import { InventoryType } from "./constants";
 
 export interface CitiesAndYearsResponse {
   city: CityAttributes;
   years: { year: number; inventoryId: string; lastUpdate: Date }[];
 }
 
-export type InventoryResponse = InventoryAttributes & {
+interface RequiredInventoryAttributes extends Required<InventoryAttributes> {}
+
+export type InventoryResponse = RequiredInventoryAttributes & {
   city: CityAttributes & {
     populationYear: number;
     population: number;


### PR DESCRIPTION
fixes the scope name from  PR https://github.com/Open-Earth-Foundation/CityCatalyst/pull/971
removes the "by activity" logic
fixes the bug where 3rd party data wasn't shown in the "by scope" view

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Hide the breakdown by activity view in the inventory results section and adjust the logic to only display the breakdown by scope, along with restructuring the data processing methods to exclude activity data aggregation.

### Why are these changes being made?
This change addresses task ON-3126, which requires hiding the breakdown view by activity to streamline the inventory output. The decision to focus only on scope-based data presentation is aimed at simplifying the data flow and ensuring efficient resource usage, especially as activity data handling has been found less critical. Restorability measures are indicated in the comments to facilitate potential future adjustments.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->