### PR TITLE
fix(api): ON-3758 group data sources by GPC refno

### DIFF
--- a/app/src/backend/AdminService.ts
+++ b/app/src/backend/AdminService.ts
@@ -314,14 +314,17 @@ export default class AdminService {
 
     // group sources by GPC reference number so we can prioritize for each choice individually
     // TODO filter out sources that don't match the inventory's inventory type/ Subcategory's ReportingLevel
-    const sourcesByReferenceNumber = groupBy(applicableSources, (source) => {
-      return (
+    const sourcesByReferenceNumber = groupBy(
+      applicableSources.filter(
+        (source) =>
+          source.subCategory?.referenceNumber ||
+          source.subSector?.referenceNumber,
+      ),
+      (source) =>
         source.subCategory?.referenceNumber ??
         source.subSector?.referenceNumber ??
-        "unknown"
-      );
-    });
-    delete sourcesByReferenceNumber["unknown"];
+        "unknown",
+    );
 
     const populationScaleFactors =
       await DataSourceService.findPopulationScaleFactors(

--- a/app/src/backend/AdminService.ts
+++ b/app/src/backend/AdminService.ts
@@ -374,11 +374,13 @@ export default class AdminService {
             }
 
             if (!isSuccessful) {
-              const message = `Wasn't able to find a data source for GPC reference number ${gpcReferenceNumber}`;
-              logger.error(`${cityLocode} - ${message}`);
+              logger.error(
+                `${cityLocode} - Wasn't able to find a data source for GPC reference number ${gpcReferenceNumber}`,
+              );
               errors.push({
                 locode: cityLocode,
-                error: message,
+                error: "no-data-source-available-for-gpc-reference-number",
+                detail: gpcReferenceNumber,
               });
             }
           }

--- a/app/src/backend/AdminService.ts
+++ b/app/src/backend/AdminService.ts
@@ -312,14 +312,15 @@ export default class AdminService {
       sources,
     );
 
-    // group sources by subsector so we can prioritize for each choice individually
-    const sourcesByReferenceNumber = groupBy(
-      applicableSources,
-      (source) =>
+    // group sources by GPC reference number so we can prioritize for each choice individually
+    // TODO filter out sources that don't match the inventory's inventory type/ Subcategory's ReportingLevel
+    const sourcesByReferenceNumber = groupBy(applicableSources, (source) => {
+      return (
         source.subCategory?.referenceNumber ??
         source.subSector?.referenceNumber ??
-        "unknown",
-    );
+        "unknown"
+      );
+    });
     delete sourcesByReferenceNumber["unknown"];
 
     const populationScaleFactors =


### PR DESCRIPTION
When calling the connect-sources API endpoint to fix prioritization of data sources

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor data source grouping logic to organize by GPC reference number instead of subsector in the AdminService.

### Why are these changes being made?

The change ensures that data sources are grouped more appropriately by their GPC reference numbers, which may provide a more effective and relevant criterion for prioritization, given more consistent reference attributes in source categories and sectors. This enhances the efficiency and accuracy of data retrieval processes.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->