### PR TITLE
<main> fix (manual input) [ON-4284] fix CO2Eq Calculations

### DIFF
--- a/app/src/backend/UnitConversionService.ts
+++ b/app/src/backend/UnitConversionService.ts
@@ -53,7 +53,7 @@ export default class UnitConversionService {
     "fuel-type-naphtha": 710, // Naphtha: 700-720 kg/m³
     "fuel-type-diesel-oil": 830, // Diesel Oil: 820-860 kg/m³
     "fuel-type-liquefied-petroleum-gases": 493, // LPG: 493-580 kg/m³
-    "fuel-type-wood/wood-waste": 700, // Wood/Wood Waste: 600-700 kg/m³ (solid state)
+    "fuel-type-wood-wood-waste": 700, // Wood/Wood Waste: 600-700 kg/m³ (solid state)
     "fuel-type-other-primary-solid-biomass": 700, // Biomass: ~600-700 kg/m³
     "fuel-type-charcoal": 250, // Charcoal: 200-300 kg/m³
     "fuel-type-natural-gas-oil": 820, // Natural Gas Oil: ~820 kg/m³

--- a/app/src/backend/formulas.ts
+++ b/app/src/backend/formulas.ts
@@ -591,11 +591,7 @@ export function handleActivityAmountTimesEmissionsFactorFormula(
         `Emissions factor for ${emissionsFactor?.gas} has no emissions per activity`,
       );
     }
-    // this rounds/ truncates!
-    const amount = Decimal.mul(
-      activityAmount,
-      emissionsFactor.emissionsPerActivity,
-    ).ceil();
+    const amount = Decimal.mul(activityAmount, emissionsFactor.emissionsPerActivity);
 
     return { gas: gasValue.gas!, amount };
   });


### PR DESCRIPTION
we were rounding very small numbers (10^-5) to 1, messing up the calculation

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Correct the CO2Eq calculation by fixing a typo in the fuel type key and removing the rounding logic in the emissions calculation.

### Why are these changes being made?
The typo in the fuel type key prevented the system from accurately identifying fuel data, potentially causing errors or inaccuracies in emissions calculations. The removal of the rounding logic aims to improve the precision of CO2 equivalent emissions calculations by ensuring no unintended truncation occurs during these calculations, allowing for more accurate reporting.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->