### PR TITLE
feat(ui/api): ON-3844 repalaces presented-elsewhere with included-elsewhere

### DIFF
--- a/app/migrations/20250512093848-update-unavailable-reason.cjs
+++ b/app/migrations/20250512093848-update-unavailable-reason.cjs
@@ -1,0 +1,20 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      UPDATE "InventoryValue"
+      SET "unavailable_reason" = 'included-elsewhere'
+      WHERE "unavailable_reason" = 'presented-elsewhere';
+    `);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      UPDATE "InventoryValue"
+      SET "unavailable_reason" = 'presented-elsewhere'
+      WHERE "unavailable_reason" = 'included-elsewhere';
+    `);
+  },
+};

--- a/app/src/app/[lng]/[inventory]/data/[step]/types.ts
+++ b/app/src/app/[lng]/[inventory]/data/[step]/types.ts
@@ -72,7 +72,7 @@ export type SubcategoryData = {
     | "no-occurrance"
     | "not-estimated"
     | "confidential-information"
-    | "presented-elsewhere"
+    | "included-elsewhere"
     | "";
   unavailableExplanation: string;
   activity: ActivityData;

--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -321,8 +321,8 @@ const SectorTabs: FC<SectorTabsProps> = ({ t, inventoryId }) => {
         value: "confidential-information",
       },
       {
-        label: t("pe"),
-        value: "presented-elsewhere",
+        label: t("ie"),
+        value: "included-elsewhere",
       },
     ],
   });

--- a/app/src/app/api/v0/inventory/[inventory]/download/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/download/route.ts
@@ -17,7 +17,7 @@ const notationKeyMapping: { [key: string]: string } = {
   "no-occurrance": "NO",
   "not-estimated": "NE",
   "confidential-information": "C",
-  "presented-elsewhere": "IE",
+  "included-elsewhere": "IE",
 };
 
 // converts sector GPC reference number to index of sheet in CIRIS file

--- a/app/src/app/api/v0/inventory/[inventory]/notation-keys/route.ts
+++ b/app/src/app/api/v0/inventory/[inventory]/notation-keys/route.ts
@@ -86,7 +86,7 @@ const saveNotationKeysRequest = z.object({
         "no-occurrance",
         "not-estimated",
         "confidential-information",
-        "presented-elsewhere",
+        "included-elsewhere",
       ]),
       unavailableExplanation: z.string().min(1),
     }),

--- a/app/src/i18n/locales/de/data.json
+++ b/app/src/i18n/locales/de/data.json
@@ -267,7 +267,7 @@
   "no-occurrance": "Die Aktivität oder der Prozess findet nicht statt oder existiert nicht innerhalb der Stadt",
   "not-estimated": "Die Emissionen für diese Aktivität werden nicht geschätzt",
   "confidential-information": "Die Emissionen könnten zur Offenlegung vertraulicher Informationen führen",
-  "presented-elsewhere": "Die Emissionen für diese Aktivität werden geschätzt und anderswo präsentiert",
+  "included-elsewhere": "Die Emissionen für diese Aktivität werden geschätzt und anderswo präsentiert",
   "unavailable-explanation": "Erklärung/ Rechtfertigung",
   "unavailable-explanation-placeholder": "Schreiben Sie detailliert, warum dieser Wert nicht enthalten ist",
   "unavailable-explanation-required": "Bitte fügen Sie eine Erklärung/ Rechtfertigung hinzu",

--- a/app/src/i18n/locales/de/manage-subsectors.json
+++ b/app/src/i18n/locales/de/manage-subsectors.json
@@ -1208,7 +1208,6 @@
   "emissions-from-grid-supplied-energy-consumed-in-power-plant-auxiliary-operations-within-the-city-boundary": "Emissionen aus dem Netz gelieferter Energie, die in Hilfsbetrieben von Kraftwerken innerhalb der Stadtgrenze verbraucht wird",
   "emissions-from-grid-supplied-energy-consumed-within-the-city-boundary-for-railways": "Emissionen aus dem Netz gelieferter Energie, die innerhalb der Stadtgrenzen für Eisenbahnen verbraucht wird",
   "deselect-all": "Alle abwählen",
-  "pe": "PE (Anderswo präsentiert)",
   "success": "Erfolg",
   "notation-keys-updated": "Notenschlüssel aktualisiert",
   "quick-action-applied": "Schnellaktion angewendet",

--- a/app/src/i18n/locales/de/manage-subsectors.json
+++ b/app/src/i18n/locales/de/manage-subsectors.json
@@ -201,7 +201,7 @@
   "no-occurrance": "Die Aktivität oder der Prozess findet nicht statt oder existiert nicht innerhalb der Stadt",
   "not-estimated": "Die Emissionen für diese Aktivität werden nicht geschätzt",
   "confidential-information": "Die Emissionen könnten zur Offenlegung vertraulicher Informationen führen",
-  "presented-elsewhere": "Die Emissionen für diese Aktivität werden geschätzt und anderswo präsentiert",
+  "included-elsewhere": "Die Emissionen für diese Aktivität werden geschätzt und anderswo präsentiert",
   "unavailable-explanation": "Erklärung/ Rechtfertigung",
   "unavailable-explanation-placeholder": "Schreiben Sie detailliert, warum dieser Wert nicht enthalten ist",
   "unavailable-explanation-required": "Bitte fügen Sie eine Erklärung/ Rechtfertigung hinzu",

--- a/app/src/i18n/locales/en/data.json
+++ b/app/src/i18n/locales/en/data.json
@@ -177,7 +177,7 @@
   "no-occurrance": "The activity or process does not occur or exist within the city",
   "not-estimated": "The emissions for this activity are not estimated",
   "confidential-information": "The emissions could lead to the disclosure of confidential information",
-  "presented-elsewhere": "The emissions for this activity are estimated and presented elsewhere",
+  "included-elsewhere": "The emissions for this activity are estimated and presented elsewhere",
   "unavailable-explanation": "Explanation/ Justification",
   "unavailable-explanation-placeholder": "Write in detail why this value is not included",
   "unavailable-explanation-required": "Please add an explanation/ justification",

--- a/app/src/i18n/locales/en/manage-subsectors.json
+++ b/app/src/i18n/locales/en/manage-subsectors.json
@@ -201,7 +201,7 @@
   "no-occurrance": "The activity or process does not occur or exist within the city",
   "not-estimated": "The emissions for this activity are not estimated",
   "confidential-information": "The emissions could lead to the disclosure of confidential information",
-  "presented-elsewhere": "The emissions for this activity are estimated and presented elsewhere",
+  "included-elsewhere": "The emissions for this activity are estimated and presented elsewhere",
   "unavailable-explanation": "Explanation/ Justification",
   "unavailable-explanation-placeholder": "Write in detail why this value is not included",
   "unavailable-explanation-required": "Please add an explanation/ justification",

--- a/app/src/i18n/locales/es/data.json
+++ b/app/src/i18n/locales/es/data.json
@@ -170,7 +170,7 @@
   "no-occurrance": "La actividad o proceso no ocurre o no existe dentro de la ciudad",
   "not-estimated": "Las emisiones para esta actividad no son estimadas",
   "confidential-information": "Las emisiones podrían llevar a la divulgación de información confidencial",
-  "presented-elsewhere": "Las emisiones para esta actividad están estimadas y presentadas en otra parte",
+  "included-elsewhere": "Las emisiones para esta actividad están estimadas y presentadas en otra parte",
   "unavailable-explanation": "Explicación/ Justificación",
   "unavailable-explanation-placeholder": "Escribe en detalle por qué este valor no está incluido",
   "unavailable-explanation-required": "Por favor añade una explicación/ justificación",

--- a/app/src/i18n/locales/es/manage-subsectors.json
+++ b/app/src/i18n/locales/es/manage-subsectors.json
@@ -201,7 +201,7 @@
   "no-occurrance": "La actividad o proceso no ocurre o existe dentro de la ciudad",
   "not-estimated": "Las emisiones para esta actividad no están estimadas",
   "confidential-information": "Las emisiones podrían llevar a la divulgación de información confidencial",
-  "presented-elsewhere": "Las emisiones de esta actividad se estiman y se presentan en otro lugar",
+  "included-elsewhere": "Las emisiones de esta actividad se estiman y se presentan en otro lugar",
   "unavailable-explanation": "Explicación/ Justificación",
   "unavailable-explanation-placeholder": "Escriba en detalle por qué este valor no está incluido",
   "unavailable-explanation-required": "Por favor, añade una explicación/justificación",

--- a/app/src/i18n/locales/es/manage-subsectors.json
+++ b/app/src/i18n/locales/es/manage-subsectors.json
@@ -1208,7 +1208,6 @@
   "emissions-from-grid-supplied-energy-consumed-in-power-plant-auxiliary-operations-within-the-city-boundary": "Emisiones de energía suministrada por la red consumida en operaciones auxiliares de la planta de energía dentro del límite de la ciudad",
   "emissions-from-grid-supplied-energy-consumed-within-the-city-boundary-for-railways": "Emisiones de energía suministrada por la red consumida dentro del límite de la ciudad para ferrocarriles",
   "deselect-all": "Deseleccionar todo",
-  "pe": "PE (Presentado en otro lugar)",
   "success": "Éxito",
   "notation-keys-updated": "Claves de notación actualizadas",
   "quick-action-applied": "Acción rápida aplicada",

--- a/app/src/i18n/locales/pt/data.json
+++ b/app/src/i18n/locales/pt/data.json
@@ -175,7 +175,7 @@
   "no-occurrance": "A atividade ou processo não ocorre ou existe dentro da cidade",
   "not-estimated": "As emissões para esta atividade não são estimadas",
   "confidential-information": "As emissões podem levar à divulgação de informações confidenciais",
-  "presented-elsewhere": "As emissões para esta atividade são estimadas e apresentadas em outro lugar",
+  "included-elsewhere": "As emissões para esta atividade são estimadas e apresentadas em outro lugar",
   "unavailable-explanation": "Explicação/Justificativa",
   "unavailable-explanation-placeholder": "Escreva em detalhes por que este valor não está incluído",
   "unavailable-explanation-required": "Por favor, adicione uma explicação/justificativa",

--- a/app/src/i18n/locales/pt/manage-subsectors.json
+++ b/app/src/i18n/locales/pt/manage-subsectors.json
@@ -1208,7 +1208,6 @@
   "emissions-from-grid-supplied-energy-consumed-in-power-plant-auxiliary-operations-within-the-city-boundary": "Emissões de energia fornecida pela rede consumida em operações auxiliares de usinas de energia dentro do limite da cidade",
   "emissions-from-grid-supplied-energy-consumed-within-the-city-boundary-for-railways": "Emissões de energia fornecida pela rede consumida dentro dos limites da cidade para ferrovias",
   "deselect-all": "Deselecionar tudo",
-  "pe": "PE (Apresentado em outro lugar)",
   "success": "Sucesso",
   "notation-keys-updated": "Chaves de notação atualizadas",
   "quick-action-applied": "Ação rápida aplicada",

--- a/app/src/i18n/locales/pt/manage-subsectors.json
+++ b/app/src/i18n/locales/pt/manage-subsectors.json
@@ -201,7 +201,7 @@
   "no-occurrance": "A atividade ou processo não ocorre ou existe dentro da cidade",
   "not-estimated": "As emissões para esta atividade não são estimadas",
   "confidential-information": "As emissões poderiam levar à divulgação de informações confidenciais",
-  "presented-elsewhere": "As emissões para esta atividade são estimadas e apresentadas em outro lugar",
+  "included-elsewhere": "As emissões para esta atividade são estimadas e apresentadas em outro lugar",
   "unavailable-explanation": "Explicação/ Justificativa",
   "unavailable-explanation-placeholder": "Escreva em detalhes por que este valor não está incluído",
   "unavailable-explanation-required": "Por favor, adicione uma explicação/justificativa",


### PR DESCRIPTION
Changes
- Replaces notation key value presented elsewhere with included elsewhere
- Updates translation keys and strings
- Updates subcategory type key value
- Updates CIRIS file download route mapping key
- Updates notation-key manager route
- Adds migration to update all occurences
- Removes presented elsewhere translations

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Replace all occurrences of "presented-elsewhere" with "included-elsewhere" across the codebase and update related internationalization files and UI components accordingly.

### Why are these changes being made?

This change is being made to standardize the terminology across the application, ensuring consistency in the user interface and underlying data structures. The new term "included-elsewhere" better reflects the intended meaning related to emissions data handling, offering clearer communication to users.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->