### PR TITLE
isaac/bug/on-3523/wrong-year-over-year-calculations

### DIFF
--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
@@ -367,13 +367,20 @@ export function EmissionPerSectors({
                 (sector) => sector.sectorName === sectorData.sectorName,
               );
 
+              console.log(yearlyMap);
+              console.log("lastYearData", lastYearData);
+
               if (lastYearData) {
-                const sectorAmount = BigInt(sectorData.co2eq);
-                const lastYearDifference =
-                  sectorAmount - BigInt(lastYearData.co2eq);
-                percentageChange = Number(
-                  (lastYearDifference * 100n) / BigInt(lastYearData.co2eq),
-                );
+                if (BigInt(lastYearData.co2eq) === 0n) {
+                  percentageChange = 100;
+                } else {
+                  const sectorAmount = BigInt(sectorData.co2eq);
+                  const lastYearDifference =
+                    sectorAmount - BigInt(lastYearData.co2eq);
+                  percentageChange = Number(
+                    (lastYearDifference * 100n) / BigInt(lastYearData.co2eq),
+                  );
+                }
               }
             }
 

--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
@@ -372,7 +372,7 @@ export function EmissionPerSectors({
                 const lastYearDifference =
                   sectorAmount - BigInt(lastYearData.co2eq);
                 percentageChange = Number(
-                  (lastYearDifference * 100n) / sectorAmount,
+                  (lastYearDifference * 100n) / BigInt(lastYearData.co2eq),
                 );
               }
             }

--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/index.tsx
@@ -367,9 +367,6 @@ export function EmissionPerSectors({
                 (sector) => sector.sectorName === sectorData.sectorName,
               );
 
-              console.log(yearlyMap);
-              console.log("lastYearData", lastYearData);
-
               if (lastYearData) {
                 if (BigInt(lastYearData.co2eq) === 0n) {
                   percentageChange = 100;


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the calculation of year-over-year percentage change by correctly dividing by the previous year's data, and handle cases where last year's data equals zero.

### Why are these changes being made?

Users reported incorrect year-over-year emission percentage changes due to division by the wrong denominator, which has been adjusted to use last year's data; additionally, a condition was added to gracefully handle cases where last year's emission data is zero to prevent division errors.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->