### PR TITLE
Nina/feat/on 3549/invite collaborator tests

### DIFF
--- a/app/jest.config.ts
+++ b/app/jest.config.ts
@@ -8,21 +8,33 @@ import preset from "ts-jest/presets/index.js";
 
 const config: JestConfigWithTsJest = {
   ...preset.defaultsESM,
+
+  // Empty string means process all node_modules
+  // Only process TypeScript files with ts-jest
   transform: {
     "^.+\\.tsx?$": [
       "ts-jest",
       {
-        tsconfig: "tsconfig.json",
+        tsconfig: "tests/tsconfig.json",
         useESM: true,
       },
     ],
   },
-  testEnvironment: "node",
-  roots: ["<rootDir>"],
-  modulePaths: ["<rootDir>"],
+
+  // The critical part - transform all ESM modules in node_modules
+  transformIgnorePatterns: [
+    "/node_modules/(?!(.+\\.mjs$|fetch-blob|formdata-polyfill|node-fetch|data-uri-to-buffer|web-streams-polyfill))",
+  ],
+
+  extensionsToTreatAsEsm: [".ts", ".tsx"],
+
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
   },
+
+  testEnvironment: "node",
+  roots: ["<rootDir>"],
+  modulePaths: ["<rootDir>"],
   setupFiles: ["<rootDir>/jest.setup.ts"],
 
   // enable worker threads feature to fix BigInt serialization issue

--- a/app/tests/api/organization_invite.jest.ts
+++ b/app/tests/api/organization_invite.jest.ts
@@ -1,0 +1,125 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import {
+  GET as getOrganizationInvites,
+  POST as createOrganizationInvite,
+} from "@/app/api/v0/organizations/[organizationId]/invitations/route";
+import { db } from "@/models";
+import { mockRequest, setupTests, testUserID } from "../helpers";
+import { Organization } from "@/models/Organization";
+import { OrganizationInvite } from "@/models/OrganizationInvite";
+import { randomUUID } from "node:crypto";
+import { AppSession, Auth } from "@/lib/auth";
+import { InviteStatus, OrganizationRole, Roles } from "@/util/types";
+import { CreateOrganizationInviteRequest } from "@/util/validation";
+import EmailService from "@/backend/EmailService";
+import { SentMessageInfo } from "nodemailer"; // Import the correct type
+
+const organizationData = {
+  name: "Test Organization",
+  contactEmail: "test@organization.com",
+  contactNumber: "1234567890",
+};
+
+const inviteData: CreateOrganizationInviteRequest = {
+  organizationId: randomUUID(),
+  inviteeEmail: "consultant@example.org",
+  role: OrganizationRole.COLLABORATOR,
+};
+
+const mockAdminSession: AppSession = {
+  user: { id: testUserID, role: Roles.Admin },
+  expires: "1h",
+};
+
+const mockUserSession: AppSession = {
+  user: { id: testUserID, role: Roles.User },
+  expires: "1h",
+};
+
+describe("Organization Invitations API", () => {
+  let organization: Organization;
+  let prevGetServerSession = Auth.getServerSession;
+
+  beforeAll(async () => {
+    setupTests();
+    await db.initialize();
+    EmailService.sendOrganizationInvitationEmail = jest
+      .fn<() => Promise<SentMessageInfo>>()
+      .mockResolvedValue(true);
+  });
+
+  beforeEach(async () => {
+    await db.models.Organization.destroy({
+      where: { name: organizationData.name },
+    });
+    Auth.getServerSession = jest.fn(() => Promise.resolve(mockAdminSession));
+    organization = await db.models.Organization.create({
+      ...organizationData,
+      organizationId: inviteData.organizationId,
+    });
+  });
+
+  afterAll(async () => {
+    Auth.getServerSession = prevGetServerSession;
+    if (db.sequelize) await db.sequelize.close();
+  });
+
+  it("should allow admin to invite a consultant", async () => {
+    const req = mockRequest(inviteData);
+    const res = await createOrganizationInvite(req, {
+      params: { organizationId: inviteData.organizationId },
+    });
+    expect(res.status).toEqual(200);
+    const data = await res.json();
+    expect(data.organizationId).toEqual(inviteData.organizationId);
+    expect(data.email).toEqual(inviteData.inviteeEmail);
+    expect(data.role).toEqual(inviteData.role);
+  });
+
+  it("should reject non-admin from inviting a consultant", async () => {
+    Auth.getServerSession = jest.fn(() => Promise.resolve(mockUserSession));
+    const req = mockRequest(inviteData);
+    const res = await createOrganizationInvite(req, {
+      params: { organizationId: inviteData.organizationId },
+    });
+    expect(res.status).toEqual(403);
+  });
+
+  it("should allow admin to fetch all invitations", async () => {
+    await OrganizationInvite.create({
+      id: randomUUID(),
+      organizationId: inviteData.organizationId,
+      email: inviteData.inviteeEmail,
+      role: inviteData.role as OrganizationRole,
+      status: InviteStatus.PENDING,
+    });
+
+    const req = mockRequest();
+    const res = await getOrganizationInvites(req, {
+      params: { organizationId: inviteData.organizationId },
+    });
+    expect(res.status).toEqual(200);
+    const data = await res.json();
+    expect(data).toHaveLength(1);
+    expect(data[0].email).toEqual(inviteData.inviteeEmail);
+    expect(data[0].role).toEqual(inviteData.role);
+    expect(data[0].status).toEqual(InviteStatus.PENDING);
+  });
+
+  it("should reject non-admin from fetching invitations", async () => {
+    Auth.getServerSession = jest.fn(() => Promise.resolve(mockUserSession));
+    const req = mockRequest();
+    const res = await getOrganizationInvites(req, {
+      params: { organizationId: inviteData.organizationId },
+    });
+    expect(res.status).toEqual(403);
+  });
+});

--- a/app/tests/tsconfig.json
+++ b/app/tests/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["../src/*"]
+    },
+    "baseUrl": "."
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": [
+    "node_modules",
+    "e2e/**/*",
+    "playwright.config.ts",
+    "cypress/**/*",
+    "cypress.config.ts"
+  ]
+}


### PR DESCRIPTION
The tests are passing locally but still getting error on the CI:
![image](https://github.com/user-attachments/assets/c7da0491-e0eb-4d09-b122-031134da735c)

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Implement organization invitation feature with new database migration, TypeScript models, API routes, and email invitation template along with associated tests.

### Why are these changes being made?
The changes are intended to extend the functionality of the application by enabling administrators to send and manage invitations to users for joining an organization. This required creating appropriate data models, API endpoints to handle invite creation and retrieval, and an email template to notify invitees, enhancing overall organizational management in the application. The existing "CityInviteStatus" was consolidated to "InviteStatus" to maintain consistency and reuse across different invitation use cases.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->