### PR TITLE
fix(ui): don't redirect to invites page without a token in query params

### DIFF
--- a/app/src/app/[lng]/auth/login/page.tsx
+++ b/app/src/app/[lng]/auth/login/page.tsx
@@ -53,10 +53,17 @@ export default function Login({
 
   const searchParams = useSearchParams();
   const queryParams = Object.fromEntries(searchParams.entries());
-  const callbackUrl = decodeURIComponent(queryParams.callbackUrl || "");
-  const finalCallbackUrl =
-    callbackUrl ||
-    `/${lng}/user/invite?${new URLSearchParams(queryParams).toString()}`;
+  let callbackUrl = decodeURIComponent(queryParams.callbackUrl || "");
+
+  // only redirect to user invite page as a fallback if there is a token present in the search params
+  if (!callbackUrl) {
+    if ("token" in queryParams) {
+      const paramsString = new URLSearchParams(queryParams).toString();
+      callbackUrl = `/${lng}/user/invites?${paramsString}`;
+    } else {
+      callbackUrl = "/";
+    }
+  }
 
   const { showLoginSuccessToast } = useAuthToast(t);
   const onSubmit: SubmitHandler<LoginInputs> = async (data) => {
@@ -65,12 +72,12 @@ export default function Login({
         redirect: false,
         email: data.email,
         password: data.password,
-        callbackUrl: finalCallbackUrl,
+        callbackUrl,
       });
 
       if (res?.ok && !res?.error) {
         showLoginSuccessToast();
-        router.push(finalCallbackUrl);
+        router.push(callbackUrl);
         setError("");
         return;
       } else {
@@ -115,7 +122,7 @@ export default function Login({
       >
         {t("no-account")}{" "}
         <Link
-          href={`/auth/signup?callbackUrl=${encodeURIComponent(finalCallbackUrl)}`}
+          href={`/auth/signup?callbackUrl=${encodeURIComponent(callbackUrl)}`}
           className="underline"
         >
           {t("sign-up")}


### PR DESCRIPTION
Fixes 404 error after login when navigating directly to login page

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify the login page to prevent redirection to the invites page if query parameters lack a token.

### Why are these changes being made?

Previously, users could be redirected to the invites page even when query parameters didn't include a token, causing unnecessary navigational logic that could be confusing. This change ensures redirection only occurs when a token is present, improving navigation accuracy.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->