### PR TITLE
[ON-3137] fix bigint conversion

### DIFF
--- a/app/src/backend/ActivityService.ts
+++ b/app/src/backend/ActivityService.ts
@@ -352,7 +352,8 @@ export default class ActivityService {
               gasValue.gasAmount = BigInt(
                 gases
                   .find((gas) => gas.gas === gasValue.gas)
-                  ?.amount?.toNumber() ?? 0,
+                  ?.amount?.toNumber()
+                  .toFixed(0) ?? 0,
               );
             }
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the conversion of a BigInt from a floating-point number by using the `toFixed(0)` method to ensure no fractional part remains before conversion.

### Why are these changes being made?

The changes address a bug where fractional values could inadvertently affect conversion to BigInt, potentially causing errors or incorrect gas amount calculations. Using `toFixed(0)` ensures the number is properly formatted as an integer string, eliminating fractions before `BigInt` conversion, and thus enhancing reliability and correctness in gas processing logic.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->