### PR TITLE
Fix/on 2950 decimal entry foreign language

### DIFF
--- a/app/src/components/Tabs/Activity/activity-accordion.tsx
+++ b/app/src/components/Tabs/Activity/activity-accordion.tsx
@@ -32,7 +32,7 @@ import { MdModeEditOutline, MdMoreVert } from "react-icons/md";
 import { FiTrash2 } from "react-icons/fi";
 import { ExtraField, findMethodology, Methodology } from "@/util/form-schema";
 import { useParams } from "next/navigation";
-import { regionalLocales } from "@/util/constants";
+import { REGIONALLOCALES } from "@/util/constants";
 
 interface IActivityGroup {
   activityData: ActivityValue[];
@@ -253,7 +253,7 @@ const ActivityAccordion: FC<ActivityAccordionProps> = ({
                     {convertKgToTonnes(
                       activity?.co2eq,
                       null,
-                      regionalLocales[lng as string],
+                      REGIONALLOCALES[lng as string],
                     )}
                   </Td>
                   <Td>
@@ -412,7 +412,7 @@ const ActivityAccordion: FC<ActivityAccordionProps> = ({
                                 0n,
                               ),
                               null,
-                              regionalLocales[lng as string],
+                              REGIONALLOCALES[lng as string],
                             )}{" "}
                           </Text>
                         </Box>

--- a/app/src/components/Tabs/Activity/activity-accordion.tsx
+++ b/app/src/components/Tabs/Activity/activity-accordion.tsx
@@ -31,6 +31,8 @@ import React, { FC, useMemo } from "react";
 import { MdModeEditOutline, MdMoreVert } from "react-icons/md";
 import { FiTrash2 } from "react-icons/fi";
 import { ExtraField, findMethodology, Methodology } from "@/util/form-schema";
+import { useParams } from "next/navigation";
+import { regionalLocales } from "@/util/constants";
 
 interface IActivityGroup {
   activityData: ActivityValue[];
@@ -61,6 +63,7 @@ const ActivityAccordion: FC<ActivityAccordionProps> = ({
   onEditActivity,
   referenceNumber,
 }) => {
+  const { lng } = useParams();
   // perform the group by logic when there's more than one activity.
   // split the data into groups
   // for each table group by the group by field
@@ -246,7 +249,13 @@ const ActivityAccordion: FC<ActivityAccordionProps> = ({
                     {parseFloat(activity?.activityData[title])}{" "}
                     {t(activity?.activityData[title + "-unit"])}
                   </Td>
-                  <Td>{convertKgToTonnes(activity?.co2eq)}</Td>
+                  <Td>
+                    {convertKgToTonnes(
+                      activity?.co2eq,
+                      null,
+                      regionalLocales[lng as string],
+                    )}
+                  </Td>
                   <Td>
                     <Popover>
                       <PopoverTrigger>
@@ -402,6 +411,8 @@ const ActivityAccordion: FC<ActivityAccordionProps> = ({
                                   acc + BigInt(curr.co2eq as bigint),
                                 0n,
                               ),
+                              null,
+                              regionalLocales[lng as string],
                             )}{" "}
                           </Text>
                         </Box>

--- a/app/src/components/Tabs/Activity/direct-measure-table.tsx
+++ b/app/src/components/Tabs/Activity/direct-measure-table.tsx
@@ -34,6 +34,8 @@ import {
   MANUAL_INPUT_HIERARCHY,
 } from "@/util/form-schema";
 import { AddIcon } from "@chakra-ui/icons";
+import { useParams } from "next/navigation";
+import { regionalLocales } from "@/util/constants";
 
 interface DirectMeasureTableProps {
   t: TFunction;
@@ -52,6 +54,7 @@ const DirectMeasureTable: FC<DirectMeasureTableProps> = ({
   t,
   showActivityModal,
 }) => {
+  const { lng } = useParams();
   const directMeasure = MANUAL_INPUT_HIERARCHY[referenceNumber as string]
     .directMeasure as DirectMeasure;
   const extraFields = directMeasure["extra-fields"] as ExtraField[];
@@ -134,18 +137,21 @@ const DirectMeasureTable: FC<DirectMeasureTableProps> = ({
                   {convertKgToTonnes(
                     activity?.activityData?.co2_amount * 1000,
                     "CO2e",
+                    regionalLocales[lng as string],
                   )}
                 </Td>
                 <Td isNumeric isTruncated>
                   {convertKgToTonnes(
                     activity?.activityData?.n2o_amount * 1000,
                     "N2O",
+                    regionalLocales[lng as string],
                   )}
                 </Td>
                 <Td isNumeric isTruncated>
                   {convertKgToTonnes(
                     activity?.activityData?.ch4_amount * 1000,
                     "CH4",
+                    regionalLocales[lng as string],
                   )}
                 </Td>
                 <Td>
@@ -292,6 +298,8 @@ const DirectMeasureTable: FC<DirectMeasureTableProps> = ({
                                   acc + BigInt(curr.co2eq as bigint),
                                 0n,
                               ),
+                              null,
+                              regionalLocales[lng as string],
                             )}{" "}
                           </Text>
                         </Box>

--- a/app/src/components/Tabs/Activity/direct-measure-table.tsx
+++ b/app/src/components/Tabs/Activity/direct-measure-table.tsx
@@ -35,7 +35,7 @@ import {
 } from "@/util/form-schema";
 import { AddIcon } from "@chakra-ui/icons";
 import { useParams } from "next/navigation";
-import { regionalLocales } from "@/util/constants";
+import { REGIONALLOCALES } from "@/util/constants";
 
 interface DirectMeasureTableProps {
   t: TFunction;
@@ -137,21 +137,21 @@ const DirectMeasureTable: FC<DirectMeasureTableProps> = ({
                   {convertKgToTonnes(
                     activity?.activityData?.co2_amount * 1000,
                     "CO2e",
-                    regionalLocales[lng as string],
+                    REGIONALLOCALES[lng as string],
                   )}
                 </Td>
                 <Td isNumeric isTruncated>
                   {convertKgToTonnes(
                     activity?.activityData?.n2o_amount * 1000,
                     "N2O",
-                    regionalLocales[lng as string],
+                    REGIONALLOCALES[lng as string],
                   )}
                 </Td>
                 <Td isNumeric isTruncated>
                   {convertKgToTonnes(
                     activity?.activityData?.ch4_amount * 1000,
                     "CH4",
-                    regionalLocales[lng as string],
+                    REGIONALLOCALES[lng as string],
                   )}
                 </Td>
                 <Td>
@@ -299,7 +299,7 @@ const DirectMeasureTable: FC<DirectMeasureTableProps> = ({
                                 0n,
                               ),
                               null,
-                              regionalLocales[lng as string],
+                              REGIONALLOCALES[lng as string],
                             )}{" "}
                           </Text>
                         </Box>

--- a/app/src/components/Tabs/Activity/emission-data-section.tsx
+++ b/app/src/components/Tabs/Activity/emission-data-section.tsx
@@ -35,7 +35,7 @@ import HeadingText from "@/components/heading-text";
 import { MdMoreVert } from "react-icons/md";
 import { FaNetworkWired } from "react-icons/fa";
 import { FiTrash2 } from "react-icons/fi";
-import { regionalLocales } from "@/util/constants";
+import { REGIONALLOCALES } from "@/util/constants";
 import { useParams } from "next/navigation";
 
 interface EmissionDataSectionProps {
@@ -364,7 +364,7 @@ const EmissionDataSection = ({
                       {convertKgToTonnes(
                         inventoryValue?.co2eq as bigint,
                         null,
-                        regionalLocales[lng as string],
+                        REGIONALLOCALES[lng as string],
                       )}
                     </Text>
                   </Box>

--- a/app/src/components/Tabs/Activity/emission-data-section.tsx
+++ b/app/src/components/Tabs/Activity/emission-data-section.tsx
@@ -35,6 +35,8 @@ import HeadingText from "@/components/heading-text";
 import { MdMoreVert } from "react-icons/md";
 import { FaNetworkWired } from "react-icons/fa";
 import { FiTrash2 } from "react-icons/fi";
+import { regionalLocales } from "@/util/constants";
+import { useParams } from "next/navigation";
 
 interface EmissionDataSectionProps {
   t: TFunction;
@@ -117,6 +119,8 @@ const EmissionDataSection = ({
     setSelectedActivityValue(activity);
     onAddActivityModalOpen();
   };
+
+  const { lng } = useParams();
 
   const renderSuggestedActivities = () => (
     <>
@@ -357,7 +361,11 @@ const EmissionDataSection = ({
                       fontWeight="semibold"
                       fontSize="headline.md"
                     >
-                      {convertKgToTonnes(inventoryValue?.co2eq as bigint)}
+                      {convertKgToTonnes(
+                        inventoryValue?.co2eq as bigint,
+                        null,
+                        regionalLocales[lng as string],
+                      )}
                     </Text>
                   </Box>
                 </Box>

--- a/app/src/components/formatted-number-input.tsx
+++ b/app/src/components/formatted-number-input.tsx
@@ -8,6 +8,7 @@ import {
   NumberInputProps,
 } from "@chakra-ui/react";
 import { useParams } from "next/navigation";
+import { regionalLocales } from "@/util/constants";
 
 interface FormattedNumberInputProps extends NumberInputProps {
   control: Control<any, any>;
@@ -24,13 +25,6 @@ interface FormattedNumberInputProps extends NumberInputProps {
   localization?: string;
   t: Function;
 }
-
-const regionalLocales: Record<string, string> = {
-  es: "es-ES", // Spanish (Spain)
-  en: "en-US", // English (United States)
-  pt: "pt-PT", // Portuguese (Portugal)
-  de: "de-DE", // German (Germany)
-};
 
 function FormattedNumberInput({
   control,

--- a/app/src/components/formatted-number-input.tsx
+++ b/app/src/components/formatted-number-input.tsx
@@ -8,7 +8,7 @@ import {
   NumberInputProps,
 } from "@chakra-ui/react";
 import { useParams } from "next/navigation";
-import { regionalLocales } from "@/util/constants";
+import { REGIONALLOCALES } from "@/util/constants";
 
 interface FormattedNumberInputProps extends NumberInputProps {
   control: Control<any, any>;
@@ -52,7 +52,7 @@ function FormattedNumberInput({
 
   const format = (nval: number | string) => {
     nval = nval.toString();
-    const locale = regionalLocales[lng as string] || "en-US"; // Get the user's locale
+    const locale = REGIONALLOCALES[lng as string] || "en-US"; // Get the user's locale
     const decimalSeparator = (1.1).toLocaleString(locale).substring(1, 2); // Detect the decimal separator
 
     // Check if the input ends with a decimal separator
@@ -82,7 +82,7 @@ function FormattedNumberInput({
   // Parse the formatted string into a raw number
   const parse = (val: string) => {
     const localeDecimalSeparator = (1.1)
-      .toLocaleString(regionalLocales[lng as string])
+      .toLocaleString(REGIONALLOCALES[lng as string])
       .substring(1, 2); // Get the decimal separator for the current locale
 
     const normalizedVal = val.replace(
@@ -96,7 +96,7 @@ function FormattedNumberInput({
   };
 
   const isCharacterValid = (char: string) => {
-    const normalizedLocale = regionalLocales[lng as string] || "en-US"; // Default to en-US
+    const normalizedLocale = REGIONALLOCALES[lng as string] || "en-US"; // Default to en-US
     const decimalSeparator = (1.1)
       .toLocaleString(normalizedLocale)
       .substring(1, 2);

--- a/app/src/components/formatted-number-input.tsx
+++ b/app/src/components/formatted-number-input.tsx
@@ -21,8 +21,16 @@ interface FormattedNumberInputProps extends NumberInputProps {
   id?: string;
   miniAddon?: boolean;
   testId?: string;
+  localization?: string;
   t: Function;
 }
+
+const regionalLocales: Record<string, string> = {
+  es: "es-ES", // Spanish (Spain)
+  en: "en-US", // English (United States)
+  pt: "pt-PT", // Portuguese (Portugal)
+  de: "de-DE", // German (Germany)
+};
 
 function FormattedNumberInput({
   control,
@@ -48,22 +56,41 @@ function FormattedNumberInput({
     name,
   });
 
-  // Format the number according to the locale
   const format = (nval: number | string) => {
-    let val = parseFloat(nval as string);
+    nval = nval.toString();
+    const locale = regionalLocales[lng as string] || "en-US"; // Get the user's locale
+    const decimalSeparator = (1.1).toLocaleString(locale).substring(1, 2); // Detect the decimal separator
 
-    const lastItemDot = nval.toString().slice(-1) === ".";
-    if (isNaN(val)) return "";
-    return (
-      new Intl.NumberFormat(lng, {
-        maximumFractionDigits: 20,
-      }).format(val) + (lastItemDot ? "." : "")
-    );
+    // Check if the input ends with a decimal separator
+
+    const endsWithSeparator = nval.toString().slice(-1) === decimalSeparator;
+
+    // Replace the locale-specific separator with a dot for parsing
+    const normalizedValue = nval.replace(decimalSeparator, ".");
+
+    // Parse the number
+    const numericValue = parseFloat(normalizedValue);
+
+    // If the input is not a valid number, return it as is
+    if (isNaN(numericValue)) return nval;
+
+    // Format the number part
+    const formattedNumber = new Intl.NumberFormat(locale, {
+      maximumFractionDigits: 20,
+    }).format(numericValue);
+
+    // If the input ends with a separator, add it back to the formatted string
+    return endsWithSeparator
+      ? `${formattedNumber}${decimalSeparator}`
+      : formattedNumber;
   };
 
   // Parse the formatted string into a raw number
   const parse = (val: string) => {
-    const localeDecimalSeparator = (1.1).toLocaleString(lng).substring(1, 2); // Get the decimal separator for the current locale
+    const localeDecimalSeparator = (1.1)
+      .toLocaleString(regionalLocales[lng as string])
+      .substring(1, 2); // Get the decimal separator for the current locale
+
     const normalizedVal = val.replace(
       new RegExp(`[^0-9${localeDecimalSeparator}-]`, "g"),
       "",
@@ -72,6 +99,19 @@ function FormattedNumberInput({
     return isNaN(parseFloat(normalizedNumber))
       ? ""
       : normalizedNumber.toString();
+  };
+
+  const isCharacterValid = (char: string) => {
+    const normalizedLocale = regionalLocales[lng as string] || "en-US"; // Default to en-US
+    const decimalSeparator = (1.1)
+      .toLocaleString(normalizedLocale)
+      .substring(1, 2);
+
+    // Build the regex dynamically to include the decimal separator
+    const validRegex = new RegExp(`^[0-9${decimalSeparator}]$`);
+
+    // Check if the character matches the valid regex
+    return validRegex.test(char);
   };
 
   return (
@@ -96,12 +136,13 @@ function FormattedNumberInput({
       render={({ field }) => (
         <InputGroup>
           <NumberInput
+            ste
             isDisabled={isDisabled}
             value={format(field.value)}
             onChange={(valueAsString) => {
-              const parsedValue = parse(valueAsString);
-              field.onChange(parsedValue);
+              field.onChange(valueAsString);
             }}
+            isValidCharacter={isCharacterValid}
             onBlur={(e) => {
               e.preventDefault();
               const parsedValue = parse(e.target.value);

--- a/app/src/util/constants.ts
+++ b/app/src/util/constants.ts
@@ -137,7 +137,7 @@ export const getSectorByName = (name: string) =>
 export const getReferenceNumberByName = (name: keyof ISector) =>
   findBy("name", name)?.referenceNumber;
 
-export const regionalLocales: Record<string, string> = {
+export const REGIONALLOCALES: Record<string, string> = {
   es: "es-ES", // Spanish (Spain)
   en: "en-US", // English (United States)
   pt: "pt-PT", // Portuguese (Portugal)

--- a/app/src/util/constants.ts
+++ b/app/src/util/constants.ts
@@ -3,7 +3,7 @@ import { PiPlant, PiTrashLight } from "react-icons/pi";
 import { TbBuildingCommunity } from "react-icons/tb";
 import { IconBaseProps } from "react-icons";
 import { LiaIndustrySolid } from "react-icons/lia";
-import { appTheme, SectorColors } from "@/lib/app-theme"; // Import the appTheme
+import { SectorColors } from "@/lib/app-theme"; // Import the appTheme
 
 export const maxPopulationYearDifference = 5;
 
@@ -136,3 +136,10 @@ export const getSectorByName = (name: string) =>
 
 export const getReferenceNumberByName = (name: keyof ISector) =>
   findBy("name", name)?.referenceNumber;
+
+export const regionalLocales: Record<string, string> = {
+  es: "es-ES", // Spanish (Spain)
+  en: "en-US", // English (United States)
+  pt: "pt-PT", // Portuguese (Portugal)
+  de: "de-DE", // German (Germany)
+};

--- a/app/src/util/helpers.ts
+++ b/app/src/util/helpers.ts
@@ -278,9 +278,9 @@ export function convertKgToKiloTonnes(
 
 export function convertKgToTonnes(
   valueInKg: number | Decimal | bigint,
-  gas?: string,
+  gas?: string | null,
+  locale = "en-US",
 ): string {
-  const locale = "en-US";
   const gasSuffix = gas ? ` ${gas}` : " CO2e";
 
   const kg = toDecimal(valueInKg);


### PR DESCRIPTION
- Fix the issue with entering decimal separators in Number Inputs  using non-english locale
- Localize emission values on all data tables

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor the code to support locale-specific decimal formatting and number parsing for foreign language entries within the `Activity` components by passing the appropriate locale to number formatting functions and updating the `formatted-number-input` component to use locale-specific decimal separators.

### Why are these changes being made?
To address issue ON-2950, where decimal entries were not correctly handled in foreign language contexts, potentially leading to misinterpretation of numerical data. By incorporating locale-specific formatting and parsing, users can accurately enter and view numbers according to regional conventions, improving user experience and reducing errors. This solution leverages an accentuated focus on determining locale with `regionalLocales` constants and `useParams` for enhanced adaptability, though it might require further refinement for dynamic locale support in future iterations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->