### PR TITLE
[ON-3150] use datasource id to delete datasources, instead of subcategoryid

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/[step]/page.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/page.tsx
@@ -519,7 +519,7 @@ export default function AddDataSteps({
           async (inventoryValue: InventoryValueAttributes) => {
             return await disconnectThirdPartyData({
               inventoryId: inventoryValue.inventoryId,
-              subCategoryId: inventoryValue.subCategoryId,
+              datasourceId: inventoryValue.datasourceId,
             });
           },
         ),

--- a/app/src/app/api/v0/datasource/[inventoryId]/datasource/[datasourceId]/route.ts
+++ b/app/src/app/api/v0/datasource/[inventoryId]/datasource/[datasourceId]/route.ts
@@ -5,22 +5,24 @@ import { NextResponse } from "next/server";
 import UserService from "@/backend/UserService";
 
 export const DELETE = apiHandler(async (_req, { params, session }) => {
-  const inventory = await UserService.findUserInventory(
-    params.inventoryId,
-    session,
-  );
+  await UserService.findUserInventory(params.inventoryId, session);
 
-  const subcategoryValue = await db.models.InventoryValue.findOne({
+  const inventoryValues = await db.models.InventoryValue.findAll({
     where: {
       datasourceId: params.datasourceId,
       inventoryId: params.inventoryId,
     },
   });
-  if (!subcategoryValue) {
+  if (inventoryValues.length === 0) {
     throw new createHttpError.NotFound("Inventory value not found");
   }
 
-  await subcategoryValue.destroy();
+  await db.models.InventoryValue.destroy({
+    where: {
+      datasourceId: params.datasourceId,
+      inventoryId: params.inventoryId,
+    },
+  });
 
-  return NextResponse.json({ data: subcategoryValue, deleted: true });
+  return NextResponse.json({ data: inventoryValues, deleted: true });
 });

--- a/app/src/app/api/v0/datasource/[inventoryId]/datasource/[datasourceId]/route.ts
+++ b/app/src/app/api/v0/datasource/[inventoryId]/datasource/[datasourceId]/route.ts
@@ -1,0 +1,26 @@
+import { db } from "@/models";
+import { apiHandler } from "@/util/api";
+import createHttpError from "http-errors";
+import { NextResponse } from "next/server";
+import UserService from "@/backend/UserService";
+
+export const DELETE = apiHandler(async (_req, { params, session }) => {
+  const inventory = await UserService.findUserInventory(
+    params.inventoryId,
+    session,
+  );
+
+  const subcategoryValue = await db.models.InventoryValue.findOne({
+    where: {
+      datasourceId: params.datasourceId,
+      inventoryId: params.inventoryId,
+    },
+  });
+  if (!subcategoryValue) {
+    throw new createHttpError.NotFound("Inventory value not found");
+  }
+
+  await subcategoryValue.destroy();
+
+  return NextResponse.json({ data: subcategoryValue, deleted: true });
+});

--- a/app/src/app/api/v0/inventory/[inventory]/value/[subcategory]/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/value/[subcategory]/route.ts
@@ -222,24 +222,3 @@ export const PATCH = apiHandler(async (req, { params, session }) => {
 
   return NextResponse.json({ data: inventoryValue });
 });
-
-export const DELETE = apiHandler(async (_req, { params, session }) => {
-  const inventory = await UserService.findUserInventory(
-    params.inventory,
-    session,
-  );
-
-  const subcategoryValue = await db.models.InventoryValue.findOne({
-    where: {
-      subCategoryId: params.subcategory,
-      inventoryId: inventory.inventoryId,
-    },
-  });
-  if (!subcategoryValue) {
-    throw new createHttpError.NotFound("Inventory value not found");
-  }
-
-  await subcategoryValue.destroy();
-
-  return NextResponse.json({ data: subcategoryValue, deleted: true });
-});

--- a/app/src/components/Tabs/Activity/external-data-section.tsx
+++ b/app/src/components/Tabs/Activity/external-data-section.tsx
@@ -66,7 +66,7 @@ const ExternalDataSection = ({
   ) => {
     await disconnectThirdPartyData({
       inventoryId: inventoryValue.inventoryId,
-      subCategoryId: inventoryValue.subCategoryId,
+      datasourceId: inventoryValue.datasourceId,
     });
     toast({
       status: "error",

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -501,9 +501,9 @@ export const api = createApi({
       },
     }),
     disconnectThirdPartyData: builder.mutation({
-      query: ({ inventoryId, subCategoryId }) => ({
+      query: ({ inventoryId, datasourceId }) => ({
         method: "DELETE",
-        url: `inventory/${inventoryId}/value/${subCategoryId}`,
+        url: `datasource/${inventoryId}/datasource/${datasourceId}`,
       }),
       invalidatesTags: ["InventoryValue", "InventoryProgress"],
       transformResponse: (response: { data: EmissionsFactorResponse }) =>

--- a/app/tests/api/datasource.jest.ts
+++ b/app/tests/api/datasource.jest.ts
@@ -1,19 +1,27 @@
 import { GET as getDataSourcesForSector } from "@/app/api/v0/datasource/[inventoryId]/[sectorId]/route";
 import { GET as getAllDataSources } from "@/app/api/v0/datasource/[inventoryId]/route";
+import { DELETE as deleteInventoryValue } from "@/app/api/v0/datasource/[inventoryId]/datasource/[datasourceId]/route";
 import { db } from "@/models";
 import { randomUUID } from "node:crypto";
 import { literal, Op } from "sequelize";
-import { cascadeDeleteDataSource, mockRequest, setupTests } from "../helpers";
+import {
+  cascadeDeleteDataSource,
+  expectStatusCode,
+  mockRequest,
+  setupTests,
+  testUserID,
+} from "../helpers";
 import { City } from "@/models/City";
 import { CreateInventoryRequest } from "@/util/validation";
 import { Sector } from "@/models/Sector";
 import { Inventory } from "@/models/Inventory";
 import fetchMock from "fetch-mock";
-import { beforeAll, afterAll, describe, it, expect } from "@jest/globals";
+import { afterAll, beforeAll, describe, expect, it, jest } from "@jest/globals";
 import {
   GlobalWarmingPotentialTypeEnum,
   InventoryTypeEnum,
 } from "@/util/enums";
+import { AppSession, Auth } from "@/lib/auth";
 
 const locode = "XX_DATASOURCE_CITY";
 const sectorName = "XX_DATASOURCE_TEST_1";
@@ -33,6 +41,11 @@ const sourceLocations = [
   "DE,US,XX",
   "DE_BLN,US_NY,XX_DATASOURCE_CITY",
 ];
+
+const mockSession: AppSession = {
+  user: { id: testUserID, role: "user" },
+  expires: "1h",
+};
 
 const apiEndpoint =
   "http://localhost:4000/api/v0/climatetrace/city/:locode/:year/:gpcReferenceNumber";
@@ -59,9 +72,12 @@ describe("DataSource API", () => {
   let city: City;
   let inventory: Inventory;
   let sector: Sector;
+  let prevGetServerSession = Auth.getServerSession;
 
   beforeAll(async () => {
     setupTests();
+    Auth.getServerSession = jest.fn(() => Promise.resolve(mockSession));
+
     await db.initialize();
 
     await db.models.Inventory.destroy({ where: { year: inventoryData.year } });
@@ -74,7 +90,11 @@ describe("DataSource API", () => {
       locode,
       name: "CC_",
     });
-
+    await db.models.CityUser.create({
+      cityUserId: randomUUID(),
+      userId: testUserID,
+      cityId: city.cityId,
+    });
     await db.models.SubCategory.destroy({ where: { subcategoryName } });
     await db.models.SubSector.destroy({ where: { subsectorName } });
     await db.models.Sector.destroy({ where: { sectorName } });
@@ -126,6 +146,7 @@ describe("DataSource API", () => {
   });
 
   afterAll(async () => {
+    Auth.getServerSession = prevGetServerSession;
     if (db.sequelize) await db.sequelize.close();
   });
 
@@ -157,4 +178,48 @@ describe("DataSource API", () => {
   });
 
   it.todo("should apply data sources");
+
+  it("should delete an inventory value", async () => {
+    const datasource = await db.models.DataSource.findOne({
+      // @ts-ignore
+      where: {
+        url: {
+          [Op.ne]: null,
+        },
+      },
+    });
+    console.log("datasource", JSON.stringify(datasource, null, 2)); // TODO NINA
+    const { datasourceId } = datasource;
+    const inventoryValueId = randomUUID();
+    await db.models.InventoryValue.create({
+      id: inventoryValueId,
+      datasourceId,
+      inventoryId: inventory.inventoryId,
+    });
+    const req = mockRequest();
+    const res = await deleteInventoryValue(req, {
+      params: {
+        inventoryId: inventory.inventoryId,
+        datasourceId,
+      },
+    });
+    await expectStatusCode(res, 200);
+    const { deleted } = await res.json();
+    expect(deleted).toEqual(true);
+    const deletedInventoryValue = await db.models.InventoryValue.findOne({
+      where: { id: inventoryValueId },
+    });
+    expect(deletedInventoryValue).toBeNull();
+  });
+
+  it("should not delete a non-existing inventory value", async () => {
+    const req = mockRequest();
+    const res = await deleteInventoryValue(req, {
+      params: {
+        inventoryId: randomUUID(),
+        datasourceId: randomUUID(),
+      },
+    });
+    await expectStatusCode(res, 404);
+  });
 });

--- a/app/tests/api/inventory_value.jest.ts
+++ b/app/tests/api/inventory_value.jest.ts
@@ -1,5 +1,4 @@
 import {
-  DELETE as deleteInventoryValue,
   GET as findInventoryValue,
   PATCH as upsertInventoryValue,
 } from "@/app/api/v0/inventory/[inventory]/value/[subcategory]/route";
@@ -281,32 +280,5 @@ describe("Inventory Value API", () => {
       error: { issues },
     } = await res.json();
     expect(issues.length).toEqual(3);
-  });
-
-  it("should delete an inventory value", async () => {
-    const req = mockRequest(inventoryValue2);
-    const res = await deleteInventoryValue(req, {
-      params: {
-        inventory: inventory.inventoryId,
-        subcategory: subCategory.subcategoryId,
-      },
-    });
-    await expectStatusCode(res, 200);
-    const { data, deleted } = await res.json();
-    expect(deleted).toEqual(true);
-    expectToBeLooselyEqual(data.co2eq, co2eq);
-    expect(data.activityUnits).toEqual(activityUnits);
-    expectToBeLooselyEqual(data.activityValue, activityValue);
-  });
-
-  it("should not delete a non-existing inventory value", async () => {
-    const req = mockRequest(inventoryValue2);
-    const res = await deleteInventoryValue(req, {
-      params: {
-        inventory: randomUUID(),
-        subcategory: randomUUID(),
-      },
-    });
-    await expectStatusCode(res, 404);
   });
 });


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the datasource deletion functionality to use `datasourceId` instead of `subCategoryId` throughout the application, including in API routes, services, and related tests.

### Why are these changes being made?

The changes are made to improve accuracy and clarity when performing operations related to datasource deletion, as `datasourceId` offers a more precise identifier compared to `subCategoryId`. This update reduces potential confusion and aligns with the overall data management strategy in keeping identifiers consistent for data manipulation tasks. As a more accurate approach, it resolves associated errors and improves maintenance of the codebase.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->