### PR TITLE
fix(ui): tabs on InventoryResult missing content 

### DIFF
--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
@@ -176,9 +176,11 @@ function SectorTabs({
         return (
           <Tabs.Content value={name} key={name}>
             {isTopEmissionsResponseLoading ? (
-              <ProgressCircleRoot>
-                <ProgressCircleRing cap="round" />
-              </ProgressCircleRoot>
+              <Center w="full" h="full">
+                <ProgressCircleRoot>
+                  <ProgressCircleRing cap="round" />
+                </ProgressCircleRoot>
+              </Center>
             ) : (
               <Card.Root divideX="2px" divideColor="border.overlay">
                 <SectorHeader

--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
@@ -129,6 +129,7 @@ function SectorTabs({
     <Tabs.Root
       // align="start"
       variant="line"
+      defaultValue={SECTORS[0].name}
       // index={selectedIndex}
       // onChange={(index) => setSelectedIndex(index)}
     >

--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   Card,
   CardHeader,
+  Center,
   Heading,
   HStack,
   Icon,
@@ -182,7 +183,7 @@ function SectorTabs({
                 </ProgressCircleRoot>
               </Center>
             ) : (
-              <Card.Root divideX="2px" divideColor="border.overlay">
+              <Card.Root divideX="2px" divideColor="border.overlay" p={4}>
                 <SectorHeader
                   icon={icon}
                   sectorName={t(name)}

--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
@@ -135,7 +135,7 @@ function SectorTabs({
       <Tabs.List>
         {getSectorsForInventory(inventory?.inventoryType).map(
           ({ icon, name }, index) => (
-            <Tabs.Trigger key={index} value="">
+            <Tabs.Trigger key={index} value={name}>
               <Icon
                 as={icon}
                 height="24px"


### PR DESCRIPTION
Happened after Chakra v3 migration - tab trigger values weren't properly set, same with the defaultValue