### PR TITLE
fix(ui): load existing data into notation key manager

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/NotationsDefinitionAccordion.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/NotationsDefinitionAccordion.tsx
@@ -63,7 +63,6 @@ const NotationsDefinitionAccordion: FC<NotationsDefinitionAccordionProps> = ({
           >
             {t("notation-key-question")}
           </Text>
-          <Accordion.ItemIndicator />
         </AccordionItemTrigger>
         <AccordionItemContent>
           <Accordion.ItemBody>

--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -33,6 +33,9 @@ import { toaster } from "@/components/ui/toaster";
 import RouteChangeDialog from "./RouteChangeDialog";
 import { usePathname, useRouter } from "next/navigation";
 import ProgressLoader from "@/components/ProgressLoader";
+import type { SubCategoryAttributes } from "@/models/SubCategory";
+import type { InventoryValueAttributes } from "@/models/InventoryValue";
+import type { SubSectorAttributes } from "@/models/SubSector";
 
 interface SubcategoryItem {
   subSectorId: string;
@@ -103,6 +106,12 @@ interface CardInputs {
   explanation: string;
 }
 
+interface ScopeData {
+  subCategory?: SubCategoryAttributes;
+  inventoryValue?: InventoryValueAttributes;
+  subSector?: SubSectorAttributes;
+}
+
 const SectorTabs: FC<SectorTabsProps> = ({ t, inventoryId }) => {
   const router = useRouter();
 
@@ -136,18 +145,17 @@ const SectorTabs: FC<SectorTabsProps> = ({ t, inventoryId }) => {
 
   useEffect(() => {
     if (!isSectorDataLoading && !error && sectorData?.result) {
-      // cardInputs[sectorData.result[0].subCategory.subcategoryId] = {};
-      const result = Object.entries(sectorData.result).flatMap(
-        ([_sectorRefno, scopes]: [string, any]) => {
-          return scopes.map((scope: any) => [
-            scope.subCategory?.subcategoryId,
-            {
-              notationKey: scope.inventoryValue?.unavailableReason,
-              explanation: scope.inventoryValue?.unavailableExplanation,
-            },
-          ]);
-        },
-      );
+      const result = Object.entries(
+        sectorData.result as Record<string, ScopeData[]>,
+      ).flatMap(([_sectorRefno, scopes]: [string, ScopeData[]]) => {
+        return scopes.map((scope: ScopeData) => [
+          scope.subCategory?.subcategoryId,
+          {
+            notationKey: scope.inventoryValue?.unavailableReason,
+            explanation: scope.inventoryValue?.unavailableExplanation,
+          },
+        ]);
+      });
       setCardInputs((prev) => {
         const newInputs: Record<string, CardInputs> = { ...prev };
         // If there are selected cards, update only those; otherwise update all items.

--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -12,7 +12,6 @@ import {
 } from "@chakra-ui/react";
 import { TFunction } from "i18next";
 import React, { FC, useEffect, useMemo, useState } from "react";
-import { SubSectorWithRelations } from "../[step]/types";
 import { StationaryEnergyIcon } from "@/components/icons";
 import { BiSelectMultiple } from "react-icons/bi";
 
@@ -104,12 +103,9 @@ interface CardInputs {
   explanation: string;
 }
 
-const SectorTabs: FC<SectorTabsProps> = ({ inventoryId, t }) => {
+const SectorTabs: FC<SectorTabsProps> = ({ t, inventoryId }) => {
   const router = useRouter();
 
-  const [unfinishedSubsectorsData, setUnfinishedSubsectorsData] = useState<
-    SubSectorWithRelations[] | undefined
-  >([]);
   // State to track selected subsector IDs per sector (keyed by sector ID)
   const [selectedCardsBySector, setSelectedCardsBySector] = useState<
     Record<string, string[]>
@@ -136,6 +132,29 @@ const SectorTabs: FC<SectorTabsProps> = ({ inventoryId, t }) => {
     { inventoryId: inventoryId! },
     { skip: !inventoryId },
   );
+
+  useEffect(() => {
+    if (!isSectorDataLoading && !error && sectorData?.result) {
+      // cardInputs[sectorData.result[0].subCategory.subcategoryId] = {};
+      const result = Object.entries(sectorData.result).flatMap(
+        ([_sectorRefno, scopes]: [string, any]) => {
+          return scopes.map((scope: any) => [
+            scope.subCategory.subcategoryId,
+            {
+              notationKey: scope.inventoryValue.unavailableReason,
+              explanation: scope.inventoryValue.unavailableExplanation,
+            },
+          ]);
+        },
+      );
+      setCardInputs((prev) => {
+        const newInputs: Record<string, CardInputs> = { ...prev };
+        // If there are selected cards, update only those; otherwise update all items.
+        Object.assign(newInputs, Object.fromEntries(result));
+        return newInputs;
+      });
+    }
+  }, [error, isSectorDataLoading, sectorData]);
 
   useEffect(() => {
     // Adjust the dirty check as needed (e.g., also include quickActionValues)

--- a/app/src/app/api/v0/inventory/[inventory]/notation-keys/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/notation-keys/route.ts
@@ -10,7 +10,7 @@ import { InventoryTypeEnum } from "@/util/constants";
 
 const validSectorRefNos = {
   [InventoryTypeEnum.GPC_BASIC]: ["I", "II", "III"],
-  [InventoryTypeEnum.GPC_BASIC_PLUS]: ["I", "II", "III", "IV", "V", "VI"],
+  [InventoryTypeEnum.GPC_BASIC_PLUS]: ["I", "II", "III", "IV", "V"],
 };
 
 // returns { success: true, result: { [sectorReferenceNumber]: { subSector, subCategory, inventoryValue }[] } }
@@ -44,13 +44,6 @@ export const GET = apiHandler(async (_req, { session, params }) => {
 
     const inventoryType =
       inventory.inventoryType ?? InventoryTypeEnum.GPC_BASIC;
-    console.log(
-      "refno vorhanden?",
-      sector.referenceNumber,
-      inventoryType,
-      validSectorRefNos[inventoryType],
-      validSectorRefNos[inventoryType].includes(sector.referenceNumber),
-    );
     return validSectorRefNos[inventoryType].includes(sector.referenceNumber);
   });
 


### PR DESCRIPTION
Shows existing unavailable reason/ explanation (which allows editing/ updating).

Don't clear inputs on save (to allow further editing).

Hides extra arrow on accordion.

Hides unnecessary sectors in tabs (directly from API response)

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Load existing data into the notation key manager by modifying the SectorTabs component to update state with existing data and filtering applicable sectors based on inventory type in the API route.

### Why are these changes being made?

These changes are intended to enhance the user interface by pre-populating fields with existing notation data, improving usability, and ensuring the accuracy of displayed sectors based on inventory types. The adjustments streamline the workflow by reducing redundant input actions for the user and align the visible data with the system's inventory specifications.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->