### PR TITLE
fix: resolve units issue with csv report

### DIFF
--- a/app/src/backend/CSVDownloadService.ts
+++ b/app/src/backend/CSVDownloadService.ts
@@ -42,7 +42,7 @@ export default class CSVDownloadService {
           value.subsector_name,
           value.notation_key,
           activityValue.total_co2e,
-          "kg CO2e",
+          "t CO2e",
           activityValue.activity_amount,
           activityValue.activity_unit,
           activityValue.emission_co2,


### PR DESCRIPTION
- resolve issue with total emissions unit in generated csv file

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the CSV report to display CO2 emissions in metric tons instead of kilograms.

### Why are these changes being made?

The unit representation for CO2 emissions was incorrect in the CSV report, showing values in kilograms ("kg CO2e") instead of the standard metric tons ("t CO2e"), which is a more appropriate and industry-standard measure. This change helps to align the report with common scientific and environmental reporting practices.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->