### PR TITLE
fix: adds translation for email

### DIFF
--- a/app/src/i18n/locales/de/settings.json
+++ b/app/src/i18n/locales/de/settings.json
@@ -71,5 +71,6 @@
   "invite-cancel-fail": "Einladung konnte nicht storniert werden",
   "invite-sent": "Einladung erfolgreich gesendet",
   "invite-send-fail": "Einladung konnte nicht gesendet werden",
-  "number-of-cities": "# der Städte"
+  "number-of-cities": "# der Städte",
+  "email-placeholder": "E-Mail-Adresse"
 }

--- a/app/src/i18n/locales/en/settings.json
+++ b/app/src/i18n/locales/en/settings.json
@@ -71,5 +71,6 @@
   "invite-cancel-fail": "Invite couldn't be canceled",
   "invite-sent": "Invite sent successfully",
   "invite-send-fail": "Invite couldn't be sent",
-  "number-of-cities": "# of cities"
+  "number-of-cities": "# of cities",
+  "email-placeholder": "Email address"
 }

--- a/app/src/i18n/locales/es/settings.json
+++ b/app/src/i18n/locales/es/settings.json
@@ -71,5 +71,6 @@
   "invite-cancel-fail": "No se pudo cancelar la invitación",
   "invite-sent": "Invitación enviada con éxito",
   "invite-send-fail": "No se pudo enviar la invitación",
-  "number-of-cities": "# de ciudades"
+  "number-of-cities": "# de ciudades",
+  "email-placeholder": "Dirección de correo electrónico"
 }

--- a/app/src/i18n/locales/pt/settings.json
+++ b/app/src/i18n/locales/pt/settings.json
@@ -71,5 +71,6 @@
   "invite-cancel-fail": "Não foi possível cancelar o convite",
   "invite-sent": "Convite enviado com sucesso",
   "invite-send-fail": "Não foi possível enviar o convite",
-  "number-of-cities": "# de cidades"
+  "number-of-cities": "# de cidades",
+  "email-placeholder": "Endereço de e-mail"
 }


### PR DESCRIPTION
Changes
- Adds translations for email address placeholder

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add translations for the email placeholder in German, English, Spanish, and Portuguese localization files.

### Why are these changes being made?

To ensure users have a consistent experience across different languages by providing a translated placeholder for email input fields, which previously lacked this translation. This update improves the internationalization support of the application by covering missing translations in the settings configurations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->