### PR TITLE
feat(ci): use different env vars for S3 upload in prod

### DIFF
--- a/.github/workflows/web-tag.yml
+++ b/.github/workflows/web-tag.yml
@@ -155,10 +155,12 @@ jobs:
             "NEXT_PUBLIC_OPENCLIMATE_API_URL=https://app.openclimate.network" \
             "OPENCLIMATE_API_URL=https://app.openclimate.network" \
             "NEXT_PUBLIC_FEATURE_FLAGS=ENTERPRISE_MODE" \
+            "AWS_FILE_UPLOAD_S3_BUCKET_ID=citycatalyst-files-prod" \
+            "AWS_FILE_UPLOAD_REGION=us-east-1" \
             "AWS_REGION"=${{secrets.AWS_REGION}} \
-            "AWS_ACCESS_KEY_ID"=${{secrets.AWS_ACCESS_KEY_ID}} \
-            "AWS_SECRET_ACCESS_KEY"=${{secrets.AWS_SECRET_ACCESS_KEY}} \
-            "AWS_S3_BUCKET_ID"=${{secrets.AWS_S3_BUCKET_ID}} \
+            "AWS_ACCESS_KEY_ID"=${{secrets.AWS_ACCESS_KEY_ID_PROD}} \
+            "AWS_SECRET_ACCESS_KEY"=${{secrets.AWS_SECRET_ACCESS_KEY_PROD}} \
+            "AWS_S3_BUCKET_ID"=${{secrets.AWS_S3_BUCKET_ID_PROD}} \
             CDP_API_KEY=${{secrets.CDP_API_KEY_TEST}}
           kubectl create -f k8s/prod/cc-prod-create-admin.yml -n default
           kubectl rollout restart deployment cc-web-deploy -n default


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Use different environment variables for AWS S3 upload configuration in the production environment within the GitHub CI/CD workflow.

### Why are these changes being made?

This change ensures that production deployments utilize the correct secure credentials and specific S3 bucket identifiers distinct from those used in other environments, enhancing security and aligning with best practices for handling sensitive production data. The update provides a clear separation of environment-specific configurations and reduces the risk of mishandling production data with non-production credentials.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->