### PR TITLE
fix the query to allow for historical dates

### DIFF
--- a/global-api/routes/ghgi_emission_forecast.py
+++ b/global-api/routes/ghgi_emission_forecast.py
@@ -13,7 +13,7 @@ def db_city_emission_forecast(actor_id, forecast_year, spatial_granularity):
             SELECT actor_id,cluster_id,cluster_name,cluster_description,gpc_sector,forecast_year,future_year,growth_rate
             FROM modelled.ghgi_emission_forecast
             WHERE actor_id = :actor_id
-            AND forecast_year = :forecast_year
+            AND future_year >= :forecast_year
             AND spatial_granularity = :spatial_granularity
             """
         )


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the SQL query to allow fetching emission forecasts for historical as well as future dates by comparing `future_year` to `forecast_year`.

### Why are these changes being made?

The previous query condition restricted the results to only the specified `forecast_year`, which excluded data for years before this year. By changing the comparison to `future_year >= :forecast_year`, we ensure that we can retrieve forecasts for all years on or after the specified `forecast_year`, addressing the need for accessing historical data.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->