### PR TITLE
fix(ui): sets population validation input to explicitly accept numbers

### DIFF
--- a/app/src/components/steps/add-population-data-step.tsx
+++ b/app/src/components/steps/add-population-data-step.tsx
@@ -194,7 +194,13 @@ export default function SetPopulationDataStep({
                   control={control}
                   rules={{
                     required: t("population-required"),
+                    validate: (value) => {
+                      return (
+                        !isNaN(Number(value)) || t("population-must-be-number")
+                      );
+                    },
                   }}
+                  type="number"
                   placeholder={t("country-population-placeholder")}
                   size="lg"
                   shadow="1dp"
@@ -239,6 +245,7 @@ export default function SetPopulationDataStep({
                   px={0}
                   {...register("countryPopulationYear", {
                     required: t("inventory-year-required"),
+                    valueAsNumber: true,
                   })}
                 >
                   {years.map((year: number, i: number) => (
@@ -293,7 +300,13 @@ export default function SetPopulationDataStep({
                   control={control}
                   rules={{
                     required: t("population-required"),
+                    validate: (value) => {
+                      return (
+                        !isNaN(Number(value)) || t("population-must-be-number")
+                      );
+                    },
                   }}
+                  type="number"
                   placeholder={t("region-or-province-population-placeholder")}
                   size="lg"
                   shadow="1dp"
@@ -327,6 +340,7 @@ export default function SetPopulationDataStep({
                   px={0}
                   {...register("regionPopulationYear", {
                     required: t("inventory-year-required"),
+                    valueAsNumber: true,
                   })}
                 >
                   {years.map((year: number, i: number) => (
@@ -376,9 +390,15 @@ export default function SetPopulationDataStep({
                   control={control}
                   rules={{
                     required: t("population-required"),
+                    validate: (value) => {
+                      return (
+                        !isNaN(Number(value)) || t("population-must-be-number")
+                      );
+                    },
                   }}
                   placeholder={t("city-population-placeholder")}
                   size="lg"
+                  type="number"
                   shadow="1dp"
                   w="400px"
                   fontSize="body.lg"
@@ -410,6 +430,7 @@ export default function SetPopulationDataStep({
                   px={0}
                   {...register("cityPopulationYear", {
                     required: t("inventory-year-required"),
+                    valueAsNumber: true,
                   })}
                 >
                   {years.map((year: number, i: number) => (


### PR DESCRIPTION
Changes
- Adds more validation rules to population inputs
- During testing there was a special case while adding and inventory for Vicente Lopez that resulted in a valiation error response from the server.

![image](https://github.com/user-attachments/assets/319a564b-c0a2-4cf6-a01a-2de34ae62df0)
