### PR TITLE
fix(ui): ON-3492 unable to delete activities in manual input

### DIFF
--- a/app/src/components/Modals/delete-activity-modal.tsx
+++ b/app/src/components/Modals/delete-activity-modal.tsx
@@ -24,7 +24,7 @@ interface DeleteAllActivitiesModalProps {
   isOpen: boolean;
   onClose: any;
   t: TFunction;
-  selectedActivityValue: ActivityValue;
+  selectedActivityValue: ActivityValue | undefined;
   resetSelectedActivityValue: () => void;
   inventoryId: string;
   setDeleteActivityDialogOpen: Function;
@@ -50,10 +50,15 @@ const DeleteActivityModal: FC<DeleteAllActivitiesModalProps> = ({
 
   // define the function to delete all activities
   const handleDeleteActivity = async () => {
+    if (!selectedActivityValue) {
+      console.error("Selected activity value missing when deleting activity!");
+      return;
+    }
+
     // call the delete all activities mutation
     const response = await deleteActivityValue({
       inventoryId,
-      activityValueId: selectedActivityValue.id,
+      activityValueId: selectedActivityValue?.id,
     });
     if (response.data?.success) {
       showSuccessToast();

--- a/app/src/components/Tabs/Activity/emission-data-section.tsx
+++ b/app/src/components/Tabs/Activity/emission-data-section.tsx
@@ -55,8 +55,9 @@ const EmissionDataSection = ({
   changeMethodology,
   inventoryValue,
 }: EmissionDataSectionProps) => {
-  const [selectedActivityValue, setSelectedActivityValue] =
-    useState<ActivityValue>();
+  const [selectedActivityValue, setSelectedActivityValue] = useState<
+    ActivityValue | undefined
+  >();
   const [selectedActivity, setSelectedActivity] = useState<
     SuggestedActivity | undefined
   >();
@@ -80,7 +81,8 @@ const EmissionDataSection = ({
   // Delete Activity Dialog
   const [openActivityDeleteDialog, setActivityDeleteDataDialogOpen] =
     useState(false);
-  const handleDeleteActivityDataDialog = () => {
+  const handleDeleteActivityDataDialog = (activity: ActivityValue) => {
+    setSelectedActivityValue(activity);
     setActivityDeleteDataDialogOpen(true);
   };
 


### PR DESCRIPTION
Fixes being unable to click the delete activity button in the modal on the subsector data page.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update `selectedActivityValue` to handle undefined states by adjusting its type and adding a validation check when an activity is being deleted.

### Why are these changes being made?

These changes are necessary to prevent errors caused by undefined `selectedActivityValue` when attempting to delete an activity. By ensuring `selectedActivityValue` can be undefined and checking its presence, we improve the robustness of the activity deletion feature, preventing runtime errors and providing a better user experience.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->