### PR TITLE
bug: [ON-3481] show scaling methodology only when it's needed

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/[step]/SourceDrawer.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/SourceDrawer.tsx
@@ -1,6 +1,5 @@
 import type { SectorAttributes } from "@/models/Sector";
 import {
-  chakra,
   Heading,
   HStack,
   Icon,
@@ -12,12 +11,7 @@ import {
 } from "@chakra-ui/react";
 import type { TFunction } from "i18next";
 import { RefObject } from "react";
-import {
-  MdArrowBack,
-  MdHomeWork,
-  MdInfoOutline,
-  MdOpenInNew,
-} from "react-icons/md";
+import { MdArrowBack, MdHomeWork, MdInfoOutline } from "react-icons/md";
 import type { DataSourceData, DataSourceWithRelations } from "./types";
 import { getTranslationFromDict } from "@/i18n";
 import { convertKgToTonnes, toKebabCase } from "@/util/helpers";
@@ -33,10 +27,8 @@ import SourceDrawerTags from "./SourceDrawerTags";
 import { TitleLarge, TitleMedium } from "@/components/Texts/Title";
 import { SourceDrawerActivityTable } from "./SourceDrawerActivityTable";
 import { BodyLarge } from "@/components/Texts/Body";
-import { api } from "@/services/api";
-import { HeadlineLarge } from "@/components/Texts/Headline";
-import LabelLarge from "@/components/Texts/Label";
 import { DisplayMedium } from "@/components/Texts/Display";
+import ScalingSection from "./[subsector]/ScalingSection";
 
 export function SourceDrawer({
   source,
@@ -65,13 +57,6 @@ export function SourceDrawer({
   t: TFunction;
   inventoryId: string;
 }) {
-  const { data: populations } = api.useGetInventoryPopulationsQuery(
-    inventoryId,
-    {
-      skip: !inventoryId,
-    },
-  );
-
   const emissionsToBeIncluded = () => {
     let number, unit;
     let converted;
@@ -237,91 +222,11 @@ export function SourceDrawer({
                     </BodyLarge>
                   </VStack>
                   <Separator />
-                  <Stack>
-                    <VStack align="flex-start">
-                      <HStack align="flex-start">
-                        <TitleLarge>{t("how-data-was-scaled")}</TitleLarge>
-                      </HStack>
-                      <BodyLarge>
-                        {t("about-data-availability-description")}
-                      </BodyLarge>
-                    </VStack>
-                    {populations &&
-                      populations.population &&
-                      populations.countryPopulation && (
-                        <HStack
-                          width={"70%"}
-                          justifyContent="center"
-                          alignItems="center"
-                          margin="24px auto"
-                        >
-                          <VStack>
-                            <HeadlineLarge>
-                              {populations.population}
-                            </HeadlineLarge>
-                            <LabelLarge paddingTop={4}>
-                              {t("city-population")}
-                            </LabelLarge>
-                            <LabelLarge>{populations.year}</LabelLarge>
-                          </VStack>
-                          <VStack>
-                            <BodyLarge fontSize={40}>/</BodyLarge>
-                            <LabelLarge paddingTop={4}></LabelLarge>
-                          </VStack>
-                          <VStack>
-                            <HeadlineLarge>
-                              {populations.countryPopulation}
-                            </HeadlineLarge>
-                            <LabelLarge paddingTop={4}>
-                              {t("country-population")}
-                            </LabelLarge>
-                            <LabelLarge>
-                              {populations.countryPopulationYear}
-                            </LabelLarge>
-                          </VStack>
-                          <VStack>
-                            <BodyLarge fontSize={40}>=</BodyLarge>
-                            <LabelLarge paddingTop={4}></LabelLarge>
-                          </VStack>
-                          <VStack>
-                            <HeadlineLarge>
-                              {populations.population /
-                                populations.countryPopulation}
-                            </HeadlineLarge>
-                            <LabelLarge paddingTop={4}>
-                              {t("scaling-factor")}
-                            </LabelLarge>
-                          </VStack>
-                        </HStack>
-                      )}
-                    <chakra.hr borderColor="border.neutral" />
-                    <TitleLarge>
-                      {t("methodology")}
-                      <Link
-                        href={source.methodologyUrl}
-                        target="_blank"
-                        rel="noreferrer noopener"
-                      >
-                        <Icon as={MdOpenInNew} color="content.link" ml={2} />
-                      </Link>
-                    </TitleLarge>
-                    <BodyLarge>
-                      {getTranslationFromDict(source.methodologyDescription)}
-                    </BodyLarge>
-                    <TitleLarge verticalAlign="baseline">
-                      {t("transform-data-heading")}
-                      <Link
-                        href="https://citycatalyst.openearth.org"
-                        target="_blank"
-                        rel="noreferrer noopener"
-                      >
-                        <Icon as={MdOpenInNew} color="content.link" ml={2} />
-                      </Link>
-                    </TitleLarge>
-                    <BodyLarge>
-                      {getTranslationFromDict(source.transformationDescription)}
-                    </BodyLarge>
-                  </Stack>
+                  <ScalingSection
+                    source={source}
+                    t={t}
+                    inventoryId={inventoryId}
+                  />
                 </Stack>
               </DrawerBody>
             )}

--- a/app/src/app/[lng]/[inventory]/data/[step]/[subsector]/ScalingSection.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/[subsector]/ScalingSection.tsx
@@ -1,0 +1,112 @@
+import { chakra, HStack, Icon, Link, Stack, VStack } from "@chakra-ui/react";
+import { MdOpenInNew } from "react-icons/md";
+import { getTranslationFromDict } from "@/i18n";
+import { TitleLarge } from "@/components/Texts/Title";
+import { BodyLarge } from "@/components/Texts/Body";
+import { HeadlineLarge } from "@/components/Texts/Headline";
+import LabelLarge from "@/components/Texts/Label";
+import { api } from "@/services/api";
+import { DataSourceWithRelations } from "@/app/[lng]/[inventory]/data/[step]/types";
+import { TFunction } from "i18next";
+
+interface ScalingSectionProps {
+  source: DataSourceWithRelations;
+  t: TFunction;
+  inventoryId?: string;
+}
+
+const ScalingSection = ({ source, t, inventoryId }: ScalingSectionProps) => {
+  const { data: populations } = api.useGetInventoryPopulationsQuery(
+    inventoryId!,
+    {
+      skip: !inventoryId,
+    },
+  );
+  const isDownscaled =
+    source.retrievalMethod == "global_api_downscaled_by_population";
+  const isCountryResolution = source.spatialResolution === "country";
+  const areaPopulation = isCountryResolution
+    ? populations?.countryPopulation
+    : populations?.regionPopulation;
+  const areaPopulationYear = isCountryResolution
+    ? populations?.countryPopulationYear
+    : populations?.regionPopulationYear;
+  if (isDownscaled && populations?.population) {
+    return (
+      <Stack>
+        <VStack align="flex-start">
+          <HStack align="flex-start">
+            <TitleLarge>{t("how-data-was-scaled")}</TitleLarge>
+          </HStack>
+          <BodyLarge>{t("about-data-availability-description")}</BodyLarge>
+        </VStack>
+        {areaPopulation && (
+          <HStack
+            width={"70%"}
+            justifyContent="center"
+            alignItems="center"
+            margin="24px auto"
+          >
+            <VStack>
+              <HeadlineLarge>{populations.population}</HeadlineLarge>
+              <LabelLarge paddingTop={4}>{t("city-population")}</LabelLarge>
+              <LabelLarge>{populations.year}</LabelLarge>
+            </VStack>
+            <VStack>
+              <BodyLarge fontSize={40}>/</BodyLarge>
+              <LabelLarge paddingTop={4}></LabelLarge>
+            </VStack>
+            <VStack>
+              <HeadlineLarge>{areaPopulation}</HeadlineLarge>
+              <LabelLarge paddingTop={4}>
+                {isCountryResolution
+                  ? t("country-population")
+                  : t("region-population")}
+              </LabelLarge>
+              <LabelLarge>{areaPopulationYear}</LabelLarge>
+            </VStack>
+            <VStack>
+              <BodyLarge fontSize={40}>=</BodyLarge>
+              <LabelLarge paddingTop={4}></LabelLarge>
+            </VStack>
+            <VStack>
+              <HeadlineLarge>
+                {populations.population / areaPopulation}
+              </HeadlineLarge>
+              <LabelLarge paddingTop={4}>{t("scaling-factor")}</LabelLarge>
+            </VStack>
+          </HStack>
+        )}
+        <chakra.hr borderColor="border.neutral" />
+        <TitleLarge>
+          {t("methodology")}
+          <Link
+            href={source.methodologyUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            <Icon as={MdOpenInNew} color="content.link" ml={2} />
+          </Link>
+        </TitleLarge>
+        <BodyLarge>
+          {getTranslationFromDict(source.methodologyDescription)}
+        </BodyLarge>
+        <TitleLarge verticalAlign="baseline">
+          {t("transform-data-heading")}
+          <Link
+            href="https://citycatalyst.openearth.org"
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            <Icon as={MdOpenInNew} color="content.link" ml={2} />
+          </Link>
+        </TitleLarge>
+        <BodyLarge>
+          {getTranslationFromDict(source.transformationDescription)}
+        </BodyLarge>
+      </Stack>
+    );
+  }
+};
+
+export default ScalingSection;

--- a/app/src/app/[lng]/[inventory]/data/[step]/[subsector]/ScalingSection.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/[subsector]/ScalingSection.tsx
@@ -107,6 +107,7 @@ const ScalingSection = ({ source, t, inventoryId }: ScalingSectionProps) => {
       </Stack>
     );
   }
+  return null;
 };
 
 export default ScalingSection;

--- a/app/src/i18n/locales/en/data.json
+++ b/app/src/i18n/locales/en/data.json
@@ -1149,6 +1149,7 @@
   "not-detailed": "Not detailed",
   "city-population": "City population",
   "country-population": "Country population",
+  "region-population": "Region population",
   "scaling-factor": "Scaling factor",
   "kg": "kg",
   "emissions-from-transmission-and-distribution-losses-from-grid-supplied-energy-consumption": "Emissions from transmission and distribution losses from grid-supplied energy consumption",


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the scaling methodology display logic in SourceDrawer to be encapsulated within a new ScalingSection component that is only rendered when necessary, and update localization data to include "region-population".

### Why are these changes being made?

This change addresses a bug by ensuring that the scaling methodology is shown only when applicable, enhancing code maintainability by isolating this logic into a separate component. Additionally, the inclusion of "region-population" in localization supports the expanded conditional logic needed for accurate data representation, aligning the display more closely with the source data's spatial resolution.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->