### PR TITLE
Default missing emission factors to 0

### DIFF
--- a/app/src/components/Modals/activity-modal/activity-modal-body.tsx
+++ b/app/src/components/Modals/activity-modal/activity-modal-body.tsx
@@ -163,9 +163,9 @@ const ActivityModalBody = ({
                 .emissionsPerActivity
             : "";
 
-        setValue("activity.CO2EmissionFactor", co2Val ? co2Val : "");
-        setValue("activity.N2OEmissionFactor", n2oVal ? n2oVal : "");
-        setValue("activity.CH4EmissionFactor", ch4Val ? ch4Val : "");
+        setValue("activity.CO2EmissionFactor", co2Val ? co2Val : 0);
+        setValue("activity.N2OEmissionFactor", n2oVal ? n2oVal : 0);
+        setValue("activity.CH4EmissionFactor", ch4Val ? ch4Val : 0);
         setValue("activity.emissionFactorName", emissionFactor?.name);
         setValue("activity.emissionFactorReference", emissionFactor?.reference);
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Default missing emission factors to 0 in the ActivityModalBody component.

### Why are these changes being made?

To ensure that when emission factors for CO2, N2O, and CH4 are not provided or available, they default to 0 instead of an empty string, eliminating potential calculation errors and ensuring consistent data handling in emissions-related processes. This change addresses edge cases where missing values could lead to undefined behavior or runtime errors.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->