### PR TITLE
Feat/on 3624 undo behavior for cancel button

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -37,7 +37,6 @@ import { toaster } from "@/components/ui/toaster";
 import RouteChangeDialog from "./RouteChangeDialog";
 import { usePathname, useRouter } from "next/navigation";
 import ProgressLoader from "@/components/ProgressLoader";
-import { se } from "date-fns/locale";
 
 interface SectorTabsProps {
   t: TFunction;

--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -37,6 +37,7 @@ import { toaster } from "@/components/ui/toaster";
 import RouteChangeDialog from "./RouteChangeDialog";
 import { usePathname, useRouter } from "next/navigation";
 import ProgressLoader from "@/components/ProgressLoader";
+import { se } from "date-fns/locale";
 
 interface SectorTabsProps {
   t: TFunction;
@@ -236,7 +237,19 @@ const SectorTabs: FC<SectorTabsProps> = ({
       },
     ],
   });
-
+  // handle undo changes
+  const handleUndoChanges = () => {
+    setCardInputs({});
+    setIsDirty(false);
+    setQuickActionValues({});
+    setSelectedCardsBySector({});
+    toaster.create({
+      title: t("success"),
+      description: t("changes-undone"),
+      type: "info",
+    });
+  };
+  // sector tab content - subsectors
   const renderSectorTabContent = () =>
     inventoryData?.sectorProgress.map(({ sector, subSectors }) => {
       // Filter to get only unfinished subsectors
@@ -604,7 +617,13 @@ const SectorTabs: FC<SectorTabsProps> = ({
                 justifyContent="flex-end"
                 gap="16px"
               >
-                <Button height="56px" width="150px" variant="outline">
+                <Button
+                  height="56px"
+                  width="150px"
+                  variant="outline"
+                  onClick={handleUndoChanges}
+                  disabled={!isDirty}
+                >
                   {t("cancel")}
                 </Button>
                 <Button
@@ -613,6 +632,7 @@ const SectorTabs: FC<SectorTabsProps> = ({
                   variant="solid"
                   onClick={() => handleUpdateNotationKeys()}
                   loading={isLoading}
+                  disabled={!isDirty}
                 >
                   {t("update")}
                 </Button>

--- a/app/src/i18n/locales/en/manage-subsectors.json
+++ b/app/src/i18n/locales/en/manage-subsectors.json
@@ -1214,5 +1214,6 @@
   "quick-action-applied": "Quick action applied",
   "changes-can-be-lost": "Your changes can be lost",
   "changes-can-be-lost-description": "Do you want to discard all changes made since last edit? This cannot be undone.",
-  "no-unfinished-subsectors": "No unfinished subsectors."
+  "no-unfinished-subsectors": "No unfinished subsectors.",
+  "changes-undone": "Changes undone"
 }


### PR DESCRIPTION
Changes
- Adds undo action for notation key manager
- Adds disabled prop to buttons to prevent empty submissions

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement undo behavior for the cancel button in the SectorTabs component, including adding toast notifications and enabling/disabling buttons based on current edit state.

### Why are these changes being made?

These changes enhance user experience by allowing users to revert changes made to sector data before they are saved, preventing accidental data loss. The approach includes user feedback through toast notifications, ensuring clarity on the action's outcome, and improves workflow flexibility by tracking whether current edits exist.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->