### PR TITLE
[ON-3144] fix save multiple direct measures

### DIFF
--- a/app/src/backend/ActivityService.ts
+++ b/app/src/backend/ActivityService.ts
@@ -243,6 +243,16 @@ export default class ActivityService {
       );
     }
 
+    if (!inventoryValueId) {
+      const existingInventoryValue = await db.models.InventoryValue.findOne({
+        where: { gpcReferenceNumber: inventoryValueParams?.gpcReferenceNumber },
+      });
+      if (existingInventoryValue) {
+        throw new createHttpError.BadRequest(
+          `Inventory value for reference number ${existingInventoryValue.gpcReferenceNumber} already exists`,
+        );
+      }
+    }
     return await db.sequelize?.transaction(
       async (transaction: Transaction): Promise<ActivityValue> => {
         if (inventoryValueId && inventoryValueParams) {


### PR DESCRIPTION
The request has either inventoryValueId or inventoryValueParams, never both. When  inventoryValueId was present, we got undefined on the gpcReferenceNumber and the funtion failed. We should only look for InventoryValue by gpcReferenceNumber if we don't already have the inventoryValueId


<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add logic to check for existing inventory values by `gpcReferenceNumber` before saving multiple direct measures in `ActivityService.ts`, and throw a `BadRequest` error if a duplicate is found.

### Why are these changes being made?

These changes prevent duplicate inventory values from being saved when the `gpcReferenceNumber` already exists in the database, which resolves a problem where multiple entries could inadvertently lead to data inconsistencies or errors during processing of direct measures. This approach ensures that each `gpcReferenceNumber` remains unique, maintaining data integrity.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->