### PR TITLE
feat(gtm):[on-3456] fixes the shifting glitch of the percentage-breakdown component

### DIFF
--- a/app/src/components/percentage-breakdown-input.tsx
+++ b/app/src/components/percentage-breakdown-input.tsx
@@ -183,7 +183,7 @@ const PercentageBreakdownInput: FC<FormInputProps> = ({
             </Field>
           </Group>
         </PopoverTrigger>
-        <PopoverContent w="full" portalled={false}>
+        <PopoverContent w="full" className="overflow-scroll">
           <PopoverArrow />
           <PopoverBody
             w="full"


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add `overflow-scroll` class to the `PopoverContent` in the `percentage-breakdown-input.tsx` component to fix the shifting glitch.

### Why are these changes being made?

The change addresses a UX bug where the component content shifts unexpectedly due to overflow issues; adding the `overflow-scroll` class ensures consistent rendering without disrupting the layout, resolving user-reported issues effectively.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->