### PR TITLE
fix(api): don't return a 404 error when no emissions factors are found

### DIFF
--- a/app/src/app/api/v0/emissions-factor/route.ts
+++ b/app/src/app/api/v0/emissions-factor/route.ts
@@ -110,9 +110,5 @@ export const POST = apiHandler(async (req: NextRequest, _context: {}) => {
     ["world", parsedLocode].includes(actorId as string),
   );
 
-  if (output.length === 0) {
-    throw new createHttpError.NotFound("Emissions factors not found");
-  }
-
   return NextResponse.json({ data: output });
 });


### PR DESCRIPTION
The API route `/api/v0/emissions-factor` now returns an empty array instead of a 404 error when no emissions factors are found.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the 404 error when no emissions factors are found and ensure the API returns a JSON response with an empty data set instead.

### Why are these changes being made?

Previously, the API would return a 404 error if no emissions factors were found, which implied client error, though it is valid for some queries to yield no results. Returning an empty JSON makes the API more robust and offers an accurate representation of a search that yields no data, facilitating better client handling of such cases.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->