### PR TITLE
fix: adds correct toast type

### DIFF
--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -412,7 +412,7 @@ const SectorTabs: FC<SectorTabsProps> = ({ t, inventoryId }) => {
         toaster.create({
           title: t("success"),
           description: t("quick-action-applied"),
-          type: "info",
+          type: "success",
         });
       };
 


### PR DESCRIPTION
changes
- changes toast type from info to success

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Update the toast notification type from "info" to "success" in the `SectorTabs` component.

### Why are these changes being made?
The toast notification's nature was incorrectly represented as "info," which did not accurately reflect the successful outcome of the action taken. Changing the type to "success" provides a more appropriate and clear feedback to the users indicating that the quick action was applied successfully.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->