### PR TITLE
feat(api): ON-3637 allow editing notation keys again after save

### DIFF
--- a/app/src/app/api/v0/inventory/[inventory]/notation-keys/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/notation-keys/route.ts
@@ -23,7 +23,12 @@ export const GET = apiHandler(async (_req, { session, params }) => {
   const inventoryProgress =
     await InventoryProgressService.getInventoryProgress(inventory);
   const unfinishedSubSectors = inventoryProgress.sectorProgress.flatMap(
-    (sector) => sector.subSectors.filter((subsector) => !subsector.completed),
+    (sector) =>
+      sector.subSectors.filter((subSector) => {
+        // return unfinished subsectors or ones that are using notation keys (InventoryValue.unavailableReason)
+        // so they can be changed again after saving
+        return !subSector.completed || subSector.unavailableReasons.length > 0;
+      }),
   );
 
   return NextResponse.json({

--- a/app/src/backend/InventoryProgressService.ts
+++ b/app/src/backend/InventoryProgressService.ts
@@ -162,26 +162,28 @@ export default class InventoryProgressService {
           inventoryTypeSubCategoryCount,
         ); // TODO remove this when scope 3 is added back for SECTOR 1 and 2 in BASIC+;
         let completedCount = 0;
+        let unavailableReasons: string[] = [];
         if (inventoryValues?.length > 0) {
-          completedCount = inventoryValues.filter(
+          const currentSubSectorValues = inventoryValues.filter(
             (inventoryValue) =>
               inventoryValue.subSectorId === subSector.subsectorId,
-          ).length;
-          completed = completedCount === totalCount;
+          );
+          unavailableReasons = currentSubSectorValues
+            .map((inventoryValue) => inventoryValue.unavailableReason!)
+            .filter((reason) => !!reason);
+          completed = completedCount === currentSubSectorValues.length;
         }
         return {
           completed,
           completedCount,
           totalCount,
-          ...{
-            sectorId: subSector.sectorId, // optional string defaults to empty string
-            referenceNumber: subSector.referenceNumber, // optional string defaults to empty string
-            scopeId: subSector.scopeId,
-            subsectorId: subSector.subsectorId,
-            subsectorName: subSector.subsectorName,
-            subCategories: subSector.subCategories,
-          },
-          // ...subSector,
+          unavailableReasons,
+          sectorId: subSector.sectorId, // optional string defaults to empty string
+          referenceNumber: subSector.referenceNumber, // optional string defaults to empty string
+          scopeId: subSector.scopeId,
+          subsectorId: subSector.subsectorId,
+          subsectorName: subSector.subsectorName,
+          subCategories: subSector.subCategories,
         };
       });
 


### PR DESCRIPTION
When the subsector was finished and the page/ API data reloaded, the subsector would not be shown anymore. Now it is in case it uses any notation keys for any of its scopes.