### PR TITLE
fix(api): ON-3122 prevent duplicate InventoryValues

### DIFF
--- a/app/src/backend/ActivityService.ts
+++ b/app/src/backend/ActivityService.ts
@@ -228,6 +228,16 @@ export default class ActivityService {
       inventoryValueId,
     });
 
+    // check if there is an existing InventoryValue for the reference number
+    const inventoryValue = await db.models.InventoryValue.findOne({
+      where: { id: inventoryValueId },
+    });
+    if (inventoryValue && inventoryValueId == undefined) {
+      throw new createHttpError.BadRequest(
+        `Inventory value for reference number ${inventoryValue.gpcReferenceNumber} already exists`,
+      );
+    }
+
     return await db.sequelize?.transaction(
       async (transaction: Transaction): Promise<ActivityValue> => {
         if (inventoryValueId && inventoryValueParams) {

--- a/app/src/backend/ActivityService.ts
+++ b/app/src/backend/ActivityService.ts
@@ -229,12 +229,17 @@ export default class ActivityService {
     });
 
     // check if there is an existing InventoryValue for the reference number
-    const inventoryValue = await db.models.InventoryValue.findOne({
-      where: { id: inventoryValueId },
-    });
-    if (inventoryValue && inventoryValueId == undefined) {
+    if (!inventoryValueId && !inventoryValueParams) {
       throw new createHttpError.BadRequest(
-        `Inventory value for reference number ${inventoryValue.gpcReferenceNumber} already exists`,
+        "Either inventoryValueId or inventory must be provided",
+      );
+    }
+    const existingInventoryValue = await db.models.InventoryValue.findOne({
+      where: { gpcReferenceNumber: inventoryValueParams?.gpcReferenceNumber },
+    });
+    if (existingInventoryValue && !inventoryValueId) {
+      throw new createHttpError.BadRequest(
+        `Inventory value for reference number ${existingInventoryValue.gpcReferenceNumber} already exists`,
       );
     }
 


### PR DESCRIPTION
If somebody else had added a data source to your inventory but you hadn't reloaded your page yet, this would lead to you being able to add another InventoryValue for the same GPC refno as the frontend state was inconsistent.

This PR prevents this in the backend by throwing an error if no inventoryValueId was passed but there is an existing value in the DB for the given GPC reference number.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add validation to prevent the creation of duplicate InventoryValues based on the `gpcReferenceNumber` in `ActivityService.ts`.

### Why are these changes being made?

This change addresses a bug (ON-3122) where multiple InventoryValues could be created with the same `gpcReferenceNumber`, leading to data inconsistencies. By checking for existing entries before creating a new InventoryValue, we ensure data integrity and prevent potential errors down the line.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->