### PR TITLE
feat(api): allow defining and updating project ID of cities

### DIFF
--- a/app/src/app/api/v0/admin/bulk/route.ts
+++ b/app/src/app/api/v0/admin/bulk/route.ts
@@ -9,6 +9,7 @@ const createBulkInventoriesRequest = z.object({
   years: z.array(z.number().int().positive()), // List of years to create inventories for
   scope: z.enum(["gpc_basic", "gpc_basic_plus"]), // Scope selection (gpc_basic or gpc_basic_plus)
   gwp: z.enum(["AR5", "AR6"]), // GWP selection (AR5 or AR6)
+  projectId: z.string().uuid(), // project to which the inventories should be assigned
 });
 
 export const POST = apiHandler(async (req, { session }) => {

--- a/app/src/app/api/v0/admin/update-inventories/route.ts
+++ b/app/src/app/api/v0/admin/update-inventories/route.ts
@@ -7,6 +7,7 @@ const updateInventoriesRequest = z.object({
   userEmail: z.string().email(), // Email of the user whose inventories are to be updated
   cityLocodes: z.array(z.string()).max(100), // List of city locodes
   years: z.array(z.number().int().positive()).max(10), // List of years to update inventories for
+  projectId: z.string().uuid(), // Project ID to which the inventories should be assigned
 });
 
 export const POST = apiHandler(async (req, { session }) => {

--- a/app/src/backend/AdminService.ts
+++ b/app/src/backend/AdminService.ts
@@ -159,19 +159,11 @@ export default class AdminService {
       ],
     });
 
-    const updateableCityIds: string[] = [];
     for (const inventory of inventories) {
       if (!inventory.city?.locode) {
         throw new createHttpError.NotFound(
           "City or locode not found for inventory " + inventory.inventoryId,
         );
-      }
-
-      if (
-        !updateableCityIds.includes(inventory.city.cityId) &&
-        inventory.city.projectId !== props.projectId
-      ) {
-        updateableCityIds.push(inventory.city.cityId);
       }
 
       // Connect all data sources, rank them by priority, check if they connect
@@ -181,11 +173,6 @@ export default class AdminService {
       );
       errors.push(...sourceErrors);
     }
-
-    await db.models.City.update(
-      { projectId: props.projectId },
-      { where: { cityId: { [Op.in]: updateableCityIds } } },
-    );
 
     return { errors };
   }

--- a/app/tests/api/admin.jest.ts
+++ b/app/tests/api/admin.jest.ts
@@ -20,6 +20,7 @@ import {
 } from "@/backend/AdminService";
 import { Op } from "sequelize";
 import _ from "lodash";
+import { DEFAULT_PROJECT_ID } from "@/util/constants";
 
 const mockSession: AppSession = {
   user: { id: testUserID, role: Roles.User },
@@ -35,11 +36,12 @@ const cityLocodeMap: Record<string, string> = {
   "BR AAX": "Araxá",
 };
 const mockBulkInventoriesRequest: BulkInventoryCreateProps = {
-  cityLocodes: ["US NYC", "DE BER", "BR AAX"],
+  cityLocodes: ["BR AAX"],
   emails: [testUserData.email],
-  years: [2022, 2023, 2024],
+  years: [2022],
   scope: "gpc_basic_plus",
   gwp: "AR6",
+  projectId: DEFAULT_PROJECT_ID,
 };
 
 const mockConnectSourcesRequest: BulkInventoryUpdateProps = {


### PR DESCRIPTION
In bulk inventory creation and bulk inventory update API endpoints

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add the ability to define and update the project ID associated with city inventories through new fields in bulk create and update operations.

### Why are these changes being made?
Currently, associating a project ID with city inventories is not supported, limiting our ability to organize and manage inventories by projects. By introducing this feature, users can better manage inventories within their respective projects, enhancing functionality and alignment with user requirements.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->