### PR TITLE
fix/ON-4299-button-icon-overflowing

### DIFF
--- a/app/src/components/GHGIHomePage/DownloadAndShareModals/PublishButtons.tsx
+++ b/app/src/components/GHGIHomePage/DownloadAndShareModals/PublishButtons.tsx
@@ -43,7 +43,8 @@ const PublishButtons = ({
         <Button
           key={title}
           my="16px"
-          mx="16px"
+          pr="16px"
+          pl="35px"
           variant="ghost"
           disabled={!isAvailable}
           minHeight="100px"


### PR DESCRIPTION
changes
- Removes margins and uses padding instead, this fixes the overflowing