### PR TITLE
bug: [ON-3242] fix routing when invalid invite

### DIFF
--- a/app/src/app/[lng]/user/invites/page.tsx
+++ b/app/src/app/[lng]/user/invites/page.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Center, CircularProgress } from "@chakra-ui/react";
 import { useAcceptInviteMutation } from "@/services/api";
 import { logger } from "@/services/logger";
 import InviteErrorView from "./InviteErrorView";
-import { useRouter } from "next/navigation";
 import { emailPattern, tokenRegex, uuidRegex } from "@/util/validation";
 
 const AcceptInvitePage = ({ params: { lng } }: { params: { lng: string } }) => {
@@ -59,6 +58,8 @@ const AcceptInvitePage = ({ params: { lng } }: { params: { lng: string } }) => {
 
             if (!data?.success || !!error) {
               setError(true);
+            } else {
+              router.push(`/`);
             }
           } catch (error) {
             setError(true);
@@ -82,7 +83,7 @@ const AcceptInvitePage = ({ params: { lng } }: { params: { lng: string } }) => {
 
   if (isError || error) return <InviteErrorView lng={lng} />;
 
-  router.push(`/`);
+  return null;
 };
 
 export default AcceptInvitePage;


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the routing logic to navigate users to the home page (`/`) only when an invite is valid by adding a condition to check for errors before performing the routing.

### Why are these changes being made?

The existing implementation incorrectly routed users to the home page even when an invite was invalid. This change ensures that users are only redirected to the home page when there is no error, maintaining the correct application flow and improving user experience. The commented-out code indicates the previously incorrect behavior was intentionally deactivated.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->