### PR TITLE
chore: include new s3 credentials in workflow

### DIFF
--- a/.github/workflows/web-develop.yml
+++ b/.github/workflows/web-develop.yml
@@ -171,6 +171,8 @@ jobs:
             "NEXT_PUBLIC_OPENCLIMATE_API_URL=https://openclimate.openearth.dev" \
             "OPENCLIMATE_API_URL=https://openclimate.openearth.dev" \
             "NEXT_PUBLIC_FEATURE_FLAGS=ENTERPRISE_MODE,CAP_TAB_ENABLED" \
+            "AWS_FILE_UPLOAD_S3_BUCKET_ID=citycatalyst-files" \
+            "AWS_FILE_UPLOAD_REGION=us-east-1"\
             "AWS_REGION"=${{secrets.AWS_REGION}} \
             "AWS_ACCESS_KEY_ID"=${{secrets.AWS_ACCESS_KEY_ID}} \
             "AWS_SECRET_ACCESS_KEY"=${{secrets.AWS_SECRET_ACCESS_KEY}} \

--- a/.github/workflows/web-tag.yml
+++ b/.github/workflows/web-tag.yml
@@ -155,6 +155,8 @@ jobs:
             "NEXT_PUBLIC_OPENCLIMATE_API_URL=https://app.openclimate.network" \
             "OPENCLIMATE_API_URL=https://app.openclimate.network" \
             "NEXT_PUBLIC_FEATURE_FLAGS=ENTERPRISE_MODE" \
+            "AWS_FILE_UPLOAD_S3_BUCKET_ID=citycatalyst-files" \
+            "AWS_FILE_UPLOAD_REGION=us-east-1" \
             "AWS_REGION"=${{secrets.AWS_REGION}} \
             "AWS_ACCESS_KEY_ID"=${{secrets.AWS_ACCESS_KEY_ID}} \
             "AWS_SECRET_ACCESS_KEY"=${{secrets.AWS_SECRET_ACCESS_KEY}} \

--- a/.github/workflows/web-tag.yml
+++ b/.github/workflows/web-tag.yml
@@ -155,8 +155,6 @@ jobs:
             "NEXT_PUBLIC_OPENCLIMATE_API_URL=https://app.openclimate.network" \
             "OPENCLIMATE_API_URL=https://app.openclimate.network" \
             "NEXT_PUBLIC_FEATURE_FLAGS=ENTERPRISE_MODE" \
-            "AWS_FILE_UPLOAD_S3_BUCKET_ID=citycatalyst-files" \
-            "AWS_FILE_UPLOAD_REGION=us-east-1" \
             "AWS_REGION"=${{secrets.AWS_REGION}} \
             "AWS_ACCESS_KEY_ID"=${{secrets.AWS_ACCESS_KEY_ID}} \
             "AWS_SECRET_ACCESS_KEY"=${{secrets.AWS_SECRET_ACCESS_KEY}} \

--- a/.github/workflows/web-test.yml
+++ b/.github/workflows/web-test.yml
@@ -148,6 +148,8 @@ jobs:
             "NEXT_PUBLIC_OPENCLIMATE_API_URL=https://openclimate.openearth.dev" \
             "OPENCLIMATE_API_URL=https://openclimate.openearth.dev" \
             "NEXT_PUBLIC_FEATURE_FLAGS=ENTERPRISE_MODE,CAP_TAB_ENABLED" \
+            "AWS_FILE_UPLOAD_S3_BUCKET_ID=citycatalyst-files" \
+            "AWS_FILE_UPLOAD_REGION=us-east-1" \
             "AWS_REGION"=${{secrets.AWS_REGION}} \
             "AWS_ACCESS_KEY_ID"=${{secrets.AWS_ACCESS_KEY_ID}} \
             "AWS_SECRET_ACCESS_KEY"=${{secrets.AWS_SECRET_ACCESS_KEY}} \


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add new S3 bucket credentials `AWS_FILE_UPLOAD_S3_BUCKET_ID` and `AWS_FILE_UPLOAD_REGION` to GitHub workflows `web-develop.yml` and `web-tag.yml`.

### Why are these changes being made?

These changes are being made to facilitate file uploads to the designated S3 bucket (`citycatalyst-files`) in the specified AWS region (us-east-1). This inclusion is necessary to ensure the workflows have the required S3 configuration and credentials, thereby enabling seamless integration with AWS for file handling tasks.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->