### PR TITLE
Feat/on 3699 add city search component to bulk actions

### DIFF
--- a/app/src/app/[lng]/admin/bulk-inventory-actions/BulkActionsTabContent.tsx
+++ b/app/src/app/[lng]/admin/bulk-inventory-actions/BulkActionsTabContent.tsx
@@ -20,6 +20,7 @@ import { Trans } from "react-i18next";
 import CustomSelectableButton from "@/components/custom-selectable-buttons";
 import { Button } from "@/components/ui/button";
 import { RadioGroup } from "@/components/ui/custom-radio";
+import CityAutocompleteInput from "./CityAutoCompleteInput";
 
 interface BulkActionsTabContentProps {
   t: TFunction;
@@ -182,39 +183,19 @@ const BulkActionsTabContent: FC<BulkActionsTabContentProps> = ({ t }) => {
                 required: t("cities-input-required"),
               }}
               render={({ field, fieldState: { error } }) => (
-                <CommaSeperatedInput
-                  initialValues={field.value}
-                  onChange={handleCitiesChange}
-                  field="cities"
+                <CityAutocompleteInput
+                  // You can pass an empty array as the initial list or map your existing form values to the City type if available
+                  initialValues={[]}
+                  onChange={(selectedCities) => {
+                    // Update form field with only the cityLocode values
+                    field.onChange(selectedCities.map((city) => city.actor_id));
+                  }}
                   t={t}
-                  errors={error}
-                  inputType="text"
-                  tipContent={
-                    <Box
-                      display={"flex"}
-                      gap="8px"
-                      alignItems="center"
-                      fontSize="body.sm"
-                      color="content.tertiary"
-                      fontWeight="400"
-                    >
-                      <Icon
-                        as={MdInfoOutline}
-                        color="content.link"
-                        boxSize={4}
-                      />
-                      <Text>{t("know-your-city-tip")}</Text>
-                      <Link
-                        href="https://unece.org/trade/cefact/unlocode-code-list-country-and-territory"
-                        textDecor="underline"
-                      >
-                        {t("un-locode-link")}
-                      </Link>
-                    </Box>
-                  }
+                  error={error}
                 />
               )}
             />
+
             <Controller
               name="years"
               defaultValue={[]}

--- a/app/src/app/[lng]/admin/bulk-inventory-actions/CityAutoCompleteInput.tsx
+++ b/app/src/app/[lng]/admin/bulk-inventory-actions/CityAutoCompleteInput.tsx
@@ -1,0 +1,191 @@
+"use client";
+import React, { useState, useRef } from "react";
+import {
+  Box,
+  Input,
+  Tag,
+  TagLabel,
+  ListItem,
+  Spinner,
+  List,
+  Text,
+} from "@chakra-ui/react";
+import { useGetOCCityQuery } from "@/services/api";
+import { useOutsideClick } from "@/lib/use-outside-click";
+
+type GeoPath = {
+  actor_id: string;
+  name: string;
+  type: string;
+};
+
+export interface City {
+  name: string;
+  actor_id: string;
+  root_path_geo: GeoPath[];
+}
+
+interface CityAutocompleteInputProps {
+  initialValues?: City[];
+  onChange: (cities: City[]) => void;
+  t: (key: string) => string;
+  error?: { message?: string };
+}
+
+const CityAutocompleteInput: React.FC<CityAutocompleteInputProps> = ({
+  initialValues = [],
+  onChange,
+  t,
+  error,
+}) => {
+  const [inputValue, setInputValue] = useState("");
+  const [selectedCities, setSelectedCities] = useState<City[]>(initialValues);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Hide dropdown when clicking outside
+  //   useOutsideClick(containerRef, () => setShowDropdown(false));
+
+  // Trigger city search if input length > 2
+  const { data: citiesData, isLoading: isCityLoading } = useGetOCCityQuery(
+    inputValue,
+    {
+      skip: inputValue.length <= 2,
+    },
+  );
+
+  console.log("citiesData", citiesData);
+
+  const handleSelectCity = (city: City) => {
+    // Prevent duplicate entries
+    if (!selectedCities.some((c) => c.actor_id === city.actor_id)) {
+      const newSelected = [...selectedCities, city];
+      setSelectedCities(newSelected);
+      onChange(newSelected);
+    }
+    setInputValue("");
+    setShowDropdown(false);
+  };
+
+  const handleRemoveCity = (locode: string) => {
+    const newSelected = selectedCities.filter(
+      (city) => city.actor_id !== locode,
+    );
+    setSelectedCities(newSelected);
+    onChange(newSelected);
+  };
+
+  const renderParentPath = (path: GeoPath[]) => {
+    let pathString = "";
+    const pathCopy = [...path];
+
+    pathCopy
+      ?.reverse()
+      .slice(1)
+      .map((parent: any) => {
+        if (pathString) {
+          pathString = pathString + " > ";
+        }
+        pathString = pathString + parent.name;
+      });
+
+    return pathString;
+  };
+
+  return (
+    <Box position="relative" ref={containerRef}>
+      <Input
+        h="56px"
+        boxShadow="1dp"
+        placeholder={t("search-city-placeholder")}
+        value={inputValue}
+        onChange={(e) => {
+          setInputValue(e.target.value);
+          setShowDropdown(true);
+        }}
+        onFocus={() => setShowDropdown(true)}
+      />
+      {showDropdown && inputValue.length > 2 && (
+        <Box
+          position="absolute"
+          width="100%"
+          bg="white"
+          zIndex={10}
+          border="1px solid #ccc"
+          borderRadius="md"
+          mt="2"
+          maxH="200px"
+          overflowY="auto"
+        >
+          {isCityLoading ? (
+            <Box textAlign="center" py="2">
+              <Spinner size="sm" />
+            </Box>
+          ) : (
+            <>
+              {citiesData && citiesData.length > 0 ? (
+                <List.Root>
+                  {citiesData.map((city: City, index: number) => (
+                    <List.Item
+                      key={index}
+                      cursor="pointer"
+                      p="2"
+                      _hover={{
+                        bg: "interactive.secondary",
+                        color: "base.light",
+                      }}
+                      onClick={() => handleSelectCity(city)}
+                    >
+                      <Text>
+                        {city.name} ({city.actor_id})
+                      </Text>
+                      <Text fontSize="body.md">
+                        {renderParentPath(city.root_path_geo)}
+                      </Text>
+                    </List.Item>
+                  ))}
+                </List.Root>
+              ) : (
+                <Box textAlign="center" py="2">
+                  {t("no-cities-found") || "No cities found"}
+                </Box>
+              )}
+            </>
+          )}
+        </Box>
+      )}
+      <Box mt="2" display="flex" flexWrap="wrap" gap="2">
+        {selectedCities.map((city, index) => (
+          <Tag.Root
+            key={index}
+            size="md"
+            borderRadius="16px"
+            p="6px"
+            px="20px"
+            variant="solid"
+            bg="background.neutral"
+            color="content.alternative"
+            display="flex"
+            justifyContent="center"
+          >
+            <Tag.Label fontWeight="400">{city.actor_id}</Tag.Label>
+            <Tag.EndElement color="interactive.control">
+              <Tag.CloseTrigger
+                onClick={() => handleRemoveCity(city.actor_id)}
+                boxSize={6}
+                mt="-6px"
+              />
+            </Tag.EndElement>
+          </Tag.Root>
+        ))}
+      </Box>
+      {error && (
+        <Box color="red.500" mt="2">
+          {error.message}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default CityAutocompleteInput;

--- a/app/src/app/[lng]/admin/bulk-inventory-actions/CityAutoCompleteInput.tsx
+++ b/app/src/app/[lng]/admin/bulk-inventory-actions/CityAutoCompleteInput.tsx
@@ -54,8 +54,6 @@ const CityAutocompleteInput: React.FC<CityAutocompleteInputProps> = ({
     },
   );
 
-  console.log("citiesData", citiesData);
-
   const handleSelectCity = (city: City) => {
     // Prevent duplicate entries
     if (!selectedCities.some((c) => c.actor_id === city.actor_id)) {

--- a/app/src/i18n/locales/en/admin.json
+++ b/app/src/i18n/locales/en/admin.json
@@ -106,5 +106,6 @@
   "remove-user": "Remove user",
   "confirm-remove-project-user": "Are you sure you want to remove the user with the email: <bold>{{email}}</bold> from the <bold>{{projectName}}</bold> project?",
   "confirm-remove-city-user": "Are you sure you want to remove the user with the email: <bold>{{email}}</bold> from <bold>{{cityName}}</bold",
-  "confirm-org-admin-delete": "Are you sure you want to remove the organization owner with the email: <bold>{{email}}</bold> from <bold>{{orgName}}</bold>?"
+  "confirm-org-admin-delete": "Are you sure you want to remove the organization owner with the email: <bold>{{email}}</bold> from <bold>{{orgName}}</bold>?",
+  "search-city-placeholder": "Search city"
 }


### PR DESCRIPTION
Changes
- Adds search city component that allows admins to search for a desired city, this component also allows them to select and push the city to the bulk array.
- Selected cities are rendered as locodes in form of tags

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add a new `CityAutocompleteInput` component to the bulk inventory actions and replace the existing `CommaSeperatedInput` for city selection.

### Why are these changes being made?
The current city input method was less user-friendly, requiring users to enter city codes manually. Introducing an autocomplete feature allows users to search and select cities more intuitively and efficiently, enhancing user experience in bulk actions. This implementation updates both the UI component and relevant localization resources.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->