### PR TITLE
fix: remove ghg from ef seed data

### DIFF
--- a/app/seeders/20231114094254-emissions-factors.cjs
+++ b/app/seeders/20231114094254-emissions-factors.cjs
@@ -7,7 +7,7 @@ const { bulkUpsert } = require("./util/util.cjs");
 const folders = [
   "EFDB_2006_IPCC_guidelines",
   "CarbonFootPrint_2023",
-  "ghgprotocol",
+  //"ghgprotocol",
 ];
 
 const toJson = ({


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Comment out "ghgprotocol" from the seed data folders array in `20231114094254-emissions-factors.cjs`.

### Why are these changes being made?

The "ghgprotocol" data is not required for the emissions factors seed process, leading to erroneous or redundant data loading. This change streamlines the seed data to include only necessary data sources and prevent future confusion or errors.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->