### PR TITLE
fix(api): handle + characters in email URLs to prevent space conversion

### DIFF
--- a/app/src/app/api/v0/projects/[project]/users/route.ts
+++ b/app/src/app/api/v0/projects/[project]/users/route.ts
@@ -26,8 +26,12 @@ export const DELETE = apiHandler(async (req, { params, session }) => {
   // 2. Get Path Parameter (projectId)
   const { project: projectId } = params;
 
-  // 3. Get Query Parameter (email) from the URL
-  const email = req.nextUrl.searchParams.get("email");
+  // 3. Get Query Parameter (email) from the URL and properly decode it
+  const url = new URL(req.url);
+  const emailParam = url.searchParams.get("email");
+  // The searchParams.get() already decodes, but converts + to space
+  // We need to manually decode to preserve the + character
+  const email = emailParam ? emailParam.replace(/ /g, "+") : null;
 
   const project = await Project.findByPk(projectId as string);
   if (!project) {

--- a/app/src/app/api/v0/projects/[project]/users/route.ts
+++ b/app/src/app/api/v0/projects/[project]/users/route.ts
@@ -26,12 +26,9 @@ export const DELETE = apiHandler(async (req, { params, session }) => {
   // 2. Get Path Parameter (projectId)
   const { project: projectId } = params;
 
-  // 3. Get Query Parameter (email) from the URL and properly decode it
+  // 3. Get Query Parameter (email) from the URL
   const url = new URL(req.url);
-  const emailParam = url.searchParams.get("email");
-  // The searchParams.get() already decodes, but converts + to space
-  // We need to manually decode to preserve the + character
-  const email = emailParam ? emailParam.replace(/ /g, "+") : null;
+  const email = url.searchParams.get("email");
 
   const project = await Project.findByPk(projectId as string);
   if (!project) {

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -1060,7 +1060,7 @@ export const api = createApi({
       deleteProjectUser: builder.mutation({
         query: (data: { projectId: string; email: string }) => ({
           method: "DELETE",
-          url: `/projects/${data.projectId}/users?email=${data.email}`,
+          url: `/projects/${data.projectId}/users?email=${encodeURIComponent(data.email)}`,
         }),
         transformResponse: (response: any) => response,
         invalidatesTags: ["ProjectUsers"],
@@ -1068,7 +1068,7 @@ export const api = createApi({
       deleteCityUser: builder.mutation({
         query: (data: { cityId: string; email: string }) => ({
           method: "DELETE",
-          url: `/city/${data.cityId}/user?email=${data.email}`,
+          url: `/city/${data.cityId}/user?email=${encodeURIComponent(data.email)}`,
         }),
         transformResponse: (response: any) => response,
         invalidatesTags: ["ProjectUsers"],
@@ -1076,7 +1076,7 @@ export const api = createApi({
       deleteOrganizationAdminUser: builder.mutation({
         query: (data: { organizationId: string; email: string }) => ({
           method: "DELETE",
-          url: `/organizations/${data.organizationId}/users?email=${data.email}`,
+          url: `/organizations/${data.organizationId}/users?email=${encodeURIComponent(data.email)}`,
         }),
         transformResponse: (response: any) => response,
         invalidatesTags: ["ProjectUsers"],


### PR DESCRIPTION
URL searchParams.get() automatically converts + to spaces, breaking emails
like cephas+1@openearth.org. This fix restores + characters after decoding.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify the handling of email query parameters in URL to preserve + characters by replacing spaces with +.

### Why are these changes being made?

In the current implementation, '+' characters in email addresses are incorrectly converted to spaces due to standard URL decoding behavior. This change ensures that the email addresses are correctly interpreted by manually replacing spaces back to '+', thus preserving the original email format as intended.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->