### PR TITLE
bug: [ON-3484] fix Misalignment between the totals in subcategory and total emissions

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/[step]/SourceDrawer.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/SourceDrawer.tsx
@@ -86,7 +86,6 @@ export function SourceDrawer({
     }
     if (!!totalEmissions && totalEmissions !== "?") {
       converted = convertKgToTonnes(parseFloat(totalEmissions) * 1000);
-      debugger;
     }
     if (!converted) {
       return { number: totalEmissionsData ?? totalEmissions, unit: "" };

--- a/app/src/app/[lng]/[inventory]/data/[step]/SourceDrawer.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/SourceDrawer.tsx
@@ -73,7 +73,6 @@ export function SourceDrawer({
   );
 
   const emissionsToBeIncluded = () => {
-    let number, unit;
     let converted;
     if (!!totalEmissionsData && totalEmissionsData !== "?") {
       converted = convertKgToTonnes(parseFloat(totalEmissionsData));
@@ -86,7 +85,8 @@ export function SourceDrawer({
       totalEmissions = "?";
     }
     if (!!totalEmissions && totalEmissions !== "?") {
-      converted = convertKgToTonnes(parseInt(totalEmissions));
+      converted = convertKgToTonnes(parseFloat(totalEmissions) * 1000);
+      debugger;
     }
     if (!converted) {
       return { number: totalEmissionsData ?? totalEmissions, unit: "" };


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Fix the misalignment between subcategory totals and total emissions by correcting the conversion logic from kilograms to tonnes and ensuring accuracy in computation.

### Why are these changes being made?
The previous implementation led to discrepancies in displayed emissions due to incorrect conversion, resulting in a bug that misrepresented total emissions. This change addresses the source of the misalignment by correctly applying the conversion factor and utilizing type-casting to handle numerical precision, ensuring consistency across category calculations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->