### PR TITLE
fix(api): add better error feedback for AdminService.ensureIsAdmin

### DIFF
--- a/app/scripts/create-admin.ts
+++ b/app/scripts/create-admin.ts
@@ -36,7 +36,7 @@ async function createAdmin() {
   );
   const newUser = await db.models.User.create({
     userId: randomUUID(),
-    name: "Admin",
+    name: "admin",
     email: email,
     passwordHash,
     role: Roles.Admin,

--- a/app/src/backend/AdminService.ts
+++ b/app/src/backend/AdminService.ts
@@ -161,10 +161,18 @@ export default class AdminService {
   }
 
   private static ensureIsAdmin(session: AppSession | null) {
+    // Ensure user is signed in
+    const isSignedIn = !!session?.user;
+    if (!isSignedIn) {
+      throw new createHttpError.Unauthorized("Not signed in");
+    }
+
     // Ensure user has admin role
     const isAdmin = session?.user?.role === Roles.Admin;
     if (!isAdmin) {
-      throw new createHttpError.Unauthorized("Not signed in as an admin");
+      throw new createHttpError.Unauthorized(
+        "Not signed in as an admin: " + session?.user?.role,
+      );
     }
   }
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Improve error feedback in `AdminService.ensureIsAdmin` to provide more context when authorization checks fail, and update the `createAdmin` script to use "admin" as the role name.

### Why are these changes being made?

Previously, the error message for users failing the admin check was generic, potentially leading to confusion; the updated message includes the user's current role for clarity. Additionally, changing "Admin" to "admin" in the `createAdmin` function standardizes the role naming convention, likely to maintain consistency with other parts of the system.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->