### PR TITLE
feat: wellness endpoints for k8s

### DIFF
--- a/app/src/app/api/v0/check/health/route.ts
+++ b/app/src/app/api/v0/check/health/route.ts
@@ -1,0 +1,19 @@
+import { apiHandler } from "@/util/api";
+import { NextResponse } from "next/server";
+import pkg from "../../../../../../package.json";
+import { db } from "@/models/index";
+
+export const GET = apiHandler(async () => {
+  if (!db.initialized) {
+    throw new Error("Database not yet initialized");
+  }
+  try {
+    await db.sequelize?.query('SELECT 1');
+    return NextResponse.json({
+      message: "healthy",
+      version: pkg.version
+    });
+  } catch (error) {
+    throw new Error("Database connection is not working");
+  }
+});

--- a/app/src/app/api/v0/check/health/route.ts
+++ b/app/src/app/api/v0/check/health/route.ts
@@ -13,7 +13,11 @@ export const GET = apiHandler(async () => {
       message: "healthy",
       version: pkg.version
     });
-  } catch (error) {
-    throw new Error("Database connection is not working");
+  } catch (error:any) {
+    throw new Error(
+      "Database connection is not working: " + (error instanceof Error)
+        ? error.message
+        : "unknown reason",
+    );
   }
 });

--- a/app/src/app/api/v0/check/health/route.ts
+++ b/app/src/app/api/v0/check/health/route.ts
@@ -2,22 +2,52 @@ import { apiHandler } from "@/util/api";
 import { NextResponse } from "next/server";
 import pkg from "../../../../../../package.json";
 import { db } from "@/models/index";
+import { logger } from "@/services/logger";
 
-export const GET = apiHandler(async () => {
-  if (!db.initialized) {
-    throw new Error("Database not yet initialized");
+let lastCheckTime = 0;
+let lastCheckResult = false;
+const CACHE_TTL = 5000; // 5 seconds
+
+const checkDatabase = async () => {
+  const now = Date.now();
+  if (now - lastCheckTime < CACHE_TTL) {
+    return lastCheckResult;
   }
   try {
-    await db.sequelize?.query('SELECT 1');
-    return NextResponse.json({
-      message: "healthy",
-      version: pkg.version
-    });
-  } catch (error:any) {
-    throw new Error(
+    await db.sequelize?.query("SELECT 1");
+    lastCheckResult = true;
+  } catch (error: any) {
+    lastCheckResult = false;
+    logger.error(
       "Database connection is not working: " + (error instanceof Error)
         ? error.message
         : "unknown reason",
     );
   }
+  lastCheckTime = now;
+  return lastCheckResult;
+};
+
+export const GET = apiHandler(async () => {
+  if (!db.initialized) {
+    throw new Error("Database not yet initialized");
+  }
+
+  const result = await checkDatabase();
+
+  if (result) {
+    return NextResponse.json({
+      message: "healthy",
+      version: pkg.version,
+    });
+  } else {
+    return NextResponse.json(
+      {
+        message: "database-connection-failed",
+        version: pkg.version,
+      },
+      { status: 500 },
+    );
+  }
 });
+

--- a/app/src/app/api/v0/check/liveness/route.ts
+++ b/app/src/app/api/v0/check/liveness/route.ts
@@ -1,0 +1,10 @@
+import { apiHandler } from "@/util/api";
+import { NextResponse } from "next/server";
+import pkg from "../../../../../../package.json";
+
+export const GET = apiHandler(async () => {
+  return NextResponse.json({
+    message: "alive",
+    version: pkg.version
+  });
+});


### PR DESCRIPTION
This adds two probe API endpoints for the Web app to help with k8s deployment (see https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/ ):

- /api/v0/check/liveness/ simply checks if the server is up and returns some constant data
- /api/v0/check/health/ checks if the server is able to operate. Right now, it checks if it can run a simple database query.

Once these are in the app, I will add them to the Kubernetes deployment.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add health and liveness endpoints for Kubernetes in the API to check application status and version.

### Why are these changes being made?

These changes provide necessary endpoints for Kubernetes to monitor the application's health and liveness, facilitating improved deployment management and enabling automatic health checks. The approach ensures that the application can respond with its status and the current version, aiding in better observability and operational efficiency.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->