### PR TITLE
ON4434 - "New password" text appears duplicated

### DIFF
--- a/app/src/app/[lng]/auth/update-password/page.tsx
+++ b/app/src/app/[lng]/auth/update-password/page.tsx
@@ -86,7 +86,6 @@ export default function UpdatePassword(props: {
                 {t("password-hint")}
               </>
             }
-            label={t("new-password")}
           >
             <PasswordInput
               register={register}


### PR DESCRIPTION
## Summary
- remove duplicated "New Password" label on update password page

## Testing
- `npm run api:test` *(fails: SequelizeConnectionRefusedError)*
- `npm run e2e:test` *(fails: Could not find a production build)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ab9007c768832aab9bfca1a1512668

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the duplicated "New password" label from the password input field in the update-password component.

### Why are these changes being made?

The "New password" text appeared twice in the UI, possibly leading to confusion. Removing the label resolves the duplication issue and improves user experience by ensuring the label is displayed only once, in alignment with the design intent.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->