### PR TITLE
bug(report results) [ON-3931]: fix styling of explanation tooltip modal

### DIFF
--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsForecast/GrowthRatesExplanationModal.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsForecast/GrowthRatesExplanationModal.tsx
@@ -12,6 +12,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { DisplayLarge } from "@/components/Texts/Display";
 
 export function GrowthRatesExplanationModal({
   t,
@@ -52,40 +53,36 @@ export function GrowthRatesExplanationModal({
         </DialogHeader>
         <Box divideX="1px" borderColor="border.overlay" borderWidth="1px" />
         <DialogBody>
-          <Text
-            color="content.primary"
-            fontWeight="bold"
-            lineHeight="headline.sm"
-            fontSize="24px"
-            fontFamily="heading"
-            fontStyle="normal"
-          >
-            {t("city-typology-and-clusters")}
-          </Text>
-          <Text
-            my={"12px"}
-            color="content.primary"
-            lineHeight="24px"
-            fontSize="16px"
-            fontStyle="normal"
-            fontWeight="regular"
-          >
-            {t("city-typology-and-clusters-description")}
-          </Text>
+          <VStack alignItems={"left"} justifyItems={"end"} p="24px">
+            <Text
+              color="content.primary"
+              fontWeight="bold"
+              lineHeight="headline.sm"
+              fontSize="24px"
+              fontFamily="heading"
+              fontStyle="normal"
+            >
+              {t("city-typology-and-clusters")}
+            </Text>
+            <Text
+              my={"12px"}
+              color="content.primary"
+              lineHeight="24px"
+              fontSize="16px"
+              fontStyle="normal"
+              fontWeight="regular"
+            >
+              {t("city-typology-and-clusters-description")}
+            </Text>
+          </VStack>
           <HStack
             my={"12px"}
             mx={"24px"}
             marginTop={"48px"}
             alignItems={"flex-end"}
           >
-            <VStack alignItems={"center"}>
-              <Heading
-                fontSize="display.lg"
-                textAlign="center"
-                color="content.primary"
-              >
-                {cluster?.id}
-              </Heading>
+            <VStack alignItems={"left"} justifyItems={"end"} p="24px">
+              <DisplayLarge color="black">{cluster?.id}</DisplayLarge>
               <Text
                 fontSize="label.lg"
                 fontStyle="normal"
@@ -99,15 +96,15 @@ export function GrowthRatesExplanationModal({
                 {t("cluster-#")}
               </Text>
             </VStack>
-            <VStack alignItems={"left"} justifyItems={"end"}>
-              <Heading
+            <VStack alignItems={"left"} justifyItems={"end"} p="24px">
+              <DisplayLarge
                 fontSize="body.xl"
                 color="content.primary"
                 lineHeight="32px"
                 fontWeight="regular"
               >
                 {cluster?.description?.[lng]}
-              </Heading>
+              </DisplayLarge>
               <Text
                 fontFamily="Poppins"
                 fontSize="label.lg"
@@ -122,28 +119,30 @@ export function GrowthRatesExplanationModal({
               </Text>
             </VStack>
           </HStack>
-          <Text
-            color="content.primary"
-            fontWeight="bold"
-            lineHeight="headline.sm"
-            fontSize="24px"
-            fontFamily="heading"
-            fontStyle="normal"
-          >
-            {t("methodology-and-assumptions")}
-          </Text>
-          <Text
-            my={"12px"}
-            color="content.primary"
-            lineHeight="24px"
-            fontSize="16px"
-            fontStyle="normal"
-            fontWeight="regular"
-          >
-            {t("methodology-and-assumptions-description")}
-          </Text>
+          <VStack alignItems={"left"} justifyItems={"end"} p="24px">
+            <Text
+              color="content.primary"
+              fontWeight="bold"
+              lineHeight="headline.sm"
+              fontSize="24px"
+              fontFamily="heading"
+              fontStyle="normal"
+            >
+              {t("methodology-and-assumptions")}
+            </Text>
+            <Text
+              my={"12px"}
+              color="content.primary"
+              lineHeight="24px"
+              fontSize="16px"
+              fontStyle="normal"
+              fontWeight="regular"
+            >
+              {t("methodology-and-assumptions-description")}
+            </Text>
+          </VStack>
           <Box>
-            <Box display="flex" justifySelf={"center"}>
+            <Box display="flex" justifySelf={"center"} width="100%" px="24px">
               <GrowthRatesExplanationModalTable
                 growthRates={growthRates}
                 t={t}

--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsForecast/GrowthRatesExplanationModalTable.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsForecast/GrowthRatesExplanationModalTable.tsx
@@ -24,7 +24,7 @@ export const GrowthRatesExplanationModalTable = ({
   ];
 
   return (
-    <Table.Root striped>
+    <Table.Root>
       <Table.Header>
         <Table.Row>
           <Table.ColumnHeader>
@@ -46,8 +46,11 @@ export const GrowthRatesExplanationModalTable = ({
         </Table.Row>
       </Table.Header>
       <Table.Body>
-        {emissionsSectors.map((sector) => (
-          <Table.Row key={sector.name}>
+        {emissionsSectors.map((sector, i) => (
+          <Table.Row
+            backgroundColor={i % 2 === 0 ? "background.neutral" : "white"}
+            key={sector.name}
+          >
             <Table.Cell>{t(getNameTranslationString(sector))}</Table.Cell>
             {Object.keys(growthRates)
               .slice(0, 4)

--- a/app/src/components/Texts/Display.tsx
+++ b/app/src/components/Texts/Display.tsx
@@ -32,3 +32,17 @@ export const DisplayMedium = ({ children, ...props }: HeadingProps) => (
     {children}
   </Heading>
 );
+
+export const DisplayLarge = ({ children, ...props }: HeadingProps) => (
+  <Heading
+    as="h1"
+    color="content.alternative"
+    fontSize="display.lg"
+    lineHeight="64px"
+    fontWeight="600"
+    fontStyle="normal"
+    {...props}
+  >
+    {children}
+  </Heading>
+);


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/692eef2e-f6bf-4587-a00f-f0d2a4119531)


<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor the `GrowthRatesExplanationModal` and its associated table to improve styling and readability by introducing the `VStack` layout, adjusting paddings, and custom styled components for text display.

### Why are these changes being made?
The previous layout and styling of the explanation tooltip modal were inconsistent and did not adhere to the design guidelines, leading to suboptimal user interface aesthetics. The introduction of the `VStack` layout and custom `DisplayLarge` component enhances the visual hierarchy and user interface coherence, addressing these styling inconsistencies effectively. Additionally, alternating row colors for the table enhances readability of the data.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->