### PR TITLE
feat(ui): ON-3575 implement center indicatorPlacement mode for accordion

### DIFF
--- a/app/src/components/ui/accordion.tsx
+++ b/app/src/components/ui/accordion.tsx
@@ -3,14 +3,14 @@ import * as React from "react";
 import { LuChevronDown } from "react-icons/lu";
 
 interface AccordionItemTriggerProps extends Accordion.ItemTriggerProps {
-  indicatorPlacement?: "start" | "end";
+  indicatorPlacement?: "start" | "center" | "end";
 }
 
 export const AccordionItemTrigger = React.forwardRef<
   HTMLButtonElement,
   AccordionItemTriggerProps
 >(function AccordionItemTrigger(props, ref) {
-  const { children, indicatorPlacement = "end", ...rest } = props;
+  const { children, indicatorPlacement = "center", ...rest } = props;
   return (
     <Accordion.ItemTrigger {...rest} ref={ref} pr="16px">
       {indicatorPlacement === "start" && (
@@ -18,8 +18,13 @@ export const AccordionItemTrigger = React.forwardRef<
           <LuChevronDown />
         </Accordion.ItemIndicator>
       )}
-      <HStack gap="4" flex="1" textAlign="start" width="full">
+      <HStack gap="4" flex="1" textAlign="center" justify="center" width="full">
         {children}
+        {indicatorPlacement === "center" && (
+          <Accordion.ItemIndicator>
+            <Icon as={LuChevronDown} size="2xl" />
+          </Accordion.ItemIndicator>
+        )}
       </HStack>
       {indicatorPlacement === "end" && (
         <Accordion.ItemIndicator>

--- a/app/src/components/ui/accordion.tsx
+++ b/app/src/components/ui/accordion.tsx
@@ -18,7 +18,13 @@ export const AccordionItemTrigger = React.forwardRef<
           <LuChevronDown />
         </Accordion.ItemIndicator>
       )}
-      <HStack gap="4" flex="1" textAlign="center" justify="center" width="full">
+      <HStack
+        gap="4"
+        flex="1"
+        width="full"
+        textAlign={indicatorPlacement === "center" ? "center" : "start"}
+        justify={indicatorPlacement === "center" ? "center" : "flex-start"}
+      >
         {children}
         {indicatorPlacement === "center" && (
           <Accordion.ItemIndicator>


### PR DESCRIPTION
And make it the default

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement a "center" `indicatorPlacement` mode for the `AccordionItemTrigger` component in the accordion UI.

### Why are these changes being made?

This change provides a new positioning option for the accordion indicator, offering more flexibility in UI customization as requested in feature ON-3575. By default, the indicator is now centrally aligned unless specified otherwise, which addresses the requirement for a enhanced visual design.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->