### PR TITLE
bug(ui): show error toast when error is present

### DIFF
--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
@@ -103,7 +103,7 @@ function SectorTabs({
     description: t("error-fetching-sector-breakdown"),
   });
 
-  if (!error) {
+  if (error) {
     showErrorToast();
     console.error("Error fetching sector breakdown:", error);
   }


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the conditional logic to display an error toast and log an error message when an error is present during sector breakdown fetching.

### Why are these changes being made?

The previous implementation incorrectly skipped showing the error toast when an error occurred due to a logical inversion. This fix corrects the logic to improve error handling and debugging by ensuring users are notified of errors and relevant messages are logged.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->