### PR TITLE
isaac/fix/on-4105-admin-role-limitation

### DIFF
--- a/app/src/app/[lng]/organization/[id]/account-settings/team/index.tsx
+++ b/app/src/app/[lng]/organization/[id]/account-settings/team/index.tsx
@@ -48,6 +48,7 @@ import AddCollaboratorsModal from "@/components/HomePage/AddCollaboratorModal/Ad
 import { uniqBy } from "lodash";
 import RemoveUserModal from "@/app/[lng]/admin/organization/[id]/team/RemoveUserModal";
 import { Trans } from "react-i18next";
+import { useSession } from "next-auth/react";
 
 const TeamSettings = ({ lng, id }: { lng: string; id: string }) => {
   const { t } = useTranslation(lng, "settings");
@@ -69,6 +70,7 @@ const TeamSettings = ({ lng, id }: { lng: string; id: string }) => {
 
   const [selectedProject, setSelectedProject] = React.useState<string[]>([]);
   const [selectedCity, setSelectedCity] = React.useState<string | null>("");
+  const sessionData = useSession();
 
   const { data: organization, isLoading: isOrganizationLoading } =
     useGetOrganizationQuery(id);
@@ -186,10 +188,10 @@ const TeamSettings = ({ lng, id }: { lng: string; id: string }) => {
         display="flex"
         gap={9}
         mt={12}
-        alignItems="center"
+        alignItems="flex-start"
         justifyContent="space-between"
       >
-        <Box w="250px" flex={1}>
+        <Box w="250px" overflowY="hidden" flex={1}>
           <Text
             fontSize="title.md"
             mb={3}
@@ -360,56 +362,58 @@ const TeamSettings = ({ lng, id }: { lng: string; id: string }) => {
                   </Table.Cell>
 
                   <Table.Cell>
-                    <MenuRoot>
-                      <MenuTrigger>
-                        <IconButton
-                          data-testid="activity-more-icon"
-                          aria-label="more-icon"
-                          variant="ghost"
-                          color="content.tertiary"
-                        >
-                          <Icon as={MdMoreVert} size="lg" />
-                        </IconButton>
-                      </MenuTrigger>
-                      <MenuContent
-                        w="auto"
-                        borderRadius="8px"
-                        shadow="2dp"
-                        px="0"
-                      >
-                        <MenuItem
-                          value={t("remove-user")}
-                          valueText={t("remove-user")}
-                          p="16px"
-                          display="flex"
-                          alignItems="center"
-                          gap="16px"
-                          _hover={{
-                            bg: "content.link",
-                            cursor: "pointer",
-                          }}
-                          className="group"
-                          onClick={() => {
-                            setIsDeleteModalOpen(true);
-                            setUserToRemove(item);
-                          }}
-                        >
-                          <Icon
-                            className="group-hover:text-white"
-                            color="sentiment.negativeDefault"
-                            as={RiDeleteBin6Line}
-                            h="24px"
-                            w="24px"
-                          />
-                          <Text
-                            className="group-hover:text-white"
-                            color="content.primary"
+                    {sessionData.data?.user.email !== item.email && (
+                      <MenuRoot>
+                        <MenuTrigger>
+                          <IconButton
+                            data-testid="activity-more-icon"
+                            aria-label="more-icon"
+                            variant="ghost"
+                            color="content.tertiary"
                           >
-                            {t("remove-user")}
-                          </Text>
-                        </MenuItem>
-                      </MenuContent>
-                    </MenuRoot>
+                            <Icon as={MdMoreVert} size="lg" />
+                          </IconButton>
+                        </MenuTrigger>
+                        <MenuContent
+                          w="auto"
+                          borderRadius="8px"
+                          shadow="2dp"
+                          px="0"
+                        >
+                          <MenuItem
+                            value={t("remove-user")}
+                            valueText={t("remove-user")}
+                            p="16px"
+                            display="flex"
+                            alignItems="center"
+                            gap="16px"
+                            _hover={{
+                              bg: "content.link",
+                              cursor: "pointer",
+                            }}
+                            className="group"
+                            onClick={() => {
+                              setIsDeleteModalOpen(true);
+                              setUserToRemove(item);
+                            }}
+                          >
+                            <Icon
+                              className="group-hover:text-white"
+                              color="sentiment.negativeDefault"
+                              as={RiDeleteBin6Line}
+                              h="24px"
+                              w="24px"
+                            />
+                            <Text
+                              className="group-hover:text-white"
+                              color="content.primary"
+                            >
+                              {t("remove-user")}
+                            </Text>
+                          </MenuItem>
+                        </MenuContent>
+                      </MenuRoot>
+                    )}
                   </Table.Cell>
                 </Table.Row>
               )}

--- a/app/src/app/api/v0/organizations/[organization]/invitations/route.ts
+++ b/app/src/app/api/v0/organizations/[organization]/invitations/route.ts
@@ -15,6 +15,7 @@ import InviteToOrganizationTemplate from "@/lib/emails/InviteToOrganizationTempl
 import { User } from "@/models/User";
 import EmailService from "@/backend/EmailService";
 import { logger } from "@/services/logger";
+import { OrganizationAdmin } from "@/models/OrganizationAdmin";
 
 export const GET = apiHandler(async (_req, { params, session }) => {
   const { organization: organizationId } = params;
@@ -41,6 +42,23 @@ export const POST = apiHandler(async (req, { params, session }) => {
   const org = await Organization.findByPk(organizationId);
   if (!org) {
     throw new createHttpError.NotFound("organization-not-found");
+  }
+
+  const existingOrgAdmins = await OrganizationAdmin.findAll({
+    include: [
+      {
+        model: User,
+        where: { email: validatedData.inviteeEmails },
+      },
+    ],
+  });
+
+  if (existingOrgAdmins.length > 0) {
+    throw new createHttpError.BadRequest(
+      `The following users are already admins for another organization: ${existingOrgAdmins
+        .map((admin) => admin.user.email)
+        .join(", ")}`,
+    );
   }
 
   const failedInvites: { email: string }[] = [];

--- a/app/src/app/api/v0/organizations/[organization]/invitations/route.ts
+++ b/app/src/app/api/v0/organizations/[organization]/invitations/route.ts
@@ -1,5 +1,6 @@
 import { OrganizationInvite } from "@/models/OrganizationInvite";
 import { Organization } from "@/models/Organization";
+import { Op } from "sequelize";
 import {
   CreateOrganizationInviteRequest,
   createOrganizationInviteRequest,
@@ -48,7 +49,11 @@ export const POST = apiHandler(async (req, { params, session }) => {
     include: [
       {
         model: User,
-        where: { email: validatedData.inviteeEmails },
+        where: {
+          email: {
+            [Op.in]: validatedData.inviteeEmails,
+          },
+        },
       },
     ],
   });

--- a/app/src/app/api/v0/organizations/[organization]/invitations/route.ts
+++ b/app/src/app/api/v0/organizations/[organization]/invitations/route.ts
@@ -49,6 +49,7 @@ export const POST = apiHandler(async (req, { params, session }) => {
     include: [
       {
         model: User,
+        as: "user",
         where: {
           email: {
             [Op.in]: validatedData.inviteeEmails,


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Restrict users who are already organization admins from being invited to another organization's admin role and ensure that actions to remove users in the TeamSettings component can only be performed by other users.

### Why are these changes being made?
The changes enforce role exclusivity, preventing an admin from being added to multiple organizations, which maintains security and organizational boundaries across the application. Additionally, the UI adjustment in the TeamSettings avoids self-deactivation scenarios, ensuring that team management functionalities are appropriately safeguarded.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->