### PR TITLE
fix: adds condition to render admin menu item

### DIFF
--- a/app/src/components/navigation-bar.tsx
+++ b/app/src/components/navigation-bar.tsx
@@ -28,6 +28,7 @@ import {
 import { Avatar } from "@/components/ui/avatar";
 
 import { Button } from "@/components/ui/button";
+import { Roles } from "@/util/types";
 
 function countryFromLanguage(language: string) {
   return language == "en" ? "us" : language;
@@ -259,28 +260,30 @@ export function NavigationBar({
                 minH="128px"
                 zIndex={2000}
               >
-                <MenuItem
-                  value="admin"
-                  paddingTop="12px"
-                  paddingBottom="12px"
-                  px="16px"
-                  onClick={() => router.push(`/admin`)}
-                >
-                  <Box display="flex" alignItems="center">
-                    {" "}
-                    <Icon
-                      as={MdAspectRatio}
-                      boxSize={6}
-                      color={
-                        userMenuHighlight === "admin"
-                          ? "background.neutral"
-                          : "content.tertiary"
-                      }
-                      mr={4}
-                    />
-                    <Text fontSize="title.md">{t("admin")}</Text>
-                  </Box>
-                </MenuItem>
+                {userInfo?.role === Roles.Admin && (
+                  <MenuItem
+                    value="admin"
+                    paddingTop="12px"
+                    paddingBottom="12px"
+                    px="16px"
+                    onClick={() => router.push(`/admin`)}
+                  >
+                    <Box display="flex" alignItems="center">
+                      {" "}
+                      <Icon
+                        as={MdAspectRatio}
+                        boxSize={6}
+                        color={
+                          userMenuHighlight === "admin"
+                            ? "background.neutral"
+                            : "content.tertiary"
+                        }
+                        mr={4}
+                      />
+                      <Text fontSize="title.md">{t("admin")}</Text>
+                    </Box>
+                  </MenuItem>
+                )}
                 <MenuItem
                   value="settings"
                   paddingTop="12px"


### PR DESCRIPTION
Changes
- Adds condition to render admin menu item

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a condition to render the admin menu item based on the user's role in the navigation bar component.

### Why are these changes being made?

Without this condition, the admin menu item is rendered for all users indiscriminately. This change ensures that only users with an admin role will see the admin menu item, enhancing both security and user experience by preventing unauthorized access to admin features.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->