### PR TITLE
fix: first scope tab not selected by default on subsector page

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/[step]/[subsector]/page.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/[subsector]/page.tsx
@@ -188,18 +188,9 @@ function SubSectorPage({
     isInventoryValueLoading ||
     isInventoryProgressLoading ||
     isUserInfoLoading;
-  const [referenceNumber, setReferenceNumber] = useState<string>(
-    `${searchParams.get("refNo")}.1`,
-  );
-
-  useEffect(() => {
-    if (scopes.length > 0 && !loadingState && subSectorData) {
-      setReferenceNumber(subSectorData.referenceNumber!);
-    }
-  }, [scopes, loadingState, subSectorData]);
 
   return (
-    <Tabs.Root defaultValue={referenceNumber}>
+    <Tabs.Root defaultValue="0">
       <MotionBox
         bg="background.backgroundLight"
         className="fixed z-10 top-0 w-full transition-all"
@@ -416,7 +407,7 @@ function SubSectorPage({
               <Tabs.Trigger
                 key={index}
                 className="[&[aria-selected='false']]:border-[transparent]"
-                value={scope.referenceNumber}
+                value={index.toString()}
                 mt="40px"
               >
                 <Text
@@ -436,20 +427,27 @@ function SubSectorPage({
           {loadingState ? (
             <LoadingState />
           ) : (
-            scopes?.map((scope) => {
+            scopes?.map((scope, index) => {
               return (
-                <ActivityTab
-                  referenceNumber={scope.referenceNumber!}
-                  key={scope.referenceNumber}
-                  t={t}
-                  inventoryId={inventoryId}
-                  subsectorId={subsector}
-                  step={step}
-                  activityData={activityData}
-                  inventoryValues={getFilteredInventoryValues(
-                    scope.referenceNumber,
-                  )}
-                />
+                <Tabs.Content
+                  key={index}
+                  value={index.toString()}
+                  p="0"
+                  pt="48px"
+                >
+                  <ActivityTab
+                    referenceNumber={scope.referenceNumber!}
+                    key={scope.referenceNumber}
+                    t={t}
+                    inventoryId={inventoryId}
+                    subsectorId={subsector}
+                    step={step}
+                    activityData={activityData}
+                    inventoryValues={getFilteredInventoryValues(
+                      scope.referenceNumber,
+                    )}
+                  />
+                </Tabs.Content>
               );
             })
           )}

--- a/app/src/components/Tabs/Activity/activity-tab.tsx
+++ b/app/src/components/Tabs/Activity/activity-tab.tsx
@@ -220,171 +220,157 @@ const ActivityTab: FC<ActivityTabProps> = ({
 
   return (
     <>
-      <Tabs.Content
-        key={referenceNumber}
-        value={referenceNumber}
-        p="0"
-        pt="48px"
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent="space-between"
+        mb="48px"
       >
-        <Box
-          display="flex"
-          alignItems="center"
-          justifyContent="space-between"
-          mb="48px"
-        >
-          <HeadingText
-            data-testid="manual-input-header"
-            title={t("add-data-manually")}
+        <HeadingText
+          data-testid="manual-input-header"
+          title={t("add-data-manually")}
+        />
+        <Box display="flex" alignItems="center" gap="16px" fontSize="label.lg">
+          {(isLoading || isDeletingInventoryValue) && (
+            <Spinner size="sm" color="border.neutral" />
+          )}
+          <Switch
+            disabled={!!externalInventoryValue}
+            checked={
+              showUnavailableForm || !!inventoryValue?.unavailableExplanation
+            }
+            onChange={handleSwitch}
           />
-          <Box
-            display="flex"
-            alignItems="center"
-            gap="16px"
-            fontSize="label.lg"
+          <Text
+            opacity={!!externalInventoryValue ? 0.4 : 1}
+            fontFamily="heading"
+            fontWeight="medium"
           >
-            {(isLoading || isDeletingInventoryValue) && (
-              <Spinner size="sm" color="border.neutral" />
-            )}
-            <Switch
-              disabled={!!externalInventoryValue}
-              checked={
-                showUnavailableForm || !!inventoryValue?.unavailableExplanation
-              }
-              onChange={handleSwitch}
-            />
-            <Text
-              opacity={!!externalInventoryValue ? 0.4 : 1}
-              fontFamily="heading"
-              fontWeight="medium"
-            >
-              {t("scope-not-applicable")}
-            </Text>
-          </Box>
+            {t("scope-not-applicable")}
+          </Text>
         </Box>
-        {inventoryValue?.unavailableExplanation && !showUnavailableForm && (
-          <Box h="auto" px="24px" py="32px" bg="base.light" borderRadius="8px">
-            <Box mb="8px">
-              <HeadingText title={t("scope-unavailable-title")} />
-              <Text
-                letterSpacing="wide"
-                fontSize="body.lg"
-                fontWeight="normal"
-                color="interactive.control"
-                mb="48px"
-              >
-                {t("scope-unavailable-description")}
-              </Text>
+      </Box>
+      {inventoryValue?.unavailableExplanation && !showUnavailableForm && (
+        <Box h="auto" px="24px" py="32px" bg="base.light" borderRadius="8px">
+          <Box mb="8px">
+            <HeadingText title={t("scope-unavailable-title")} />
+            <Text
+              letterSpacing="wide"
+              fontSize="body.lg"
+              fontWeight="normal"
+              color="interactive.control"
+              mb="48px"
+            >
+              {t("scope-unavailable-description")}
+            </Text>
 
-              <Box
-                display="flex"
-                gap="48px"
-                alignItems="center"
-                borderWidth="1px"
-                borderRadius="12px"
-                borderColor="border.neutral"
-                py={4}
-                pl={6}
-                pr={3}
-              >
-                <Box>
-                  <Text
-                    fontWeight="bold"
-                    fontSize="title.md"
-                    fontFamily="heading"
-                  >
-                    {t(notationKey)}
-                  </Text>
-                  <Text fontSize="body.md" color="interactive.control">
-                    {t("notation-key")}
-                  </Text>
-                </Box>
+            <Box
+              display="flex"
+              gap="48px"
+              alignItems="center"
+              borderWidth="1px"
+              borderRadius="12px"
+              borderColor="border.neutral"
+              py={4}
+              pl={6}
+              pr={3}
+            >
+              <Box>
                 <Text
-                  fontSize="body.md"
-                  fontFamily="body"
-                  flex="1 0 0"
-                  className="overflow-ellipsis line-clamp-2"
+                  fontWeight="bold"
+                  fontSize="title.md"
+                  fontFamily="heading"
                 >
-                  <Text fontSize="body.md" fontFamily="body">
-                    <strong> {t("reason")}: </strong>
-                    {t(inventoryValue?.unavailableReason as string)}
-                  </Text>
+                  {t(notationKey)}
                 </Text>
-                <Text
-                  fontSize="body.md"
-                  flex="1 0 0"
-                  fontFamily="body"
-                  className="line-clamp-2"
-                >
-                  {inventoryValue.unavailableExplanation}
+                <Text fontSize="body.md" color="interactive.control">
+                  {t("notation-key")}
                 </Text>
-                <IconButton
-                  onClick={showUnavailableFormFunc}
-                  aria-label="edit"
-                  variant="ghost"
-                  color="content.tertiary"
-                >
-                  <Icon as={MdModeEditOutline} size="lg" />
-                </IconButton>
               </Box>
+              <Text
+                fontSize="body.md"
+                fontFamily="body"
+                flex="1 0 0"
+                className="overflow-ellipsis line-clamp-2"
+              >
+                <Text fontSize="body.md" fontFamily="body">
+                  <strong> {t("reason")}: </strong>
+                  {t(inventoryValue?.unavailableReason as string)}
+                </Text>
+              </Text>
+              <Text
+                fontSize="body.md"
+                flex="1 0 0"
+                fontFamily="body"
+                className="line-clamp-2"
+              >
+                {inventoryValue.unavailableExplanation}
+              </Text>
+              <IconButton
+                onClick={showUnavailableFormFunc}
+                aria-label="edit"
+                variant="ghost"
+                color="content.tertiary"
+              >
+                <Icon as={MdModeEditOutline} size="lg" />
+              </IconButton>
             </Box>
           </Box>
-        )}
-        {showUnavailableForm && (
-          <ScopeUnavailable
-            inventoryId={inventoryId}
-            gpcReferenceNumber={referenceNumber}
-            subSectorId={subsectorId}
+        </Box>
+      )}
+      {showUnavailableForm && (
+        <ScopeUnavailable
+          inventoryId={inventoryId}
+          gpcReferenceNumber={referenceNumber}
+          subSectorId={subsectorId}
+          t={t}
+          onSubmit={() => setShowUnavailableForm(false)}
+          reason={inventoryValue?.unavailableReason}
+          justification={inventoryValue?.unavailableExplanation}
+        />
+      )}
+      {!scopeNotApplicable && externalInventoryValue && (
+        <Box h="auto" px="24px" py="32px" bg="base.light" borderRadius="8px">
+          <ExternalDataSection
             t={t}
-            onSubmit={() => setShowUnavailableForm(false)}
-            reason={inventoryValue?.unavailableReason}
-            justification={inventoryValue?.unavailableExplanation}
+            inventoryValue={externalInventoryValue as unknown as InventoryValue}
           />
-        )}
-        {!scopeNotApplicable && externalInventoryValue && (
-          <Box h="auto" px="24px" py="32px" bg="base.light" borderRadius="8px">
-            <ExternalDataSection
-              t={t}
-              inventoryValue={
-                externalInventoryValue as unknown as InventoryValue
-              }
-            />
-          </Box>
-        )}
-        {!scopeNotApplicable && !externalInventoryValue && (
-          <>
-            {isMethodologySelected ? (
-              <Box
-                h="auto"
-                px="24px"
-                py="32px"
-                bg="base.light"
-                borderRadius="8px"
-              >
-                {" "}
-                <EmissionDataSection
-                  t={t}
-                  methodology={methodology}
-                  inventoryId={inventoryId}
-                  subsectorId={subsectorId}
-                  refNumberWithScope={referenceNumber}
-                  activityValues={activityValues as unknown as ActivityValue[]}
-                  suggestedActivities={suggestedActivities}
-                  totalEmissions={totalEmissions}
-                  changeMethodology={changeMethodology}
-                  inventoryValue={inventoryValue as unknown as InventoryValue}
-                />
-              </Box>
-            ) : (
-              <SelectMethodology
+        </Box>
+      )}
+      {!scopeNotApplicable && !externalInventoryValue && (
+        <>
+          {isMethodologySelected ? (
+            <Box
+              h="auto"
+              px="24px"
+              py="32px"
+              bg="base.light"
+              borderRadius="8px"
+            >
+              {" "}
+              <EmissionDataSection
                 t={t}
-                methodologies={methodologies}
-                handleMethodologySelected={handleMethodologySelected}
-                directMeasure={directMeasure}
+                methodology={methodology}
+                inventoryId={inventoryId}
+                subsectorId={subsectorId}
+                refNumberWithScope={referenceNumber}
+                activityValues={activityValues as unknown as ActivityValue[]}
+                suggestedActivities={suggestedActivities}
+                totalEmissions={totalEmissions}
+                changeMethodology={changeMethodology}
+                inventoryValue={inventoryValue as unknown as InventoryValue}
               />
-            )}
-          </>
-        )}
-      </Tabs.Content>
+            </Box>
+          ) : (
+            <SelectMethodology
+              t={t}
+              methodologies={methodologies}
+              handleMethodologySelected={handleMethodologySelected}
+              directMeasure={directMeasure}
+            />
+          )}
+        </>
+      )}
     </>
   );
 };


### PR DESCRIPTION
Also simplify default tab handling by not using full reference numbers as tab values

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the subsector page to set the first scope tab as the default selection and update the `Tabs.Content` component positioning within the subsector page and activity tab components.

### Why are these changes being made?

The changes address an issue where the first scope tab was not being selected by default on the subsector page by initializing `Tabs.Root` with a "0" default value. The refactor improves the tab navigation and ensures consistency by standardizing the use of index-based values for tab selection rather than relying on reference numbers, thus providing a more robust and maintainable structure for handling tabs across different components.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->