### PR TITLE
fix: adds shadow to notation key dropdown

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -650,6 +650,7 @@ const SectorTabs: FC<SectorTabsProps> = ({ t, inventoryId }) => {
                                       borderWidth="1px"
                                       borderColor="border.neutral"
                                       borderRadius="md"
+                                      shadow="1dp"
                                     >
                                       <SelectValueText
                                         color="content.tertiary"


### PR DESCRIPTION
Changes
- Adds shadow to enhence the select dropdown visbility

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a shadow to the notation key dropdown in SectorTabs component.

### Why are these changes being made?

This change enhances the UI by providing a subtle shadow effect which improves the dropdown's visual prominence and accessibility within the application, addressing user feedback on styling improvements.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->