### PR TITLE
Fix missing Spanish translation for role in admin team page

### DIFF
--- a/app/src/i18n/locales/en/admin.json
+++ b/app/src/i18n/locales/en/admin.json
@@ -106,6 +106,7 @@
   "bulk-inventory-creation-success": "Inventories created successfully",
   "invite-collaborator": "Invite collaborator",
   "project-team-heading": "{{proj_name}} Team",
+  "role": "Role",
   "owner": "Owner",
   "admin": "Admin",
   "collaborator": "Collaborator",

--- a/app/src/i18n/locales/es/admin.json
+++ b/app/src/i18n/locales/es/admin.json
@@ -97,6 +97,7 @@
   "bulk-inventory-creation-success": "Inventarios creados con éxito",
   "invite-collaborator": "Invitar colaborador",
   "project-team-heading": "Equipo de {{proj_name}}",
+  "role": "Rol",
   "owner": "Propietario",
   "admin": "Administrador",
   "collaborator": "Colaborador",


### PR DESCRIPTION
## Summary
- localize 'role' label on admin team page

## Testing
- `npm test` *(fails: Process from config.webServer was not able to start)*
- `npm run jest` *(fails: SequelizeConnectionRefusedError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a3337be984832ab9c689a3fe31d345

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add missing translation for "Role" in the Spanish localization file for the admin team page.

### Why are these changes being made?

The "Role" translation was missing in the Spanish localization file, causing inconsistency in the language support for the admin team page. This change ensures that both English and Spanish locales have equivalent entries, improving the user experience for Spanish-speaking users.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->