### PR TITLE
fix: on-4242 wrong project list on invite modal

### DIFF
--- a/app/src/app/[lng]/admin/organization/[id]/team/page.tsx
+++ b/app/src/app/[lng]/admin/organization/[id]/team/page.tsx
@@ -464,7 +464,6 @@ const AdminOrganizationTeamPage = (props: {
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         organizationId={id}
-        isAdmin={true}
       />
       <RemoveUserModal
         t={t}

--- a/app/src/app/[lng]/organization/[id]/account-settings/team/index.tsx
+++ b/app/src/app/[lng]/organization/[id]/account-settings/team/index.tsx
@@ -426,7 +426,6 @@ const TeamSettings = ({ lng, id }: { lng: string; id: string }) => {
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         organizationId={id}
-        isAdmin={true}
       />
       <RemoveUserModal
         t={t}

--- a/app/src/backend/UserService.ts
+++ b/app/src/backend/UserService.ts
@@ -460,10 +460,9 @@ export default class UserService {
     if (!session) throw new createHttpError.Unauthorized("Unauthorized");
 
     // OEF admin and organization owner can see all projects
-    const orgOwner = await hasOrgOwnerLevelAccess(
-      organizationId,
-      session.user.id,
-    );
+    const orgOwner =
+      (await hasOrgOwnerLevelAccess(organizationId, session.user.id)) ||
+      session.user.role === Roles.Admin;
     if (session.user.role == Roles.Admin || orgOwner) {
       return await UserService.findAllProjectForAdminAndOwner(organizationId);
     }


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the `isAdmin` property and refactor project fetching logic in the AddCollaboratorsModal to show appropriate project lists based on organization ID or user role.

### Why are these changes being made?

The invite modal was incorrectly listing projects due to the reliance on the `isAdmin` flag, which led to project visibility issues. By leveraging organization IDs and ensuring proper access checks via `UserService`, these changes ensure that the project list is tailored both to organizational context and user roles, improving accuracy and administrative control.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->