### PR TITLE
feat(api): ON-3610 create separate connect-sources endpoint

### DIFF
--- a/app/src/app/api/v0/admin/connect-sources/route.ts
+++ b/app/src/app/api/v0/admin/connect-sources/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 
 const connectBulkSourcesRequest = z.object({
+  userEmail: z.string().email(), // Email of the user whose invnetories are to be connected
   cityLocodes: z.array(z.string()).max(100), // List of city locodes
   years: z.array(z.number().int().positive()).max(10), // List of years to create inventories for (can be comma separated input, multiple select dropdown etc., so multiple years can be chosen)
 });

--- a/app/src/app/api/v0/admin/connect-sources/route.ts
+++ b/app/src/app/api/v0/admin/connect-sources/route.ts
@@ -1,0 +1,15 @@
+import AdminService from "@/backend/AdminService";
+import { apiHandler } from "@/util/api";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+const connectBulkSourcesRequest = z.object({
+  cityLocodes: z.array(z.string()), // List of city locodes
+  years: z.array(z.number().int().positive()), // List of years to create inventories for (can be comma separated input, multiple select dropdown etc., so multiple years can be chosen)
+});
+
+export const POST = apiHandler(async (req, { session }) => {
+  const props = connectBulkSourcesRequest.parse(await req.json());
+  const result = await AdminService.bulkConnectDataSources(props, session);
+  return NextResponse.json(result);
+});

--- a/app/src/app/api/v0/admin/connect-sources/route.ts
+++ b/app/src/app/api/v0/admin/connect-sources/route.ts
@@ -4,8 +4,8 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 
 const connectBulkSourcesRequest = z.object({
-  cityLocodes: z.array(z.string()), // List of city locodes
-  years: z.array(z.number().int().positive()), // List of years to create inventories for (can be comma separated input, multiple select dropdown etc., so multiple years can be chosen)
+  cityLocodes: z.array(z.string()).max(100), // List of city locodes
+  years: z.array(z.number().int().positive()).max(10), // List of years to create inventories for (can be comma separated input, multiple select dropdown etc., so multiple years can be chosen)
 });
 
 export const POST = apiHandler(async (req, { session }) => {

--- a/app/src/backend/AdminService.ts
+++ b/app/src/backend/AdminService.ts
@@ -19,6 +19,7 @@ export interface BulkInventoryProps {
 }
 
 export interface BulkConnectSourcesProps {
+  userEmail: string; // Email of the user whose inventories are to be connected
   cityLocodes: string[]; // List of city locodes
   years: number[]; // List of years to create inventories for
 }
@@ -129,6 +130,14 @@ export default class AdminService {
           as: "city",
           attributes: ["locode"],
           where: { locode: { [Op.in]: props.cityLocodes } },
+          include: [
+            {
+              model: db.models.User,
+              as: "users",
+              attributes: ["userId"],
+              where: { email: props.userEmail },
+            },
+          ],
         },
       ],
     });

--- a/app/src/backend/AdminService.ts
+++ b/app/src/backend/AdminService.ts
@@ -278,6 +278,7 @@ export default class AdminService {
               source,
               inventory,
               populationScaleFactors,
+              true, // force replace existing InventoryValue entries
             );
             if (result.success) {
               isSuccessful = true;

--- a/app/src/backend/AdminService.ts
+++ b/app/src/backend/AdminService.ts
@@ -120,7 +120,7 @@ export default class AdminService {
     const errors: { locode: string; error: string }[] = [];
 
     const inventories = await db.models.Inventory.findAll({
-      attributes: ["inventoryId", "cityLocode"],
+      attributes: ["inventoryId"],
       where: {
         year: { [Op.in]: props.years },
       },


### PR DESCRIPTION
Independent of bulk inventory creation

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Create a separate `connect-sources` endpoint in the API, which allows for bulk connection of data sources based on specified city locodes and years, independent of inventory creation.

### Why are these changes being made?
This change provides a distinct endpoint that caters to specific administrative needs by connecting data sources without tying them directly to the inventory creation process, improving modularity and ease of management. It also ensures that only users with admin roles can perform these operations, maintaining control and security.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->