### PR TITLE
fix: adds istruncated prop to breadcrumb link

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/[step]/[subsector]/page.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/[subsector]/page.tsx
@@ -244,6 +244,7 @@ function SubSectorPage({
                       <BreadcrumbLink
                         href={`/${inventoryId}/data`}
                         color="content.tertiary"
+                        isTruncated
                       >
                         {t("all-sectors")}
                       </BreadcrumbLink>
@@ -252,6 +253,7 @@ function SubSectorPage({
                       <BreadcrumbLink
                         href={`/${inventoryId}/data/${step}`}
                         color="content.tertiary"
+                        isTruncated
                       >
                         {t(getSectorName(step))}
                       </BreadcrumbLink>


### PR DESCRIPTION
Changes
- Adds isTruncated props to breadcrumb link this prevents text from overflowing into the second line

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add the `isTruncated` prop to the `BreadcrumbLink` component instances on the SubSectorPage.

### Why are these changes being made?

These changes are implemented to ensure that the breadcrumb links accommodate longer text by truncating it to fit within the available space. This improvement enhances the user interface by preventing text overflow, thus maintaining a cleaner and more readable breadcrumb trail.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->