### PR TITLE
[ON-3176] invalidate cache for report results when disconnecting 3rd party data

### DIFF
--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -512,7 +512,7 @@ export const api = createApi({
         method: "DELETE",
         url: `datasource/${inventoryId}/datasource/${datasourceId}`,
       }),
-      invalidatesTags: ["InventoryValue", "InventoryProgress"],
+      invalidatesTags: ["InventoryValue", "InventoryProgress", "ReportResults"],
       transformResponse: (response: { data: EmissionsFactorResponse }) =>
         response.data,
     }),


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Invalidate the cache for "ReportResults" when disconnecting third-party data sources.

### Why are these changes being made?
This change ensures that any cached report results are cleared and refreshed when a third-party data source is disconnected, preventing users from viewing stale data that may no longer be relevant or accurate.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->