### PR TITLE
fix: correct units difference between country and city total emissions

### DIFF
--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsWidget.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsWidget.tsx
@@ -72,9 +72,10 @@ const EmissionsWidget = ({
   inventory?: InventoryResponse;
   population?: PopulationAttributes;
 }) => {
+  // Country total is in tonnes, inventory total is in kg
   const percentageOfCountrysEmissions =
     inventory?.totalEmissions && inventory?.totalCountryEmissions
-      ? (inventory.totalEmissions / inventory.totalCountryEmissions) * 100
+      ? (inventory.totalEmissions / (inventory.totalCountryEmissions * 1000)) * 100
       : undefined;
   const emissionsPerCapita =
     inventory?.totalEmissions && population?.population


### PR DESCRIPTION
The units we pull from OpenClimate for total country emissions are in tonnes, and we use kilograms in CityCatalyst. I updated the display code to correct it.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the units difference between country total emissions and city total emissions by converting the country total emissions from tonnes to kilograms for accurate percentage calculation.

### Why are these changes being made?

Previously, there was a unit mismatch where country emissions were in tonnes, and city emissions were in kilograms, causing incorrect percentage calculations. By multiplying the country emissions by 1000, both values are now in kilograms, ensuring accurate comparison and calculation.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->