### PR TITLE
fix(db): create migration to remove duplicate inventory values for the same GPC refno

### DIFF
--- a/app/migrations/20250625163028-duplicate-inventory-values.cjs
+++ b/app/migrations/20250625163028-duplicate-inventory-values.cjs
@@ -4,7 +4,7 @@
 module.exports = {
   async up(queryInterface) {
     return queryInterface.sequelize.transaction(async (transaction) => {
-      // 1. Update the co2eq of the kept InventoryValue (sum of all duplicates)
+      // Update the co2eq of the kept InventoryValue (sum of all duplicates)
       await queryInterface.sequelize.query(`
         WITH ranked AS (
           SELECT
@@ -41,7 +41,7 @@ module.exports = {
         WHERE iv.id = tk.id_to_keep;
       `);
 
-      // 2. Reassign ActivityValue entries to the kept InventoryValue
+      // Reassign ActivityValue entries to the kept InventoryValue
       await queryInterface.sequelize.query(`
         WITH ranked AS (
           SELECT
@@ -72,7 +72,7 @@ module.exports = {
         WHERE av.inventory_value_id = d.id_to_remove;
       `);
 
-      // 3. Remove the duplicate InventoryValue entries
+      // Remove the duplicate InventoryValue entries
       await queryInterface.sequelize.query(`
         WITH ranked AS (
           SELECT
@@ -89,6 +89,7 @@ module.exports = {
         USING ranked r
         WHERE iv.id = r.id AND r.rn > 1;
       `);
+
       // Add unique constraint to prevent future duplicates
       await queryInterface.addConstraint("InventoryValue", {
         fields: ["inventory_id", "gpc_reference_number"],

--- a/app/migrations/20250625163028-duplicate-inventory-values.cjs
+++ b/app/migrations/20250625163028-duplicate-inventory-values.cjs
@@ -5,8 +5,8 @@ module.exports = {
   async up(queryInterface) {
     return queryInterface.sequelize.transaction(async (transaction) => {
       // Update the co2eq of the kept InventoryValue (sum of all duplicates)
-      await queryInterface.sequelize.query(`
-        WITH ranked AS (
+      await queryInterface.sequelize.query(
+        `WITH ranked AS (
           SELECT
             id,
             inventory_id,
@@ -38,12 +38,13 @@ module.exports = {
         UPDATE "InventoryValue" iv
         SET co2eq = tk.total_co2eq
         FROM to_keep tk
-        WHERE iv.id = tk.id_to_keep;
-      `);
+        WHERE iv.id = tk.id_to_keep;`,
+        { transaction },
+      );
 
       // Reassign ActivityValue entries to the kept InventoryValue
-      await queryInterface.sequelize.query(`
-        WITH ranked AS (
+      await queryInterface.sequelize.query(
+        `WITH ranked AS (
           SELECT
             id,
             inventory_id,
@@ -69,12 +70,13 @@ module.exports = {
         UPDATE "ActivityValue" av
         SET inventory_value_id = d.id_to_keep
         FROM duplicates d
-        WHERE av.inventory_value_id = d.id_to_remove;
-      `);
+        WHERE av.inventory_value_id = d.id_to_remove;`,
+        { transaction },
+      );
 
       // Remove the duplicate InventoryValue entries
-      await queryInterface.sequelize.query(`
-        WITH ranked AS (
+      await queryInterface.sequelize.query(
+        `WITH ranked AS (
           SELECT
             id,
             inventory_id,
@@ -87,8 +89,9 @@ module.exports = {
         )
         DELETE FROM "InventoryValue" iv
         USING ranked r
-        WHERE iv.id = r.id AND r.rn > 1;
-      `);
+        WHERE iv.id = r.id AND r.rn > 1;`,
+        { transaction },
+      );
 
       // Add unique constraint to prevent future duplicates
       await queryInterface.addConstraint("InventoryValue", {

--- a/app/migrations/20250625163028-duplicate-inventory-values.cjs
+++ b/app/migrations/20250625163028-duplicate-inventory-values.cjs
@@ -1,0 +1,46 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      /* await queryInterface.sequelize.query(`
+        SELECT * from "InventoryValue" iv1 JOIN "InventoryValue" iv2 on iv1.inventory_id = iv2.inventory_id AND iv1.gpc_reference_number = iv2.gpc_reference_number WHERE iv1.id < iv2.id;
+      `); */
+      // merge the values and save them to the database
+      await queryInterface.sequelize.query(`
+        WITH duplicates AS (
+          SELECT iv1.id AS id1, iv2.id AS id2, iv1.inventory_id, iv1.gpc_reference_number, SUM(iv1.value) AS total_value
+          FROM "InventoryValue" iv1
+          JOIN "InventoryValue" iv2 ON iv1.inventory_id = iv2.inventory_id
+          AND iv1.gpc_reference_number = iv2.gpc_reference_number
+          WHERE iv1.id < iv2.id
+          GROUP BY iv1.inventory_id, iv1.gpc_reference_number
+        )
+        UPDATE "InventoryValue" iv
+        SET value = d.total_value
+        FROM duplicates d
+        WHERE iv.id = d.id1
+        AND iv.inventory_id = d.inventory_id
+        AND iv.gpc_reference_number = d.gpc_reference_number;
+      `);
+
+      // add unique constraint to prevent future duplicates
+      await queryInterface.addConstraint("InventoryValue", {
+        fields: ["inventory_id", "gpc_reference_number"],
+        type: "unique",
+        name: "InventoryValue_inventory_refno_unique_constraint",
+        transaction,
+      });
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    // add unique constraint to prevent future duplicates
+    await queryInterface.removeConstraint(
+      "InventoryValue",
+      "InventoryValue_inventory_refno_unique_constraint",
+      { transaction },
+    );
+  },
+};


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Create a database migration script to remove duplicate inventory values for the same GPC reference number and add a unique constraint to prevent such duplicates in the future.

### Why are these changes being made?

These changes address the issue of duplicate entries in the "InventoryValue" table, which could lead to incorrect inventory reporting. By merging duplicate entries, ensuring associated "ActivityValue" records are updated, and enforcing a unique constraint, the integrity and accuracy of the inventory data are maintained.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->