### PR TITLE
fix(ui):ON-3866 adds logic to render default project and adds translations

### DIFF
--- a/app/src/components/HomePage/Hero.tsx
+++ b/app/src/components/HomePage/Hero.tsx
@@ -79,10 +79,10 @@ export function Hero({
                     <Link
                       href={`/public/project/${inventory?.city?.project?.projectId}`}
                     >
-                      <ProjectTitle inventory={inventory} />
+                      <ProjectTitle inventory={inventory} t={t} />
                     </Link>
                   ) : (
-                    <ProjectTitle inventory={inventory} />
+                    <ProjectTitle inventory={inventory} t={t} />
                   )}
                   <Box className="flex items-center gap-4">
                     {inventory?.city ? (
@@ -309,7 +309,13 @@ export function Hero({
   );
 }
 
-function ProjectTitle({ inventory }: { inventory: InventoryResponse }) {
+function ProjectTitle({
+  inventory,
+  t,
+}: {
+  inventory: InventoryResponse;
+  t: TFunction;
+}) {
   return (
     <Text
       fontSize="title.md"
@@ -317,7 +323,9 @@ function ProjectTitle({ inventory }: { inventory: InventoryResponse }) {
       fontWeight="semibold"
       color="white"
     >
-      {inventory?.city?.project?.name}
+      {inventory?.city?.project?.name === "cc_project_default"
+        ? t("default-project")
+        : inventory?.city?.project?.name}
     </Text>
   );
 }

--- a/app/src/components/HomePage/ProjectDrawer.tsx
+++ b/app/src/components/HomePage/ProjectDrawer.tsx
@@ -79,7 +79,9 @@ const ProjectList = ({
               fontWeight="regular"
               color="content.primary"
             >
-              {project.name}
+              {project.name === "cc_project_default"
+                ? t("default-project")
+                : project.name}
             </Text>
             <Icon color="content.primary" as={MdKeyboardArrowRight} />
           </Button>

--- a/app/src/i18n/locales/de/dashboard.json
+++ b/app/src/i18n/locales/de/dashboard.json
@@ -189,5 +189,6 @@
   "tab-cap-title": "Priorisierung von Klimaschutzmaßnahmen",
   "dashboard": "Armaturenbrett",
   "about": "Über",
-  "collaborators": "Mitarbeiter"
+  "collaborators": "Mitarbeiter",
+  "default-project": "Standardprojekt"
 }

--- a/app/src/i18n/locales/en/dashboard.json
+++ b/app/src/i18n/locales/en/dashboard.json
@@ -190,5 +190,6 @@
   "dashboard": "Dashboard",
   "about": "About",
   "collaborators": "Collaborators",
-  "go-to": "Go to..."
+  "go-to": "Go to...",
+  "default-project": "Default Project"
 }

--- a/app/src/i18n/locales/es/dashboard.json
+++ b/app/src/i18n/locales/es/dashboard.json
@@ -192,5 +192,6 @@
   "tab-cap-title": "Priorización de la acción climática",
   "dashboard": "Tablero",
   "about": "Acerca de",
-  "collaborators": "Colaboradores"
+  "collaborators": "Colaboradores",
+  "default-project": "Proyecto predeterminado"
 }

--- a/app/src/i18n/locales/pt/dashboard.json
+++ b/app/src/i18n/locales/pt/dashboard.json
@@ -190,5 +190,6 @@
   "tab-cap-title": "Priorização de ações climáticas",
   "dashboard": "Painel de controle",
   "about": "Sobre",
-  "collaborators": "Colaboradores"
+  "collaborators": "Colaboradores",
+  "default-project": "Projeto padrão"
 }


### PR DESCRIPTION
Changes
- Adds logic to render default project instead of `cc_project_default` on dashboard and drawer
- Adds translations for other languages

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add logic to render a default project name in the UI and update translations to include a new key for "default-project" in multiple languages.

### Why are these changes being made?
These changes address the need to properly display a default project name in the UI when a specific condition is met and to ensure translation consistency across supported languages so that users experience a localized interface. This approach aids in improving user experience by providing clarity and ensuring that the application UI accommodates multiple languages effectively.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->