### PR TITLE
fix(ui): ON-3698 clamp dashboard subsector progress to max 100%

### DIFF
--- a/app/src/components/Cards/SectorCard.tsx
+++ b/app/src/components/Cards/SectorCard.tsx
@@ -1,12 +1,13 @@
 "use client";
 import SubSectorCard from "@/components/Cards/SubSectorCard";
 import { InventoryResponse, SectorProgress } from "@/util/types";
-import { Accordion, Box, Button, Heading, Icon, Text } from "@chakra-ui/react";
+import { Box, Button, Heading, Icon, Text } from "@chakra-ui/react";
 import NextLink from "next/link";
 
 import { useState } from "react";
 import { SegmentedProgress } from "../SegmentedProgress";
 import {
+  clamp,
   convertSectorReferenceNumberToNumber,
   formatPercent,
 } from "@/util/helpers";
@@ -29,7 +30,7 @@ export function SectorCard({
   t,
   inventory,
 }: {
-  sectorProgress: SectorProgress;
+  sectorProgress?: SectorProgress;
   sector: ISector;
   t: TFunction;
   inventory: InventoryResponse;
@@ -40,10 +41,12 @@ export function SectorCard({
   let totalProgress = 0,
     thirdPartyProgress = 0,
     uploadedProgress = 0;
-  if (sectorProgress.total > 0) {
-    thirdPartyProgress = sectorProgress.thirdParty / sectorProgress.total;
-    uploadedProgress = sectorProgress.uploaded / sectorProgress.total;
-    totalProgress = thirdPartyProgress + uploadedProgress;
+  if (sectorProgress && sectorProgress.total > 0) {
+    thirdPartyProgress = clamp(
+      sectorProgress.thirdParty / sectorProgress.total,
+    );
+    uploadedProgress = clamp(sectorProgress.uploaded / sectorProgress.total);
+    totalProgress = clamp(thirdPartyProgress + uploadedProgress);
   }
   /*** Data ***/
   const {
@@ -146,7 +149,7 @@ export function SectorCard({
                 <Trans t={t}>sub-sectors-required</Trans>
               </Text>
               <Box className="grid grid-cols-3 gap-4 py-4">
-                {sectorProgress.subSectors.map((subSector, i) => (
+                {sectorProgress?.subSectors?.map((subSector, i) => (
                   <NextLink
                     key={i}
                     href={`/${inventory.inventoryId}/data/${convertSectorReferenceNumberToNumber(sector.referenceNumber)}/${subSector.subsectorId}`}


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Clamp the dashboard subsector progress values to a maximum of 100% in the `SectorCard` component and update the handling of optional `sectorProgress` values.

### Why are these changes being made?
Progress can exceed 100% due to calculation errors, leading to inaccurate UI representation; the clamping ensures that displayed progress values remain logical and capped at 100%. Additionally, handling `sectorProgress` as an optional value improves robustness against undefined data inputs and prevents potential runtime errors.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->