### PR TITLE
 fix: ON-4358 - "Project" appears in English when creating inventory

### DIFF
--- a/app/src/i18n/locales/de/onboarding.json
+++ b/app/src/i18n/locales/de/onboarding.json
@@ -73,6 +73,7 @@
   "recent-searches-no-results": "Sie haben keine kürzlichen Suchen",
   "failed-to-add-city": "Fehler beim Hinzufügen der Stadt",
   "failed-to-create-inventory": "Fehler beim Erstellen des Inventars",
+  "project": "Projekt",
   "select-project": "Projekt auswählen",
   "city-count-limit-reached": "Stadtanzahllimit erreicht",
   "welcome-top": "Willkommen bei CityCatalyst",

--- a/app/src/i18n/locales/en/onboarding.json
+++ b/app/src/i18n/locales/en/onboarding.json
@@ -71,6 +71,7 @@
   "recent-searches-no-results": "You have no recent searches",
   "failed-to-add-city": "Failed to add city",
   "failed-to-create-inventory": "Failed to create inventory",
+  "project": "Project",
   "select-project": "Select Project",
   "city-count-limit-reached": "City count limit reached",
   "welcome-top": "Welcome to CityCatalyst",

--- a/app/src/i18n/locales/es/onboarding.json
+++ b/app/src/i18n/locales/es/onboarding.json
@@ -74,6 +74,7 @@
   "recent-searches-no-results": "No tienes búsquedas recientes",
   "failed-to-add-city": "Fallo al agregar la ciudad",
   "failed-to-create-inventory": "Fallo al crear inventario",
+  "project": "Proyecto",
   "select-project": "Seleccionar Proyecto",
   "city-count-limit-reached": "Límite de ciudades alcanzado",
   "welcome-top": "Bienvenido a CityCatalyst",

--- a/app/src/i18n/locales/fr/onboarding.json
+++ b/app/src/i18n/locales/fr/onboarding.json
@@ -71,6 +71,7 @@
   "recent-searches-no-results": "Vous n'avez aucune recherche récente",
   "failed-to-add-city": "Échec de l'ajout de la ville",
   "failed-to-create-inventory": "Échec de la création de l'inventaire",
+  "project": "Projet",
   "select-project": "Sélectionner le projet",
   "city-count-limit-reached": "Limite du nombre de villes atteinte",
   "welcome-top": "Bienvenue à CityCatalyst",

--- a/app/src/i18n/locales/pt/onboarding.json
+++ b/app/src/i18n/locales/pt/onboarding.json
@@ -73,6 +73,7 @@
   "recent-searches-no-results": "Você não tem pesquisas recentes",
   "failed-to-add-city": "Falha ao adicionar cidade",
   "failed-to-create-inventory": "Falha ao criar inventário",
+  "project": "Projeto",
   "select-project": "Selecionar Projeto",
   "city-count-limit-reached": "Limite de contagem de cidades atingido",
   "welcome-top": "Bem-vindo ao CityCatalyst",


### PR DESCRIPTION
## Summary
- add missing "project" translations to onboarding locales so project dropdowns localize correctly

## Testing
- `npm test` *(fails: Could not find a production build in the '.next' directory)*
- `npm run api:test` *(fails: SequelizeConnectionRefusedError - database not available)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5bda5b8d4832aa64bf2a493df0732

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add "project" translation to the onboarding JSON files for multiple languages (German, English, Spanish, French, and Portuguese). 

### Why are these changes being made?

This change was made to ensure consistent multilingual support by adding the translation for the term "project" across all relevant onboarding locales. This will help improve user experience by providing a more complete and localized onboarding process.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->