### PR TITLE
on-4108/hide unavailable download formats | on-4107, bugfixes

### DIFF
--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsForecast/EmissionsForecastCard.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsForecast/EmissionsForecastCard.tsx
@@ -38,7 +38,9 @@ export const EmissionsForecastCard = ({
       <Card.Root paddingY="0px" paddingX="0px" height="100%" width="100%">
         <CardHeader>
           <HStack>
-            <TitleMedium>{t("breakdown-of-sub-sector-emissions")}</TitleMedium>
+            <TitleMedium>
+              {t("no-action-emissions-forecast-by-sector")}
+            </TitleMedium>
             {" | "}
             <HStack
               onClick={() => setIsExplanationModalOpen(true)}

--- a/app/src/app/[lng]/auth/signup/page.tsx
+++ b/app/src/app/[lng]/auth/signup/page.tsx
@@ -5,6 +5,7 @@ import PasswordInput from "@/components/password-input";
 import { useTranslation } from "@/i18n/client";
 
 import { Box, Heading, Icon, Input, Link, Text } from "@chakra-ui/react";
+import LabelLarge from "@/components/Texts/Label";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState, use } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
@@ -123,7 +124,7 @@ export default function Signup(props: { params: Promise<{ lng: string }> }) {
       </Text>
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
         <Field
-          label={t("full-name")}
+          label={<LabelLarge>{t("full-name")}</LabelLarge>}
           invalid={!!errors.name}
           errorText={
             <Box display="flex" gap="6px">
@@ -170,7 +171,7 @@ export default function Signup(props: { params: Promise<{ lng: string }> }) {
           shouldValidate={false}
         />
         <Field
-          label={t("preferred-language")}
+          label={<LabelLarge>{t("preferred-language")}</LabelLarge>}
           invalid={!!errors.preferredLanguage}
           errorText={
             <Box display="flex" gap="6px">

--- a/app/src/components/HomePage/DownloadAndShareModals/DownloadButtons.tsx
+++ b/app/src/components/HomePage/DownloadAndShareModals/DownloadButtons.tsx
@@ -21,10 +21,10 @@ const DownloadButtons = ({
   inventoryYear: number | undefined;
 }) => {
   const DOWNLOAD_BUTTONS = {
-    ciris: { isAvailable: false },
+    // ciris: { isAvailable: false },
     ecrf: { isAvailable: true },
     csv: { isAvailable: true },
-    pdf: { isAvailable: false },
+    // pdf: { isAvailable: false },
   };
 
   enum STATUS {

--- a/app/src/components/email-input.tsx
+++ b/app/src/components/email-input.tsx
@@ -3,6 +3,7 @@ import { Icon, Input, Text } from "@chakra-ui/react";
 import { FieldError } from "react-hook-form";
 import { Fieldset } from "@chakra-ui/react";
 import { Field } from "@/components/ui/field";
+import LabelLarge from "@/components/Texts/Label";
 
 export default function EmailInput({
   children,
@@ -25,15 +26,7 @@ export default function EmailInput({
 }) {
   return (
     <Field
-      label={
-        <Text
-          fontWeight="medium"
-          fontFamily="heading"
-          color="content.secondary"
-        >
-          {name}
-        </Text>
-      }
+      label={<LabelLarge>{name}</LabelLarge>}
       invalid={!!error}
       errorText={error?.message}
     >

--- a/app/src/components/password-input.tsx
+++ b/app/src/components/password-input.tsx
@@ -5,6 +5,7 @@ import { TFunction } from "i18next";
 import { Field } from "@/components/ui/field";
 import { PasswordInput as ChakraPasswordInput } from "@/components/ui/password-input";
 import { IoMdEye, IoMdEyeOff } from "react-icons/io";
+import LabelLarge from "@/components/Texts/Label";
 
 export default function PasswordInput({
   children,
@@ -37,15 +38,7 @@ export default function PasswordInput({
   return (
     <Field
       invalid={!!error}
-      label={
-        <Text
-          fontWeight="medium"
-          fontFamily="heading"
-          color="content.secondary"
-        >
-          {name}
-        </Text>
-      }
+      label={<LabelLarge>{name}</LabelLarge>}
       errorText={error?.message}
       w={w}
     >

--- a/app/src/i18n/locales/de/dashboard.json
+++ b/app/src/i18n/locales/de/dashboard.json
@@ -89,7 +89,7 @@
   "%-of-emissions": "% der Emissionen",
   "of-total-emissions": "der Gesamtemissionen",
   "view-total-emissions-data-by-GPC-required-sectors": "Gesamt-Emissionsdaten nach GPC erforderlichen Sektoren anzeigen",
-  "breakdown-of-sub-sector-emissions": "No-Action-Emissionsprognose nach Sektor",
+  "breakdown-of-sub-sector-emissions": "Aufschlüsselung der Emissionen nach Teilsektoren",
   "N/A": "N/V",
   "activity-type": "Aktivitätstyp",
   "consumption": "Verbrauch",

--- a/app/src/i18n/locales/en/dashboard.json
+++ b/app/src/i18n/locales/en/dashboard.json
@@ -91,7 +91,7 @@
   "%-of-emissions": "% of emissions",
   "of-total-emissions": "of total emissions",
   "view-total-emissions-data-by-GPC-required-sectors": "View total emissions data by GPC required sectors",
-  "breakdown-of-sub-sector-emissions": "No-action emissions forecast by sector",
+  "breakdown-of-sub-sector-emissions": "Breakdown of sub-sector emissions ",
   "N/A": "N/A",
   "activity-type": "activity type",
   "consumption": "consumption",

--- a/app/src/i18n/locales/es/dashboard.json
+++ b/app/src/i18n/locales/es/dashboard.json
@@ -76,7 +76,7 @@
   "%-of-emissions": "% de las emisiones",
   "of-total-emissions": "de las emisiones totales",
   "view-total-emissions-data-by-GPC-required-sectors": "Vea los datos totales de emisiones por sectores requeridos por el GPC",
-  "breakdown-of-sub-sector-emissions": "Pronóstico de emisiones por sector sin acción",
+  "breakdown-of-sub-sector-emissions": "Desglose de emisiones por subsector",
   "N/A": "N/A",
   "activity-type": "Tipo de actividad",
   "consumption": "Consumo",

--- a/app/src/i18n/locales/fr/dashboard.json
+++ b/app/src/i18n/locales/fr/dashboard.json
@@ -91,7 +91,7 @@
   "%-of-emissions": "% des émissions",
   "of-total-emissions": "des émissions totales",
   "view-total-emissions-data-by-GPC-required-sectors": "Voir les données totales d'émissions par secteurs requis par le GPC",
-  "breakdown-of-sub-sector-emissions": "Prévisions des émissions sans action par secteur",
+  "breakdown-of-sub-sector-emissions": "Répartition des émissions par sous-secteur",
   "N/A": "S/O",
   "activity-type": "type d'activité",
   "consumption": "consommation",

--- a/app/src/i18n/locales/pt/dashboard.json
+++ b/app/src/i18n/locales/pt/dashboard.json
@@ -87,7 +87,7 @@
   "%-of-emissions": "% das emissões",
   "of-total-emissions": "das emissões totais",
   "view-total-emissions-data-by-GPC-required-sectors": "Veja os dados totais de emissões por setores exigidos pelo GPC",
-  "breakdown-of-sub-sector-emissions": "Previsão de emissões por setor sem ação",
+  "breakdown-of-sub-sector-emissions": "Divisão das emissões por subsetor",
   "N/A": "N/A",
   "activity-type": "Tipo de atividade",
   "consumption": "Consumo",


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Revise the title for the emissions forecast in the `EmissionsForecastCard` component, update translation strings for the breakdown of sub-sector emissions across multiple languages, and comment out unavailable download format options in `DownloadButtons`.

### Why are these changes being made?

The changes are being made to correct the text for emissions breakdown titles to provide clarity and consistency across different languages, and to prevent users from seeing and attempting to select download formats (CIRIS and PDF) that are currently unavailable, thus improving the user experience.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->