### PR TITLE
fix(ui): ON-4024 prevent null string from making it into API calls

### DIFF
--- a/app/src/app/[lng]/[inventory]/layout.tsx
+++ b/app/src/app/[lng]/[inventory]/layout.tsx
@@ -24,10 +24,15 @@ export default function DataLayout({
   const { data: userInfo, isLoading: isUserInfoLoading } =
     api.useGetUserInfoQuery();
 
-  const inventoryId = userInfo?.defaultInventoryId || inventory;
+  let inventoryId: string | null;
+  if (inventory && inventory !== "null") {
+    inventoryId = inventory;
+  } else {
+    inventoryId = userInfo?.defaultInventoryId ?? null;
+  }
 
   const { data: inventoryOrgData, isLoading: isInventoryOrgDataLoading } =
-    useGetOrganizationForInventoryQuery(inventoryId, {
+    useGetOrganizationForInventoryQuery(inventoryId!, {
       skip: !inventoryId,
     });
 

--- a/app/src/components/HomePage/HomePage.tsx
+++ b/app/src/components/HomePage/HomePage.tsx
@@ -54,11 +54,22 @@ export default function HomePage({
   const { data: userInfo, isLoading: isUserInfoLoading } =
     api.useGetUserInfoQuery();
 
-  const inventoryIdFromParam =
-    inventoryId || inventoryParam || userInfo?.defaultInventoryId;
+  // make sure that the inventory ID is using valid values
+  let inventoryIdFromParam: string | undefined;
+  if (inventoryId && inventoryId != "null") {
+    inventoryIdFromParam = inventoryId;
+  } else if (inventoryParam && inventoryParam != "null") {
+    if (typeof inventoryParam !== "string") {
+      inventoryIdFromParam = inventoryParam[0];
+    } else {
+      inventoryIdFromParam = inventoryParam;
+    }
+  } else {
+    inventoryIdFromParam = userInfo?.defaultInventoryId ?? undefined;
+  }
 
   const { data: inventory, isLoading: isInventoryLoading } =
-    api.useGetInventoryQuery((inventoryIdFromParam as string) || "default");
+    api.useGetInventoryQuery(inventoryIdFromParam ?? "default");
 
   useEffect(() => {
     if (!inventoryIdFromParam && !isInventoryLoading && inventory) {
@@ -76,7 +87,6 @@ export default function HomePage({
         }
       } else {
         // fixes warning "Cannot update a component (`Router`) while rendering a different component (`Home`)"
-
         setTimeout(() => router.push(`/onboarding`), 0);
       }
     }
@@ -87,9 +97,7 @@ export default function HomePage({
   // https://redux-toolkit.js.org/rtk-query/usage/customizing-queries#performing-multiple-requests-with-a-single-query
 
   const { data: inventoryProgress, isLoading: isInventoryProgressLoading } =
-    api.useGetInventoryProgressQuery(
-      (inventoryIdFromParam as string) || "default",
-    );
+    api.useGetInventoryProgressQuery(inventoryIdFromParam ?? "default");
 
   const { data: city } = api.useGetCityQuery(inventory?.cityId!, {
     skip: !inventory?.cityId,
@@ -115,14 +123,12 @@ export default function HomePage({
   }, [cityYears]);
 
   const { data: inventoryOrgData, isLoading: isInventoryOrgDataLoading } =
-    useGetOrganizationForInventoryQuery(inventoryIdFromParam as string, {
+    useGetOrganizationForInventoryQuery(inventoryIdFromParam!, {
       skip: !inventoryIdFromParam,
     });
 
   const { setLogoUrl } = useLogo();
   const { setTheme } = useTheme();
-
-  console.log(inventoryIdFromParam);
 
   useEffect(() => {
     if (inventoryOrgData) {

--- a/app/src/components/navigation-bar.tsx
+++ b/app/src/components/navigation-bar.tsx
@@ -69,9 +69,12 @@ export function NavigationBar({
   const { t } = useTranslation(lng, "navigation");
   const { logoUrl } = useLogo();
   const { inventory: inventoryParam } = useParams();
-  const inventoryIdFromParam = inventoryParam;
+  let inventoryIdFromParam = inventoryParam !== "null" ? inventoryParam : null;
+  if (Array.isArray(inventoryIdFromParam)) {
+    inventoryIdFromParam = inventoryIdFromParam[0];
+  }
   const { data: inventory, isLoading: isInventoryLoading } =
-    api.useGetInventoryQuery((inventoryIdFromParam as string) || "default");
+    api.useGetInventoryQuery(inventoryIdFromParam ?? "default");
   const { data: userAccessStatus } = useGetUserAccessStatusQuery(
     {},
     {


### PR DESCRIPTION
Use default instead of `"null"` in inventory-related API calls on HomePage, NavigationBar, root inventory layout

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Update the UI logic to prevent the string "null" from being used as a valid inventory identifier in API calls.

### Why are these changes being made?
APIs were receiving "null" as a string from certain components, leading to incorrect behavior or errors; this fix ensures only valid inventory IDs or default values are used, improving the robustness and predictability of API interactions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->