### PR TITLE
fix: ON-3570 changes background color from default gray to white

### DIFF
--- a/app/src/app/[lng]/[inventory]/settings/page.tsx
+++ b/app/src/app/[lng]/[inventory]/settings/page.tsx
@@ -101,7 +101,11 @@ export default function Settings({
           </Box>
           <Box marginTop="48px" borderBottomColor={"border.overlay"}>
             <Tabs.Root defaultValue="my-profile" variant="enclosed">
-              <Tabs.List p={0} w="full">
+              <Tabs.List
+                p={0}
+                w="full"
+                backgroundColor="background.backgroundLight"
+              >
                 <Tabs.Trigger
                   value="my-profile"
                   _selected={{


### PR DESCRIPTION
Changes
- Changes default bg color for tablists to white (backgroundLight)

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Change the background color of the `Tabs.List` component from the default gray to white in the settings page.

### Why are these changes being made?
The default gray background color was not consistent with the design guidelines, which required a white background to improve visual clarity and consistency across the application's user interface. This change ensures that the settings page aligns with the specified design standards.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->