### PR TITLE
fix added the datasource for emissions factor in route

### DIFF
--- a/global-api/routes/ghgi_emissions.py
+++ b/global-api/routes/ghgi_emissions.py
@@ -150,6 +150,7 @@ def db_query(datasource_name, spatial_granularity, actor_id, gpc_reference_numbe
 						'gas_name' , e.gas_name,
 						'emissions_value', e.emissions_value,
 						'emissionfactor_value', ef.emissionfactor_value,
+						'emissionfactor_datasource', ef.datasource_name,
 						'activity_value', e.activity_value::numeric,
 						'gwp', COALESCE(gwp.{gwp},0),
 						'emissions_value_100yr', COALESCE(e.emissions_value * gwp.{gwp},0),


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add the `emissionfactor_datasource` field to the emissions factor data retrieval in the `db_query` method within the `ghgi_emissions.py` route.

### Why are these changes being made?
This change is made to ensure that the data source of the emission factors is explicitly included in query results, enhancing data transparency and allowing consumers of the API to trace the origin of emission factor values. It aligns with the requirement for clearer data provenance in emissions reporting.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->