### PR TITLE
fix(api): remove unused join on ActivityValue for fetchInventoryValuesBySector

### DIFF
--- a/app/src/backend/ResultsService.ts
+++ b/app/src/backend/ResultsService.ts
@@ -314,7 +314,6 @@ const fetchInventoryValuesBySector = async (
            iv.datasource_id,
            ds.datasource_name
     FROM "InventoryValue" iv
-           LEFT JOIN "ActivityValue" av ON av.inventory_value_id = iv.id
            JOIN "Sector" s ON iv.sector_id = s.sector_id
            JOIN "SubSector" ss ON iv.sub_sector_id = ss.subsector_id
            LEFT JOIN "SubCategory" sc ON iv.sub_category_id = sc.subcategory_id


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the unused LEFT JOIN on "ActivityValue" in the fetchInventoryValuesBySector query.

### Why are these changes being made?

The join on "ActivityValue" was not contributing to the query's output and could lead to unnecessary complexity and potential performance issues. Removing it simplifies the query and ensures optimal execution without altering the intended data retrieval.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->