### PR TITLE
Bug: [on 3484] fix total emissions included

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/[step]/SourceDrawer.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/SourceDrawer.tsx
@@ -197,7 +197,6 @@ export function SourceDrawer({
                   <TitleMedium>{t("disaggregated-analysis")}</TitleMedium>
                   {sourceData?.records && (
                     <SourceDrawerActivityTable
-                      sectorId={sector?.sectorId}
                       activities={sourceData.records}
                       t={t}
                     />

--- a/app/src/app/[lng]/[inventory]/data/[step]/SourceDrawerActivityTable.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/SourceDrawerActivityTable.tsx
@@ -15,13 +15,11 @@ import { Overline } from "@/components/Texts/Overline";
 interface SourceDrawerActivityTableProps {
   activities: DataSourceActivityDataRecord[];
   t: TFunction;
-  sectorId: string | undefined;
 }
 
 export function SourceDrawerActivityTable({
   activities,
   t,
-  sectorId,
 }: SourceDrawerActivityTableProps) {
   const getTotalEmissions = () => {
     const emissions = activities.reduce((acc, activity) => {

--- a/app/src/app/[lng]/[inventory]/data/[step]/SourceDrawerActivityTable.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/SourceDrawerActivityTable.tsx
@@ -21,14 +21,9 @@ export function SourceDrawerActivityTable({
   activities,
   t,
 }: SourceDrawerActivityTableProps) {
-  const getTotalEmissions = () => {
-    const emissions = activities.reduce((acc, activity) => {
-      return (
-        acc +
-        activity.gases.reduce((acc, gas) => {
-          return acc + gas.emissions_value_100yr;
-        }, 0)
-      );
+  const getTotalEmissions = (activity: DataSourceActivityDataRecord) => {
+    const emissions = activity.gases.reduce((acc, gas) => {
+      return acc + gas.emissions_value_100yr;
     }, 0);
     return convertKgToTonnes(emissions);
   };
@@ -55,7 +50,7 @@ export function SourceDrawerActivityTable({
                       .map((e) => t(e))
                       .join(" > ")}
                 </BodyMedium>
-                <TitleSmall>{`${t("total")} ${getTotalEmissions()}`}</TitleSmall>
+                <TitleSmall>{`${t("total")} ${getTotalEmissions(activity)}`}</TitleSmall>
               </HStack>
             </AccordionItemTrigger>
             <AccordionItemContent>

--- a/app/src/i18n/locales/en/dashboard.json
+++ b/app/src/i18n/locales/en/dashboard.json
@@ -174,5 +174,6 @@
   "afolu-land": "Land",
   "rate": "rate",
   "sector": "sector",
-  "an-error-occurred": "An error occurred"
+  "an-error-occurred": "An error occurred",
+  "error-fetching-sector-breakdown": "Error fetching sector breakdown"
 }


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor `getTotalEmissions` to correctly accept an activity as a parameter and update translation strings to include "error-fetching-sector-breakdown".

### Why are these changes being made?

The calculation of total emissions was incorrect due to a missing parameter in the `getTotalEmissions` function call; this has been fixed to improve accuracy by passing the correct `activity` object. Additionally, a new translation string has been added to handle error messaging for sector breakdown fetching, enhancing the application's internationalization support.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->