### PR TITLE
fix(api): delete existing data when refno not applicable

### DIFF
--- a/app/src/app/api/v0/inventory/[inventory]/value/[subcategory]/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/value/[subcategory]/route.ts
@@ -93,7 +93,7 @@ export const PATCH = apiHandler(async (req, { params, session }) => {
     body.co2eq = undefined;
     body.co2eqYears = undefined;
 
-    // for existing data, find left over ActivityValues and GasValues and delete them
+    // for existing data, delete left over ActivityValues
     if (inventoryValue) {
       await db.models.ActivityValue.destroy({
         where: { inventoryValueId: inventoryValue.id },

--- a/app/src/app/api/v0/inventory/[inventory]/value/[subcategory]/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/value/[subcategory]/route.ts
@@ -82,10 +82,30 @@ export const PATCH = apiHandler(async (req, { params, session }) => {
     );
   }
 
+  // check if data is marked as not occurring/ otherwise unavailable
+  if (body.unavailableReason || body.unavailableExplanation) {
+    if (!body.unavailableReason || !body.unavailableExplanation) {
+      throw new createHttpError.BadRequest(
+        "unavailableReason and unavailableExplanation need to both be provided if one is used",
+      );
+    }
+
+    body.co2eq = undefined;
+    body.co2eqYears = undefined;
+
+    // for existing data, find left over ActivityValues and GasValues and delete them
+    if (inventoryValue) {
+      await db.models.ActivityValue.destroy({
+        where: { inventoryValueId: inventoryValue.id },
+      });
+    }
+  }
+
   if (inventoryValue) {
     inventoryValue = await inventoryValue.update({
       ...body,
       id: inventoryValue.id,
+      datasourceId: body.unavailableReason ? null : inventoryValue.datasourceId,
     });
   } else {
     inventoryValue = await db.models.InventoryValue.create({

--- a/app/src/app/api/v0/inventory/[inventory]/value/subsector/[subsector]/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/value/subsector/[subsector]/route.ts
@@ -71,7 +71,7 @@ export const PATCH = apiHandler(async (req, { params, session }) => {
     body.co2eq = undefined;
     body.co2eqYears = undefined;
 
-    // for existing data, find left over ActivityValues and GasValues and delete them
+    // for existing data, delete left over ActivityValues
     if (inventoryValue) {
       await db.models.ActivityValue.destroy({
         where: { inventoryValueId: inventoryValue.id },

--- a/app/src/app/api/v0/inventory/[inventory]/value/subsector/[subsector]/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/value/subsector/[subsector]/route.ts
@@ -60,10 +60,30 @@ export const PATCH = apiHandler(async (req, { params, session }) => {
     },
   });
 
+  // check if data is marked as not occurring/ otherwise unavailable
+  if (body.unavailableReason || body.unavailableExplanation) {
+    if (!body.unavailableReason || !body.unavailableExplanation) {
+      throw new createHttpError.BadRequest(
+        "unavailableReason and unavailableExplanation need to both be provided if one is used",
+      );
+    }
+
+    body.co2eq = undefined;
+    body.co2eqYears = undefined;
+
+    // for existing data, find left over ActivityValues and GasValues and delete them
+    if (inventoryValue) {
+      await db.models.ActivityValue.destroy({
+        where: { inventoryValueId: inventoryValue.id },
+      });
+    }
+  }
+
   if (inventoryValue) {
     inventoryValue = await inventoryValue.update({
       ...body,
       id: inventoryValue.id,
+      datasourceId: body.unavailableReason ? null : inventoryValue.datasourceId,
     });
   } else {
     inventoryValue = await db.models.InventoryValue.create({

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -280,7 +280,14 @@ export const api = createApi({
       }),
       transformResponse: (response: { data: InventoryValueAttributes }) =>
         response.data,
-      invalidatesTags: ["InventoryProgress", "InventoryValue"],
+      invalidatesTags: [
+        "Inventory",
+        "InventoryProgress",
+        "InventoryValue",
+        "ActivityValue", // because they are deleted when IV is marked as not available
+        "ReportResults",
+        "YearlyReportResults",
+      ],
     }),
     deleteInventoryValue: builder.mutation<
       InventoryValueAttributes,


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Introduce logic to delete existing related `ActivityValues` and set certain fields to `undefined` when `unavailableReason` or `unavailableExplanation` are provided, along with updating invalidation tags related to data marked as not occurring/unavailable in the API routes for inventory values.

### Why are these changes being made?

This change handles cases where inventory data is not applicable by ensuring that both `unavailableReason` and `unavailableExplanation` must be provided together, otherwise throwing an error. Additionally, it cleans up data integrity by deleting associated `ActivityValues` and ensuring fields that are not applicable are set to `undefined`, while also updating caching tags to reflect these data deletions accurately. This approach maintains consistency and avoids partial data when the inventory value is not available.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->