### PR TITLE
fix(db): create migration to re-run changes from OrganizationInvite m…

### DIFF
--- a/app/migrations/20250310140714-OrganizationInvite_create.cjs
+++ b/app/migrations/20250310140714-OrganizationInvite_create.cjs
@@ -38,12 +38,12 @@ module.exports = {
       role: {
         type: Sequelize.ENUM("admin", "collaborator"),
       },
-      created: {
+      created_at: {
         type: Sequelize.DATE,
         allowNull: false,
         defaultValue: Sequelize.fn("now"),
       },
-      last_updated: {
+      updated_at: {
         type: Sequelize.DATE,
         allowNull: false,
         defaultValue: Sequelize.fn("now"),

--- a/app/migrations/20250416145927-organization-invite-rename-timestamps.cjs
+++ b/app/migrations/20250416145927-organization-invite-rename-timestamps.cjs
@@ -1,0 +1,31 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // the previous migration was edited after being deployed, so make sure this column is renamed
+    await queryInterface.renameColumn(
+      "OrganizationInvite",
+      "created_at",
+      "created",
+    );
+    await queryInterface.renameColumn(
+      "OrganizationInvite",
+      "updated_at",
+      "last_updated",
+    );
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.renameColumn(
+      "OrganizationInvite",
+      "created",
+      "created_at",
+    );
+    await queryInterface.renameColumn(
+      "OrganizationInvite",
+      "last_updated",
+      "updated_at",
+    );
+  },
+};


### PR DESCRIPTION
…igration

To make sure they are executed on the servers

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Create a new migration to rename the `created_at` and `updated_at` columns in the `OrganizationInvite` table to `created` and `last_updated` respectively.

### Why are these changes being made?

The previous migration was altered after deployment, leading to discrepancies that need to be corrected by ensuring consistent column naming. This change addresses these inconsistencies and maintains backward compatibility by including a down function to revert if necessary.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->