### PR TITLE
ON-4428 - "Password" shown in English on login

### DIFF
--- a/app/src/components/password-input.tsx
+++ b/app/src/components/password-input.tsx
@@ -12,7 +12,7 @@ export default function PasswordInput({
   error,
   register,
   t,
-  name = "Password",
+  name,
   id = "password",
   w,
   shouldValidate = false,
@@ -30,6 +30,7 @@ export default function PasswordInput({
 }) {
   // Password checks
   const password = watchPassword || "";
+  const labelName = name || t("password");
   const hasLowercase = /[a-z]/.test(password);
   const hasMinLength = password.length >= 8;
   const hasUppercase = /[A-Z]/.test(password);
@@ -38,7 +39,7 @@ export default function PasswordInput({
   return (
     <Field
       invalid={!!error}
-      label={<LabelLarge>{name}</LabelLarge>}
+      label={<LabelLarge>{labelName}</LabelLarge>}
       errorText={error?.message}
       w={w}
     >


### PR DESCRIPTION
## Summary
- Use translation for PasswordInput label when name not specified

## Testing
- `npm test` *(fails: SequelizeConnectionRefusedError; process from config.webServer was not able to start)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8fdd7354832aa0504f062ee3a4a3

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the `PasswordInput` component to localize the 'Password' field label by default, using the translation function `t`.

### Why are these changes being made?

Currently, the 'Password' field label is hardcoded in English, failing to accommodate localization needs. This change leverages the translation function `t` to ensure the label is displayed in the user's target language, enhancing internationalization support.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->