### PR TITLE
fix(ui): ON-3906 incorrect emissions factor inputs enable/ disabled state

### DIFF
--- a/app/src/components/Modals/activity-modal/activity-modal-body.tsx
+++ b/app/src/components/Modals/activity-modal/activity-modal-body.tsx
@@ -9,7 +9,6 @@ import {
   Spinner,
   Text,
   Textarea,
-  useRadioGroup,
 } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import BuildingTypeSelectInput from "../../building-select-input";
@@ -123,7 +122,6 @@ const ActivityModalBody = ({
     control,
     defaultValue: selectedActivity?.prefills?.[0].value,
   });
-  const { getRootProps, getItemProps, value } = useRadioGroup(field);
 
   let prefix = "";
   const [isEmissionFactorInputDisabled, setIsEmissionFactorInputDisabled] =

--- a/app/src/components/Modals/activity-modal/activity-modal-body.tsx
+++ b/app/src/components/Modals/activity-modal/activity-modal-body.tsx
@@ -130,7 +130,7 @@ const ActivityModalBody = ({
     useState<boolean>(true);
 
   useEffect(() => {
-    setIsEmissionFactorInputDisabled(emissionsFactorTypeValue === "custom");
+    setIsEmissionFactorInputDisabled(emissionsFactorTypeValue !== "custom");
   }, [emissionsFactorTypeValue]);
 
   useEffect(() => {

--- a/app/src/components/Modals/activity-modal/activity-modal-body.tsx
+++ b/app/src/components/Modals/activity-modal/activity-modal-body.tsx
@@ -113,7 +113,7 @@ const ActivityModalBody = ({
     name: `activity.${title}-unit` as any,
   });
 
-  const emissionFactorTypeValue = useWatch({
+  const emissionsFactorTypeValue = useWatch({
     control,
     name: "activity.emissionFactorType",
   });
@@ -130,12 +130,15 @@ const ActivityModalBody = ({
     useState<boolean>(true);
 
   useEffect(() => {
-    if (emissionsFactorTypes.length > 0 && emissionFactorTypeValue) {
+    setIsEmissionFactorInputDisabled(emissionsFactorTypeValue === "custom");
+  }, [emissionsFactorTypeValue]);
+
+  useEffect(() => {
+    if (emissionsFactorTypes.length > 0 && emissionsFactorTypeValue) {
       const emissionFactor = emissionsFactorTypes.find(
-        (factor) => factor.id === emissionFactorTypeValue,
+        (factor) => factor.id === emissionsFactorTypeValue,
       );
-      const emissionFactorType = emissionFactorTypeValue;
-      if (emissionFactorType === "custom") {
+      if (emissionsFactorTypeValue === "custom") {
         setValue(
           "activity.emissionFactorReference",
           t("custom-emission-factor-reference"),
@@ -174,7 +177,7 @@ const ActivityModalBody = ({
         setIsEmissionFactorInputDisabled(true);
       }
     }
-  }, [emissionsFactorTypes, emissionFactorTypeValue, setValue, t]);
+  }, [emissionsFactorTypes, emissionsFactorTypeValue, setValue, t]);
 
   const filteredFields = fields.filter((f) => {
     return !(f.id.includes("-source") && f.type === "text");
@@ -690,11 +693,10 @@ const ActivityModalBody = ({
                       miniAddon
                       t={t}
                       control={control}
-                      name={`activity.CO2EmissionFactor`}
+                      name="activity.CO2EmissionFactor"
                       defaultValue="0"
                       w="110px"
-                      h="full"
-                      disabled={isEmissionFactorInputDisabled}
+                      isDisabled={isEmissionFactorInputDisabled}
                     >
                       {areEmissionFactorsLoading ? (
                         <Spinner size="sm" color="border.neutral" />
@@ -736,7 +738,7 @@ const ActivityModalBody = ({
                     miniAddon
                     t={t}
                     control={control}
-                    name={`activity.N2OEmissionFactor`}
+                    name="activity.N2OEmissionFactor"
                     defaultValue="0"
                     isDisabled={isEmissionFactorInputDisabled}
                   >
@@ -774,7 +776,7 @@ const ActivityModalBody = ({
                     control={control}
                     miniAddon
                     t={t}
-                    name={`activity.CH4EmissionFactor`}
+                    name="activity.CH4EmissionFactor"
                     defaultValue="0"
                     isDisabled={isEmissionFactorInputDisabled}
                   >

--- a/app/src/components/Modals/activity-modal/activity-modal-body.tsx
+++ b/app/src/components/Modals/activity-modal/activity-modal-body.tsx
@@ -108,8 +108,6 @@ const ActivityModalBody = ({
   getValues,
   areEmissionFactorsLoading,
 }: AddActivityModalBodyProps) => {
-  //
-
   const unitValue = useWatch({
     control,
     name: `activity.${title}-unit` as any,
@@ -129,7 +127,7 @@ const ActivityModalBody = ({
 
   let prefix = "";
   const [isEmissionFactorInputDisabled, setIsEmissionFactorInputDisabled] =
-    useState<boolean>(false);
+    useState<boolean>(true);
 
   useEffect(() => {
     if (emissionsFactorTypes.length > 0 && emissionFactorTypeValue) {


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify the emissions factor inputs to be correctly enabled or disabled based on the emissions factor type input selection within the `ActivityModalBody` component of the user interface.

### Why are these changes being made?

Previously, the emissions factor inputs did not correctly reflect the enabled/disabled state when the emissions factor type was "custom", leading to potential user confusion. This change ensures that these inputs are disabled when the type is "custom", aligning with the intended user experience and UI logic. Additionally, some minor refactoring was done for variable naming consistency and readability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->