### PR TITLE
chore: move react-table types to regular dependencies

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -32,6 +32,7 @@
         "@types/pg": "^8.11.10",
         "@types/react": "18.3.10",
         "@types/react-dom": "18.2.19",
+        "@types/react-table": "^7.7.20",
         "@types/uuid": "^9.0.8",
         "@types/wellknown": "^0.5.8",
         "accept-language": "^3.0.18",
@@ -109,7 +110,6 @@
         "@types/glob": "^8.1.0",
         "@types/lodash.groupby": "^4.6.9",
         "@types/lodash.sumby": "^4.6.9",
-        "@types/react-table": "^7.7.20",
         "cypress": "^13.6.4",
         "glob": "^11.0.0",
         "jest": "^29.7.0",
@@ -9221,7 +9221,6 @@
       "version": "7.7.20",
       "resolved": "https://registry.npmjs.org/@types/react-table/-/react-table-7.7.20.tgz",
       "integrity": "sha512-ahMp4pmjVlnExxNwxyaDrFgmKxSbPwU23sGQw2gJK4EhCvnvmib2s/O/+y1dfV57dXOwpr2plfyBol+vEHbi2w==",
-      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }

--- a/app/package.json
+++ b/app/package.json
@@ -120,7 +120,8 @@
     "typescript": "5.5.4",
     "uuid": "^9.0.1",
     "wellknown": "^0.5.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "@types/react-table": "^7.7.20"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
@@ -135,7 +136,6 @@
     "@types/glob": "^8.1.0",
     "@types/lodash.groupby": "^4.6.9",
     "@types/lodash.sumby": "^4.6.9",
-    "@types/react-table": "^7.7.20",
     "cypress": "^13.6.4",
     "glob": "^11.0.0",
     "jest": "^29.7.0",


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Move `@types/react-table` from devDependencies to regular dependencies in `package.json` for consistency.

### Why are these changes being made?

The `@types/react-table` package is required at runtime, not just during development or testing phases, and therefore should be a regular dependency. This ensures its availability in production environments where it is needed.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->