### PR TITLE
fix(api): ON-3925 allow saving multiple different activities with exclusive field

### DIFF
--- a/app/src/backend/ManualnputValidationService.ts
+++ b/app/src/backend/ManualnputValidationService.ts
@@ -81,14 +81,19 @@ export default class ManualInputValidationService {
 
       // extract extra fields from the methodology
       let extraFields: ExtraField[] = [];
+      const activityTypeField = methodology.activityTypeField;
+      if (!activityTypeField) {
+        throw new createHttpError.InternalServerError(
+          `Activity type field missing for methodology ${methodologyId}`,
+        );
+      }
 
       if (methodologyId === "direct-measure") {
-        extraFields = (methodology as DirectMeasure)[
-          "extra-fields"
-        ] as ExtraField[];
+        const scopedDirectMeasure = methodology as DirectMeasure;
+        extraFields = scopedDirectMeasure["extra-fields"] as ExtraField[];
       } else {
-        let scopedMethodology = methodology as Methodology;
-        let selectedActivityOption =
+        const scopedMethodology = methodology as Methodology;
+        const selectedActivityOption =
           activityValueParams.metadata?.[
             scopedMethodology.activitySelectionField?.id as string
           ];
@@ -122,6 +127,7 @@ export default class ManualInputValidationService {
             .map((f) => ({ id: f.id, value: f.exclusive as string })),
           inventoryValueId,
           activityValueId: activityValueId as string,
+          activityTypeField,
         });
       }
 
@@ -247,23 +253,28 @@ export default class ManualInputValidationService {
     exclusiveFieldValue,
     inventoryValueId,
     activityValueId,
+    activityTypeField,
   }: {
     activityData: Record<string, any>;
     exclusiveFieldValue: { id: string; value: string }[];
     inventoryValueId: string;
     activityValueId?: string;
+    activityTypeField: string;
   }) {
     for (const field of exclusiveFieldValue) {
       const exclusiveValue = field.value;
       let errorBody: ManualValidationErrorDetails;
       let existingRecord: ActivityValue | null;
       let code: ManualInputValidationErrorCodes;
+      const newActivityType = activityData[activityTypeField];
 
       if (activityData[field.id] === exclusiveValue) {
         // check that a record exists with the field that is supposed to be exclusive
+        // activity type is used to confirm this is the same sub-category (e.g. fuel type) as the newly added value
         existingRecord = await ActivityValue.findOne({
           where: {
             [`activityData.${field.id}`]: { [Op.ne]: null },
+            [`activityData.${activityTypeField}`]: newActivityType,
             inventoryValueId: inventoryValueId,
             ...(activityValueId && { id: { [Op.ne]: activityValueId } }),
           },
@@ -273,12 +284,14 @@ export default class ManualInputValidationService {
         existingRecord = await ActivityValue.findOne({
           where: {
             [`activityData.${field.id}`]: exclusiveValue, // Check for the exclusive value
+            [`activityData.${activityTypeField}`]: newActivityType,
             inventoryValueId: inventoryValueId,
             ...(activityValueId && { id: { [Op.ne]: activityValueId } }),
           },
         });
         code = ManualInputValidationErrorCodes.EXCLUSIVE_CONFLICT;
       }
+      console.log("existing record", existingRecord);
 
       if (existingRecord) {
         errorBody = {

--- a/app/src/backend/ManualnputValidationService.ts
+++ b/app/src/backend/ManualnputValidationService.ts
@@ -291,7 +291,6 @@ export default class ManualInputValidationService {
         });
         code = ManualInputValidationErrorCodes.EXCLUSIVE_CONFLICT;
       }
-      console.log("existing record", existingRecord);
 
       if (existingRecord) {
         errorBody = {


### PR DESCRIPTION
For different activity types/ sub-categories
So it allows saving two activities for e.g. II.1.1 that both have transport type all if they have different activity types (e.g. different fuel types etc.).

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enhance `ManualInputValidationService` to support saving multiple different activities by incorporating an exclusive field and ensuring constraint validation is activity type-specific.

### Why are these changes being made?

The modification addresses the need to differentiate between activities of various types that might have conflicting exclusive fields, preventing errors during data entry. By adding an `activityTypeField`, validation now accounts for activity sub-categories, correctly allowing parallel entries while ensuring exclusivity within the same type, thereby resolving an existing issue where conflicting activity records could not be identified and processed as intended.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->