### PR TITLE
fix: relax access controls for default organization

### DIFF
--- a/app/src/backend/permissions/permissions.md
+++ b/app/src/backend/permissions/permissions.md
@@ -80,9 +80,9 @@ export type UserRole = 'ORG_ADMIN' | 'PROJECT_ADMIN' | 'COLLABORATOR' | 'NO_ACCE
 - **Permissions**:
   - ✅ EDIT_INVENTORY (only for assigned cities)
   - ✅ VIEW_CITY (only assigned cities)
+  - ✅ CREATE_CITY (only in default organization)
+  - ✅ CREATE_INVENTORY (only in default organization)
   - ❌ VIEW_ORGANIZATION (cannot view organization-wide data)
-  - ❌ CREATE_CITY
-  - ❌ CREATE_INVENTORY
   - ❌ DELETE_CITY
   - ❌ MANAGE_USERS
   - ❌ MANAGE_PROJECTS
@@ -91,6 +91,7 @@ export type UserRole = 'ORG_ADMIN' | 'PROJECT_ADMIN' | 'COLLABORATOR' | 'NO_ACCE
 - Edit inventory data for cities they've been assigned to
 - View city-specific data and analytics
 - Upload and manage data files for their assigned cities
+- **Default Organization Only**: Create cities and inventories in the default organization
 - **Important**: Cannot view other cities, projects, or organization-wide information
 
 ### 4. NO_ACCESS
@@ -186,8 +187,8 @@ Defined in `app/src/backend/PermissionService.ts:134-142`:
 
 | Action | ORG_ADMIN | PROJECT_ADMIN | COLLABORATOR |
 |--------|-----------|---------------|-------------|
-| CREATE_CITY | ✅ | ✅ | ❌ |
-| CREATE_INVENTORY | ✅ | ✅ | ❌ |
+| CREATE_CITY | ✅ | ✅ | ✅ (default org only) |
+| CREATE_INVENTORY | ✅ | ✅ | ✅ (default org only) |
 | EDIT_INVENTORY | ✅ | ✅ | ✅ (assigned cities only) |
 | DELETE_CITY | ✅ | ❌ | ❌ |
 | VIEW_ORGANIZATION | ✅ | ✅ (project scope) | ❌ |
@@ -232,3 +233,8 @@ Standardized permission errors in `app/src/util/permission-errors.ts:4-29`:
 4. **Multi-Organization Users**: A single user can have different roles across different organizations (e.g., ORG_ADMIN in one org, COLLABORATOR in another).
 
 5. **Project Admin Scope**: Project admins can only manage resources within their assigned projects, not organization-wide.
+
+6. **Default Organization Special Rules**: The default organization (`5a84ebff-33ee-457e-ab52-512b5731978b`) has relaxed permissions:
+   - COLLABORATORs can create cities and inventories (normally restricted to ORG_ADMIN/PROJECT_ADMIN)
+   - System ADMINs always have full access
+   - This enables easy onboarding and collaboration for general platform usage

--- a/app/src/components/GHGIHomePage/HomePage.tsx
+++ b/app/src/components/GHGIHomePage/HomePage.tsx
@@ -31,6 +31,7 @@ import ProgressLoader from "@/components/ProgressLoader";
 import { useOrganizationContext } from "@/hooks/organization-context-provider/use-organizational-context";
 import { useUserPermissions } from "@/hooks/useUserPermissions";
 import { UserRole } from "@/util/types";
+import { DEFAULT_ORGANIZATION_ID } from "@/util/constants";
 import { logger } from "@/services/logger";
 
 function isFetchBaseQueryError(error: unknown): error is FetchBaseQueryError {
@@ -189,7 +190,7 @@ export default function HomePage({
   }, [cityYears]);
 
   // Check user permissions for this city
-  const { userRole } = useUserPermissions({
+  const { userRole, organizationId } = useUserPermissions({
     cityId: inventory?.cityId,
     skip: !inventory?.cityId
   });
@@ -288,8 +289,9 @@ export default function HomePage({
                     >
                       {t("inventory-year")}
                     </Text>
-                    {/* Only show add inventory button for ORG_ADMIN and PROJECT_ADMIN */}
-                    {userRole !== UserRole.COLLABORATOR && userRole !== UserRole.NO_ACCESS && (
+                    {/* Only show add inventory button for ORG_ADMIN and PROJECT_ADMIN, or COLLABORATORs in default org */}
+                    {userRole !== UserRole.NO_ACCESS && 
+                     (userRole !== UserRole.COLLABORATOR || organizationId === DEFAULT_ORGANIZATION_ID) && (
                       <Button
                         data-testid="add-new-inventory-button"
                         title={t("add-new-inventory")}

--- a/app/src/components/GHGIHomePage/ProjectDrawer.tsx
+++ b/app/src/components/GHGIHomePage/ProjectDrawer.tsx
@@ -39,6 +39,7 @@ import ProjectLimitModal from "@/components/project-limit";
 import SearchInput from "@/components/SearchInput";
 import { useUserPermissions } from "@/hooks/useUserPermissions";
 import { UserRole } from "@/util/types";
+import { DEFAULT_ORGANIZATION_ID } from "@/util/constants";
 import { logger } from "@/services/logger";
 
 const ProjectList = ({
@@ -116,7 +117,7 @@ const SingleProjectView = ({
   const [isProjectLimitModalOpen, setIsProjectLimitModalOpen] = useState(false);
   
   // Check user permissions for this project
-  const { userRole } = useUserPermissions({
+  const { userRole, organizationId } = useUserPermissions({
     projectId: project.projectId,
     skip: !project.projectId
   });
@@ -182,8 +183,9 @@ const SingleProjectView = ({
         </Text>
       </Button>
       <SearchInput searchTerm={searchTerm} setSearchTerm={setSearchTerm} />
-      {/* Only show add city button for ORG_ADMIN and PROJECT_ADMIN */}
-      {userRole !== UserRole.COLLABORATOR && userRole !== UserRole.NO_ACCESS && (
+      {/* Only show add city button for ORG_ADMIN and PROJECT_ADMIN, or COLLABORATORs in default org */}
+      {userRole !== UserRole.NO_ACCESS && 
+       (userRole !== UserRole.COLLABORATOR || organizationId === DEFAULT_ORGANIZATION_ID) && (
         <Button
           variant="ghost"
           w="full"


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Relax access controls to allow COLLABORATORs to create cities and inventories within the default organization.

### Why are these changes being made?

This change is made to facilitate easier onboarding and collaboration within the platform's default organization by allowing COLLABORATORs to perform actions normally restricted to ORG_ADMINs and PROJECT_ADMINs. This approach provides flexibility for general platform use, especially within the default organization, without compromising security in other organizations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->