### PR TITLE
Add more density values for different kinds of fuels

### DIFF
--- a/app/src/backend/UnitConversionService.ts
+++ b/app/src/backend/UnitConversionService.ts
@@ -59,6 +59,28 @@ export default class UnitConversionService {
     "fuel-type-natural-gas-oil": 820, // Natural Gas Oil: ~820 kg/m³
     "fuel-type-peat": 450, // Peat: ~400-500 kg/m³
     "fuel-type-propane": 493, // Propane: ~493 kg/m³
+    "fuel-type-firewood": 450, // 225 C-kg/m³ / 0.5 carbon fraction
+    "fuel-type-anthracite": 865, // 800-930 kg/m³
+    "fuel-type-aviation-gasoline": 706,
+    "fuel-type-bitumen": 1000,
+    "fuel-type-coke-oven-coke-and-lignite-coke": 900,
+    "fuel-type-coke-oven-gas": 1,
+    "fuel-type-coking-coal": 793,
+    "fuel-type-crude-oil": 900,
+    "fuel-type-industrial-wastes": 530,
+    "fuel-type-jet-gasoline": 710,
+    "fuel-type-jet-kerosene": 800,
+    "fuel-type-lignite": 750,
+    "fuel-type-municipal-wastes": 150,
+    "fuel-type-natural-charcoal": 265,
+    "fuel-type-natural-gas-liquids": 550,
+    "fuel-type-natural-other-bituminous-coal": 1000,
+    "fuel-type-other-kerosene": 800,
+    "fuel-type-oxygen-steel-furnace-gas": 1,
+    "fuel-type-refinery-gas": 1,
+    "fuel-type-residual-fuel-oil": 975,
+    "fuel-type-sub-bituminous-coal": 865,
+    "fuel-type-waste-oils": 900
   };
 
   public static convertUnits(


### PR DESCRIPTION
This is a minimal change for ON-4386 so that it includes more types of fuels in the density calculations.

I grepped for all the fuel types we have in the manual input file:

```
grep fuel-type- src/util/form-schema/manual-input-hierarchy.json | sed "s/ //g" | sed s/\"//g | sed s/,//g | sort -u > fuels.txt         
```

Then, I added each to the density table in the calculation service, looking up the density either in ChatGPT or on Google. Most of the time, the density calculation was a really rough estimate.

This fixes the problem that was thrown, where the gas amounts were not calculated if there wasn't an EF for mass for that fuel, or if the density wasn't in the table.

Merging this will unblock a release blocker bug, so please let me know when it's done!

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add additional density values for various kinds of fuels to the `UnitConversionService`.

### Why are these changes being made?

These changes provide comprehensive density data for more fuel types, expanding the system's capability to handle a wider variety of fuel-related calculations. This ensures greater accuracy and applicability of the service in diverse industrial and environmental contexts where specific fuel density values are crucial.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->