### PR TITLE
bug(theming): [ON-3928] no theme loads for anonymous user in public dash

### DIFF
--- a/app/src/app/[lng]/[inventory]/layout.tsx
+++ b/app/src/app/[lng]/[inventory]/layout.tsx
@@ -38,6 +38,8 @@ export default function DataLayout({
     if (inventoryOrgData) {
       setLogoUrl(inventoryOrgData?.logoUrl as string);
       setTheme(inventoryOrgData?.theme?.themeKey ?? ("blue_theme" as string));
+    } else {
+      setTheme("blue_theme");
     }
   }, [isInventoryOrgDataLoading, inventoryOrgData]);
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a fallback theme for anonymous users when no theme is loaded in the public dashboard.

### Why are these changes being made?

Without these changes, anonymous users may experience broken styling since no theme would be applied, negatively affecting their user experience. The fallback to "blue_theme" ensures consistency and visual integrity for all users, addressing the issue tracked in ON-3928.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->