### PR TITLE
adds condition to render manage subsectors sector button

### DIFF
--- a/app/src/components/HomePage/TabHeader.tsx
+++ b/app/src/components/HomePage/TabHeader.tsx
@@ -60,18 +60,20 @@ export function TabHeader({
             >
               {t(title)}
             </Heading>
-            <Button
-              variant={"outline"}
-              p={6}
-              onClick={() =>
-                router.push(`/${inventory?.inventoryId}/data/manage-sectors`)
-              }
-              display="flex"
-              gap={0}
-            >
-              <Icon as={DataAlertIcon} boxSize={10} mt={3} />
-              <Text>{t("manage-missing-subsectors")}</Text>
-            </Button>
+            {!isPublic && (
+              <Button
+                variant={"outline"}
+                p={6}
+                onClick={() =>
+                  router.push(`/${inventory?.inventoryId}/data/manage-sectors`)
+                }
+                display="flex"
+                gap={0}
+              >
+                <Icon as={DataAlertIcon} boxSize={10} mt={3} />
+                <Text>{t("manage-missing-subsectors")}</Text>
+              </Button>
+            )}
           </Box>
           <Box className="flex items-center gap-3">
             <Badge>


### PR DESCRIPTION
Changes
- Adds condition using isPublic variable to hide manage subsectors button on public dashboard

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a condition to render the "manage subsectors" button only when `isPublic` is `false`.

### Why are these changes being made?

The button should be visible only to certain users, presumably those with permission to manage subsectors, ensuring it doesn't appear in public views. This change enhances security and user experience by displaying relevant options based on user access levels.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->