### PR TITLE
fix(ui, api): ON-3035 show based on previous year as N/A 

### DIFF
--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionBySectorTable.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionBySectorTable.tsx
@@ -24,13 +24,18 @@ import { toKebabCaseModified } from "@/app/[lng]/[inventory]/InventoryResultTab/
 
 interface EmissionBySectorTableProps {
   data: {
-    bySector: SectorEmission[];
+    bySector: ExtendedSectorEmission[];
     year: number;
     inventoryId: string;
   }[];
 
   lng: string;
 }
+
+type ExtendedSectorEmission = SectorEmission & {
+  percentageChange: number | null;
+  totalInventoryPercentage: number;
+};
 
 const EmissionBySectorTableSection: React.FC<EmissionBySectorTableProps> = ({
   data,
@@ -39,7 +44,7 @@ const EmissionBySectorTableSection: React.FC<EmissionBySectorTableProps> = ({
   const { t: tData } = useTranslation(lng, "data");
 
   const renderTable = (item: {
-    bySector: SectorEmission[];
+    bySector: ExtendedSectorEmission[];
     year: number;
     inventoryId: string;
   }) => {
@@ -63,35 +68,41 @@ const EmissionBySectorTableSection: React.FC<EmissionBySectorTableProps> = ({
           </Thead>
           <Tbody>
             {item.bySector?.map((sectorBreakDown, i) => {
-              const hasNotEqualToZero = sectorBreakDown.percentage !== 0;
+              const hasNonZero =
+                sectorBreakDown.percentageChange !== 0 &&
+                sectorBreakDown.percentageChange != null;
+
+              let previousYearDifference = "N/A";
+              if (sectorBreakDown.percentageChange != null) {
+                previousYearDifference =
+                  sectorBreakDown.percentageChange.toFixed(0) + "%";
+              }
+
               return (
                 <Tr key={i} isTruncated>
                   <Td>
                     {tData(toKebabCaseModified(sectorBreakDown.sectorName))}
                   </Td>
                   <Td>{convertKgToTonnes(sectorBreakDown.co2eq)}</Td>
-                  <Td>{sectorBreakDown.percentage}%</Td>
+                  <Td>{sectorBreakDown.totalInventoryPercentage}%</Td>
                   <Td
                     className="flex items-center"
                     color={
-                      sectorBreakDown.percentage < 0
+                      (sectorBreakDown.percentageChange ?? 0) < 0
                         ? "sentiment.positiveDefault"
-                        : hasNotEqualToZero
+                        : hasNonZero
                           ? "sentiment.negativeDefault"
                           : "black"
                     }
                   >
-                    {hasNotEqualToZero &&
-                      (sectorBreakDown.percentage < 0 ? (
+                    {sectorBreakDown.percentageChange != null &&
+                      hasNonZero &&
+                      (sectorBreakDown.percentageChange < 0 ? (
                         <Icon as={MdArrowDropDown} />
                       ) : (
                         <Icon as={MdArrowDropUp} />
                       ))}
-                    <Text>
-                      {hasNotEqualToZero
-                        ? `${sectorBreakDown.percentage.toFixed(0)}%`
-                        : "N/A"}
-                    </Text>
+                    <Text>{previousYearDifference}</Text>
                   </Td>
                 </Tr>
               );

--- a/app/src/backend/ActivityService.ts
+++ b/app/src/backend/ActivityService.ts
@@ -234,19 +234,7 @@ export default class ActivityService {
         "Either inventoryValueId or inventory must be provided",
       );
     }
-    const existingInventoryValue = await db.models.InventoryValue.findOne({
-      where: {
-        gpcReferenceNumber: inventoryValueParams?.gpcReferenceNumber,
-        inventoryId,
-      },
-    });
-    if (existingInventoryValue && !inventoryValueId) {
-      throw new createHttpError.BadRequest(
-        `Inventory value for reference number ${existingInventoryValue.gpcReferenceNumber} already exists`,
-      );
-    }
-
-    if (!inventoryValueId) {
+    if (inventoryValueParams) {
       const existingInventoryValue = await db.models.InventoryValue.findOne({
         where: {
           gpcReferenceNumber: inventoryValueParams?.gpcReferenceNumber,
@@ -259,6 +247,7 @@ export default class ActivityService {
         );
       }
     }
+
     return await db.sequelize?.transaction(
       async (transaction: Transaction): Promise<ActivityValue> => {
         if (inventoryValueId && inventoryValueParams) {

--- a/app/src/components/HomePage/TabHeader.tsx
+++ b/app/src/components/HomePage/TabHeader.tsx
@@ -54,6 +54,7 @@ export function TabHeader({
               fontSize="headline.sm"
               fontWeight="semibold"
               lineHeight="32"
+              pb={3}
             >
               {t(title)}
             </Heading>


### PR DESCRIPTION
Fixes the following issues:
- 0 values were displayed as N/A
- Year over year percentages weren't displayed correctly
- ON-3144 Can't save a second ActivityValue for a given GPC refno
- % of emissions and based on previous year column always had the same values with different formatting
- missing padding below tab heading on dashboard

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the `EmissionBySectorTable` to handle percentage changes and total inventory percentages appropriately, ensure previous year comparisons show "N/A" when applicable, and streamline the `ActivityService` logic for checking existing inventory values.

### Why are these changes being made?

These changes address issue ON-3035 by ensuring that comparisons to previous year data result in displaying "N/A" when no previous data is available, thus preventing misleading zero values for percentage changes. The refactoring in `ActivityService` enhances code clarity and eliminates redundancy when checking for existing inventory values, improving functionality and readability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->