### PR TITLE
fix: adds defaul input label for password input

### DIFF
--- a/app/src/components/password-input.tsx
+++ b/app/src/components/password-input.tsx
@@ -21,7 +21,7 @@ export default function PasswordInput({
   error,
   register,
   t,
-  name = t("password"),
+  name = "Password",
   id = "password",
   w,
   shouldValidate = false,


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Set a default input label for the password input to "Password".

### Why are these changes being made?

This change ensures that the password input has a consistent and user-friendly label when none is provided, enhancing user experience by preventing potential issues with missing labels. The use of a default label improves accessibility and aligns with typical naming conventions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->