### PR TITLE
[ON-3325] legend formatting

### DIFF
--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsForecast/EmissionsForecastChart.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsForecast/EmissionsForecastChart.tsx
@@ -202,7 +202,7 @@ export const EmissionsForecastChart = ({
           justify: false,
           translateX: 0,
           translateY: 60,
-          itemWidth: 140,
+          itemWidth: 120,
           itemHeight: 20,
           itemsSpacing: 4,
           symbolSize: 20,
@@ -221,7 +221,7 @@ export const EmissionsForecastChart = ({
           data: data.map((series) => ({
             id: series.id,
             color: getColorForSeries(series.id),
-            label: t(series.id),
+            label: series.id === "ippu" ? t("ippu-short") : t(series.id),
           })),
         },
       ]}


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Adjust the legend formatting in `EmissionsForecastChart.tsx` by modifying the item width and updating the label for the 'ippu' series to use a shortened translation.

### Why are these changes being made?

These changes improve the layout of the chart legend by making it more compact, which enhances visual clarity and ensures labels fit better in the allocated space. Additionally, using a shorter label for the 'ippu' series aids in better readability and alignment with design standards.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->