### PR TITLE
fix(ui, api): ON-3904 wrong GPC refno for some scopes in waste

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/[step]/[subsector]/page.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/[subsector]/page.tsx
@@ -19,7 +19,7 @@ import {
 } from "@chakra-ui/react";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { forwardRef, useEffect, useState } from "react";
+import { forwardRef, useState } from "react";
 import { MdArrowBack, MdChevronRight, MdOutlineHomeWork } from "react-icons/md";
 import {
   AnimatePresence,

--- a/app/src/app/[lng]/[inventory]/data/[step]/[subsector]/page.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/[subsector]/page.tsx
@@ -38,7 +38,7 @@ import {
   BreadcrumbRoot,
 } from "@/components/ui/breadcrumb";
 
-const MotionBox = motion(
+const MotionBox = motion.create(
   // the display name is added below, but the linter isn't picking it up
   // eslint-disable-next-line react/display-name
   forwardRef<HTMLDivElement, any>((props, ref) => <Box ref={ref} {...props} />),
@@ -147,7 +147,7 @@ function SubSectorPage({
   };
   const scopes = getFilteredSubsectorScopes();
 
-  const MotionTabList = motion(
+  const MotionTabList = motion.create(
     // the display name is added below, but the linter isn't picking it up
     // eslint-disable-next-line react/display-name
     forwardRef<HTMLDivElement, any>((props, ref) => (

--- a/app/src/app/[lng]/[inventory]/data/[step]/page.tsx
+++ b/app/src/app/[lng]/[inventory]/data/[step]/page.tsx
@@ -597,7 +597,7 @@ export default function AddDataSteps({
     };
   }, []);
 
-  const MotionBox = motion(
+  const MotionBox = motion.create(
     // the display name is added below, but the linter isn't picking it up
     // eslint-disable-next-line react/display-name
     forwardRef<HTMLDivElement, any>((props, ref) => (

--- a/app/src/backend/GPCService.ts
+++ b/app/src/backend/GPCService.ts
@@ -56,7 +56,7 @@ export default class GPCService {
       };
     }
     throw new createHttpError.BadRequest(
-      "Couldn't find sector/ subsector/ subcategory for given GPC reference number",
+      `Couldn't find sector/ subsector/ subcategory for given GPC reference number: ${gpcReferenceNumber}`,
     );
   }
 

--- a/app/src/backend/InventoryProgressService.ts
+++ b/app/src/backend/InventoryProgressService.ts
@@ -61,6 +61,7 @@ export default class InventoryProgressService {
               referenceNumber: subcategory.referenceNumber,
               subsectorId: subcategory.subsectorId,
               scopeId: subcategory.scopeId,
+              scopeName: subcategory.scope.scopeName,
               reportinglevelId: subcategory.reportinglevelId,
               created: new Date(0),
               lastUpdated: new Date(0),
@@ -72,17 +73,20 @@ export default class InventoryProgressService {
                 return true;
               }
 
-              const lastDigit = parseInt(
-                subCategory.referenceNumber?.split(".")[2] as string,
-              );
-              if (!lastDigit) {
+              if (
+                !subCategory.scopeName ||
+                !inventory.inventoryType ||
+                !sector.referenceNumber
+              ) {
                 // sectors IV and V don't have a scopeId and should only be returned for BASIC_PLUS
                 return false;
               }
+
+              const scope = Number(subCategory.scopeName);
               return getScopesForInventoryAndSector(
-                inventory.inventoryType!,
-                sector.referenceNumber!,
-              )!.includes(lastDigit);
+                inventory.inventoryType,
+                sector.referenceNumber,
+              )!.includes(scope);
             }),
         })),
       }));
@@ -223,12 +227,12 @@ export default class InventoryProgressService {
   }
 
   public static async getSortedInventoryStructure() {
-    if (
+    /* if (
       Inventory_Sector_Hierarchy.length > 0 &&
       process.env.NODE_ENV !== "test"
     ) {
       return Inventory_Sector_Hierarchy;
-    }
+    } */
     let sectors: Sector[] = await db.models.Sector.findAll({
       include: [
         {
@@ -238,6 +242,7 @@ export default class InventoryProgressService {
             {
               model: db.models.SubCategory,
               as: "subCategories",
+              include: [{ model: db.models.Scope, as: "scope" }],
             },
           ],
         },

--- a/app/src/data/inventory-structure.json
+++ b/app/src/data/inventory-structure.json
@@ -1,45 +1,14 @@
 [
   {
-    "sectorId": "86a70970-6559-4d31-bafc-fcd1b51bc8e3",
-    "sectorName": "XX_DATASOURCE_TEST_1",
-    "referenceNumber": "X",
-    "created": "2024-10-10T21:40:11.800Z",
-    "last_updated": "2024-10-10T21:40:11.800Z",
-    "subSectors": [
-      {
-        "subsectorId": "60c0b6c9-7208-439b-a27a-44599297cc1c",
-        "subsectorName": "xx-datasource-test-1",
-        "sectorId": "86a70970-6559-4d31-bafc-fcd1b51bc8e3",
-        "referenceNumber": "X.9",
-        "scopeId": null,
-        "created": "2024-10-10T21:40:11.803Z",
-        "last_updated": "2024-10-10T21:40:11.803Z",
-        "subCategories": [
-          {
-            "subcategoryId": "ed24c944-118c-427b-9dd2-c6d0bab0959b",
-            "subcategoryName": "XX_DATASOURCE_TEST_1",
-            "activityName": null,
-            "referenceNumber": "X.9.9",
-            "subsectorId": "60c0b6c9-7208-439b-a27a-44599297cc1c",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:11.807Z",
-            "last_updated": "2024-10-10T21:40:11.807Z"
-          }
-        ]
-      }
-    ]
-  },
-  {
     "sectorId": "5da765a9-1ca6-37e1-bcd6-7b387f909a4e",
     "sectorName": "Stationary Energy",
     "referenceNumber": "I",
-    "created": "2023-10-09T23:00:00.000Z",
-    "last_updated": "2023-10-09T23:00:00.000Z",
+    "created": "2023-10-09T22:00:00.000Z",
+    "last_updated": "2023-10-09T22:00:00.000Z",
     "subSectors": [
       {
         "subsectorId": "abe4c7b0-242d-3ed2-a146-48885d6fb38d",
-        "subsectorName": "residential-buildings",
+        "subsectorName": "Residential buildings",
         "sectorId": "5da765a9-1ca6-37e1-bcd6-7b387f909a4e",
         "referenceNumber": "I.1",
         "scopeId": null,
@@ -54,8 +23,14 @@
             "subsectorId": "abe4c7b0-242d-3ed2-a146-48885d6fb38d",
             "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
+              "scopeName": "1",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "6cf6f15d-536a-37dc-90c7-7d7ea75b5d01",
@@ -65,8 +40,14 @@
             "subsectorId": "abe4c7b0-242d-3ed2-a146-48885d6fb38d",
             "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
+              "scopeName": "2",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "2badf7fe-aa9c-357d-888e-7ac8b7979a50",
@@ -76,14 +57,20 @@
             "subsectorId": "abe4c7b0-242d-3ed2-a146-48885d6fb38d",
             "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
             "reportinglevelId": "2782d240-65fb-3af2-865d-c408f70a826f",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
+              "scopeName": "3",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           }
         ]
       },
       {
         "subsectorId": "a235005c-f223-3c64-a0d2-f55d6f22f32f",
-        "subsectorName": "commercial-and-institutional-buildings-and-facilities",
+        "subsectorName": "Commercial and institutional buildings and facilities",
         "sectorId": "5da765a9-1ca6-37e1-bcd6-7b387f909a4e",
         "referenceNumber": "I.2",
         "scopeId": null,
@@ -98,8 +85,14 @@
             "subsectorId": "a235005c-f223-3c64-a0d2-f55d6f22f32f",
             "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
+              "scopeName": "1",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "94bd54aa-01e7-3a2f-a1c1-a49121d8dcea",
@@ -109,8 +102,14 @@
             "subsectorId": "a235005c-f223-3c64-a0d2-f55d6f22f32f",
             "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
+              "scopeName": "2",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "32db3fd4-66f9-3d29-8cdd-9de719d3cdb7",
@@ -120,14 +119,20 @@
             "subsectorId": "a235005c-f223-3c64-a0d2-f55d6f22f32f",
             "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
             "reportinglevelId": "2782d240-65fb-3af2-865d-c408f70a826f",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
+              "scopeName": "3",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           }
         ]
       },
       {
         "subsectorId": "8de1d11d-4146-35f3-a973-e66930e68a50",
-        "subsectorName": "manufacturing-industries-and-construction",
+        "subsectorName": "Manufacturing industries and construction",
         "sectorId": "5da765a9-1ca6-37e1-bcd6-7b387f909a4e",
         "referenceNumber": "I.3",
         "scopeId": null,
@@ -142,8 +147,14 @@
             "subsectorId": "8de1d11d-4146-35f3-a973-e66930e68a50",
             "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
+              "scopeName": "1",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "59e74d03-a234-38a3-9d8f-a13e8b424167",
@@ -153,8 +164,14 @@
             "subsectorId": "8de1d11d-4146-35f3-a973-e66930e68a50",
             "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
+              "scopeName": "2",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "3ebc2363-43e5-3c1c-8270-dd6e5d823388",
@@ -164,14 +181,20 @@
             "subsectorId": "8de1d11d-4146-35f3-a973-e66930e68a50",
             "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
             "reportinglevelId": "2782d240-65fb-3af2-865d-c408f70a826f",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
+              "scopeName": "3",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           }
         ]
       },
       {
         "subsectorId": "4f342e84-0269-3f04-aceb-1d6cd0a183bc",
-        "subsectorName": "energy-industries",
+        "subsectorName": "Energy industries",
         "sectorId": "5da765a9-1ca6-37e1-bcd6-7b387f909a4e",
         "referenceNumber": "I.4",
         "scopeId": null,
@@ -186,8 +209,14 @@
             "subsectorId": "4f342e84-0269-3f04-aceb-1d6cd0a183bc",
             "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
+              "scopeName": "1",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "ac047081-bd46-3fb9-8b6b-426f20fad176",
@@ -197,8 +226,14 @@
             "subsectorId": "4f342e84-0269-3f04-aceb-1d6cd0a183bc",
             "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
+              "scopeName": "2",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "7f927890-ddf7-3d85-8931-6da122215938",
@@ -208,8 +243,14 @@
             "subsectorId": "4f342e84-0269-3f04-aceb-1d6cd0a183bc",
             "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
             "reportinglevelId": "2782d240-65fb-3af2-865d-c408f70a826f",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
+              "scopeName": "3",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "06922c49-a18e-3b86-a947-2dc833aec949",
@@ -219,14 +260,20 @@
             "subsectorId": "4f342e84-0269-3f04-aceb-1d6cd0a183bc",
             "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
             "reportinglevelId": "7b8bd2cf-13a0-3a76-8d50-e08b4321703a",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
+              "scopeName": "1",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           }
         ]
       },
       {
         "subsectorId": "95c049d1-eff9-3b26-af49-2b32982e7dd9",
-        "subsectorName": "agriculture-forestry-and-fishing-activities",
+        "subsectorName": "Agriculture, forestry and fishing activities",
         "sectorId": "5da765a9-1ca6-37e1-bcd6-7b387f909a4e",
         "referenceNumber": "I.5",
         "scopeId": null,
@@ -241,8 +288,14 @@
             "subsectorId": "95c049d1-eff9-3b26-af49-2b32982e7dd9",
             "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
+              "scopeName": "1",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "25d0ad43-454f-34c2-ae83-03c095069891",
@@ -252,8 +305,14 @@
             "subsectorId": "95c049d1-eff9-3b26-af49-2b32982e7dd9",
             "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
+              "scopeName": "2",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "0f145a59-f3e3-3739-a970-9686e968e2b2",
@@ -263,14 +322,20 @@
             "subsectorId": "95c049d1-eff9-3b26-af49-2b32982e7dd9",
             "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
             "reportinglevelId": "2782d240-65fb-3af2-865d-c408f70a826f",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
+              "scopeName": "3",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           }
         ]
       },
       {
         "subsectorId": "cfc4d8de-2b90-376c-b9d7-446aaf2d8eeb",
-        "subsectorName": "non-specified-sources",
+        "subsectorName": "Non-specified sources",
         "sectorId": "5da765a9-1ca6-37e1-bcd6-7b387f909a4e",
         "referenceNumber": "I.6",
         "scopeId": null,
@@ -285,8 +350,14 @@
             "subsectorId": "cfc4d8de-2b90-376c-b9d7-446aaf2d8eeb",
             "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
+              "scopeName": "1",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "75ca6ffd-7696-31b8-961a-45fa54ba970f",
@@ -296,8 +367,14 @@
             "subsectorId": "cfc4d8de-2b90-376c-b9d7-446aaf2d8eeb",
             "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
+              "scopeName": "2",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "1c64a6fc-ae52-3473-b00c-beaf646d8cb6",
@@ -307,14 +384,20 @@
             "subsectorId": "cfc4d8de-2b90-376c-b9d7-446aaf2d8eeb",
             "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
             "reportinglevelId": "2782d240-65fb-3af2-865d-c408f70a826f",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
+              "scopeName": "3",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           }
         ]
       },
       {
         "subsectorId": "b69c4ec7-a3c7-37a2-af4f-634d5a06a512",
-        "subsectorName": "fugitive-emissions-from-mining-processing-storage-and-transportation-of-coal",
+        "subsectorName": "Fugitive emissions from mining, processing, storage, and transportation of coal",
         "sectorId": "5da765a9-1ca6-37e1-bcd6-7b387f909a4e",
         "referenceNumber": "I.7",
         "scopeId": null,
@@ -329,14 +412,20 @@
             "subsectorId": "b69c4ec7-a3c7-37a2-af4f-634d5a06a512",
             "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
+              "scopeName": "1",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           }
         ]
       },
       {
         "subsectorId": "b32f56a1-3a4e-3cd5-9052-e06284468700",
-        "subsectorName": "fugitive-emissions-from-oil-and-natural-gas-systems",
+        "subsectorName": "Fugitive emissions from oil and natural gas systems",
         "sectorId": "5da765a9-1ca6-37e1-bcd6-7b387f909a4e",
         "referenceNumber": "I.8",
         "scopeId": null,
@@ -351,8 +440,14 @@
             "subsectorId": "b32f56a1-3a4e-3cd5-9052-e06284468700",
             "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
+              "scopeName": "1",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           }
         ]
       }
@@ -362,12 +457,12 @@
     "sectorId": "73eb7b71-159c-3eda-b7fc-f6eb53754dc3",
     "sectorName": "Transportation",
     "referenceNumber": "II",
-    "created": "2023-10-09T23:00:00.000Z",
-    "last_updated": "2023-10-09T23:00:00.000Z",
+    "created": "2023-10-09T22:00:00.000Z",
+    "last_updated": "2023-10-09T22:00:00.000Z",
     "subSectors": [
       {
         "subsectorId": "48fcfadb-90ed-34aa-80d9-fa31a90bef80",
-        "subsectorName": "on-road-transportation",
+        "subsectorName": "On-road transportation",
         "sectorId": "73eb7b71-159c-3eda-b7fc-f6eb53754dc3",
         "referenceNumber": "II.1",
         "scopeId": null,
@@ -382,8 +477,14 @@
             "subsectorId": "48fcfadb-90ed-34aa-80d9-fa31a90bef80",
             "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
+              "scopeName": "1",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "53a0b057-27fb-36f2-96a1-1facca177dc4",
@@ -393,8 +494,14 @@
             "subsectorId": "48fcfadb-90ed-34aa-80d9-fa31a90bef80",
             "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
+              "scopeName": "2",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "8a8e2b69-459e-3c7c-b978-aeddf82026e2",
@@ -404,14 +511,20 @@
             "subsectorId": "48fcfadb-90ed-34aa-80d9-fa31a90bef80",
             "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
             "reportinglevelId": "2782d240-65fb-3af2-865d-c408f70a826f",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
+              "scopeName": "3",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           }
         ]
       },
       {
         "subsectorId": "8cf35b86-9ed2-36bd-b04d-eddc47db6676",
-        "subsectorName": "railways",
+        "subsectorName": "Railways",
         "sectorId": "73eb7b71-159c-3eda-b7fc-f6eb53754dc3",
         "referenceNumber": "II.2",
         "scopeId": null,
@@ -426,8 +539,14 @@
             "subsectorId": "8cf35b86-9ed2-36bd-b04d-eddc47db6676",
             "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
+              "scopeName": "1",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "9c36256a-80e5-31a4-a3fa-a9a641135a61",
@@ -437,8 +556,14 @@
             "subsectorId": "8cf35b86-9ed2-36bd-b04d-eddc47db6676",
             "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
+              "scopeName": "2",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "5d5851fc-aca9-36fa-9db4-74e330165e1e",
@@ -448,14 +573,20 @@
             "subsectorId": "8cf35b86-9ed2-36bd-b04d-eddc47db6676",
             "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
             "reportinglevelId": "2782d240-65fb-3af2-865d-c408f70a826f",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
+              "scopeName": "3",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           }
         ]
       },
       {
         "subsectorId": "ab32c321-e9e1-31b3-9dde-f93ade472219",
-        "subsectorName": "waterborne-navigation",
+        "subsectorName": "Waterborne navigation",
         "sectorId": "73eb7b71-159c-3eda-b7fc-f6eb53754dc3",
         "referenceNumber": "II.3",
         "scopeId": null,
@@ -470,8 +601,14 @@
             "subsectorId": "ab32c321-e9e1-31b3-9dde-f93ade472219",
             "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
+              "scopeName": "1",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "9dff7279-966a-30f9-976a-8caccfa24f9f",
@@ -481,8 +618,14 @@
             "subsectorId": "ab32c321-e9e1-31b3-9dde-f93ade472219",
             "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
+              "scopeName": "2",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "320d7a15-59a9-351c-b7c3-c8053e63b8b1",
@@ -492,14 +635,20 @@
             "subsectorId": "ab32c321-e9e1-31b3-9dde-f93ade472219",
             "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
             "reportinglevelId": "2782d240-65fb-3af2-865d-c408f70a826f",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
+              "scopeName": "3",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           }
         ]
       },
       {
         "subsectorId": "5b84b809-1878-3b1b-bf6b-250c64d5e920",
-        "subsectorName": "aviation",
+        "subsectorName": "Aviation",
         "sectorId": "73eb7b71-159c-3eda-b7fc-f6eb53754dc3",
         "referenceNumber": "II.4",
         "scopeId": null,
@@ -514,8 +663,14 @@
             "subsectorId": "5b84b809-1878-3b1b-bf6b-250c64d5e920",
             "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
+              "scopeName": "1",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "96640a23-487f-3e28-86fa-0fd822f855ec",
@@ -525,8 +680,14 @@
             "subsectorId": "5b84b809-1878-3b1b-bf6b-250c64d5e920",
             "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
+              "scopeName": "2",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "ce889acf-9acd-3498-965a-3d4e5c88f57e",
@@ -536,14 +697,20 @@
             "subsectorId": "5b84b809-1878-3b1b-bf6b-250c64d5e920",
             "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
             "reportinglevelId": "2782d240-65fb-3af2-865d-c408f70a826f",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
+              "scopeName": "3",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           }
         ]
       },
       {
         "subsectorId": "e20ace37-9ba4-3a80-9d88-8cac5253c0b0",
-        "subsectorName": "off-road-transportation",
+        "subsectorName": "Off-road transportation",
         "sectorId": "73eb7b71-159c-3eda-b7fc-f6eb53754dc3",
         "referenceNumber": "II.5",
         "scopeId": null,
@@ -558,8 +725,14 @@
             "subsectorId": "e20ace37-9ba4-3a80-9d88-8cac5253c0b0",
             "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
+              "scopeName": "1",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "af0b4e08-07a1-366d-b7b8-4407614c386b",
@@ -569,8 +742,14 @@
             "subsectorId": "e20ace37-9ba4-3a80-9d88-8cac5253c0b0",
             "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "81cac15d-01d5-3d51-8bde-0f7a383585ae",
+              "scopeName": "2",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           }
         ]
       }
@@ -580,12 +759,12 @@
     "sectorId": "d5acb72e-d915-310f-b3a3-77f634bcbf5e",
     "sectorName": "Waste",
     "referenceNumber": "III",
-    "created": "2023-10-09T23:00:00.000Z",
-    "last_updated": "2023-10-09T23:00:00.000Z",
+    "created": "2023-10-09T22:00:00.000Z",
+    "last_updated": "2023-10-09T22:00:00.000Z",
     "subSectors": [
       {
         "subsectorId": "172d10c0-6b80-3173-902e-eca5c0af84c8",
-        "subsectorName": "solid-waste-disposal",
+        "subsectorName": "Solid waste disposal",
         "sectorId": "d5acb72e-d915-310f-b3a3-77f634bcbf5e",
         "referenceNumber": "III.1",
         "scopeId": null,
@@ -600,8 +779,14 @@
             "subsectorId": "172d10c0-6b80-3173-902e-eca5c0af84c8",
             "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
+              "scopeName": "1",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "32acd829-2e87-38e9-aab3-8a495577ea7d",
@@ -611,25 +796,20 @@
             "subsectorId": "172d10c0-6b80-3173-902e-eca5c0af84c8",
             "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
-          },
-          {
-            "subcategoryId": "e7218f77-9896-30db-8a47-afb6b1d084a8",
-            "subcategoryName": "Emissions from waste generated outside the city boundary and disposed in landfills or open dumps within the city boundary",
-            "activityName": null,
-            "referenceNumber": "III.1.3",
-            "subsectorId": "172d10c0-6b80-3173-902e-eca5c0af84c8",
-            "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
-            "reportinglevelId": "7b8bd2cf-13a0-3a76-8d50-e08b4321703a",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
+              "scopeName": "3",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           }
         ]
       },
       {
         "subsectorId": "a8baeb06-0ab2-3215-a93e-2fcbe0e8f8a9",
-        "subsectorName": "biological-treatment-of-waste",
+        "subsectorName": "Biological treatment of waste",
         "sectorId": "d5acb72e-d915-310f-b3a3-77f634bcbf5e",
         "referenceNumber": "III.2",
         "scopeId": null,
@@ -644,8 +824,14 @@
             "subsectorId": "a8baeb06-0ab2-3215-a93e-2fcbe0e8f8a9",
             "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
+              "scopeName": "1",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "65440ef4-1749-33ee-9cc2-7dcf62e1850a",
@@ -655,25 +841,20 @@
             "subsectorId": "a8baeb06-0ab2-3215-a93e-2fcbe0e8f8a9",
             "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
-          },
-          {
-            "subcategoryId": "70d968e6-e9f7-37d8-94e1-8197e6f8332b",
-            "subcategoryName": "Emissions from waste generated outside the city boundary but treated biologically within the city boundary",
-            "activityName": null,
-            "referenceNumber": "III.2.3",
-            "subsectorId": "a8baeb06-0ab2-3215-a93e-2fcbe0e8f8a9",
-            "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
-            "reportinglevelId": "7b8bd2cf-13a0-3a76-8d50-e08b4321703a",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
+              "scopeName": "3",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           }
         ]
       },
       {
         "subsectorId": "0ed16605-c76a-3c07-892d-4383a7618943",
-        "subsectorName": "incineration-and-open-burning",
+        "subsectorName": "Incineration and open burning",
         "sectorId": "d5acb72e-d915-310f-b3a3-77f634bcbf5e",
         "referenceNumber": "III.3",
         "scopeId": null,
@@ -688,8 +869,14 @@
             "subsectorId": "0ed16605-c76a-3c07-892d-4383a7618943",
             "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
+              "scopeName": "1",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "cabb1b2e-546d-3fa0-bb05-975733480fb3",
@@ -699,25 +886,20 @@
             "subsectorId": "0ed16605-c76a-3c07-892d-4383a7618943",
             "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
-          },
-          {
-            "subcategoryId": "7582e783-dfd5-3caa-a06a-e10bcc75e089",
-            "subcategoryName": "Emissions from waste generated outside the city boundary but treated within the city boundary",
-            "activityName": null,
-            "referenceNumber": "III.3.3",
-            "subsectorId": "0ed16605-c76a-3c07-892d-4383a7618943",
-            "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
-            "reportinglevelId": "7b8bd2cf-13a0-3a76-8d50-e08b4321703a",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
+              "scopeName": "3",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           }
         ]
       },
       {
         "subsectorId": "c465e7a2-1634-337f-819a-2dfbe147927e",
-        "subsectorName": "wastewater-treatment-and-discharge",
+        "subsectorName": "Wastewater treatment and discharge",
         "sectorId": "d5acb72e-d915-310f-b3a3-77f634bcbf5e",
         "referenceNumber": "III.4",
         "scopeId": null,
@@ -732,8 +914,14 @@
             "subsectorId": "c465e7a2-1634-337f-819a-2dfbe147927e",
             "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
+              "scopeName": "1",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           },
           {
             "subcategoryId": "4dc4b184-2d1e-3b4a-9515-9cd1a2cc03ac",
@@ -743,19 +931,14 @@
             "subsectorId": "c465e7a2-1634-337f-819a-2dfbe147927e",
             "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
             "reportinglevelId": "3e54a15f-7857-3878-9a60-b2c28e3c60fa",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
-          },
-          {
-            "subcategoryId": "af68e0d7-f55a-3827-aa53-369d98e210f8",
-            "subcategoryName": "Emissions from wastewater generated outside the city boundary but treated within the city boundary",
-            "activityName": null,
-            "referenceNumber": "III.4.3",
-            "subsectorId": "c465e7a2-1634-337f-819a-2dfbe147927e",
-            "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
-            "reportinglevelId": "7b8bd2cf-13a0-3a76-8d50-e08b4321703a",
-            "created": "2023-10-09T23:00:00.000Z",
-            "last_updated": "2023-10-09T23:00:00.000Z"
+            "created": "2023-10-09T22:00:00.000Z",
+            "last_updated": "2023-10-09T22:00:00.000Z",
+            "scope": {
+              "scopeId": "ce09d866-a134-35a8-88b8-e4f08b21af3a",
+              "scopeName": "3",
+              "created": "2023-10-09T22:00:00.000Z",
+              "last_updated": "2023-10-09T22:00:00.000Z"
+            }
           }
         ]
       }
@@ -765,12 +948,12 @@
     "sectorId": "6e986105-3df9-30de-8997-041d93537278",
     "sectorName": "Industrial Processes and Product Uses (IPPU)",
     "referenceNumber": "IV",
-    "created": "2023-10-09T23:00:00.000Z",
-    "last_updated": "2023-10-09T23:00:00.000Z",
+    "created": "2023-10-09T22:00:00.000Z",
+    "last_updated": "2023-10-09T22:00:00.000Z",
     "subSectors": [
       {
         "subsectorId": "6b23cb0a-a1c1-35f5-835e-dca1d009ae9b",
-        "subsectorName": "emissions-from-industrial-processes-occurring-within-the-city-boundary",
+        "subsectorName": "Emissions from industrial processes occurring within the city boundary",
         "sectorId": "6e986105-3df9-30de-8997-041d93537278",
         "referenceNumber": "IV.1",
         "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
@@ -780,7 +963,7 @@
       },
       {
         "subsectorId": "913775b3-0e20-3b0f-b269-2576548bcd36",
-        "subsectorName": "emissions-from-product-use-occurring-within-the-city-boundary",
+        "subsectorName": "Emissions from product use occurring within the city boundary",
         "sectorId": "6e986105-3df9-30de-8997-041d93537278",
         "referenceNumber": "IV.2",
         "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
@@ -794,12 +977,12 @@
     "sectorId": "b7845aa4-e50b-3b8c-8941-77d098a73e82",
     "sectorName": "Agriculture, Forestry, and Other Land Use (AFOLU)",
     "referenceNumber": "V",
-    "created": "2023-10-09T23:00:00.000Z",
-    "last_updated": "2023-10-09T23:00:00.000Z",
+    "created": "2023-10-09T22:00:00.000Z",
+    "last_updated": "2023-10-09T22:00:00.000Z",
     "subSectors": [
       {
         "subsectorId": "52ec93fa-99d8-3cea-8d26-e8c9d3b4afaa",
-        "subsectorName": "emissions-from-livestock-within-the-city-boundary",
+        "subsectorName": "Emissions from livestock within the city boundary",
         "sectorId": "b7845aa4-e50b-3b8c-8941-77d098a73e82",
         "referenceNumber": "V.1",
         "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
@@ -809,7 +992,7 @@
       },
       {
         "subsectorId": "36adcd97-2d47-3997-af8f-bcb8b92639f0",
-        "subsectorName": "emissions-from-land-within-the-city-boundary",
+        "subsectorName": "Emissions from land within the city boundary",
         "sectorId": "b7845aa4-e50b-3b8c-8941-77d098a73e82",
         "referenceNumber": "V.2",
         "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
@@ -819,7 +1002,7 @@
       },
       {
         "subsectorId": "3eb70366-95b3-3293-a701-83a5f617648e",
-        "subsectorName": "emissions-from-aggregate-sources-and-non-co2-emission-sources-on-land-within-the-city-boundary",
+        "subsectorName": "Emissions from aggregate sources and non-CO2 emission sources on land within the city boundary",
         "sectorId": "b7845aa4-e50b-3b8c-8941-77d098a73e82",
         "referenceNumber": "V.3",
         "scopeId": "503d4c60-3ff0-3d2b-9ea0-6fb5b0078031",
@@ -833,12 +1016,12 @@
     "sectorId": "501ace3b-f63f-3267-bd57-69ad6ff5ab77",
     "sectorName": "Other Scope 3",
     "referenceNumber": "VI",
-    "created": "2023-10-09T23:00:00.000Z",
-    "last_updated": "2023-10-09T23:00:00.000Z",
+    "created": "2023-10-09T22:00:00.000Z",
+    "last_updated": "2023-10-09T22:00:00.000Z",
     "subSectors": [
       {
         "subsectorId": "401a7571-4951-3e40-be4c-f8b5ea41583f",
-        "subsectorName": "other-scope-3",
+        "subsectorName": "Other Scope 3",
         "sectorId": "501ace3b-f63f-3267-bd57-69ad6ff5ab77",
         "referenceNumber": "VI.1",
         "scopeId": null,
@@ -849,423 +1032,384 @@
     ]
   },
   {
-    "sectorId": "47243e5f-15c3-4ff3-8b8f-388c2da11ca6",
-    "sectorName": "XX_INVENTORY_PROGRESS_TEST1",
+    "sectorId": "cd9dc3bf-48d9-4c14-ac9d-2096337627e3",
+    "sectorName": "sectorName",
     "referenceNumber": null,
-    "created": "2024-10-10T21:40:13.305Z",
-    "last_updated": "2024-10-10T21:40:13.305Z",
+    "created": "2025-04-16T12:40:22.441Z",
+    "last_updated": "2025-04-16T12:40:22.441Z",
     "subSectors": [
       {
-        "subsectorId": "2a0c2005-f99e-4773-b26c-2f326525b6f6",
-        "subsectorName": "xx-inventory-progress-test1-progress-test1",
-        "sectorId": "47243e5f-15c3-4ff3-8b8f-388c2da11ca6",
-        "referenceNumber": null,
+        "subsectorId": "fc01400c-9ff2-41ee-aa42-42d40f1084aa",
+        "subsectorName": "datasource_service_test",
+        "sectorId": "cd9dc3bf-48d9-4c14-ac9d-2096337627e3",
+        "referenceNumber": "I.4.4",
         "scopeId": null,
-        "created": "2024-10-10T21:40:13.305Z",
-        "last_updated": "2024-10-10T21:40:13.305Z",
+        "created": "2025-04-16T12:40:22.450Z",
+        "last_updated": "2025-04-16T12:40:22.450Z",
         "subCategories": [
           {
-            "subcategoryId": "de03ffb9-6e5e-41ba-88d8-f3fd177d242b",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST1_PROGRESS_TEST1_PROGRESS_TEST1",
+            "subcategoryId": "654784fd-e221-489b-a90d-10670dfbf1f5",
+            "subcategoryName": "datasource_service_test",
             "activityName": null,
             "referenceNumber": null,
-            "subsectorId": "2a0c2005-f99e-4773-b26c-2f326525b6f6",
+            "subsectorId": "fc01400c-9ff2-41ee-aa42-42d40f1084aa",
             "scopeId": null,
             "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          },
-          {
-            "subcategoryId": "75a796d3-1347-4125-bb4f-91315e8a0694",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST1_PROGRESS_TEST1_PROGRESS_TEST2",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "2a0c2005-f99e-4773-b26c-2f326525b6f6",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          },
-          {
-            "subcategoryId": "0388cd47-33fc-4474-85bf-fded6f9b1408",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST1_PROGRESS_TEST1_PROGRESS_TEST3",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "2a0c2005-f99e-4773-b26c-2f326525b6f6",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          }
-        ]
-      },
-      {
-        "subsectorId": "2d4f4d8b-631f-4b57-8a27-d0e045706dcf",
-        "subsectorName": "xx-inventory-progress-test1-progress-test2",
-        "sectorId": "47243e5f-15c3-4ff3-8b8f-388c2da11ca6",
-        "referenceNumber": null,
-        "scopeId": null,
-        "created": "2024-10-10T21:40:13.305Z",
-        "last_updated": "2024-10-10T21:40:13.305Z",
-        "subCategories": [
-          {
-            "subcategoryId": "f96ffb73-acc2-42c0-9b24-89f4090b4544",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST1_PROGRESS_TEST2_PROGRESS_TEST1",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "2d4f4d8b-631f-4b57-8a27-d0e045706dcf",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          },
-          {
-            "subcategoryId": "832191ff-34c9-41a8-a2d1-d7e5327a6755",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST1_PROGRESS_TEST2_PROGRESS_TEST2",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "2d4f4d8b-631f-4b57-8a27-d0e045706dcf",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          },
-          {
-            "subcategoryId": "346fbaec-8d8a-4d89-90cc-2445e56356d4",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST1_PROGRESS_TEST2_PROGRESS_TEST3",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "2d4f4d8b-631f-4b57-8a27-d0e045706dcf",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          }
-        ]
-      },
-      {
-        "subsectorId": "18d600c7-7402-4f4c-9be1-cf89cfd550af",
-        "subsectorName": "xx-inventory-progress-test1-progress-test3",
-        "sectorId": "47243e5f-15c3-4ff3-8b8f-388c2da11ca6",
-        "referenceNumber": null,
-        "scopeId": null,
-        "created": "2024-10-10T21:40:13.305Z",
-        "last_updated": "2024-10-10T21:40:13.305Z",
-        "subCategories": [
-          {
-            "subcategoryId": "5cd03560-fec2-4665-a04f-be725c4a74c4",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST1_PROGRESS_TEST3_PROGRESS_TEST1",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "18d600c7-7402-4f4c-9be1-cf89cfd550af",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          },
-          {
-            "subcategoryId": "2e5ef0f5-9ad5-473c-bb2c-b80a9cb09f1a",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST1_PROGRESS_TEST3_PROGRESS_TEST2",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "18d600c7-7402-4f4c-9be1-cf89cfd550af",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          },
-          {
-            "subcategoryId": "fdaee7b8-8807-46dd-8b29-0deb45735969",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST1_PROGRESS_TEST3_PROGRESS_TEST3",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "18d600c7-7402-4f4c-9be1-cf89cfd550af",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
+            "created": "2025-04-16T12:40:22.457Z",
+            "last_updated": "2025-04-16T12:40:22.457Z",
+            "scope": null
           }
         ]
       }
     ]
   },
   {
-    "sectorId": "00f4189c-dfe0-4b5b-9ddb-820b268588d7",
-    "sectorName": "XX_INVENTORY_PROGRESS_TEST2",
+    "sectorId": "e48915db-a1ed-49f8-955d-b1a84980eb48",
+    "sectorName": "sectorName",
     "referenceNumber": null,
-    "created": "2024-10-10T21:40:13.305Z",
-    "last_updated": "2024-10-10T21:40:13.305Z",
+    "created": "2025-04-16T12:45:32.373Z",
+    "last_updated": "2025-04-16T12:45:32.373Z",
     "subSectors": [
       {
-        "subsectorId": "22baab3a-e970-426e-90ea-e2d45a5aed91",
-        "subsectorName": "xx-inventory-progress-test2-progress-test1",
-        "sectorId": "00f4189c-dfe0-4b5b-9ddb-820b268588d7",
-        "referenceNumber": null,
+        "subsectorId": "b9405863-0fda-44fb-ba06-97354b7fa96f",
+        "subsectorName": "datasource_service_test",
+        "sectorId": "e48915db-a1ed-49f8-955d-b1a84980eb48",
+        "referenceNumber": "I.4.4",
         "scopeId": null,
-        "created": "2024-10-10T21:40:13.305Z",
-        "last_updated": "2024-10-10T21:40:13.305Z",
+        "created": "2025-04-16T12:45:32.382Z",
+        "last_updated": "2025-04-16T12:45:32.382Z",
         "subCategories": [
           {
-            "subcategoryId": "cd2ffdd5-0ef9-49b0-adb6-e8cb5f824861",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST2_PROGRESS_TEST1_PROGRESS_TEST1",
+            "subcategoryId": "93d9768d-7076-46c4-9f93-18c5569e6a82",
+            "subcategoryName": "datasource_service_test",
             "activityName": null,
             "referenceNumber": null,
-            "subsectorId": "22baab3a-e970-426e-90ea-e2d45a5aed91",
+            "subsectorId": "b9405863-0fda-44fb-ba06-97354b7fa96f",
             "scopeId": null,
             "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          },
-          {
-            "subcategoryId": "3df3954c-316d-4add-8968-c55b285b50c7",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST2_PROGRESS_TEST1_PROGRESS_TEST2",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "22baab3a-e970-426e-90ea-e2d45a5aed91",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          },
-          {
-            "subcategoryId": "c61ad9dd-8023-4e0c-9a4f-b16fc633da30",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST2_PROGRESS_TEST1_PROGRESS_TEST3",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "22baab3a-e970-426e-90ea-e2d45a5aed91",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          }
-        ]
-      },
-      {
-        "subsectorId": "c9769b66-b5d3-4c07-b72d-e44884f0223a",
-        "subsectorName": "xx-inventory-progress-test2-progress-test2",
-        "sectorId": "00f4189c-dfe0-4b5b-9ddb-820b268588d7",
-        "referenceNumber": null,
-        "scopeId": null,
-        "created": "2024-10-10T21:40:13.305Z",
-        "last_updated": "2024-10-10T21:40:13.305Z",
-        "subCategories": [
-          {
-            "subcategoryId": "c6d844d5-1f4d-4229-970f-06bc208f1c11",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST2_PROGRESS_TEST2_PROGRESS_TEST1",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "c9769b66-b5d3-4c07-b72d-e44884f0223a",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          },
-          {
-            "subcategoryId": "1e1b5268-c85c-45af-8d3f-159ae6ae1019",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST2_PROGRESS_TEST2_PROGRESS_TEST2",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "c9769b66-b5d3-4c07-b72d-e44884f0223a",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          },
-          {
-            "subcategoryId": "1e704b39-dcbe-49f8-8b6f-4fafa5d9e4eb",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST2_PROGRESS_TEST2_PROGRESS_TEST3",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "c9769b66-b5d3-4c07-b72d-e44884f0223a",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          }
-        ]
-      },
-      {
-        "subsectorId": "9289e347-ae37-4bcd-8666-4559efb01347",
-        "subsectorName": "xx-inventory-progress-test2-progress-test3",
-        "sectorId": "00f4189c-dfe0-4b5b-9ddb-820b268588d7",
-        "referenceNumber": null,
-        "scopeId": null,
-        "created": "2024-10-10T21:40:13.305Z",
-        "last_updated": "2024-10-10T21:40:13.305Z",
-        "subCategories": [
-          {
-            "subcategoryId": "30b4c0b3-826e-4cfc-ad7f-8cc30b7ea527",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST2_PROGRESS_TEST3_PROGRESS_TEST1",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "9289e347-ae37-4bcd-8666-4559efb01347",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          },
-          {
-            "subcategoryId": "fbe3bdc0-010b-4421-a353-a46f5173548e",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST2_PROGRESS_TEST3_PROGRESS_TEST2",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "9289e347-ae37-4bcd-8666-4559efb01347",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          },
-          {
-            "subcategoryId": "7568b861-400c-4212-926c-a2f0501797c1",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST2_PROGRESS_TEST3_PROGRESS_TEST3",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "9289e347-ae37-4bcd-8666-4559efb01347",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
+            "created": "2025-04-16T12:45:32.394Z",
+            "last_updated": "2025-04-16T12:45:32.394Z",
+            "scope": null
           }
         ]
       }
     ]
   },
   {
-    "sectorId": "e800e0e1-951b-4310-abf6-bc400cfd3841",
-    "sectorName": "XX_INVENTORY_PROGRESS_TEST3",
+    "sectorId": "d34ddb95-486d-4ed7-86cf-63a7b96ab29f",
+    "sectorName": "sectorName",
     "referenceNumber": null,
-    "created": "2024-10-10T21:40:13.305Z",
-    "last_updated": "2024-10-10T21:40:13.305Z",
+    "created": "2025-04-16T13:17:24.023Z",
+    "last_updated": "2025-04-16T13:17:24.023Z",
     "subSectors": [
       {
-        "subsectorId": "7cf66270-0a07-4aec-ab58-f18d952ff527",
-        "subsectorName": "xx-inventory-progress-test3-progress-test1",
-        "sectorId": "e800e0e1-951b-4310-abf6-bc400cfd3841",
-        "referenceNumber": null,
+        "subsectorId": "f150852f-c218-4e86-a274-686dc56e370b",
+        "subsectorName": "datasource_service_test",
+        "sectorId": "d34ddb95-486d-4ed7-86cf-63a7b96ab29f",
+        "referenceNumber": "I.4.4",
         "scopeId": null,
-        "created": "2024-10-10T21:40:13.305Z",
-        "last_updated": "2024-10-10T21:40:13.305Z",
+        "created": "2025-04-16T13:17:24.030Z",
+        "last_updated": "2025-04-16T13:17:24.030Z",
         "subCategories": [
           {
-            "subcategoryId": "ecc73418-aec2-48f0-bf1c-bb190d5b1ea3",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST3_PROGRESS_TEST1_PROGRESS_TEST1",
+            "subcategoryId": "41b20cea-4b0f-47d9-8eef-e24ef8e091a4",
+            "subcategoryName": "datasource_service_test",
             "activityName": null,
             "referenceNumber": null,
-            "subsectorId": "7cf66270-0a07-4aec-ab58-f18d952ff527",
+            "subsectorId": "f150852f-c218-4e86-a274-686dc56e370b",
             "scopeId": null,
             "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          },
-          {
-            "subcategoryId": "42e6c302-a59b-408f-b07a-15a6da7dfbf8",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST3_PROGRESS_TEST1_PROGRESS_TEST2",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "7cf66270-0a07-4aec-ab58-f18d952ff527",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          },
-          {
-            "subcategoryId": "8fc19aee-f948-4670-95a4-4c66312fd074",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST3_PROGRESS_TEST1_PROGRESS_TEST3",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "7cf66270-0a07-4aec-ab58-f18d952ff527",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
+            "created": "2025-04-16T13:17:24.036Z",
+            "last_updated": "2025-04-16T13:17:24.036Z",
+            "scope": null
           }
         ]
-      },
+      }
+    ]
+  },
+  {
+    "sectorId": "bc869308-4aa3-4c40-8d50-e7c39c03da47",
+    "sectorName": "sectorName",
+    "referenceNumber": null,
+    "created": "2025-03-04T11:20:58.479Z",
+    "last_updated": "2025-03-04T11:20:58.479Z",
+    "subSectors": [
       {
-        "subsectorId": "ba30d625-0585-47dc-8d01-ec9f91eab138",
-        "subsectorName": "xx-inventory-progress-test3-progress-test2",
-        "sectorId": "e800e0e1-951b-4310-abf6-bc400cfd3841",
-        "referenceNumber": null,
+        "subsectorId": "d632aab9-a61a-45a5-9a58-caa4c5c7c177",
+        "subsectorName": "datasource_service_test",
+        "sectorId": "bc869308-4aa3-4c40-8d50-e7c39c03da47",
+        "referenceNumber": "I.4.4",
         "scopeId": null,
-        "created": "2024-10-10T21:40:13.305Z",
-        "last_updated": "2024-10-10T21:40:13.305Z",
+        "created": "2025-03-04T11:20:58.499Z",
+        "last_updated": "2025-03-04T11:20:58.499Z",
         "subCategories": [
           {
-            "subcategoryId": "b5a15cd5-dbe5-422e-b168-faa3142f4c44",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST3_PROGRESS_TEST2_PROGRESS_TEST1",
+            "subcategoryId": "a399c795-04be-4e81-9086-e942b7a2db66",
+            "subcategoryName": "datasource_service_test",
             "activityName": null,
             "referenceNumber": null,
-            "subsectorId": "ba30d625-0585-47dc-8d01-ec9f91eab138",
+            "subsectorId": "d632aab9-a61a-45a5-9a58-caa4c5c7c177",
             "scopeId": null,
             "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          },
-          {
-            "subcategoryId": "59238fba-9a3e-439c-ba32-e174d002bb59",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST3_PROGRESS_TEST2_PROGRESS_TEST2",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "ba30d625-0585-47dc-8d01-ec9f91eab138",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          },
-          {
-            "subcategoryId": "fb77061d-6094-4c2d-b0bd-a09e0f452318",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST3_PROGRESS_TEST2_PROGRESS_TEST3",
-            "activityName": null,
-            "referenceNumber": null,
-            "subsectorId": "ba30d625-0585-47dc-8d01-ec9f91eab138",
-            "scopeId": null,
-            "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
+            "created": "2025-03-04T11:20:58.504Z",
+            "last_updated": "2025-03-04T11:20:58.504Z",
+            "scope": null
           }
         ]
-      },
+      }
+    ]
+  },
+  {
+    "sectorId": "58650581-f2c3-442f-aebc-a1129cb51b82",
+    "sectorName": "sectorName",
+    "referenceNumber": null,
+    "created": "2025-03-04T11:22:54.014Z",
+    "last_updated": "2025-03-04T11:22:54.014Z",
+    "subSectors": [
       {
-        "subsectorId": "cc605439-431e-4597-9233-6d3868d76a3e",
-        "subsectorName": "xx-inventory-progress-test3-progress-test3",
-        "sectorId": "e800e0e1-951b-4310-abf6-bc400cfd3841",
-        "referenceNumber": null,
+        "subsectorId": "f129eb31-aac7-4449-8df8-2cd2d847df37",
+        "subsectorName": "datasource_service_test",
+        "sectorId": "58650581-f2c3-442f-aebc-a1129cb51b82",
+        "referenceNumber": "I.4.4",
         "scopeId": null,
-        "created": "2024-10-10T21:40:13.305Z",
-        "last_updated": "2024-10-10T21:40:13.305Z",
+        "created": "2025-03-04T11:22:54.019Z",
+        "last_updated": "2025-03-04T11:22:54.019Z",
         "subCategories": [
           {
-            "subcategoryId": "dbb85828-4636-4b6b-ac3b-3f3ec5158356",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST3_PROGRESS_TEST3_PROGRESS_TEST1",
+            "subcategoryId": "69a04221-cc57-47e3-ba93-5451b4fd1e79",
+            "subcategoryName": "datasource_service_test",
             "activityName": null,
             "referenceNumber": null,
-            "subsectorId": "cc605439-431e-4597-9233-6d3868d76a3e",
+            "subsectorId": "f129eb31-aac7-4449-8df8-2cd2d847df37",
             "scopeId": null,
             "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          },
+            "created": "2025-03-04T11:22:54.025Z",
+            "last_updated": "2025-03-04T11:22:54.025Z",
+            "scope": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "sectorId": "cabf3002-baac-4a57-8036-9cc5efb170b3",
+    "sectorName": "sectorName",
+    "referenceNumber": null,
+    "created": "2025-03-04T12:29:04.885Z",
+    "last_updated": "2025-03-04T12:29:04.885Z",
+    "subSectors": [
+      {
+        "subsectorId": "dbf1d97c-6fbd-4aec-91b7-6312cab3eb60",
+        "subsectorName": "datasource_service_test",
+        "sectorId": "cabf3002-baac-4a57-8036-9cc5efb170b3",
+        "referenceNumber": "I.4.4",
+        "scopeId": null,
+        "created": "2025-03-04T12:29:04.891Z",
+        "last_updated": "2025-03-04T12:29:04.891Z",
+        "subCategories": [
           {
-            "subcategoryId": "0395f3e3-6a4f-4f90-abf2-d16c2e3e3691",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST3_PROGRESS_TEST3_PROGRESS_TEST2",
+            "subcategoryId": "d4da54f2-2faa-4cb2-8ff6-859ace2f339b",
+            "subcategoryName": "datasource_service_test",
             "activityName": null,
             "referenceNumber": null,
-            "subsectorId": "cc605439-431e-4597-9233-6d3868d76a3e",
+            "subsectorId": "dbf1d97c-6fbd-4aec-91b7-6312cab3eb60",
             "scopeId": null,
             "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
-          },
+            "created": "2025-03-04T12:29:04.895Z",
+            "last_updated": "2025-03-04T12:29:04.895Z",
+            "scope": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "sectorId": "9e23934c-8389-46dc-8ea0-0390ba80c6d5",
+    "sectorName": "sectorName",
+    "referenceNumber": null,
+    "created": "2025-03-04T12:33:47.059Z",
+    "last_updated": "2025-03-04T12:33:47.059Z",
+    "subSectors": [
+      {
+        "subsectorId": "455c6a72-4c4c-490a-b878-5bd8fd9f18fa",
+        "subsectorName": "datasource_service_test",
+        "sectorId": "9e23934c-8389-46dc-8ea0-0390ba80c6d5",
+        "referenceNumber": "I.4.4",
+        "scopeId": null,
+        "created": "2025-03-04T12:33:47.066Z",
+        "last_updated": "2025-03-04T12:33:47.066Z",
+        "subCategories": [
           {
-            "subcategoryId": "b624c18d-9c07-48db-a1d0-b268d1c0d70f",
-            "subcategoryName": "XX_INVENTORY_PROGRESS_TEST3_PROGRESS_TEST3_PROGRESS_TEST3",
+            "subcategoryId": "a0628389-9b77-490e-a7ce-c4a0e791cac2",
+            "subcategoryName": "datasource_service_test",
             "activityName": null,
             "referenceNumber": null,
-            "subsectorId": "cc605439-431e-4597-9233-6d3868d76a3e",
+            "subsectorId": "455c6a72-4c4c-490a-b878-5bd8fd9f18fa",
             "scopeId": null,
             "reportinglevelId": null,
-            "created": "2024-10-10T21:40:13.305Z",
-            "last_updated": "2024-10-10T21:40:13.305Z"
+            "created": "2025-03-04T12:33:47.071Z",
+            "last_updated": "2025-03-04T12:33:47.071Z",
+            "scope": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "sectorId": "d57717d2-c27f-40d3-82aa-a24634fdb8cf",
+    "sectorName": "sectorName",
+    "referenceNumber": null,
+    "created": "2025-03-11T13:06:52.412Z",
+    "last_updated": "2025-03-11T13:06:52.412Z",
+    "subSectors": [
+      {
+        "subsectorId": "147ba7bf-8668-4493-874d-485134706b35",
+        "subsectorName": "datasource_service_test",
+        "sectorId": "d57717d2-c27f-40d3-82aa-a24634fdb8cf",
+        "referenceNumber": "I.4.4",
+        "scopeId": null,
+        "created": "2025-03-11T13:06:52.451Z",
+        "last_updated": "2025-03-11T13:06:52.451Z",
+        "subCategories": [
+          {
+            "subcategoryId": "04fd75c6-4955-4e04-856c-55a3ad684f32",
+            "subcategoryName": "datasource_service_test",
+            "activityName": null,
+            "referenceNumber": null,
+            "subsectorId": "147ba7bf-8668-4493-874d-485134706b35",
+            "scopeId": null,
+            "reportinglevelId": null,
+            "created": "2025-03-11T13:06:52.478Z",
+            "last_updated": "2025-03-11T13:06:52.478Z",
+            "scope": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "sectorId": "d35a4366-0d20-489f-886e-15f96f7c9c2c",
+    "sectorName": "sectorName",
+    "referenceNumber": null,
+    "created": "2025-03-11T13:11:17.898Z",
+    "last_updated": "2025-03-11T13:11:17.898Z",
+    "subSectors": [
+      {
+        "subsectorId": "fcfb173d-1514-4b51-95c1-60c3a4d9dc06",
+        "subsectorName": "datasource_service_test",
+        "sectorId": "d35a4366-0d20-489f-886e-15f96f7c9c2c",
+        "referenceNumber": "I.4.4",
+        "scopeId": null,
+        "created": "2025-03-11T13:11:17.903Z",
+        "last_updated": "2025-03-11T13:11:17.903Z",
+        "subCategories": [
+          {
+            "subcategoryId": "fa01c70b-9c78-4a30-88a1-843b3392e1ed",
+            "subcategoryName": "datasource_service_test",
+            "activityName": null,
+            "referenceNumber": null,
+            "subsectorId": "fcfb173d-1514-4b51-95c1-60c3a4d9dc06",
+            "scopeId": null,
+            "reportinglevelId": null,
+            "created": "2025-03-11T13:11:17.909Z",
+            "last_updated": "2025-03-11T13:11:17.909Z",
+            "scope": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "sectorId": "ff8b7ab3-731e-40d7-9082-a0a34222688b",
+    "sectorName": "sectorName",
+    "referenceNumber": null,
+    "created": "2025-03-11T13:11:57.141Z",
+    "last_updated": "2025-03-11T13:11:57.141Z",
+    "subSectors": [
+      {
+        "subsectorId": "f27b5567-6136-4df6-8ee4-fd9b576a75c8",
+        "subsectorName": "datasource_service_test",
+        "sectorId": "ff8b7ab3-731e-40d7-9082-a0a34222688b",
+        "referenceNumber": "I.4.4",
+        "scopeId": null,
+        "created": "2025-03-11T13:11:57.153Z",
+        "last_updated": "2025-03-11T13:11:57.153Z",
+        "subCategories": [
+          {
+            "subcategoryId": "da03575a-20f0-463c-93b1-753d46e7bdc7",
+            "subcategoryName": "datasource_service_test",
+            "activityName": null,
+            "referenceNumber": null,
+            "subsectorId": "f27b5567-6136-4df6-8ee4-fd9b576a75c8",
+            "scopeId": null,
+            "reportinglevelId": null,
+            "created": "2025-03-11T13:11:57.170Z",
+            "last_updated": "2025-03-11T13:11:57.170Z",
+            "scope": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "sectorId": "6db003fe-7379-47fd-9875-ff7e83b7df6c",
+    "sectorName": "sectorName",
+    "referenceNumber": null,
+    "created": "2025-03-25T13:50:12.925Z",
+    "last_updated": "2025-03-25T13:50:12.925Z",
+    "subSectors": [
+      {
+        "subsectorId": "68d18fd6-8ab0-41f5-ace3-4a1addb47169",
+        "subsectorName": "datasource_service_test",
+        "sectorId": "6db003fe-7379-47fd-9875-ff7e83b7df6c",
+        "referenceNumber": "I.4.4",
+        "scopeId": null,
+        "created": "2025-03-25T13:50:12.932Z",
+        "last_updated": "2025-03-25T13:50:12.932Z",
+        "subCategories": [
+          {
+            "subcategoryId": "888bdfa2-5d4b-4af1-a1a8-a0170ae32df1",
+            "subcategoryName": "datasource_service_test",
+            "activityName": null,
+            "referenceNumber": null,
+            "subsectorId": "68d18fd6-8ab0-41f5-ace3-4a1addb47169",
+            "scopeId": null,
+            "reportinglevelId": null,
+            "created": "2025-03-25T13:50:12.940Z",
+            "last_updated": "2025-03-25T13:50:12.940Z",
+            "scope": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "sectorId": "60bec88d-e467-45f6-8ab8-f57cabe8b252",
+    "sectorName": "sectorName",
+    "referenceNumber": null,
+    "created": "2025-04-16T12:39:59.416Z",
+    "last_updated": "2025-04-16T12:39:59.416Z",
+    "subSectors": [
+      {
+        "subsectorId": "3ff08b54-76b3-4b4d-94fd-60827ba4a79c",
+        "subsectorName": "datasource_service_test",
+        "sectorId": "60bec88d-e467-45f6-8ab8-f57cabe8b252",
+        "referenceNumber": "I.4.4",
+        "scopeId": null,
+        "created": "2025-04-16T12:39:59.433Z",
+        "last_updated": "2025-04-16T12:39:59.433Z",
+        "subCategories": [
+          {
+            "subcategoryId": "7da0d34b-2c86-49d8-94b3-43632539ddb3",
+            "subcategoryName": "datasource_service_test",
+            "activityName": null,
+            "referenceNumber": null,
+            "subsectorId": "3ff08b54-76b3-4b4d-94fd-60827ba4a79c",
+            "scopeId": null,
+            "reportinglevelId": null,
+            "created": "2025-04-16T12:39:59.441Z",
+            "last_updated": "2025-04-16T12:39:59.441Z",
+            "scope": null
           }
         ]
       }

--- a/app/src/util/form-schema/manual-input-hierarchy.json
+++ b/app/src/util/form-schema/manual-input-hierarchy.json
@@ -4096,7 +4096,7 @@
       ]
     }
   },
-  "III.1.3": {
+  "III.1.2": {
     "scope": 3,
     "activityTypeField": "total-municipal-solid-waste-disposed",
     "methodologies": [
@@ -4308,7 +4308,7 @@
       ]
     }
   },
-  "III.2.3": {
+  "III.2.2": {
     "scope": 3,
     "methodologies": [
       {
@@ -4516,7 +4516,7 @@
       ]
     }
   },
-  "III.3.3": {
+  "III.3.2": {
     "scope": 3,
     "methodologies": [
       {


### PR DESCRIPTION
Fixes:
- wrong scope comparison based on last GPC refno digit instead of associated scope in inventory progress endpoint
- can't save manual input form for GPC refnos III.1.2, III.2.2, III.3.2 (all of which are scope 3 but have a refno ending in 2, which was wrongly defined in the MI JSON file)