### PR TITLE
fix(ui): crash on public dashboard when targetYears wasn't loaded yet

### DIFF
--- a/app/src/util/helpers.ts
+++ b/app/src/util/helpers.ts
@@ -366,3 +366,7 @@ const compareGpcRefNumbers = (a: string, b: string) => {
 export const sortGpcReferenceNumbers = (refNumbers: string[]): string[] => {
   return [...refNumbers].sort(compareGpcRefNumbers);
 };
+
+export const isEmptyObject = (obj: Record<string, any>) => {
+  return Object.keys(obj).length === 0 && obj.constructor === Object;
+};


### PR DESCRIPTION
Fixes this error on the public dashboard (and probably normal dashboard too):

![image](https://github.com/user-attachments/assets/85d2821b-1e43-48ce-9e4d-36d2a5beaec9)

Although it occurs rarely because it depends on the order that the API requests resolve in and is fixed when the data is cached, so fixed by a reload.

Nicer to have it work immediately though :sweat_smile:

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a check for empty `targetYears` object to prevent a crash when data isn't loaded yet on the public dashboard, and introduce a utility function `isEmptyObject` to aid in this validation.

### Why are these changes being made?

The changes ensure that the application doesn't crash when `targetYears` data is absent by checking for an empty object before processing. This approach prevents potential null reference errors and adds robustness through code validation and error logging, thereby enhancing user experience on the public dashboard.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->