### PR TITLE
[ON-3137] fix bigint conversion

### DIFF
--- a/app/src/backend/ActivityService.ts
+++ b/app/src/backend/ActivityService.ts
@@ -352,7 +352,8 @@ export default class ActivityService {
               gasValue.gasAmount = BigInt(
                 gases
                   .find((gas) => gas.gas === gasValue.gas)
-                  ?.amount?.toNumber() ?? 0,
+                  ?.amount?.toNumber()
+                  .toFixed(0) ?? 0,
               );
             }
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the conversion of the `amount` to a number before converting to BigInt in `ActivityService.ts` by using `toFixed(0)`.

### Why are these changes being made?

The previous conversion method might have led to precision issues or conversion errors since `toNumber()` alone might not provide the desired integer format for BigInt conversion. Using `toFixed(0)` ensures the `amount` is properly formatted as an integer string before conversion, thus preventing potential runtime errors or incorrect values.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->