### PR TITLE
fix: emissions from global api rounded

### DIFF
--- a/global-api/routes/ghgi_emissions.py
+++ b/global-api/routes/ghgi_emissions.py
@@ -13,7 +13,7 @@ def db_query_total(datasource_name, spatial_granularity, actor_id, gpc_reference
         query = text(
             f"""
             SELECT		upper(e.gas_name) as gas_name,
-             			sum(e.emissions_value) as emissions_value,
+             			round(sum(e.emissions_value)) as emissions_value,
              			COALESCE(max(gwp.{gwp}),0) as gwp_100yr,
              			COALESCE(sum(e.emissions_value * gwp.{gwp}),0) as emissions_value_100yr,
                         COALESCE(sum(e.emissions_value * gwp2.{gwp}),0) as emissions_value_20yr
@@ -64,8 +64,8 @@ def db_query_eq_total(datasource_name, spatial_granularity, actor_id, gpc_refere
 
         query = text(
             f"""
-            SELECT		COALESCE(sum(e.emissions_value * gwp.{gwp}),0) as emissions_value_100yr,
-                        COALESCE(sum(e.emissions_value * gwp2.{gwp}),0) as emissions_value_20yr
+            SELECT		round(COALESCE(sum(e.emissions_value * gwp.{gwp}),0)) as emissions_value_100yr,
+                        round(COALESCE(sum(e.emissions_value * gwp2.{gwp}),0)) as emissions_value_20yr
             FROM 		modelled.emissions e
             LEFT JOIN 	modelled.emissions_factor ef
             ON 			e.emissionfactor_id = ef.emissionfactor_id
@@ -148,13 +148,13 @@ def db_query(datasource_name, spatial_granularity, actor_id, gpc_reference_numbe
 						ARRAY_AGG(
 						json_build_object(
 						'gas_name' , e.gas_name,
-						'emissions_value', e.emissions_value,
+						'emissions_value', round(e.emissions_value),
 						'emissionfactor_value', ef.emissionfactor_value,
 						'emissionfactor_datasource', ef.datasource_name,
 						'activity_value', e.activity_value::numeric,
 						'gwp', COALESCE(gwp.{gwp},0),
-						'emissions_value_100yr', COALESCE(e.emissions_value * gwp.{gwp},0),
-						'emissions_value_20yr', COALESCE(e.emissions_value * gwp2.{gwp},0)
+						'emissions_value_100yr', round(COALESCE(e.emissions_value * gwp.{gwp},0)),
+						'emissions_value_20yr', round(COALESCE(e.emissions_value * gwp2.{gwp},0))
 						)) AS gas_info
                      FROM 		modelled.emissions e
                      LEFT JOIN 	modelled.emissions_factor ef


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Round emissions values and their calculations to the nearest whole number in the global API's emissions queries.

### Why are these changes being made?

Rounding emissions values improves data readability and reporting accuracy by presenting figures in a simpler, more digestible format. This enhances user experience and aligns with common data presentation standards when precise decimal details are unnecessary.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->