### PR TITLE
fix: fixes failure to read template file error on dev

### DIFF
--- a/app/src/backend/ECRFDownloadService.ts
+++ b/app/src/backend/ECRFDownloadService.ts
@@ -12,6 +12,8 @@ import { bigIntToDecimal } from "@/util/big_int";
 import PopulationService from "@/backend/PopulationService";
 import CityBoundaryService from "@/backend/CityBoundaryService";
 import { logger } from "@/services/logger";
+import fs from "fs";
+import path from "path";
 
 const ECRF_TEMPLATE_PATH = "./templates/ecrf_template.xlsx";
 
@@ -31,7 +33,21 @@ export default class ECRFDownloadService {
     const workbook = new Excel.Workbook();
     try {
       // Load the workbook
-      await workbook.xlsx.readFile(ECRF_TEMPLATE_PATH);
+      const templatePath = path.resolve(
+        process.cwd(),
+        "templates",
+        "ecrf_template.xlsx",
+      );
+
+      if (!fs.existsSync(templatePath)) {
+        logger.error(
+          { err: `File not found at path: ${templatePath}` },
+          "Error reading or writing Excel file",
+        );
+        throw new Error(`File not found at path: ${templatePath}`);
+      }
+
+      await workbook.xlsx.readFile(templatePath);
       await this.writeToSheet1(workbook, output, t);
       await this.writeToSheet2(workbook, output, t);
       await this.writeToSheet3(workbook, output, t);
@@ -40,7 +56,7 @@ export default class ECRFDownloadService {
       logger.info("Workbook has been generated successfully");
       return buffer;
     } catch (error) {
-      logger.error({err: error}, "Error reading or writing Excel file");
+      logger.error({ err: error }, "Error reading or writing Excel file");
       throw createHttpError.InternalServerError(
         "Error reading or writing Excel file",
       );


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Import `fs` and `path` modules to check for the existence of the template file path and handle errors accordingly in the `ECRFDownloadService`.

### Why are these changes being made?

Previously, there was a failure to read the template file on the development environment due to incorrect file path handling. By using the `path` module to generate an absolute path and the `fs` module to check for the file's existence, this fix ensures better error handling and resolves the path issue, thus avoiding runtime errors when the file is not found.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->