### PR TITLE
fix(notation-keys): include GPC reference number when creating inventory values

### DIFF
--- a/app/src/app/api/v0/inventory/[inventory]/notation-keys/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/notation-keys/route.ts
@@ -150,6 +150,7 @@ export const POST = apiHandler(async (req, { session, params }) => {
             subSectorId: subCategory?.subsectorId,
             sectorId: subCategory?.subsector?.sectorId,
             inventoryId,
+            gpcReferenceNumber: subCategory?.referenceNumber,
           },
           { transaction },
         );


### PR DESCRIPTION
- Add gpcReferenceNumber field from subcategory when creating new inventory values
- Ensure data consistency with other parts of the application
- Fix issue where GPC reference numbers were missing from notation key records

This change ensures that when notation keys are saved, the GPC reference number 
from the subcategory is properly stored in the InventoryValue record,