### PR TITLE
bug(report results) [ON-3939]: fix sector name

### DIFF
--- a/app/src/i18n/locales/en/dashboard.json
+++ b/app/src/i18n/locales/en/dashboard.json
@@ -191,5 +191,7 @@
   "about": "About",
   "collaborators": "Collaborators",
   "go-to": "Go to...",
-  "default-project": "Default Project"
+  "default-project": "Default Project",
+  "industrial-processes-and-product-uses-ippu": "IPPU",
+  "agriculture-forestry-and-other-land-use-afolu": "AFOLU"
 }


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add entries for "industrial-processes-and-product-uses-ippu" and "agriculture-forestry-and-other-land-use-afolu" to the dashboard's English locale file.

### Why are these changes being made?

These changes address a bug related to incorrect sector names in the report results, ensuring that the correct abbreviations for IPPU and AFOLU are displayed. This improves the clarity and accuracy of the sector information in the dashboard.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->