### PR TITLE
feat(ui): show error toast when saving notation keys fails

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -117,6 +117,11 @@ const SectorTabs: FC<SectorTabsProps> = ({
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
   }, [isDirty]);
 
+  const { showErrorToast } = UseErrorToast({
+    title: t("failure"),
+    description: t("notation-keys-save-failed"),
+  });
+
   // update notation keys for subsectors from api service
   const [createNotationKeys, { isLoading, isError, data, status }] =
     api.useUpdateOrCreateNotationKeysMutation();
@@ -144,10 +149,6 @@ const SectorTabs: FC<SectorTabsProps> = ({
 
     // payload according to the schema
     const payload = { notationKeys: notationKeysArray };
-    const { showErrorToast } = UseErrorToast({
-      title: t("failure"),
-      description: t("notation-keys-save-failed"),
-    });
 
     try {
       await createNotationKeys({

--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -37,6 +37,7 @@ import { toaster } from "@/components/ui/toaster";
 import RouteChangeDialog from "./RouteChangeDialog";
 import { usePathname, useRouter } from "next/navigation";
 import ProgressLoader from "@/components/ProgressLoader";
+import { UseErrorToast } from "@/hooks/Toasts";
 
 interface SectorTabsProps {
   t: TFunction;
@@ -143,6 +144,10 @@ const SectorTabs: FC<SectorTabsProps> = ({
 
     // payload according to the schema
     const payload = { notationKeys: notationKeysArray };
+    const { showErrorToast } = UseErrorToast({
+      title: t("failure"),
+      description: t("notation-keys-save-failed"),
+    });
 
     try {
       await createNotationKeys({
@@ -159,12 +164,9 @@ const SectorTabs: FC<SectorTabsProps> = ({
         });
     } catch (error) {
       console.error("Failed to update notation keys", error);
+      showErrorToast();
     }
   };
-
-  if (isError) {
-    console.error("Failed to update notation keys", isError);
-  }
 
   // Modal handlers for unsaved changes
   const confirmNavigation = () => {

--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/page.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Box } from "@chakra-ui/react";
-import React, { useEffect } from "react";
+import React from "react";
 import Heading from "./Heading";
 import { useTranslation } from "@/i18n/client";
 import NotationsDefinitionAccordion from "./NotationsDefinitionAccordion";


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add an error toast notification when saving notation keys fails in the `SectorTabs` component.

### Why are these changes being made?

This change provides immediate user feedback when an error occurs during the save operation, enhancing the user experience by clearly indicating when the action was unsuccessful. Prior to this, the error was only logged to the console without a visual indication to the user.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->