### PR TITLE
feat: fetch the population source and show it in the tooltip

### DIFF
--- a/app/src/components/HomePage/Hero.tsx
+++ b/app/src/components/HomePage/Hero.tsx
@@ -39,11 +39,11 @@ export function Hero({
   t,
 }: HeroProps) {
   const { data: cityData } = useGetOCCityDataQuery(inventory.city?.locode!, {
-    skip: !inventory.city?.locode!,
+    skip: !inventory.city?.locode,
   });
   const popWithDS = cityData?.population?.find(
-    (p:any) => p.population == population?.population &&
-          p.year == population?.year
+    (p:any) => p.population === population?.population &&
+          p.year === population?.year
   );
   return (
     <Box bg="brand.primary" className="w-full h-[491px] pt-[150px]" px={8}>

--- a/app/src/components/HomePage/Hero.tsx
+++ b/app/src/components/HomePage/Hero.tsx
@@ -16,6 +16,7 @@ import type { PopulationAttributes } from "@/models/Population";
 import type { InventoryResponse } from "@/util/types";
 import { Tooltip } from "@/components/ui/tooltip";
 import { useGetOCCityDataQuery } from "@/services/api";
+import { useMemo } from "react";
 
 const CityMap = dynamic(() => import("@/components/CityMap"), { ssr: false });
 
@@ -41,10 +42,16 @@ export function Hero({
   const { data: cityData } = useGetOCCityDataQuery(inventory.city?.locode!, {
     skip: !inventory.city?.locode,
   });
-  const popWithDS = cityData?.population?.find(
-    (p:any) => p.population === population?.population &&
-          p.year === population?.year
+  const popWithDS = useMemo(
+    () =>
+      cityData?.population?.find(
+        (p: { population: number; year: number }) =>
+          p.population === population?.population &&
+          p.year === population?.year,
+      ),
+    [cityData?.population, population?.population, population?.year],
   );
+
   return (
     <Box bg="brand.primary" className="w-full h-[491px] pt-[150px]" px={8}>
       <Box className="flex mx-auto max-w-full w-[1090px]">
@@ -171,7 +178,9 @@ export function Hero({
                       <Tooltip
                         content={
                           <>
-                            { popWithDS ? popWithDS.datasource.name : t('source-open-climate') }
+                            {popWithDS
+                              ? popWithDS.datasource.name
+                              : t("source-open-climate")}
                             <br />
                             {t("population-year", {
                               year: population?.year,

--- a/app/src/components/HomePage/Hero.tsx
+++ b/app/src/components/HomePage/Hero.tsx
@@ -15,6 +15,7 @@ import type { TFunction } from "i18next";
 import type { PopulationAttributes } from "@/models/Population";
 import type { InventoryResponse } from "@/util/types";
 import { Tooltip } from "@/components/ui/tooltip";
+import { useGetOCCityDataQuery } from "@/services/api";
 
 const CityMap = dynamic(() => import("@/components/CityMap"), { ssr: false });
 
@@ -37,6 +38,13 @@ export function Hero({
   population,
   t,
 }: HeroProps) {
+  const { data: cityData } = useGetOCCityDataQuery(inventory.city?.locode!, {
+    skip: !inventory.city?.locode!,
+  });
+  const popWithDS = cityData?.population?.find(
+    (p:any) => p.population == population?.population &&
+          p.year == population?.year
+  );
   return (
     <Box bg="brand.primary" className="w-full h-[491px] pt-[150px]" px={8}>
       <Box className="flex mx-auto max-w-full w-[1090px]">
@@ -163,9 +171,7 @@ export function Hero({
                       <Tooltip
                         content={
                           <>
-                            <Trans i18nKey="source-open-climate" t={t}>
-                              {`Source: OpenClimate`}
-                            </Trans>
+                            { popWithDS ? popWithDS.datasource.name : t('source-open-climate') }
                             <br />
                             {t("population-year", {
                               year: population?.year,

--- a/app/src/i18n/locales/en/dashboard.json
+++ b/app/src/i18n/locales/en/dashboard.json
@@ -176,5 +176,6 @@
   "rate": "rate",
   "sector": "sector",
   "an-error-occurred": "An error occurred",
-  "error-fetching-sector-breakdown": "Error fetching sector breakdown"
+  "error-fetching-sector-breakdown": "Error fetching sector breakdown",
+  "source-open-climate": "Source: OpenClimate"
 }


### PR DESCRIPTION
Fetch the city population data source (well, *probable* data source... we match by population value and year) and show it in the tooltip popup in the Hero.

I considered a lot of different options, like saving the population data source in the inventory at onboarding time, but since we only use it in this single place, I opted to just do another API call to get it.

It would be cool to only do the API call in the unlikely event that someone hovers the tooltip, but I can't find an easy way to do this. So, we're paying an extra API hit on the dashboard.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fetch the population data source using `useGetOCCityDataQuery` and display it in the tooltip on the homepage.

### Why are these changes being made?

These changes enhance the user interface by providing more context for the population data displayed on the homepage. By fetching the city data source and displaying it in the tooltip, users can identify the exact source of the population information, thereby improving transparency and trust in the data presented.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->