### PR TITLE
fix(ui): clamp inventory progress between 0 and 100%

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/[step]/page.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/page.tsx
@@ -20,6 +20,7 @@ import { api } from "@/services/api";
 import { logger } from "@/services/logger";
 import {
   bytesToMB,
+  clamp,
   convertSectorReferenceNumberToNumber,
   nameToI18NKey,
 } from "@/util/helpers";
@@ -259,9 +260,12 @@ export default function AddDataSteps({
       if (sectorProgress.total === 0) {
         return step;
       }
-      const connectedProgress =
-        sectorProgress.thirdParty / sectorProgress.total;
-      const addedProgress = sectorProgress.uploaded / sectorProgress.total;
+      const connectedProgress = clamp(
+        sectorProgress.thirdParty / sectorProgress.total,
+      );
+      const addedProgress = clamp(
+        sectorProgress.uploaded / sectorProgress.total,
+      );
       step.connectedProgress = Math.max(
         connectedProgress,
         step.connectedProgress,
@@ -290,7 +294,7 @@ export default function AddDataSteps({
   }, [activeStep]);
 
   const totalStepCompletion = currentStep
-    ? currentStep.connectedProgress + currentStep.addedProgress
+    ? clamp(currentStep.connectedProgress + currentStep.addedProgress)
     : 0;
   const formatPercentage = (percentage: number) =>
     Math.round(percentage * 1000) / 10;

--- a/app/src/components/HomePage/InventoryCalculationTab.tsx
+++ b/app/src/components/HomePage/InventoryCalculationTab.tsx
@@ -4,7 +4,7 @@ import { SectorCard } from "@/components/Cards/SectorCard";
 import { SegmentedProgress } from "@/components/SegmentedProgress";
 import { CircleIcon } from "@/components/icons";
 import { useTranslation } from "@/i18n/client";
-import { formatPercent } from "@/util/helpers";
+import { clamp, formatPercent } from "@/util/helpers";
 import { InventoryProgressResponse, InventoryResponse } from "@/util/types";
 import {
   Badge,
@@ -19,7 +19,6 @@ import { Trans } from "react-i18next/TransWithoutContext";
 import { TabHeader } from "@/components/HomePage/TabHeader";
 import { BlueSubtitle } from "@/components/Texts/BlueSubtitle";
 import { getSectorsForInventory, SECTORS } from "@/util/constants";
-import { UseErrorToast } from "@/hooks/Toasts";
 
 const getSectorProgresses = (
   inventoryProgress: InventoryProgressResponse,
@@ -47,9 +46,9 @@ export default function InventoryCalculationTab({
     uploadedProgress = 0;
   if (inventoryProgress && inventoryProgress.totalProgress.total > 0) {
     const { uploaded, thirdParty, total } = inventoryProgress.totalProgress;
-    totalProgress = (uploaded + thirdParty) / total;
-    thirdPartyProgress = thirdParty / total;
-    uploadedProgress = uploaded / total;
+    totalProgress = clamp((uploaded + thirdParty) / total);
+    thirdPartyProgress = clamp(thirdParty / total);
+    uploadedProgress = clamp(uploaded / total);
   }
 
   const sectorsForInventory = inventory

--- a/app/src/util/helpers.ts
+++ b/app/src/util/helpers.ts
@@ -371,3 +371,6 @@ export const sortGpcReferenceNumbers = (refNumbers: string[]): string[] => {
 export const isEmptyObject = (obj: Record<string, any>) => {
   return Object.keys(obj).length === 0 && obj.constructor === Object;
 };
+
+export const clamp = (num: number, min: number = 0, max: number = 1) =>
+  Math.min(Math.max(num, min), max);


### PR DESCRIPTION
On dashboard and add data (sector) pages

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Clamp inventory progress calculations between 0 and 100% using a new utility function `clamp` to ensure progress values remain within the valid range.

### Why are these changes being made?

This change addresses issues where inventory progress values could exceed the intended limits, causing incorrect UI behavior by clamping these values to a normalized range between 0 and 100%. Implementing a utility function ensures consistency and reusability across different parts of the codebase.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->