### PR TITLE
fix(e2e): log out before performing invalid data test in login.spec.ts

### DIFF
--- a/app/e2e/helpers.ts
+++ b/app/e2e/helpers.ts
@@ -27,17 +27,6 @@ export async function signup(
   return await result.json();
 }
 
-export async function logOut(
-  request: APIRequestContext,
-  callbackUrl: string | undefined = undefined,
-) {
-  const suffix = callbackUrl ? `?callbackUrl=${callbackUrl}` : "";
-  const result = await request.post("/api/auth/signout" + suffix, {});
-  console.error(await result.text());
-  expect(result.ok()).toBeTruthy();
-  return await result.json();
-}
-
 export async function createInventory(
   request: APIRequestContext,
   name: string,

--- a/app/e2e/login.spec.ts
+++ b/app/e2e/login.spec.ts
@@ -2,7 +2,9 @@ import { test, expect } from "@playwright/test";
 import { expectText, signup } from "./helpers";
 import { randomUUID } from "node:crypto";
 
-test.beforeEach(async ({ page }) => {
+test.beforeEach(async ({ page, context }) => {
+  // make sure user is logged out to prevent order of execution issues
+  await context.clearCookies();
   await page.goto("/en/auth/login");
 });
 
@@ -29,11 +31,7 @@ test.describe("Login page", () => {
     await expect(page).not.toHaveURL("/en/auth/login/");
   });
 
-  test("shows errors when entering invalid data", async ({ page, request }) => {
-    // make sure user is logged out to prevent order of execution issues
-    await page.goto("/api/auth/signout");
-
-    await page.goto("/en/auth/login");
+  test("shows errors when entering invalid data", async ({ page }) => {
     await expectText(page, "Log In to City Catalyst");
 
     await page.locator('input[name="email"]').fill("testopenearthorg");

--- a/app/e2e/login.spec.ts
+++ b/app/e2e/login.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, APIRequestContext } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import { expectText, signup } from "./helpers";
 import { randomUUID } from "node:crypto";
 
@@ -29,7 +29,11 @@ test.describe("Login page", () => {
     await expect(page).not.toHaveURL("/en/auth/login/");
   });
 
-  test("shows errors when entering invalid data", async ({ page }) => {
+  test("shows errors when entering invalid data", async ({ page, request }) => {
+    // make sure user is logged out to prevent order of execution issues
+    await page.goto("/api/auth/signout");
+
+    await page.goto("/en/auth/login");
     await expectText(page, "Log In to City Catalyst");
 
     await page.locator('input[name="email"]').fill("testopenearthorg");


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Ensure the user is logged out before performing the invalid data test in `login.spec.ts` by navigating to the signout endpoint prior to the test execution.

### Why are these changes being made?

Logging out before the test ensures the test environment is in a consistent and known state, preventing potential order of execution issues that might arise if the user is already logged in. This change helps to maintain the reliability and accuracy of end-to-end tests by avoiding false positives or negatives due to session-related issues.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->