### PR TITLE
WIP: feat: add a custom server for logging ON-3130

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -67,6 +67,7 @@
         "pg-hstore": "^2.3.4",
         "pigeon-maps": "^0.21.6",
         "pino": "^9.3.2",
+        "pino-http": "^10.3.0",
         "postcss": "8.4.31",
         "react": "18.3.1",
         "react-circle-flags": "^0.0.20",
@@ -22862,6 +22863,17 @@
       "dependencies": {
         "readable-stream": "^4.0.0",
         "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-http": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-10.3.0.tgz",
+      "integrity": "sha512-kaHQqt1i5S9LXWmyuw6aPPqYW/TjoDPizPs4PnDW4hSpajz2Uo/oisNliLf7We1xzpiLacdntmw8yaZiEkppQQ==",
+      "dependencies": {
+        "get-caller-file": "^2.0.5",
+        "pino": "^9.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^4.0.0"
       }
     },
     "node_modules/pino-std-serializers": {

--- a/app/package.json
+++ b/app/package.json
@@ -93,6 +93,7 @@
     "pg-hstore": "^2.3.4",
     "pigeon-maps": "^0.21.6",
     "pino": "^9.3.2",
+    "pino-http": "^10.3.0",
     "postcss": "8.4.31",
     "react": "18.3.1",
     "react-circle-flags": "^0.0.20",

--- a/app/server.ts
+++ b/app/server.ts
@@ -1,0 +1,42 @@
+import { createServer } from "http";
+import { parse } from "url";
+import next from "next";
+import pinoHttp from "pino-http";
+import { IncomingMessage } from "http";
+import nextConfig from "./next.config.mjs";
+
+const port = parseInt(process.env.PORT || "3000", 10);
+const dev = process.env.NODE_ENV !== "production";
+const app = next({ dev, conf: nextConfig });
+const handle = app.getRequestHandler();
+
+const httpLogger = pinoHttp({
+  customLogLevel: (
+    req: IncomingMessage,
+    res: any,
+    err: Error | undefined,
+  ): string => {
+    if (err || (res && res.statusCode && res.statusCode >= 500)) {
+      return "error";
+    } else if (res && res.statusCode && res.statusCode >= 400) {
+      return "warn";
+    } else {
+      return "info";
+    }
+  },
+});
+
+app.prepare().then(() => {
+  createServer((req, res) => {
+    httpLogger(req, res, () => {
+      const parsedUrl = parse(req.url!, true);
+      handle(req, res, parsedUrl);
+    });
+  }).listen(port);
+
+  console.log(
+    `> Server listening at http://localhost:${port} as ${
+      dev ? "development" : process.env.NODE_ENV
+    }`,
+  );
+});


### PR DESCRIPTION
The only way I could find to get logging of all our HTTP requests was to create a custom server that loads NextJS itself. 

https://nextjs.org/docs/pages/building-your-application/configuring/custom-server

I don't think this is the path we want to take; it means we lose a lot of NextJS features.

The next best solution I've seen is patching the NextJS library and adding your logging code directly to it! Which is definitely a lot worse.

If someone else gets a good idea of how to do detailed server-side logging on the app, please let me know. Right now I'm stumped.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add a custom server for logging HTTP requests using `pino-http` in the `server.ts` file and update dependencies accordingly in `package.json` and `package-lock.json`.

### Why are these changes being made?
These changes introduce structured logging to our server for better monitoring and debugging capabilities, using `pino-http` for efficient HTTP request logs. This enhancement aligns with ON-3130 user story requirements, ensuring that any errors and significant events can be logged at appropriate levels for improved observability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->