### PR TITLE
[ON-3157] fix wrong unit in 3rd party drawer

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/[step]/SourceDrawer.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/SourceDrawer.tsx
@@ -60,8 +60,10 @@ export function SourceDrawer({
   t: TFunction;
 }) {
   const emissionsToBeIncluded = () => {
+    let number, unit;
+    let converted;
     if (!!totalEmissionsData && totalEmissionsData !== "?") {
-      return convertKgToTonnes(parseFloat(totalEmissionsData));
+      converted = convertKgToTonnes(parseFloat(totalEmissionsData));
     }
     const emissionsData = sourceData?.totals?.emissions?.co2eq_100yr;
     let totalEmissions = emissionsData
@@ -71,9 +73,15 @@ export function SourceDrawer({
       totalEmissions = "?";
     }
     if (!!totalEmissions && totalEmissions !== "?") {
-      return convertKgToTonnes(parseInt(totalEmissions));
+      converted = convertKgToTonnes(parseInt(totalEmissions));
     }
-    return totalEmissionsData ?? totalEmissions;
+    if (!converted) {
+      return { number: totalEmissionsData ?? totalEmissions, unit: "" };
+    }
+    return {
+      number: converted.split(" ")[0],
+      unit: converted.split(" ").slice(1).join(" "),
+    };
   };
   return (
     <Drawer
@@ -175,7 +183,7 @@ export function SourceDrawer({
 
               <HStack align="baseline">
                 <Heading fontSize="57px" lineHeight="64px">
-                  {emissionsToBeIncluded().split(" ")[0]}
+                  {emissionsToBeIncluded().number}
                 </Heading>
                 <Text
                   color="content.tertiary"
@@ -184,7 +192,7 @@ export function SourceDrawer({
                   fontFamily="heading"
                   fontWeight={600}
                 >
-                  {emissionsToBeIncluded().split(" ").slice(1).join(" ")}
+                  {emissionsToBeIncluded().unit}
                 </Text>
               </HStack>
 

--- a/app/src/app/[lng]/[inventory]/data/[step]/SourceDrawer.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/SourceDrawer.tsx
@@ -32,6 +32,7 @@ import type { DataSourceData, DataSourceWithRelations } from "./types";
 import { DataCheckIcon, ScaleIcon } from "@/components/icons";
 import { FiTarget } from "react-icons/fi";
 import { getTranslationFromDict } from "@/i18n";
+import { convertKgToTonnes } from "@/util/helpers";
 
 export function SourceDrawer({
   source,
@@ -58,14 +59,22 @@ export function SourceDrawer({
   totalEmissionsData?: string;
   t: TFunction;
 }) {
-  const emissionsData = sourceData?.totals?.emissions?.co2eq_100yr;
-  let totalEmissions = emissionsData
-    ? ((Number(emissionsData) * sourceData?.scaleFactor) / 1000).toFixed(2)
-    : "?";
-  if (sourceData?.issue) {
-    totalEmissions = "?";
-  }
-
+  const emissionsToBeIncluded = () => {
+    if (!!totalEmissionsData && totalEmissionsData !== "?") {
+      return convertKgToTonnes(parseFloat(totalEmissionsData));
+    }
+    const emissionsData = sourceData?.totals?.emissions?.co2eq_100yr;
+    let totalEmissions = emissionsData
+      ? ((Number(emissionsData) * sourceData?.scaleFactor) / 1000).toFixed(2)
+      : "?";
+    if (sourceData?.issue) {
+      totalEmissions = "?";
+    }
+    if (!!totalEmissions && totalEmissions !== "?") {
+      return convertKgToTonnes(parseInt(totalEmissions));
+    }
+    return totalEmissionsData ?? totalEmissions;
+  };
   return (
     <Drawer
       isOpen={isOpen}
@@ -166,9 +175,7 @@ export function SourceDrawer({
 
               <HStack align="baseline">
                 <Heading fontSize="57px" lineHeight="64px">
-                  {t("intlNumber", {
-                    val: totalEmissionsData ?? totalEmissions,
-                  })}
+                  {emissionsToBeIncluded().split(" ")[0]}
                 </Heading>
                 <Text
                   color="content.tertiary"
@@ -177,7 +184,7 @@ export function SourceDrawer({
                   fontFamily="heading"
                   fontWeight={600}
                 >
-                  TCO2e
+                  {emissionsToBeIncluded().split(" ").slice(1).join(" ")}
                 </Text>
               </HStack>
 

--- a/app/src/i18n/locales/de/data.json
+++ b/app/src/i18n/locales/de/data.json
@@ -309,7 +309,6 @@
   "file-deletion-error-description": "Etwas ist während der Dateilöschung schief gelaufen",
   "file-deletion-success": "Datei erfolgreich gelöscht",
   "coming-soon": "Bald Verfügbar",
-  "intlNumber": "{{val, Nummer}}",
   "fuel-combustion-residential-buildings-direct-measure-methodology": "Direkte Messung",
   "energy-consumption-residential-buildings-direct-measure-methodology": "Direkte Messung",
   "fuel-consumption-commercial-buildings-direct-measure-methodology": "Direkte Messung",

--- a/app/src/i18n/locales/en/data.json
+++ b/app/src/i18n/locales/en/data.json
@@ -277,7 +277,6 @@
   "file-deletion-error-description": "Something went wrong during file deletion",
   "file-deletion-success": "file deleted successfully",
   "coming-soon": "Coming Soon",
-  "intlNumber": "{{val, number}}",
   "fuel-combustion-residential-buildings-direct-measure-methodology": "Direct Measure",
   "energy-consumption-residential-buildings-direct-measure-methodology": "Direct Measure",
   "fuel-consumption-commercial-buildings-direct-measure-methodology": "Direct Measure",

--- a/app/src/i18n/locales/es/data.json
+++ b/app/src/i18n/locales/es/data.json
@@ -271,7 +271,6 @@
   "file-deletion-error-description": "Algo salió mal durante la eliminación del archivo",
   "file-deletion-success": "archivo eliminado con éxito",
   "coming-soon": "Próximamente",
-  "intlNumber": "{{val, number}}",
   "fuel-combustion-residential-buildings-direct-measure-methodology": "Medida Directa",
   "energy-consumption-residential-buildings-direct-measure-methodology": "Medida Directa",
   "fuel-consumption-commercial-buildings-direct-measure-methodology": "Medida Directa",

--- a/app/src/i18n/locales/pt/data.json
+++ b/app/src/i18n/locales/pt/data.json
@@ -273,7 +273,6 @@
   "file-deletion-error-description": "Algo deu errado durante a exclusão do arquivo",
   "file-deletion-success": "Arquivo Excluído com Sucesso",
   "coming-soon": "Em Breve",
-  "intlNumber": "{{val, number}}",
   "fuel-combustion-residential-buildings-direct-measure-methodology": "Medição Direta",
   "energy-consumption-residential-buildings-direct-measure-methodology": "Medição Direta",
   "fuel-consumption-commercial-buildings-direct-measure-methodology": "Medição Direta",


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the CO2 emission unit conversion in the SourceDrawer component by using a newly imported utility function `convertKgToTonnes` and remove unused localization keys for the number formatting.

### Why are these changes being made?

The previous implementation incorrectly displayed emission totals in an unintended unit, leading to possible misunderstandings and reporting inaccuracies. By implementing `convertKgToTonnes`, we ensure consistent unit representation across the application. Additionally, the removal of the `intlNumber` translation keys cleans up unused code, aligning with best practices for code maintainability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->