### PR TITLE
bug: Fix population service to return city & region values

### DIFF
--- a/app/src/backend/PopulationService.ts
+++ b/app/src/backend/PopulationService.ts
@@ -54,9 +54,9 @@ export default class PopulationService {
       cityId: cityId,
       population: cityPopulation?.population,
       year: cityPopulation?.year,
-      countryPopulation: countryPopulation?.population,
+      countryPopulation: countryPopulation?.countryPopulation,
       countryPopulationYear: countryPopulation?.year,
-      regionPopulation: regionPopulation?.population,
+      regionPopulation: regionPopulation?.regionPopulation,
       regionPopulationYear: regionPopulation?.year,
     };
   }


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the `PopulationService` to correctly return `countryPopulation` and `regionPopulation` values.

### Why are these changes being made?

The changes ensure that the service returns the correct population attributes for country and region by referencing the correct property names (`countryPopulation` and `regionPopulation`) in the returned object. This corrects an error where incorrect data was previously being accessed and displayed, ensuring accurate data representation.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->