### PR TITLE
Bug: disable portalling on percentage breakdown component 

### DIFF
--- a/app/src/components/percentage-breakdown-input.tsx
+++ b/app/src/components/percentage-breakdown-input.tsx
@@ -183,7 +183,7 @@ const PercentageBreakdownInput: FC<FormInputProps> = ({
             </Field>
           </Group>
         </PopoverTrigger>
-        <PopoverContent w="full" className="overflow-scroll">
+        <PopoverContent w="full" className="overflow-scroll" portalled={false}>
           <PopoverArrow />
           <PopoverBody
             w="full"


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Disable portalling on the `PopoverContent` of the percentage breakdown component.

### Why are these changes being made?

Portalling was causing rendering issues in certain layouts, which disrupted user interaction with the component. Disabling it ensures a more consistent and reliable user experience without unintended layout shifts.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->