### PR TITLE
fix: missing translations for remove user toast

### DIFF
--- a/app/src/i18n/locales/de/admin.json
+++ b/app/src/i18n/locales/de/admin.json
@@ -135,5 +135,6 @@
   "downloading-data": "Ihre Daten herunterladen",
   "download-failed": "Download fehlgeschlagen",
   "download-error": "Es gab einen Fehler beim Herunterladen",
-  "change-to-admin": "Wechseln zu Admin"
+  "change-to-admin": "Wechseln zu Admin",
+  "user-removed": "Benutzer erfolgreich entfernt"
 }

--- a/app/src/i18n/locales/en/admin.json
+++ b/app/src/i18n/locales/en/admin.json
@@ -135,5 +135,6 @@
   "updating-status": "Uploading organization status",
   "freeze-account": "Freeze account",
   "unfreeze-account": "Unfreeze account",
-  "change-to-admin": "Change to admin"
+  "change-to-admin": "Change to admin",
+  "user-removed": "User removed successfully"
 }

--- a/app/src/i18n/locales/es/auth.json
+++ b/app/src/i18n/locales/es/auth.json
@@ -64,5 +64,6 @@
   "invite-accepted": "Invitación Aceptada",
   "invite-accepted-org-details": "Has aceptado con éxito la invitación para unirte a la organización.",
   "preferred-language": "Idioma Preferido",
-  "preferred-language-required": "Por favor, seleccione su idioma preferido"
+  "preferred-language-required": "Por favor, seleccione su idioma preferido",
+  "user-removed": "Usuario eliminado con éxito"
 }

--- a/app/src/i18n/locales/fr/admin.json
+++ b/app/src/i18n/locales/fr/admin.json
@@ -135,5 +135,6 @@
   "downloading-data": "Téléchargement de vos données",
   "download-failed": "Échec du téléchargement",
   "download-error": "Une erreur s'est produite pendant le téléchargement",
-  "change-to-admin": "Changer en admin"
+  "change-to-admin": "Changer en admin",
+  "user-removed": "Utilisateur supprimé avec succès"
 }

--- a/app/src/i18n/locales/pt/admin.json
+++ b/app/src/i18n/locales/pt/admin.json
@@ -135,5 +135,6 @@
   "downloading-data": "Baixando seus dados",
   "download-failed": "Download falhou",
   "download-error": "Ocorreu um erro durante o download",
-  "change-to-admin": "Mudar para administrador"
+  "change-to-admin": "Mudar para administrador",
+  "user-removed": "Usuário removido com sucesso"
 }


### PR DESCRIPTION
Changes
- Adds missing translations for remove user toast

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add missing translations for the "user removed" toast notification in multiple languages, including German, English, Spanish, French, and Portuguese.

### Why are these changes being made?

This change addresses the missing translations of the "user removed" notification, ensuring that users receive localized feedback when removing a user. It enhances user experience by providing consistent messaging across different languages and was prioritized to maintain the application's multilingual support.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->