### PR TITLE
fix: removed comma after biome and added order by

### DIFF
--- a/global-api/routes/get_climate_actions.py
+++ b/global-api/routes/get_climate_actions.py
@@ -46,8 +46,9 @@ def db_climate_actions() -> List[Dict[str, Any]]:
                 "Dependencies",
                 "KeyPerformanceIndicators",
                 "PowersAndMandates",
-                "Biome",
+                "Biome"
             FROM climate_action
+            ORDER BY "ActionID"
         """
         )
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Remove erroneous comma after "Biome" and add an ORDER BY clause for "ActionID" in the SQL query within `get_climate_actions.py`.

### Why are these changes being made?
The removal of the comma resolves a syntax error, ensuring the query executes correctly. The addition of the ORDER BY clause ensures that results are consistently ordered by "ActionID", which is critical for predictable data handling and presentation in the application.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->