### PR TITLE
Fix/on 3680 show subsectors by scope

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -43,8 +43,10 @@ interface SubcategoryItem {
   subCategoryReferenceNumber: string;
 }
 
+type SectorReference = "I" | "II" | "III" | "IV" | "V";
+
 interface SectorGroup {
-  sectorRef: string;
+  sectorRef: SectorReference;
   // Include the full sector data (extracted from the first item)
   sector: {
     sectorId: string;
@@ -58,7 +60,7 @@ const groupScopesBySector = (data: Record<string, any[]>): SectorGroup[] => {
   return Object.entries(data).map(([sectorRef, items]) => {
     const sector = items[0]?.subSector; // assume all items in this group share the same sector
     return {
-      sectorRef,
+      sectorRef: sectorRef as SectorReference,
       sector: {
         sectorId: sector?.sectorId,
         sectorName: sector?.sectorName,
@@ -75,8 +77,8 @@ const groupScopesBySector = (data: Record<string, any[]>): SectorGroup[] => {
   });
 };
 
-// convert sector reference to GPC reference name
-const getGpcReferenceName = (ref: string, t: TFunction): string => {
+// convert sector reference number (roman numeral) to GPC sector name
+const getGPCSectorName = (sectorRef: SectorReference, t: TFunction): string => {
   const mapping: Record<string, string> = {
     I: t("stationary-energy"),
     II: t("transport"),
@@ -84,7 +86,7 @@ const getGpcReferenceName = (ref: string, t: TFunction): string => {
     IV: t("industrial-processes-and-product-uses"),
     V: t("agriculture-forestry-and-other-land-use"),
   };
-  return mapping[ref] || ref;
+  return mapping[sectorRef] || sectorRef;
 };
 
 interface SectorTabsProps {
@@ -260,7 +262,7 @@ const SectorTabs: FC<SectorTabsProps> = ({ inventoryId, t }) => {
           }}
         >
           <Text fontSize="title.md" lineClamp="2">
-            {getGpcReferenceName(group.sectorRef, t)}
+            {getGPCSectorName(group.sectorRef, t)}
           </Text>
         </Tabs.Trigger>
       );
@@ -381,7 +383,7 @@ const SectorTabs: FC<SectorTabsProps> = ({ inventoryId, t }) => {
             <Box display="flex" alignItems="center" gap="16px">
               <Icon as={StationaryEnergyIcon} color="interactive.control" />
               <Text fontSize="title.lg" fontFamily="heading" fontWeight="bold">
-                {getGpcReferenceName(group.sectorRef, t)}
+                {getGPCSectorName(group.sectorRef, t)}
               </Text>
             </Box>
             <Text fontSize="body.lg" fontFamily="body" color="content.tertiary">

--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -219,13 +219,12 @@ const SectorTabs: FC<SectorTabsProps> = ({
           description: t("notation-keys-updated"),
         });
     } catch (error) {
-      console.error("Failed to update notation keys", error);
+      toaster.error({
+        title: t("error"),
+        description: t("error-updating-notation-keys"),
+      });
     }
   };
-
-  if (isError) {
-    console.error("Failed to update notation keys", isError);
-  }
 
   // Modal handlers for unsaved changes
   const confirmNavigation = () => {

--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -82,14 +82,13 @@ const groupScopesBySector = (data: Record<string, any[]>): SectorGroup[] => {
 
 // convert sector reference to GPC reference name
 
-const getGpcReferenceName = (ref: string): string => {
+const getGpcReferenceName = (ref: string, t: TFunction): string => {
   const mapping: Record<string, string> = {
-    I: "Stationary Energy",
-    II: "Transport",
-    III: "Waste",
-    // Add additional mappings as needed:
-    IV: "Industrial Processes and Product Uses (IPPU)",
-    V: "Agriculture, Forestry, and Other Land Use (AFOLU)",
+    I: t("stationary-energy"),
+    II: t("transport"),
+    III: t("waste"),
+    IV: t("industrial-processes-and-product-uses"),
+    V: t("agriculture-forestry-and-other-land-use"),
   };
   return mapping[ref] || ref;
 };
@@ -269,7 +268,7 @@ const SectorTabs: FC<SectorTabsProps> = ({
           }}
         >
           <Text fontSize="title.md" lineClamp="2">
-            {getGpcReferenceName(group.sectorRef)}
+            {getGpcReferenceName(group.sectorRef, t)}
           </Text>
         </Tabs.Trigger>
       );
@@ -385,7 +384,7 @@ const SectorTabs: FC<SectorTabsProps> = ({
             <Box display="flex" alignItems="center" gap="16px">
               <Icon as={StationaryEnergyIcon} color="interactive.control" />
               <Text fontSize="title.lg" fontFamily="heading" fontWeight="bold">
-                {getGpcReferenceName(group.sectorRef)}
+                {getGpcReferenceName(group.sectorRef, t)}
               </Text>
             </Box>
             <Text fontSize="body.lg" fontFamily="body" color="content.tertiary">

--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -179,35 +179,36 @@ const SectorTabs: FC<SectorTabsProps> = ({
   // update notation keys for subsectors from api service
   const [createNotationKeys, { isLoading, isError, data, status }] =
     api.useUpdateOrCreateNotationKeysMutation();
-  const handleUpdateNotationKeys = async (subsectorId?: string) => {
-    let notationKeysArray;
-    if (subsectorId) {
+  const handleUpdateNotationKeys = async (subCategoryId?: string) => {
+    let notationKeys: {
+      subCategoryId: string;
+      unavailableReason: string;
+      unavailableExplanation: string;
+    }[] = [];
+    if (subCategoryId) {
       // Update a single card
-      const cardData = cardInputs[subsectorId];
+      const cardData = cardInputs[subCategoryId];
       if (!cardData) return;
-      notationKeysArray = [
+      notationKeys = [
         {
-          subSectorId: subsectorId,
+          subCategoryId,
           unavailableReason: cardData.notationKey,
           unavailableExplanation: cardData.explanation,
         },
       ];
     } else {
       // Bulk update all cards that have been edited (or, if you prefer, all selected ones)
-      notationKeysArray = Object.entries(cardInputs).map(([id, value]) => ({
-        subSectorId: id,
+      notationKeys = Object.entries(cardInputs).map(([id, value]) => ({
+        subCategoryId: id,
         unavailableReason: value.notationKey,
         unavailableExplanation: value.explanation,
       }));
     }
 
-    // payload according to the schema
-    const payload = { notationKeys: notationKeysArray };
-
     try {
       await createNotationKeys({
         inventoryId: inventoryId!,
-        ...payload,
+        notationKeys: notationKeys,
       }).unwrap();
       // clear dirty state on success
       setCardInputs({});

--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -81,7 +81,6 @@ const groupScopesBySector = (data: Record<string, any[]>): SectorGroup[] => {
 };
 
 // convert sector reference to GPC reference name
-
 const getGpcReferenceName = (ref: string, t: TFunction): string => {
   const mapping: Record<string, string> = {
     I: t("stationary-energy"),
@@ -140,9 +139,10 @@ const SectorTabs: FC<SectorTabsProps> = ({
     data: sectorData,
     isLoading: isSectorDataLoading,
     error,
-  } = api.useGetUnfinishedSubsectorsQuery({
-    inventoryId: inventoryId! && inventoryId!,
-  });
+  } = api.useGetNotationKeyScopesQuery(
+    { inventoryId: inventoryId! },
+    { skip: !inventoryId },
+  );
 
   useEffect(() => {
     // Adjust the dirty check as needed (e.g., also include quickActionValues)
@@ -244,11 +244,11 @@ const SectorTabs: FC<SectorTabsProps> = ({
   // --- Grouping the new API structure ---
   // Our API response now contains a `result` object keyed by sector ref.
   const groupedSectors: SectorGroup[] = useMemo(() => {
-    if (sectorData && sectorData.result) {
+    if (sectorData?.result) {
       return groupScopesBySector(sectorData.result);
     }
     return [];
-  }, [sectorData]);
+  }, [sectorData?.result]);
 
   if (isSectorDataLoading) {
     return <ProgressLoader />;
@@ -548,7 +548,7 @@ const SectorTabs: FC<SectorTabsProps> = ({
                               lineClamp={2}
                             >
                               {t(item.subCategoryReferenceNumber!)}{" "}
-                              {/* {t(item.subSectorName)} –{" "} Todo nice to have a subsector name showing */}
+                              {t(item.subSectorName)} –{" "}
                               {t(item.subCategoryName)}
                             </Text>
                           </CheckboxCard.Label>

--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -14,7 +14,7 @@ import {
 import { SerializedError } from "@reduxjs/toolkit";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { TFunction } from "i18next";
-import React, { FC, useEffect, useState } from "react";
+import React, { FC, useEffect, useMemo, useState } from "react";
 import { SubSectorWithRelations } from "../[step]/types";
 import { StationaryEnergyIcon } from "@/components/icons";
 import { BiSelectMultiple } from "react-icons/bi";
@@ -38,11 +38,65 @@ import RouteChangeDialog from "./RouteChangeDialog";
 import { usePathname, useRouter } from "next/navigation";
 import ProgressLoader from "@/components/ProgressLoader";
 
+// Define your transformation interfaces
+
+interface SubcategoryItem {
+  subSectorId: string;
+  subSectorName: string;
+  subCategoryId: string;
+  subCategoryName: string;
+  subCategoryReferenceNumber: string;
+}
+
+interface SectorGroup {
+  sectorRef: string;
+  // Include the full sector data (extracted from the first item)
+  sector: {
+    sectorId: string;
+    sectorName: string;
+    referenceNumber?: string;
+  };
+  items: SubcategoryItem[];
+}
+
+const groupScopesBySector = (data: Record<string, any[]>): SectorGroup[] => {
+  return Object.entries(data).map(([sectorRef, items]) => {
+    const sector = items[0]?.subSector; // assume all items in this group share the same sector
+    return {
+      sectorRef,
+      sector: {
+        sectorId: sector?.sectorId,
+        sectorName: sector?.sectorName,
+        referenceNumber: sector?.referenceNumber,
+      },
+      items: items.map((item) => ({
+        subSectorId: item.subSector.subsectorId,
+        subSectorName: item.subSector.subsectorName,
+        subCategoryId: item.subCategory.subcategoryId,
+        subCategoryName: item.subCategory.subcategoryName,
+        subCategoryReferenceNumber: item.subCategory.referenceNumber,
+      })),
+    };
+  });
+};
+
+// convert sector reference to GPC reference name
+
+const getGpcReferenceName = (ref: string): string => {
+  const mapping: Record<string, string> = {
+    I: "Stationary Energy",
+    II: "Transport",
+    III: "Waste",
+    // Add additional mappings as needed:
+    IV: "Industrial Processes and Product Uses (IPPU)",
+    V: "Agriculture, Forestry, and Other Land Use (AFOLU)",
+  };
+  return mapping[ref] || ref;
+};
+
 interface SectorTabsProps {
   t: TFunction;
-  inventoryData: InventoryProgressResponse | undefined;
-  isInventoryDataLoading: boolean;
-  inventoryDataError: FetchBaseQueryError | SerializedError | undefined;
+  inventoryId: string | undefined;
 }
 
 interface QuickActionInputs {
@@ -56,9 +110,8 @@ interface CardInputs {
 }
 
 const SectorTabs: FC<SectorTabsProps> = ({
-  inventoryData,
-  inventoryDataError,
-  isInventoryDataLoading,
+  inventoryId,
+
   t,
 }) => {
   const router = useRouter();
@@ -83,6 +136,14 @@ const SectorTabs: FC<SectorTabsProps> = ({
   const pathname = usePathname();
   const [prevPathname, setPrevPathname] = useState(pathname);
   const [nextRoute, setNextRoute] = useState<string | null>(null);
+
+  const {
+    data: sectorData,
+    isLoading: isSectorDataLoading,
+    error,
+  } = api.useGetUnfinishedSubsectorsQuery({
+    inventoryId: inventoryId! && inventoryId!,
+  });
 
   useEffect(() => {
     // Adjust the dirty check as needed (e.g., also include quickActionValues)
@@ -146,7 +207,7 @@ const SectorTabs: FC<SectorTabsProps> = ({
 
     try {
       await createNotationKeys({
-        inventoryId: inventoryData?.inventory.inventoryId!,
+        inventoryId: inventoryId!,
         ...payload,
       }).unwrap();
       // clear dirty state on success
@@ -181,26 +242,25 @@ const SectorTabs: FC<SectorTabsProps> = ({
     setShowDialog(false);
   };
 
-  useEffect(() => {
-    if (!isInventoryDataLoading) {
-      const unfinishedSubSectors = inventoryData?.sectorProgress.flatMap(
-        (sector) =>
-          sector.subSectors.filter((subsector) => !subsector.completed),
-      );
-
-      setUnfinishedSubsectorsData(unfinishedSubSectors);
+  // --- Grouping the new API structure ---
+  // Our API response now contains a `result` object keyed by sector ref.
+  const groupedSectors: SectorGroup[] = useMemo(() => {
+    if (sectorData && sectorData.result) {
+      return groupScopesBySector(sectorData.result);
     }
-  }, [inventoryData, isInventoryDataLoading, inventoryDataError]);
-  if (isInventoryDataLoading) {
+    return [];
+  }, [sectorData]);
+
+  if (isSectorDataLoading) {
     return <ProgressLoader />;
   }
 
   const renderSectorTabList = () => {
-    return inventoryData?.sectorProgress.map(({ sector }) => {
+    return groupedSectors.map((group) => {
       return (
         <Tabs.Trigger
-          key={sector.sectorId}
-          value={`tab-${sector.sectorId}`}
+          key={group.sectorRef}
+          value={`tab-${group.sectorRef}`}
           maxW="1/4"
           _selected={{
             color: "content.link",
@@ -209,7 +269,7 @@ const SectorTabs: FC<SectorTabsProps> = ({
           }}
         >
           <Text fontSize="title.md" lineClamp="2">
-            {sector.sectorName}
+            {getGpcReferenceName(group.sectorRef)}
           </Text>
         </Tabs.Trigger>
       );
@@ -251,52 +311,47 @@ const SectorTabs: FC<SectorTabsProps> = ({
   };
   // sector tab content - subsectors
   const renderSectorTabContent = () =>
-    inventoryData?.sectorProgress.map(({ sector, subSectors }) => {
-      // Filter to get only unfinished subsectors
-      const unfinishedSubsectors = subSectors.filter(
-        (subsector) => !subsector.completed,
-      );
-
+    groupedSectors.map((group) => {
+      // For each group, use the sector info from group.sector and the scopes from group.items.
+      // Here we consider all items as "unfinished" (adjust filtering if needed)
+      const unfinishedItems = group.items;
       const selectedForThisSector =
-        selectedCardsBySector[sector.sectorId] || [];
-
-      // Get quick action values for this sector, defaulting to empty strings
-      const quickValues = quickActionValues[sector.sectorId] || {
+        selectedCardsBySector[group.sector.sectorId] || [];
+      const quickValues = quickActionValues[group.sector.sectorId] || {
         notationKey: "",
         explanation: "",
       };
 
-      const handleToggleCard = (subSectorId: string) => {
+      const handleToggleCard = (cardId: string) => {
         setSelectedCardsBySector((prev) => ({
           ...prev,
-          [sector.sectorId]: prev[sector.sectorId]?.includes(subSectorId)
-            ? prev[sector.sectorId].filter((id) => id !== subSectorId)
-            : [...(prev[sector.sectorId] || []), subSectorId],
+          [group.sector.sectorId]: prev[group.sector.sectorId]?.includes(cardId)
+            ? prev[group.sector.sectorId].filter((id) => id !== cardId)
+            : [...(prev[group.sector.sectorId] || []), cardId],
         }));
       };
 
-      // Toggle select all for the current sector
       const handleSelectAll = () => {
-        if (selectedForThisSector.length === unfinishedSubsectors.length) {
-          // All are selected so unselect all
+        if (selectedForThisSector.length === unfinishedItems.length) {
           setSelectedCardsBySector((prev) => ({
             ...prev,
-            [sector.sectorId]: [],
+            [group.sector.sectorId]: [],
           }));
         } else {
-          // Select all unfinished subsectors
           setSelectedCardsBySector((prev) => ({
             ...prev,
-            [sector.sectorId]: unfinishedSubsectors.map((s) => s.subsectorId),
+            [group.sector.sectorId]: unfinishedItems.map(
+              (item) => item.subCategoryId,
+            ),
           }));
         }
       };
-      // Apply quick action values to each selected card
+
       const handleApplyToAll = () => {
         setCardInputs((prev) => {
           const newInputs = { ...prev };
-          selectedForThisSector.forEach((subSectorId) => {
-            newInputs[subSectorId] = {
+          selectedForThisSector.forEach((cardId) => {
+            newInputs[cardId] = {
               notationKey: quickValues.notationKey,
               explanation: quickValues.explanation,
             };
@@ -309,10 +364,11 @@ const SectorTabs: FC<SectorTabsProps> = ({
           type: "info",
         });
       };
+
       return (
         <Tabs.Content
-          key={sector.sectorId}
-          value={`tab-${sector.sectorId}`}
+          key={group.sectorRef}
+          value={`tab-${group.sectorRef}`}
           pt="70px"
           _open={{
             animationName: "fade-in, scale-in",
@@ -329,20 +385,18 @@ const SectorTabs: FC<SectorTabsProps> = ({
             <Box display="flex" alignItems="center" gap="16px">
               <Icon as={StationaryEnergyIcon} color="interactive.control" />
               <Text fontSize="title.lg" fontFamily="heading" fontWeight="bold">
-                {sector.sectorName}
+                {getGpcReferenceName(group.sectorRef)}
               </Text>
             </Box>
             <Text fontSize="body.lg" fontFamily="body" color="content.tertiary">
               {t("content-description")}
             </Text>
           </Box>
-          {/* Quick Action form */}
+          {/* Quick Action Form */}
           <Box mb="48px" display="flex" flexDirection="column" gap="32px">
             <Box display="flex" alignItems="center" gap="8px">
-              {/* Select All button */}
               <Button variant="ghost" onClick={handleSelectAll}>
-                {selectedForThisSector.length ===
-                unfinishedSubsectors.length ? (
+                {selectedForThisSector.length === unfinishedItems.length ? (
                   <Icon as={CgRemoveR} color="content.link" boxSize={6} />
                 ) : (
                   <Icon
@@ -356,7 +410,7 @@ const SectorTabs: FC<SectorTabsProps> = ({
                   fontFamily="heading"
                   color="content.link"
                 >
-                  {selectedForThisSector.length === unfinishedSubsectors.length
+                  {selectedForThisSector.length === unfinishedItems.length
                     ? t("deselect-all")
                     : t("quick-actions")}
                 </Text>
@@ -369,10 +423,11 @@ const SectorTabs: FC<SectorTabsProps> = ({
                   onValueChange={({ value: newValue }) =>
                     setQuickActionValues((prev) => ({
                       ...prev,
-                      [sector.sectorId]: {
-                        ...prev[sector.sectorId],
+                      [group.sector.sectorId]: {
+                        ...prev[group.sector.sectorId],
                         notationKey: newValue.toString(),
-                        explanation: prev[sector.sectorId]?.explanation || "",
+                        explanation:
+                          prev[group.sector.sectorId]?.explanation || "",
                       },
                     }))
                   }
@@ -415,7 +470,6 @@ const SectorTabs: FC<SectorTabsProps> = ({
                     {t("explanation")}
                   </Text>
                 </Field.Label>
-
                 <Input
                   placeholder={t("explanation-input-placeholder")}
                   borderWidth="1px"
@@ -426,15 +480,15 @@ const SectorTabs: FC<SectorTabsProps> = ({
                   onChange={(e) =>
                     setQuickActionValues((prev) => ({
                       ...prev,
-                      [sector.sectorId]: {
-                        ...prev[sector.sectorId],
+                      [group.sector.sectorId]: {
+                        ...prev[group.sector.sectorId],
                         explanation: e.target.value,
-                        notationKey: prev[sector.sectorId]?.notationKey || "",
+                        notationKey:
+                          prev[group.sector.sectorId]?.notationKey || "",
                       },
                     }))
                   }
                 />
-                {/* TODO add error feedback */}
                 <Field.ErrorText></Field.ErrorText>
               </Field.Root>
               <Button
@@ -446,32 +500,32 @@ const SectorTabs: FC<SectorTabsProps> = ({
               </Button>
             </Box>
           </Box>
-
-          {/* unfinished subsectors cards */}
-          {unfinishedSubsectors.length > 0 ? (
+          {/* Checkbox Cards for each item */}
+          {unfinishedItems.length > 0 ? (
             <>
               <Box
                 display="grid"
                 gridTemplateColumns="repeat(auto-fill, minmax(450px, 1fr))"
                 gap="48px"
               >
-                {unfinishedSubsectors.map((subsector) => {
-                  const cardValue = cardInputs[subsector.subsectorId] || {
+                {unfinishedItems.map((item) => {
+                  // Use the subCategoryId as the unique key for each card
+                  const cardValue = cardInputs[item.subCategoryId] || {
                     notationKey: "",
                     explanation: "",
                   };
                   return (
                     <CheckboxCard.Root
                       width="497px"
-                      key={subsector.subsectorId}
+                      key={item.subCategoryId}
                       height="344px"
                       p={0}
                       borderCollapse="border.neutral"
                       checked={selectedForThisSector.includes(
-                        subsector.subsectorId,
+                        item.subCategoryId,
                       )}
                       onCheckedChange={() =>
-                        handleToggleCard(subsector.subsectorId)
+                        handleToggleCard(item.subCategoryId)
                       }
                     >
                       <CheckboxCard.HiddenInput />
@@ -487,10 +541,11 @@ const SectorTabs: FC<SectorTabsProps> = ({
                               fontSize="title.md"
                               fontFamily="heading"
                               fontWeight="bold"
+                              lineClamp={2}
                             >
-                              {" "}
-                              {t(subsector.referenceNumber!)} {""}
-                              {t(subsector.subsectorName!)}
+                              {t(item.subCategoryReferenceNumber!)}{" "}
+                              {/* {t(item.subSectorName)} –{" "} Todo nice to have a subsector name showing */}
+                              {t(item.subCategoryName)}
                             </Text>
                           </CheckboxCard.Label>
                           <CheckboxCard.Description w="full">
@@ -507,20 +562,20 @@ const SectorTabs: FC<SectorTabsProps> = ({
                                 gap="16px"
                                 w="full"
                               >
-                                <Field.Root orientation="vertical" w="ull">
+                                <Field.Root orientation="vertical" w="full">
                                   <SelectRoot
                                     variant="outline"
                                     collection={notationKeys}
                                     w="full"
                                     value={[cardValue.notationKey]}
-                                    onValueChange={(e) =>
+                                    onValueChange={({ value }) =>
                                       setCardInputs((prev) => ({
                                         ...prev,
-                                        [subsector.subsectorId]: {
-                                          ...prev[subsector.subsectorId],
-                                          notationKey: e.value.toString(),
+                                        [item.subCategoryId]: {
+                                          ...prev[item.subCategoryId],
+                                          notationKey: value.toString(),
                                           explanation:
-                                            prev[subsector.subsectorId]
+                                            prev[item.subCategoryId]
                                               ?.explanation || "",
                                         },
                                       }))
@@ -574,7 +629,6 @@ const SectorTabs: FC<SectorTabsProps> = ({
                                       {t("explanation")}
                                     </Text>
                                   </Field.Label>
-
                                   <Textarea
                                     placeholder={t(
                                       "explanation-input-placeholder",
@@ -588,17 +642,16 @@ const SectorTabs: FC<SectorTabsProps> = ({
                                     onChange={(e) =>
                                       setCardInputs((prev) => ({
                                         ...prev,
-                                        [subsector.subsectorId]: {
-                                          ...prev[subsector.subsectorId],
+                                        [item.subCategoryId]: {
+                                          ...prev[item.subCategoryId],
                                           explanation: e.target.value,
                                           notationKey:
-                                            prev[subsector.subsectorId]
+                                            prev[item.subCategoryId]
                                               ?.notationKey || "",
                                         },
                                       }))
                                     }
                                   />
-                                  {/* TODO add error feedback */}
                                   <Field.ErrorText></Field.ErrorText>
                                 </Field.Root>
                               </Box>
@@ -650,7 +703,7 @@ const SectorTabs: FC<SectorTabsProps> = ({
       <Tabs.Root
         lazyMount
         unmountOnExit
-        defaultValue={`tab-${inventoryData?.sectorProgress[0].sector.sectorId}`}
+        defaultValue={`tab-${groupedSectors[0]?.sector.sectorName}`}
       >
         <Tabs.List>{renderSectorTabList()}</Tabs.List>
         {renderSectorTabContent()}

--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -703,7 +703,7 @@ const SectorTabs: FC<SectorTabsProps> = ({
       <Tabs.Root
         lazyMount
         unmountOnExit
-        defaultValue={`tab-${groupedSectors[0]?.sector.sectorName}`}
+        defaultValue={`tab-${groupedSectors[0]?.sectorRef}`}
       >
         <Tabs.List>{renderSectorTabList()}</Tabs.List>
         {renderSectorTabContent()}

--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -350,7 +350,12 @@ const SectorTabs: FC<SectorTabsProps> = ({
       const handleApplyToAll = () => {
         setCardInputs((prev) => {
           const newInputs = { ...prev };
-          selectedForThisSector.forEach((cardId) => {
+          // If there are selected cards, update only those; otherwise update all items.
+          const itemsToUpdate =
+            selectedForThisSector.length > 0
+              ? selectedForThisSector
+              : unfinishedItems.map((item) => item.subCategoryId);
+          itemsToUpdate.forEach((cardId) => {
             newInputs[cardId] = {
               notationKey: quickValues.notationKey,
               explanation: quickValues.explanation,

--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/page.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/page.tsx
@@ -34,12 +34,7 @@ const ManageSubSectors = ({
       >
         <Heading t={t} inventoryParam={inventory} />
         <NotationsDefinitionAccordion t={t} />
-        <SectorTabs
-          t={t}
-          inventoryData={inventoryData}
-          isInventoryDataLoading={isInventoryDataLoading}
-          inventoryDataError={inventoryDataError}
-        />
+        <SectorTabs t={t} inventoryId={inventory} />
       </Box>
       <Toaster />
     </Box>

--- a/app/src/app/api/v0/inventory/[inventory]/notation-keys/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/notation-keys/route.ts
@@ -61,7 +61,7 @@ export const GET = apiHandler(async (_req, { session, params }) => {
 const saveNotationKeysRequest = z.object({
   notationKeys: z.array(
     z.object({
-      subSectorId: z.string().uuid(),
+      subCategoryId: z.string().uuid(),
       unavailableReason: z.enum([
         "no-occurrance",
         "not-estimated",
@@ -86,7 +86,7 @@ export const POST = apiHandler(async (req, { session, params }) => {
       const existingInventoryValue = await db.models.InventoryValue.findOne({
         where: {
           inventoryId,
-          subSectorId: notationKey.subSectorId,
+          subCategoryId: notationKey.subCategoryId,
         },
         transaction,
         lock: true,

--- a/app/src/i18n/locales/en/manage-subsectors.json
+++ b/app/src/i18n/locales/en/manage-subsectors.json
@@ -1215,5 +1215,7 @@
   "changes-can-be-lost": "Your changes can be lost",
   "changes-can-be-lost-description": "Do you want to discard all changes made since last edit? This cannot be undone.",
   "no-unfinished-subsectors": "No unfinished subsectors.",
-  "changes-undone": "Changes undone"
+  "changes-undone": "Changes undone",
+  "industrial-processes-and-product-uses": "Industrial processes and product uses (IPPU)",
+  "agriculture-forestry-and-other-land-use": "Agriculture, Forestry and Other Land Use (AFOLU)"
 }

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -805,7 +805,7 @@ export const api = createApi({
           url: `/inventory/${data.inventoryId}/notation-keys`,
           method: "GET",
         }),
-        transformResponse: (response: any) => response.data,
+        transformResponse: (response: any) => response,
       }),
       // Add notation keys to subsectors with missing data missing
       updateOrCreateNotationKeys: builder.mutation({

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -800,7 +800,7 @@ export const api = createApi({
         }),
       }),
       // Get unfinished subsectors
-      getUnfinishedSubsectors: builder.query({
+      getNotationKeyScopes: builder.query({
         query: (data: { inventoryId: string }) => ({
           url: `/inventory/${data.inventoryId}/notation-keys`,
           method: "GET",
@@ -961,7 +961,7 @@ export const {
   useGetCityInvitesQuery,
   useUpdatePasswordMutation,
   useGetInventoryPopulationsQuery,
-  useGetUnfinishedSubsectorsQuery,
+  useGetNotationKeyScopesQuery,
   useUpdateOrCreateNotationKeysMutation,
   useCreateOrganizationMutation,
   useCreateProjectMutation,

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -812,7 +812,7 @@ export const api = createApi({
         query: (data: {
           inventoryId: string;
           notationKeys: {
-            subSectorId: string;
+            subCategoryId: string;
             unavailableReason: string;
             unavailableExplanation: string;
           }[];


### PR DESCRIPTION
changes
- show tab content by subsector scope
- updates rtk notation key manager get method

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the `SectorTabs` component to group subsectors by scope using new API data structure and enhance UI rendering logic across `SectorTabs` and associated hooks.

### Why are these changes being made?

These changes address ON-3680 by enabling the display of subsectors grouped by scope as defined in the updated API, enhancing usability and clarity. This approach leverages `useMemo` for efficient data transformation, improves type commitments, refines default settings, and updates the UI text to be more informative and align with expected terminologies such as converting sector references to Global Product Classification (GPC) names.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->