### PR TITLE
fix: adds mission translations for toast error  message

### DIFF
--- a/app/src/i18n/locales/de/manage-subsectors.json
+++ b/app/src/i18n/locales/de/manage-subsectors.json
@@ -1210,6 +1210,7 @@
   "deselect-all": "Alle abwählen",
   "success": "Erfolg",
   "notation-keys-updated": "Notenschlüssel aktualisiert",
+  "error-updating-notation-keys": "Fehler beim Aktualisieren der Notenschlüssel",
   "quick-action-applied": "Schnellaktion angewendet",
   "changes-can-be-lost": "Ihre Änderungen können verloren gehen",
   "changes-can-be-lost-description": "Möchten Sie alle Änderungen seit der letzten Bearbeitung verwerfen? Dies kann nicht rückgängig gemacht werden.",

--- a/app/src/i18n/locales/en/manage-subsectors.json
+++ b/app/src/i18n/locales/en/manage-subsectors.json
@@ -1210,6 +1210,7 @@
   "deselect-all": "Deselect all",
   "success": "Success",
   "notation-keys-updated": "Notation keys updated",
+  "error-updating-notation-keys": "Failed to update notation keys",
   "quick-action-applied": "Quick action applied",
   "changes-can-be-lost": "Your changes can be lost",
   "changes-can-be-lost-description": "Do you want to discard all changes made since last edit? This cannot be undone.",

--- a/app/src/i18n/locales/es/manage-subsectors.json
+++ b/app/src/i18n/locales/es/manage-subsectors.json
@@ -1210,6 +1210,7 @@
   "deselect-all": "Deseleccionar todo",
   "success": "Éxito",
   "notation-keys-updated": "Claves de notación actualizadas",
+  "error-updating-notation-keys": "Error al actualizar las claves de notación",
   "quick-action-applied": "Acción rápida aplicada",
   "changes-can-be-lost": "Tus cambios pueden perderse",
   "changes-can-be-lost-description": "¿Desea descartar todos los cambios realizados desde la última edición? Esto no se puede deshacer.",

--- a/app/src/i18n/locales/fr/manage-subsectors.json
+++ b/app/src/i18n/locales/fr/manage-subsectors.json
@@ -1210,6 +1210,7 @@
   "deselect-all": "Désélectionner tout",
   "success": "Succès",
   "notation-keys-updated": "Clés de notation mises à jour",
+  "error-updating-notation-keys": "Échec de la mise à jour des clés de notation",
   "quick-action-applied": "Action rapide appliquée",
   "changes-can-be-lost": "Vos modifications peuvent être perdues",
   "changes-can-be-lost-description": "Voulez-vous jeter toutes les modifications effectuées depuis la dernière édition ? Cela ne peut pas être annulé.",

--- a/app/src/i18n/locales/pt/manage-subsectors.json
+++ b/app/src/i18n/locales/pt/manage-subsectors.json
@@ -1210,6 +1210,7 @@
   "deselect-all": "Deselecionar tudo",
   "success": "Sucesso",
   "notation-keys-updated": "Chaves de notação atualizadas",
+  "error-updating-notation-keys": "Falha ao atualizar as chaves de notação",
   "quick-action-applied": "Ação rápida aplicada",
   "changes-can-be-lost": "As suas alterações podem ser perdidas",
   "changes-can-be-lost-description": "Deseja descartar todas as alterações feitas desde a última edição? Isso não pode ser desfeito.",


### PR DESCRIPTION
Changes
- Adds missing translations for toast error message

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add translations for the "error-updating-notation-keys" toast error message in multiple language files.

### Why are these changes being made?

These changes address missing translations for a specific error message to ensure users in German, English, Spanish, French, and Portuguese can understand the toast message related to a failure in updating notation keys, thus improving user experience and localization completeness.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->