### PR TITLE
[ON-3478] handle null co2eq for cases when scope is not applicable

### DIFF
--- a/app/src/backend/ResultsService.ts
+++ b/app/src/backend/ResultsService.ts
@@ -791,7 +791,7 @@ const prepareEmissionsData = async (inventoryId: string) => {
 
   return Object.entries(groupedEmissions).map(([referenceNumber, records]) => {
     const co2eqSum = records.reduce(
-      (sum, record) => sum + BigInt(record.co2eq),
+      (sum, record) => sum + BigInt(record.co2eq || 0),
       0n,
     );
     return {


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify the CO2 equivalent (co2eq) summation logic to handle potential null values by using a default value of 0 in `prepareEmissionsData` function.

### Why are these changes being made?

The change ensures robustness by preventing potential runtime errors when `co2eq` is null due to scopes not being applicable, thereby maintaining consistent function behavior and accurate emission calculations. This is crucial to ensure the service handles all data scenarios gracefully without requiring upstream data modification.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->