### PR TITLE
fix(api): make notation key manager GET API use scopes

### DIFF
--- a/app/src/app/api/v0/inventory/[inventory]/notation-keys/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/notation-keys/route.ts
@@ -7,8 +7,8 @@ import { randomUUID } from "node:crypto";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
-// returns list of unfinished subsectors for given inventory
-// used to decide which subsectors to show on the notation key manager
+// returns list of unfinished subsector + scopes for given inventory
+// used to decide which subsectors + scopes to show on the notation key manager
 export const GET = apiHandler(async (_req, { session, params }) => {
   const inventoryId = z.string().uuid().parse(params.inventory);
 
@@ -20,20 +20,37 @@ export const GET = apiHandler(async (_req, { session, params }) => {
     true,
   );
 
-  const inventoryProgress =
-    await InventoryProgressService.getInventoryProgress(inventory);
-  const unfinishedSubSectors = inventoryProgress.sectorProgress.flatMap(
-    (sector) =>
-      sector.subSectors.filter((subSector) => {
-        // return unfinished subsectors or ones that are using notation keys (InventoryValue.unavailableReason)
-        // so they can be changed again after saving
-        return !subSector.completed || subSector.unavailableReasons.length > 0;
+  const inventoryValues = await db.models.InventoryValue.findAll({
+    where: {
+      inventoryId: inventory.inventoryId,
+    },
+  });
+  const inventoryStructure =
+    await InventoryProgressService.getSortedInventoryStructure();
+  const allInventoryValues = inventoryStructure.flatMap((sector) =>
+    sector.subSectors.flatMap((subSector) =>
+      subSector.subCategories.flatMap((subCategory) => {
+        const inventoryValue = inventoryValues.find(
+          (value) => value.subCategoryId === subCategory.subcategoryId,
+        );
+
+        return {
+          subSector,
+          subCategory,
+          isFilled: inventoryValue != null,
+          hasNotationKey:
+            inventoryValue && inventoryValue.unavailableReason != null,
+        };
       }),
+    ),
+  );
+  const filteredInventoryValues = allInventoryValues.filter(
+    (value) => !value.isFilled || value.hasNotationKey,
   );
 
   return NextResponse.json({
     success: true,
-    result: unfinishedSubSectors,
+    result: filteredInventoryValues,
   });
 });
 

--- a/app/src/backend/InventoryProgressService.ts
+++ b/app/src/backend/InventoryProgressService.ts
@@ -227,7 +227,7 @@ export default class InventoryProgressService {
     );
   }
 
-  private static async getSortedInventoryStructure() {
+  public static async getSortedInventoryStructure() {
     if (
       Inventory_Sector_Hierarchy.length > 0 &&
       process.env.NODE_ENV !== "test"

--- a/app/src/backend/InventoryProgressService.ts
+++ b/app/src/backend/InventoryProgressService.ts
@@ -161,15 +161,11 @@ export default class InventoryProgressService {
           inventoryTypeSubCategoryCount,
         ); // TODO remove this when scope 3 is added back for SECTOR 1 and 2 in BASIC+;
         let completedCount = 0;
-        let unavailableReasons: string[] = [];
         if (inventoryValues?.length > 0) {
           const currentSubSectorValues = inventoryValues.filter(
             (inventoryValue) =>
               inventoryValue.subSectorId === subSector.subsectorId,
           );
-          unavailableReasons = currentSubSectorValues
-            .map((inventoryValue) => inventoryValue.unavailableReason!)
-            .filter((reason) => !!reason);
           completedCount = currentSubSectorValues.length;
         }
 
@@ -177,7 +173,6 @@ export default class InventoryProgressService {
           completed: completedCount === totalCount,
           completedCount,
           totalCount,
-          unavailableReasons,
           sectorId: subSector.sectorId, // optional string defaults to empty string
           referenceNumber: subSector.referenceNumber, // optional string defaults to empty string
           scopeId: subSector.scopeId,

--- a/app/src/models/InventoryValue.ts
+++ b/app/src/models/InventoryValue.ts
@@ -21,8 +21,8 @@ export interface InventoryValueAttributes {
   activityUnits?: string | null; // TODO remove
   co2eq?: bigint;
   co2eqYears?: number;
-  unavailableReason?: string;
-  unavailableExplanation?: string;
+  unavailableReason?: string | null;
+  unavailableExplanation?: string | null;
   inputMethodology?: string;
   sectorId?: string;
   subSectorId?: string;
@@ -68,8 +68,8 @@ export class InventoryValue
   activityUnits?: string | null; // TODO remove
   co2eq?: bigint;
   co2eqYears?: number;
-  unavailableReason?: string;
-  unavailableExplanation?: string;
+  unavailableReason?: string | null;
+  unavailableExplanation?: string | null;
   inputMethodology?: string;
   sectorId?: string;
   subSectorId?: string;


### PR DESCRIPTION
Return subsector + scope list instead of just subsectors, ignoring the scopes.