### PR TITLE
[ON-3037] fix emissions breakdown when there's an NA activity

### DIFF
--- a/app/src/backend/ResultsService.ts
+++ b/app/src/backend/ResultsService.ts
@@ -371,7 +371,7 @@ const fetchInventoryValuesBySector = async (
                JOIN "SubSector" ss ON iv.sub_sector_id = ss.subsector_id
                LEFT JOIN "SubCategory" sc ON iv.sub_category_id = sc.subcategory_id
                JOIN "Scope" scope ON scope.scope_id = sc.scope_id OR ss.scope_id = scope.scope_id
-      WHERE iv.inventory_id = (:inventoryId)
+      WHERE iv.inventory_id = (:inventoryId) and iv.co2eq IS NOT NULL
         AND (s.sector_name) = (:sectorName)
       GROUP BY ss.subsector_name, scope.scope_name
   `;


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the emissions breakdown by excluding inventory values where CO2eq is NULL.

### Why are these changes being made?

An issue was identified where activities with a NULL CO2eq value were incorrectly being included in emissions breakdown results, leading to "cannot convert null to bigint". The condition `iv.co2eq IS NOT NULL` ensures only relevant data is considered in the calculations, thereby improving the accuracy of the emissions breakdown.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->