### PR TITLE
fix: ON-4356 - "Role" appears in English in Team section

### DIFF
--- a/app/src/i18n/locales/de/admin.json
+++ b/app/src/i18n/locales/de/admin.json
@@ -13,6 +13,7 @@
   "project-name": "Projektname",
   "city-limit": "Stadtgrenze",
   "email": "E-Mail",
+  "role": "Rolle",
   "required": "Dieses Feld ist erforderlich",
   "invalid-email": "Ungültige E-Mail-Adresse",
   "next": "Nächster",

--- a/app/src/i18n/locales/en/admin.json
+++ b/app/src/i18n/locales/en/admin.json
@@ -15,6 +15,7 @@
   "project-name": "Project name",
   "city-limit": "City limit",
   "email": "Email",
+  "role": "Role",
   "required": "This field is required",
   "invalid-email": "Invalid email address",
   "next": "Next",

--- a/app/src/i18n/locales/es/admin.json
+++ b/app/src/i18n/locales/es/admin.json
@@ -13,6 +13,7 @@
   "project-name": "Nombre del proyecto",
   "city-limit": "Límite de la ciudad",
   "email": "Correo electrónico",
+  "role": "Rol",
   "required": "Este campo es obligatorio",
   "invalid-email": "Dirección de correo electrónico no válida",
   "next": "Siguiente",

--- a/app/src/i18n/locales/fr/admin.json
+++ b/app/src/i18n/locales/fr/admin.json
@@ -15,6 +15,7 @@
   "project-name": "Nom du projet",
   "city-limit": "Limite de la ville",
   "email": "Courriel",
+  "role": "Rôle",
   "required": "Ce champ est obligatoire",
   "invalid-email": "Adresse e-mail invalide",
   "next": "Suivant",

--- a/app/src/i18n/locales/pt/admin.json
+++ b/app/src/i18n/locales/pt/admin.json
@@ -13,6 +13,7 @@
   "project-name": "Nome do projeto",
   "city-limit": "Limite da cidade",
   "email": "Email",
+  "role": "Função",
   "required": "Este campo é obrigatório",
   "invalid-email": "Endereço de email inválido",
   "next": "Próximo",


### PR DESCRIPTION
## Summary
- add missing "role" string to admin locale files for all languages

## Testing
- `npm test` *(fails: Could not find a production build / database connection errors)*
- `npm run jest tests/api/project.jest.ts` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68a3337be984832ab9c689a3fe31d345

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add translations for the term "Role" in the admin section for German, English, Spanish, French, and Portuguese JSON localization files.

### Why are these changes being made?

The change addresses an issue where the term "Role" was not being translated in the Team section of the application, appearing in English regardless of the selected language. This addition ensures that the term is displayed correctly in the user's selected language, improving the localization and user experience.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->