### PR TITLE
fix: adds max-w to ask ai, uncomments icon

### DIFF
--- a/app/src/components/ChatBot/chat-popover.tsx
+++ b/app/src/components/ChatBot/chat-popover.tsx
@@ -65,11 +65,12 @@ export default function ChatPopover({
             fontWeight="600"
             letterSpacing="wider"
             py="26px"
+            maxW="220px"
             fontFamily="heading"
             aria-label={t("ai-expert")}
             variant="solid"
           >
-            {/* <Icon as={AskAiIcon} h={24} w={24} /> */}
+            <Icon as={AskAiIcon} h={24} w={24} />
             {t("ask-ai")}
           </Button>
         </PopoverTrigger>


### PR DESCRIPTION
Changes
- Adds max-w prop to button prevents its from stretching across the screen
- Uncomments Button Icon

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a maximum width restriction to the "Ask AI" button and uncomment the associated icon.

### Why are these changes being made?

The maximum width is introduced to ensure consistent display and avoid text overflow issues, while uncommenting the icon reinstates intended visual elements that were previously disabled for potentially debugging purposes. This approach enhances both the functionality and appearance of the chat popover component.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->