### PR TITLE
bug: [ON-3320] fix report results when inventory has no data

### DIFF
--- a/app/src/app/api/v0/inventory/[inventory]/results/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/results/route.ts
@@ -14,10 +14,10 @@ export const GET = apiHandler(
     return NextResponse.json({
       data: {
         totalEmissions: {
-          bySector: totalEmissionsBySector,
-          total: totalEmissions,
+          bySector: totalEmissionsBySector || [],
+          total: totalEmissions || 0,
         },
-        topEmissions: { bySubSector: topEmissionsBySubSector },
+        topEmissions: { bySubSector: topEmissionsBySubSector || [] },
       },
     });
   },

--- a/app/src/backend/ResultsService.ts
+++ b/app/src/backend/ResultsService.ts
@@ -770,10 +770,10 @@ export async function getEmissionResults(inventory: string): Promise<{
   const EmissionResults = await getEmissionResultsBatch([inventory]);
   const inventoryEmissionResults = EmissionResults[inventory];
   return {
-    totalEmissions: inventoryEmissionResults.totalEmissions.sumOfEmissions,
+    totalEmissions: inventoryEmissionResults?.totalEmissions?.sumOfEmissions,
     totalEmissionsBySector:
-      inventoryEmissionResults.totalEmissions.totalEmissionsBySector,
-    topEmissionsBySubSector: inventoryEmissionResults.topEmissionsBySubSector,
+      inventoryEmissionResults?.totalEmissions?.totalEmissionsBySector,
+    topEmissionsBySubSector: inventoryEmissionResults?.topEmissionsBySubSector,
   };
 }
 

--- a/app/tests/api/results.jest.ts
+++ b/app/tests/api/results.jest.ts
@@ -137,4 +137,34 @@ describe("Results API", () => {
       },
     });
   });
+
+  it("should return empty arrays when Inventory has no data", async () => {
+    const emptyInventoryId = randomUUID();
+    const emptyInventory = await db.models.Inventory.create({
+      inventoryId: emptyInventoryId,
+      ...baseInventory,
+      inventoryName: "ReportResultEmptyInventory",
+      cityId: city.cityId,
+      inventoryType: InventoryTypeEnum.GPC_BASIC,
+      globalWarmingPotentialType: GlobalWarmingPotentialTypeEnum.ar6,
+      year: 2022,
+    });
+    const req = mockRequest();
+    const res = await getResults(req, {
+      params: { inventory: emptyInventory.inventoryId },
+    });
+
+    await expectStatusCode(res, 200);
+    expect(await res.json()).toEqual({
+      data: {
+        topEmissions: {
+          bySubSector: [],
+        },
+        totalEmissions: {
+          bySector: [],
+          total: 0,
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the handling of report results when the inventory has no data by ensuring that `totalEmissions` returns default values of an empty array for sectors and a "0" string for the total, and add test cases to verify this behavior.

### Why are these changes being made?

This change addresses a bug where previous implementations failed to handle inventories without data gracefully, leading to potential errors or misleading responses. By providing default values, we ensure consistent and predictable API responses even when an inventory lacks data, thereby improving the robustness of the system. The addition of test cases ensures this behavior is validated and prevents future regression.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->