### PR TITLE
fix(ui): properly update inventory total and other caches

### DIFF
--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -236,7 +236,13 @@ export const api = createApi({
       }),
       transformResponse: (response: { data: InventoryValueAttributes }) =>
         response.data,
-      invalidatesTags: ["InventoryProgress", "InventoryValue"],
+      invalidatesTags: [
+        "Inventory",
+        "InventoryProgress",
+        "InventoryValue",
+        "ReportResults",
+        "YearlyReportResults",
+      ],
     }),
     connectDataSource: builder.mutation<
       ConnectDataSourceResponse,
@@ -249,7 +255,13 @@ export const api = createApi({
       }),
       transformResponse: (response: { data: ConnectDataSourceResponse }) =>
         response.data,
-      invalidatesTags: ["InventoryProgress"],
+      invalidatesTags: [
+        "Inventory",
+        "InventoryProgress",
+        "InventoryValue",
+        "ReportResults",
+        "YearlyReportResults",
+      ],
     }),
     updateOrCreateInventoryValue: builder.mutation<
       InventoryValueAttributes,
@@ -564,6 +576,7 @@ export const api = createApi({
       }),
       transformResponse: (response: any) => response.data,
       invalidatesTags: [
+        "Inventory",
         "ActivityValue",
         "InventoryValue",
         "InventoryProgress",
@@ -588,6 +601,7 @@ export const api = createApi({
       }),
       transformResponse: (response: any) => response.data,
       invalidatesTags: [
+        "Inventory",
         "ActivityValue",
         "InventoryValue",
         "InventoryProgress",
@@ -603,12 +617,13 @@ export const api = createApi({
       }),
       transformResponse: (response: { success: boolean }) => response,
       invalidatesTags: [
+        "Inventory",
         "ActivityValue",
         "InventoryValue",
         "InventoryProgress",
         "ReportResults",
-        "SectorBreakdown",
         "YearlyReportResults",
+        "SectorBreakdown",
       ],
     }),
     deleteAllActivityValues: builder.mutation({
@@ -626,6 +641,7 @@ export const api = createApi({
       }),
       transformResponse: (response: any) => response.data,
       invalidatesTags: [
+        "Inventory",
         "ActivityValue",
         "InventoryValue",
         "InventoryProgress",


### PR DESCRIPTION
When either data sources are connected/ disconnected or inventory values are changed or activity values are changed, update the following caches (tags) in Redux Toolkit:
- inventory total
- inventory progress
- inventory values
- report results
- yearly report results

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update cache invalidation tags in the API service to ensure proper refresh of inventory total and related data.

### Why are these changes being made?

The cache invalidation mechanism needed consistency to ensure that updates to inventory and report data reflect immediately in the UI. This change addresses discrepancies in data shown by invalidating all relevant caches when certain mutations are performed.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->