### PR TITLE
bug (project overview): [ON-3823] hide Project overview link behind FF

### DIFF
--- a/.github/workflows/web-develop.yml
+++ b/.github/workflows/web-develop.yml
@@ -170,7 +170,7 @@ jobs:
             "GLOBAL_API_URL=https://ccglobal.openearth.dev" \
             "NEXT_PUBLIC_OPENCLIMATE_API_URL=https://openclimate.openearth.dev" \
             "OPENCLIMATE_API_URL=https://openclimate.openearth.dev" \
-            "NEXT_PUBLIC_FEATURE_FLAGS=ENTERPRISE_MODE,CAP_TAB_ENABLED" \
+            "NEXT_PUBLIC_FEATURE_FLAGS=ENTERPRISE_MODE,CAP_TAB_ENABLED,PROJECT_OVERVIEW_ENABLED" \
             "AWS_REGION"=${{secrets.AWS_REGION}} \
             "AWS_ACCESS_KEY_ID"=${{secrets.AWS_ACCESS_KEY_ID}} \
             "AWS_SECRET_ACCESS_KEY"=${{secrets.AWS_SECRET_ACCESS_KEY}} \

--- a/app/src/app/[lng]/onboarding/setup/page.tsx
+++ b/app/src/app/[lng]/onboarding/setup/page.tsx
@@ -26,7 +26,7 @@ import ProgressSteps from "@/components/steps/progress-steps";
 import { Button } from "@/components/ui/button";
 import { UseErrorToast } from "@/hooks/Toasts";
 import ProgressLoader from "@/components/ProgressLoader";
-import { hasFeatureFlag } from "@/util/feature-flags";
+import { hasFeatureFlag, FeatureFlags } from "@/util/feature-flags";
 
 export type Inputs = {
   city: string;
@@ -76,7 +76,7 @@ export default function OnboardingSetup({
 
   const projectId = params.get("project");
 
-  const EnterpriseMode = hasFeatureFlag("ENTERPRISE_MODE");
+  const EnterpriseMode = hasFeatureFlag(FeatureFlags.ENTERPRISE_MODE);
 
   const { data: projectsList, isLoading } = api.useGetUserProjectsQuery(
     {},
@@ -84,7 +84,7 @@ export default function OnboardingSetup({
       skip: !EnterpriseMode,
     },
   );
-  
+
   useEffect(() => {
     if (projectsList && projectsList.length > 0) {
       setSelectedProject([projectsList[0].projectId]);

--- a/app/src/components/ClientRootLayout/index.tsx
+++ b/app/src/components/ClientRootLayout/index.tsx
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation";
 import ProgressLoader from "@/components/ProgressLoader";
 import NoAccess from "@/components/NoAccess";
 import { Roles } from "@/util/types";
-import { hasFeatureFlag } from "@/util/feature-flags";
+import { hasFeatureFlag, FeatureFlags } from "@/util/feature-flags";
 
 export function ClientRootLayout({
   lng,
@@ -19,7 +19,7 @@ export function ClientRootLayout({
   const isPublic = pathname.includes("public");
   const isInvitePage = pathname.includes("invites");
   const isAuthPage = pathname.includes("auth");
-  const EnterpriseMode = hasFeatureFlag("ENTERPRISE_MODE");
+  const EnterpriseMode = hasFeatureFlag(FeatureFlags.ENTERPRISE_MODE);
   const { data: userInfo, isLoading: isUserInfoLoading } =
     api.useGetUserInfoQuery();
 

--- a/app/src/components/HomePage/Hero.tsx
+++ b/app/src/components/HomePage/Hero.tsx
@@ -17,6 +17,7 @@ import { Tooltip } from "@/components/ui/tooltip";
 import { Trans } from "react-i18next/TransWithoutContext";
 import { getShortenNumberUnit, shortenNumber } from "@/util/helpers";
 import Link from "next/link";
+import { hasFeatureFlag, FeatureFlags } from "@/util/feature-flags";
 
 const CityMap = dynamic(() => import("@/components/CityMap"), { ssr: false });
 
@@ -69,20 +70,13 @@ export function Hero({
                   {!inventory ? <>{t("welcome")}</> : null}
                 </Text>
                 <Box className="flex flex-col gap-2">
-                  {!isPublic && (
+                  {!isPublic && hasFeatureFlag(FeatureFlags.PROJECT_OVERVIEW_ENABLED) ? (
                     <Link
                       href={`/public/project/${inventory?.city?.project?.projectId}`}
                     >
-                      <Text
-                        fontSize="title.md"
-                        w="max-content"
-                        fontWeight="semibold"
-                        color="white"
-                      >
-                        {inventory?.city?.project?.name}
-                      </Text>
+                      <ProjectTitle inventory={inventory} />
                     </Link>
-                  )}
+                  ) : <ProjectTitle inventory={inventory} />}
                   <Box className="flex items-center gap-4">
                     {inventory?.city ? (
                       <>
@@ -306,4 +300,16 @@ export function Hero({
       </Box>
     </>
   );
+}
+
+
+function ProjectTitle({ inventory }: { inventory: InventoryResponse }) {
+  return <Text
+    fontSize="title.md"
+    w="max-content"
+    fontWeight="semibold"
+    color="white"
+  >
+    {inventory?.city?.project?.name}
+  </Text>;
 }

--- a/app/src/components/HomePage/HomePage.tsx
+++ b/app/src/components/HomePage/HomePage.tsx
@@ -28,7 +28,7 @@ import {
   ProgressCircleRoot,
 } from "@/components/ui/progress-circle";
 import CapTab from "@/app/[lng]/[inventory]/CapTab";
-import { hasFeatureFlag } from "@/util/feature-flags";
+import { hasFeatureFlag, FeatureFlags } from "@/util/feature-flags";
 
 export default function HomePage({
   lng,
@@ -205,7 +205,7 @@ export default function HomePage({
                       {[
                         "tab-emission-inventory-calculation-title",
                         "tab-emission-inventory-results-title",
-                        ...(inventory?.city?.country === "Brazil" && hasFeatureFlag('CAP_TAB_ENABLED') ? ["tab-cap-title"] : []),
+                        ...(inventory?.city?.country === "Brazil" && hasFeatureFlag(FeatureFlags.CAP_TAB_ENABLED) ? ["tab-cap-title"] : []),
                       ].map((tab, index) => (
                         <Tabs.Trigger key={index} value={tab}>
                           <Text

--- a/app/src/components/steps/select-city-steps.tsx
+++ b/app/src/components/steps/select-city-steps.tsx
@@ -49,7 +49,7 @@ import {
   SelectTrigger,
   SelectValueText,
 } from "@/components/ui/select";
-import { hasFeatureFlag } from "@/util/feature-flags";
+import { hasFeatureFlag, FeatureFlags } from "@/util/feature-flags";
 
 const CityMap = dynamic(() => import("@/components/CityMap"), { ssr: false });
 
@@ -82,7 +82,7 @@ export default function SelectCityStep({
 }) {
   const searchParams = useSearchParams();
   const cityFromUrl = searchParams.get("city");
-  const EnterpriseMode = hasFeatureFlag("ENTERPRISE_MODE");
+  const EnterpriseMode = hasFeatureFlag(FeatureFlags.ENTERPRISE_MODE);
 
   const currentYear = new Date().getFullYear();
 

--- a/app/src/util/feature-flags.ts
+++ b/app/src/util/feature-flags.ts
@@ -1,5 +1,11 @@
 import { env } from "next-runtime-env";
 
+export enum FeatureFlags {
+  ENTERPRISE_MODE = "ENTERPRISE_MODE",
+  CAP_TAB_ENABLED = "CAP_TAB_ENABLED",
+  PROJECT_OVERVIEW_ENABLED = "PROJECT_OVERVIEW_ENABLED"
+}
+
 let cachedFeatureFlags: string[] | null = null;
 
 export function getFeatureFlags(): string[] {
@@ -21,6 +27,6 @@ export function getFeatureFlags(): string[] {
   return cachedFeatureFlags;
 }
 
-export function hasFeatureFlag(flag: string): boolean {
+export function hasFeatureFlag(flag: FeatureFlags): boolean {
   return getFeatureFlags().includes(flag);
 }


### PR DESCRIPTION
also, store feature flags in enum.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Hide the "Project overview" link feature behind the `PROJECT_OVERVIEW_ENABLED` feature flag and refactor feature flag usage to utilize an enumerated type for better consistency.

### Why are these changes being made?
This change improves feature management by allowing the "Project overview" link to be conditionally displayed based on configuration while ensuring that the feature flag handling is more structured and less error-prone through the use of TypeScript enums, which reduces the risk of typos and enhances code readability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->