### PR TITLE
Fix: on 3635 notation key manager bugs

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/NotationsDefinitionAccordion.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/NotationsDefinitionAccordion.tsx
@@ -57,6 +57,9 @@ const NotationsDefinitionAccordion: FC<NotationsDefinitionAccordionProps> = ({
             fontWeight="bold"
             lineHeight="28px"
             fontSize="title.lg"
+            textAlign="left"
+            display="flex"
+            flex="1"
           >
             {t("notation-key-question")}
           </Text>

--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -201,13 +201,14 @@ const SectorTabs: FC<SectorTabsProps> = ({
         <Tabs.Trigger
           key={sector.sectorId}
           value={`tab-${sector.sectorId}`}
+          maxW="1/4"
           _selected={{
             color: "content.link",
             fontWeight: "bold",
             fontFamily: "heading",
           }}
         >
-          <Text fontSize="title.md" truncate>
+          <Text fontSize="title.md" lineClamp="2">
             {sector.sectorName}
           </Text>
         </Tabs.Trigger>


### PR DESCRIPTION
Changes
- Adds flex props to align text correctly
- Adds line-clamp and max-w to sector tab text

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Adjust the styling of the NotationsDefinitionAccordion and SectorTabs components by adding flex properties to align text properly and setting a maximum width for tab triggers to improve text display.

### Why are these changes being made?
These changes address visual bugs related to text alignment and truncation within the NotationsDefinitionAccordion and SectorTabs components, enhancing user interface consistency by ensuring the text is properly aligned and does not overflow, providing a clearer UI experience.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->