### PR TITLE
fix: afolu and ippu tabs not default tab not being set

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/[step]/[subsector]/page.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/[subsector]/page.tsx
@@ -192,11 +192,9 @@ function SubSectorPage({
     `${searchParams.get("refNo")}.1`,
   );
 
-  // console.log(getSectorRefNo(step));
-
   useEffect(() => {
-    if (scopes.length > 0 && !loadingState) {
-      setReferenceNumber(scopes[0]?.referenceNumber);
+    if (scopes.length > 0 && !loadingState && subSectorData) {
+      setReferenceNumber(subSectorData.referenceNumber!);
     }
   }, [scopes, loadingState]);
 

--- a/app/src/app/[lng]/[inventory]/data/[step]/[subsector]/page.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/[subsector]/page.tsx
@@ -196,7 +196,7 @@ function SubSectorPage({
     if (scopes.length > 0 && !loadingState && subSectorData) {
       setReferenceNumber(subSectorData.referenceNumber!);
     }
-  }, [scopes, loadingState]);
+  }, [scopes, loadingState, subSectorData]);
 
   return (
     <Tabs.Root defaultValue={referenceNumber}>


### PR DESCRIPTION
Changed
- Resolves default tab not showing by using refNo from subsectors instead

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the logic to set the default reference number on the AFOLU and IPPU tabs by utilizing the `subSectorData.referenceNumber` instead of the first scope's reference number.

### Why are these changes being made?

The previous implementation did not correctly set the default reference number when the tabs were loaded, which could lead to incorrect data being displayed. By directly using `subSectorData.referenceNumber`, the default settings are accurately initialized, enhancing user experience by ensuring correct and expected data display.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->