### PR TITLE
fix: include templates folder in production image for ECRF download

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -16,5 +16,6 @@ FROM base AS release
 RUN npm ci --omit=dev
 COPY --from=full-build /app/.next ./.next
 COPY --from=full-build /app/public ./public
+COPY --from=full-build /app/templates ./templates
 EXPOSE 3000
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Include the `templates` folder in the production Docker image by adding a copy command in the Dockerfile.

### Why are these changes being made?

The change ensures that the necessary template files are available in the production environment, allowing ECRF download functionality to work as expected. The omission of the templates directory led to issues in production, and this approach aligns the Docker configuration with development setups where templates are present.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->