### PR TITLE
fix(ui): ON-4174 remove wrong alias for EmissionsFactor table in ranking query

### DIFF
--- a/app/src/app/api/v0/emissions-factor/route.ts
+++ b/app/src/app/api/v0/emissions-factor/route.ts
@@ -137,8 +137,8 @@ export const POST = apiHandler(async (req: NextRequest, _context: {}) => {
       const rank = index + 1;
       const escapedValue = db.sequelize!.escape(value);
       return `
-        WHEN "EmissionsFactor"."region" = ${escapedValue} THEN ${rank}
-        WHEN "EmissionsFactor"."actor_id" = ${escapedValue} THEN ${rank}
+        WHEN "region" = ${escapedValue} THEN ${rank}
+        WHEN "actor_id" = ${escapedValue} THEN ${rank}
       `;
     })
     .join("\n");


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the incorrect alias for the `EmissionsFactor` table in the ranking query within `route.ts`.

### Why are these changes being made?

The wrong alias was causing an issue by not correctly matching column names during query execution, leading to errors in data retrieval. This change corrects the alias usage to prevent query mismatches and ensure the desired data is accurately ranked and retrieved.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->