### PR TITLE
feat: OAuth Discovery

### DIFF
--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -22,10 +22,10 @@ const nextConfig = {
   async rewrites() {
     return [
       {
-        source: '/.well-known/oauth-authorization-server',
-        destination: '/api/v0/oauth/metadata/',
+        source: "/.well-known/oauth-authorization-server",
+        destination: "/api/v0/oauth/metadata/",
       },
-    ]
+    ];
   },
 };
 

--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -19,6 +19,14 @@ const nextConfig = {
     NEXT_AWS_SECRET_ACCESS_KEY: process.env.NEXT_AWS_SECRET_ACCESS_KEY,
     NEXT_AWS_S3_BUCKET_ID: process.env.NEXT_AWS_S3_BUCKET_ID,
   },
+  async rewrites() {
+    return [
+      {
+        source: '/.well-known/oauth-authorization-server',
+        destination: '/api/v0/oauth/metadata/',
+      },
+    ]
+  },
 };
 
 export default nextConfig;

--- a/app/src/app/api/v0/oauth/metadata/route.ts
+++ b/app/src/app/api/v0/oauth/metadata/route.ts
@@ -1,0 +1,26 @@
+import { apiHandler } from "@/util/api";
+import createHttpError from "http-errors";
+import { NextResponse } from "next/server";
+import { languages } from "@/i18n/settings";
+import { hasFeatureFlag, FeatureFlags } from "@/util/feature-flags";
+
+const DOCUMENTATION_URL = 'https://github.com/Open-Earth-Foundation/CityCatalyst/wiki/CityCatalyst-Backend-API'
+
+export const GET = apiHandler(async (_req, { session }) => {
+  if (!hasFeatureFlag(FeatureFlags.OAUTH_ENABLED)) {
+    throw createHttpError.InternalServerError("OAuth 2.0 not enabled");
+  }
+
+  const origin = _req.nextUrl.origin;
+  return NextResponse.json({
+    issuer: `${origin}/`,
+    authorization_endpoint: `${origin}/authorize/`,
+    token_endpoint: `${origin}/api/v0/token/`,
+    scopes_supported: ['read', 'write'],
+    response_types_supported: ['code'],
+    grant_types_supported: ['authorization_code', 'refresh_token'],
+    service_documentation: DOCUMENTATION_URL,
+    ui_locales_supported: languages,
+    code_challenge_methods_supported: ['S256']
+  })
+})

--- a/app/src/app/api/v0/oauth/metadata/route.ts
+++ b/app/src/app/api/v0/oauth/metadata/route.ts
@@ -5,7 +5,8 @@ import { languages } from "@/i18n/settings";
 import { hasFeatureFlag, FeatureFlags } from "@/util/feature-flags";
 import { logger } from "@/services/logger";
 
-const DOCUMENTATION_URL = 'https://github.com/Open-Earth-Foundation/CityCatalyst/wiki/CityCatalyst-Backend-API'
+const DOCUMENTATION_URL =
+  "https://github.com/Open-Earth-Foundation/CityCatalyst/wiki/CityCatalyst-Backend-API";
 
 // Definition of Authorization Server Metadata from
 // https://datatracker.ietf.org/doc/html/rfc8414#section-2
@@ -39,28 +40,30 @@ export const GET = apiHandler(async (_req) => {
   if (!hasFeatureFlag(FeatureFlags.OAUTH_ENABLED)) {
     logger.warn(
       `OAuth Metadata endpoint hit but OAuth 2.0 is not enabled.
-       Check the OAUTH_ENABLED feature flag.`
+       Check the OAUTH_ENABLED feature flag.`,
     );
     throw createHttpError.InternalServerError(
-      "OAuth 2.0 not enabled on this server"
+      "OAuth 2.0 not enabled on this server",
     );
   }
 
   const origin = _req.nextUrl.origin;
 
   if (!origin) {
-    throw createHttpError.InternalServerError('Unable to determine server origin URL');
+    throw createHttpError.InternalServerError(
+      "Unable to determine server origin URL",
+    );
   }
 
   return NextResponse.json<OAuthMetadata>({
     issuer: `${origin}/`,
     authorization_endpoint: `${origin}/authorize/`,
     token_endpoint: `${origin}/api/v0/token/`,
-    scopes_supported: ['read', 'write'],
-    response_types_supported: ['code'],
-    grant_types_supported: ['authorization_code', 'refresh_token'],
+    scopes_supported: ["read", "write"],
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
     service_documentation: DOCUMENTATION_URL,
     ui_locales_supported: languages,
-    code_challenge_methods_supported: ['S256']
-  })
-})
+    code_challenge_methods_supported: ["S256"],
+  });
+});

--- a/app/src/app/api/v0/oauth/metadata/route.ts
+++ b/app/src/app/api/v0/oauth/metadata/route.ts
@@ -7,6 +7,9 @@ import { logger } from "@/services/logger";
 
 const DOCUMENTATION_URL = 'https://github.com/Open-Earth-Foundation/CityCatalyst/wiki/CityCatalyst-Backend-API'
 
+// Definition of Authorization Server Metadata from
+// https://datatracker.ietf.org/doc/html/rfc8414#section-2
+
 interface OAuthMetadata {
   issuer: string;
   authorization_endpoint: string;

--- a/app/src/app/api/v0/oauth/metadata/route.ts
+++ b/app/src/app/api/v0/oauth/metadata/route.ts
@@ -12,6 +12,11 @@ export const GET = apiHandler(async (_req, { session }) => {
   }
 
   const origin = _req.nextUrl.origin;
+
+  if (!origin) {
+    throw createHttpError.InternalServerError('Unable to determine server origin URL');
+  }
+
   return NextResponse.json({
     issuer: `${origin}/`,
     authorization_endpoint: `${origin}/authorize/`,

--- a/app/src/app/api/v0/oauth/metadata/route.ts
+++ b/app/src/app/api/v0/oauth/metadata/route.ts
@@ -6,6 +6,31 @@ import { hasFeatureFlag, FeatureFlags } from "@/util/feature-flags";
 
 const DOCUMENTATION_URL = 'https://github.com/Open-Earth-Foundation/CityCatalyst/wiki/CityCatalyst-Backend-API'
 
+interface OAuthMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  jwks_uri?: string;
+  registration_endpoint?: string;
+  scopes_supported: string[];
+  response_types_supported: string[];
+  response_modes_supported?: string[];
+  grant_types_supported?: string[];
+  token_endpoint_auth_methods_supported?: string[];
+  token_endpoint_auth_signing_alg_values_supported?: string[];
+  service_documentation?: string;
+  ui_locales_supported?: string[];
+  op_policy_uri?: string;
+  op_tos_uri?: string;
+  revocation_endpoint?: string;
+  revocation_endpoint_auth_methods_supported?: string[];
+  revocation_endpoint_auth_signing_alg_values_supported?: string[];
+  introspection_endpoint?: string;
+  introspection_endpoint_auth_methods_supported?: string[];
+  introspection_endpoint_auth_signing_alg_values_supported?: string[];
+  code_challenge_methods_supported?: string[];
+}
+
 export const GET = apiHandler(async (_req, { session }) => {
   if (!hasFeatureFlag(FeatureFlags.OAUTH_ENABLED)) {
     throw createHttpError.InternalServerError("OAuth 2.0 not enabled");
@@ -17,7 +42,7 @@ export const GET = apiHandler(async (_req, { session }) => {
     throw createHttpError.InternalServerError('Unable to determine server origin URL');
   }
 
-  return NextResponse.json({
+  return NextResponse.json<OAuthMetadata>({
     issuer: `${origin}/`,
     authorization_endpoint: `${origin}/authorize/`,
     token_endpoint: `${origin}/api/v0/token/`,

--- a/app/src/app/api/v0/oauth/metadata/route.ts
+++ b/app/src/app/api/v0/oauth/metadata/route.ts
@@ -3,6 +3,7 @@ import createHttpError from "http-errors";
 import { NextResponse } from "next/server";
 import { languages } from "@/i18n/settings";
 import { hasFeatureFlag, FeatureFlags } from "@/util/feature-flags";
+import { logger } from "@/services/logger";
 
 const DOCUMENTATION_URL = 'https://github.com/Open-Earth-Foundation/CityCatalyst/wiki/CityCatalyst-Backend-API'
 
@@ -33,7 +34,13 @@ interface OAuthMetadata {
 
 export const GET = apiHandler(async (_req, { session }) => {
   if (!hasFeatureFlag(FeatureFlags.OAUTH_ENABLED)) {
-    throw createHttpError.InternalServerError("OAuth 2.0 not enabled");
+    logger.warn(
+      `OAuth Metadata endpoint hit but OAuth 2.0 is not enabled.
+       Check the OAUTH_ENABLED feature flag.`
+    );
+    throw createHttpError.InternalServerError(
+      "OAuth 2.0 not enabled on this server"
+    );
   }
 
   const origin = _req.nextUrl.origin;

--- a/app/src/app/api/v0/oauth/metadata/route.ts
+++ b/app/src/app/api/v0/oauth/metadata/route.ts
@@ -32,7 +32,7 @@ interface OAuthMetadata {
   code_challenge_methods_supported?: string[];
 }
 
-export const GET = apiHandler(async (_req, { session }) => {
+export const GET = apiHandler(async (_req) => {
   if (!hasFeatureFlag(FeatureFlags.OAUTH_ENABLED)) {
     logger.warn(
       `OAuth Metadata endpoint hit but OAuth 2.0 is not enabled.

--- a/app/src/middleware.ts
+++ b/app/src/middleware.ts
@@ -25,34 +25,40 @@ const excludedApi = [
   /^\/api\/v0\/auth\//,
   /^\/api\/v0\/check\//,
   /^\/api\/v0\/mock\//,
-  /^\/api\/v0\/chat\//
-]
+  /^\/api\/v0\/chat\//,
+];
 
 export async function middleware(req: NextRequestWithAuth) {
-
-  if (req.nextUrl.pathname.startsWith('/api') ||
-     req.nextUrl.pathname.startsWith('/.well-known'))
-  {
-    if (excludedApi.some(ptrn => req.nextUrl.pathname.match(ptrn))) {
+  if (
+    req.nextUrl.pathname.startsWith("/api") ||
+    req.nextUrl.pathname.startsWith("/.well-known")
+  ) {
+    if (excludedApi.some((ptrn) => req.nextUrl.pathname.match(ptrn))) {
       return NextResponse.next();
     }
-    if (req.method === 'OPTIONS') {
+    if (req.method === "OPTIONS") {
       return new Response(null, {
         status: 200,
         headers: {
-          'Access-Control-Allow-Origin': '*',
-          'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
-          'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-          'Access-Control-Max-Age': '86400', // 24 hours
-          'Access-Control-Allow-Credentials': 'false'
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "GET,POST,PUT,PATCH,DELETE,OPTIONS",
+          "Access-Control-Allow-Headers": "Content-Type, Authorization",
+          "Access-Control-Max-Age": "86400", // 24 hours
+          "Access-Control-Allow-Credentials": "false",
         },
       });
     }
     const response = NextResponse.next();
-    response.headers.set('Access-Control-Allow-Origin', '*');
-    response.headers.set('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
-    response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-    response.headers.set('Access-Control-Allow-Credentials', 'false');
+    response.headers.set("Access-Control-Allow-Origin", "*");
+    response.headers.set(
+      "Access-Control-Allow-Methods",
+      "GET,POST,PUT,PATCH,DELETE,OPTIONS",
+    );
+    response.headers.set(
+      "Access-Control-Allow-Headers",
+      "Content-Type, Authorization",
+    );
+    response.headers.set("Access-Control-Allow-Credentials", "false");
     return response;
   }
 

--- a/app/src/middleware.ts
+++ b/app/src/middleware.ts
@@ -30,7 +30,9 @@ const excludedApi = [
 
 export async function middleware(req: NextRequestWithAuth) {
 
-  if (req.nextUrl.pathname.startsWith('/api')) {
+  if (req.nextUrl.pathname.startsWith('/api') ||
+     req.nextUrl.pathname.startsWith('/.well-known'))
+  {
     if (excludedApi.some(ptrn => req.nextUrl.pathname.match(ptrn))) {
       return NextResponse.next();
     }

--- a/app/tests/api/oauth_discovery.jest.ts
+++ b/app/tests/api/oauth_discovery.jest.ts
@@ -1,28 +1,17 @@
-import {
-  GET as getMetadata,
-} from "@/app/api/v0/oauth/metadata/route";
+import { GET as getMetadata } from "@/app/api/v0/oauth/metadata/route";
 
 import { db } from "@/models";
 
-import {
-  afterAll,
-  beforeAll,
-  describe,
-  expect,
-  it,
-} from "@jest/globals";
+import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
 
-import {
-  mockRequest,
-  setupTests,
-} from "../helpers";
+import { mockRequest, setupTests } from "../helpers";
 
 import { setFeatureFlag, FeatureFlags } from "@/util/feature-flags";
 
-const URL_REGEX = /^https?:\/\/(?:(?:[a-z0-9-]+\.)+[a-z]{2,}|localhost|\d{1,3}(?:\.\d{1,3}){3})(?::\d{2,5})?(?:\/\S*)?$/
+const URL_REGEX =
+  /^https?:\/\/(?:(?:[a-z0-9-]+\.)+[a-z]{2,}|localhost|\d{1,3}(?:\.\d{1,3}){3})(?::\d{2,5})?(?:\/\S*)?$/;
 
-describe('OAuth 2.0 Authorization Server Metadata', () => {
-
+describe("OAuth 2.0 Authorization Server Metadata", () => {
   let oldFeatureFlag: boolean;
   beforeAll(async () => {
     setupTests();
@@ -36,75 +25,77 @@ describe('OAuth 2.0 Authorization Server Metadata', () => {
   });
 
   describe("GET /.well-known/oauth-authorization-server", () => {
-    let metadata: Record<string,string>
+    let metadata: Record<string, string>;
 
-    it('should return a JSON object', async () => {
+    it("should return a JSON object", async () => {
       const req = mockRequest();
       const res = await getMetadata(req, { params: Promise.resolve({}) });
       expect(res.status).toEqual(200);
-      expect(res.headers.get('Content-Type')).toEqual('application/json')
+      expect(res.headers.get("Content-Type")).toEqual("application/json");
       metadata = await res.json();
-      expect(typeof metadata).toBe('object');
-    })
+      expect(typeof metadata).toBe("object");
+    });
 
-    it('should have an issuer', () => {
-      expect(metadata).toHaveProperty('issuer');
-      expect(typeof metadata.issuer).toBe('string');
+    it("should have an issuer", () => {
+      expect(metadata).toHaveProperty("issuer");
+      expect(typeof metadata.issuer).toBe("string");
       expect(metadata.issuer).toMatch(URL_REGEX);
-    })
+    });
 
-    it('should have an authorization endpoint', () => {
-      expect(metadata).toHaveProperty('authorization_endpoint');
-      expect(typeof metadata.authorization_endpoint).toBe('string');
+    it("should have an authorization endpoint", () => {
+      expect(metadata).toHaveProperty("authorization_endpoint");
+      expect(typeof metadata.authorization_endpoint).toBe("string");
       expect(metadata.authorization_endpoint).toMatch(URL_REGEX);
-    })
+    });
 
-    it('should have a token endpoint', () => {
-      expect(metadata).toHaveProperty('token_endpoint');
-      expect(typeof metadata.token_endpoint).toBe('string');
+    it("should have a token endpoint", () => {
+      expect(metadata).toHaveProperty("token_endpoint");
+      expect(typeof metadata.token_endpoint).toBe("string");
       expect(metadata.token_endpoint).toMatch(URL_REGEX);
-    })
+    });
 
-    it('should have a list of scopes supported', () => {
-      expect(metadata).toHaveProperty('scopes_supported');
+    it("should have a list of scopes supported", () => {
+      expect(metadata).toHaveProperty("scopes_supported");
       expect(Array.isArray(metadata.scopes_supported)).toBeTruthy();
-      expect(metadata.scopes_supported).toContain('read');
-      expect(metadata.scopes_supported).toContain('write');
-    })
+      expect(metadata.scopes_supported).toContain("read");
+      expect(metadata.scopes_supported).toContain("write");
+    });
 
-    it('should have a list of response types supported', () => {
-      expect(metadata).toHaveProperty('response_types_supported');
+    it("should have a list of response types supported", () => {
+      expect(metadata).toHaveProperty("response_types_supported");
       expect(Array.isArray(metadata.response_types_supported)).toBeTruthy();
-      expect(metadata.response_types_supported).toContain('code');
-    })
+      expect(metadata.response_types_supported).toContain("code");
+    });
 
-    it('should have a list of grant types supported', () => {
-      expect(metadata).toHaveProperty('grant_types_supported');
+    it("should have a list of grant types supported", () => {
+      expect(metadata).toHaveProperty("grant_types_supported");
       expect(Array.isArray(metadata.grant_types_supported)).toBeTruthy();
-      expect(metadata.grant_types_supported).toContain('authorization_code');
-      expect(metadata.grant_types_supported).toContain('refresh_token');
-    })
+      expect(metadata.grant_types_supported).toContain("authorization_code");
+      expect(metadata.grant_types_supported).toContain("refresh_token");
+    });
 
-    it('should have a service documentation URL', () => {
-      expect(metadata).toHaveProperty('service_documentation');
-      expect(typeof metadata.issuer).toBe('string');
+    it("should have a service documentation URL", () => {
+      expect(metadata).toHaveProperty("service_documentation");
+      expect(typeof metadata.issuer).toBe("string");
       expect(metadata.service_documentation).toMatch(URL_REGEX);
-    })
+    });
 
-    it('should have a list of UI locales supported', () => {
-      expect(metadata).toHaveProperty('ui_locales_supported');
+    it("should have a list of UI locales supported", () => {
+      expect(metadata).toHaveProperty("ui_locales_supported");
       expect(Array.isArray(metadata.ui_locales_supported)).toBeTruthy();
-      expect(metadata.ui_locales_supported).toContain('de');
-      expect(metadata.ui_locales_supported).toContain('en');
-      expect(metadata.ui_locales_supported).toContain('es');
-      expect(metadata.ui_locales_supported).toContain('fr');
-      expect(metadata.ui_locales_supported).toContain('pt');
-    })
+      expect(metadata.ui_locales_supported).toContain("de");
+      expect(metadata.ui_locales_supported).toContain("en");
+      expect(metadata.ui_locales_supported).toContain("es");
+      expect(metadata.ui_locales_supported).toContain("fr");
+      expect(metadata.ui_locales_supported).toContain("pt");
+    });
 
-    it('should have a list of code challenge methods supported', () => {
-      expect(metadata).toHaveProperty('code_challenge_methods_supported');
-      expect(Array.isArray(metadata.code_challenge_methods_supported)).toBeTruthy();
-      expect(metadata.code_challenge_methods_supported).toContain('S256');
-    })
+    it("should have a list of code challenge methods supported", () => {
+      expect(metadata).toHaveProperty("code_challenge_methods_supported");
+      expect(
+        Array.isArray(metadata.code_challenge_methods_supported),
+      ).toBeTruthy();
+      expect(metadata.code_challenge_methods_supported).toContain("S256");
+    });
   });
 });

--- a/app/tests/api/oauth_discovery.jest.ts
+++ b/app/tests/api/oauth_discovery.jest.ts
@@ -1,0 +1,110 @@
+import {
+  GET as getMetadata,
+} from "@/app/api/v0/oauth/metadata/route";
+
+import { db } from "@/models";
+
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+} from "@jest/globals";
+
+import {
+  mockRequest,
+  setupTests,
+} from "../helpers";
+
+import { setFeatureFlag, FeatureFlags } from "@/util/feature-flags";
+
+const URL_REGEX = /^https?:\/\/(?:(?:[a-z0-9-]+\.)+[a-z]{2,}|localhost|\d{1,3}(?:\.\d{1,3}){3})(?::\d{2,5})?(?:\/\S*)?$/
+
+describe('OAuth 2.0 Authorization Server Metadata', () => {
+
+  let oldFeatureFlag: boolean;
+  beforeAll(async () => {
+    setupTests();
+    await db.initialize();
+    oldFeatureFlag = setFeatureFlag(FeatureFlags.OAUTH_ENABLED, true);
+  });
+
+  afterAll(async () => {
+    await db.sequelize?.close();
+    setFeatureFlag(FeatureFlags.OAUTH_ENABLED, oldFeatureFlag);
+  });
+
+  describe("GET /.well-known/oauth-authorization-server", () => {
+    let metadata: Record<string,string>
+
+    it('should return a JSON object', async () => {
+      const req = mockRequest();
+      const res = await getMetadata(req, { params: Promise.resolve({}) });
+      expect(res.status).toEqual(200);
+      expect(res.headers.get('Content-Type')).toEqual('application/json')
+      metadata = await res.json();
+      expect(typeof metadata).toBe('object');
+    })
+
+    it('should have an issuer', () => {
+      expect(metadata).toHaveProperty('issuer');
+      expect(typeof metadata.issuer).toBe('string');
+      expect(metadata.issuer).toMatch(URL_REGEX);
+    })
+
+    it('should have an authorization endpoint', () => {
+      expect(metadata).toHaveProperty('authorization_endpoint');
+      expect(typeof metadata.authorization_endpoint).toBe('string');
+      expect(metadata.authorization_endpoint).toMatch(URL_REGEX);
+    })
+
+    it('should have a token endpoint', () => {
+      expect(metadata).toHaveProperty('token_endpoint');
+      expect(typeof metadata.token_endpoint).toBe('string');
+      expect(metadata.token_endpoint).toMatch(URL_REGEX);
+    })
+
+    it('should have a list of scopes supported', () => {
+      expect(metadata).toHaveProperty('scopes_supported');
+      expect(Array.isArray(metadata.scopes_supported)).toBeTruthy();
+      expect(metadata.scopes_supported).toContain('read');
+      expect(metadata.scopes_supported).toContain('write');
+    })
+
+    it('should have a list of response types supported', () => {
+      expect(metadata).toHaveProperty('response_types_supported');
+      expect(Array.isArray(metadata.response_types_supported)).toBeTruthy();
+      expect(metadata.response_types_supported).toContain('code');
+    })
+
+    it('should have a list of grant types supported', () => {
+      expect(metadata).toHaveProperty('grant_types_supported');
+      expect(Array.isArray(metadata.grant_types_supported)).toBeTruthy();
+      expect(metadata.grant_types_supported).toContain('authorization_code');
+      expect(metadata.grant_types_supported).toContain('refresh_token');
+    })
+
+    it('should have a service documentation URL', () => {
+      expect(metadata).toHaveProperty('service_documentation');
+      expect(typeof metadata.issuer).toBe('string');
+      expect(metadata.service_documentation).toMatch(URL_REGEX);
+    })
+
+    it('should have a list of UI locales supported', () => {
+      expect(metadata).toHaveProperty('ui_locales_supported');
+      expect(Array.isArray(metadata.ui_locales_supported)).toBeTruthy();
+      expect(metadata.ui_locales_supported).toContain('de');
+      expect(metadata.ui_locales_supported).toContain('en');
+      expect(metadata.ui_locales_supported).toContain('es');
+      expect(metadata.ui_locales_supported).toContain('fr');
+      expect(metadata.ui_locales_supported).toContain('pt');
+    })
+
+    it('should have a list of code challenge methods supported', () => {
+      expect(metadata).toHaveProperty('code_challenge_methods_supported');
+      expect(Array.isArray(metadata.code_challenge_methods_supported)).toBeTruthy();
+      expect(metadata.code_challenge_methods_supported).toContain('S256');
+    })
+  });
+});


### PR DESCRIPTION
In reviewing libraries to suggest for POC clients, I found that a lot of them used [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) for configuration, figuring out the right endpoints and options for the OAuth process. The RFC defines an url, `/.well-known/oauth-authorization-server`, which should return a JSON object with certain properties that describe the layout and configuration of the OAuth 2.0 server. Note that the endpoint has to be at that specific URL on the server; see [RFC 8615](https://datatracker.ietf.org/doc/html/rfc8615) for a description of how Well-Known URIs work.

This PR implements the endpoint. It uses the `rewrites` feature of NextJS to avoid having a ".well-known" directory, which would be a hidden directory on Unix-like systems (because of the initial "."). It also exempts .well-known from language redirects, like `api` URLs. There is a unit test to make sure the endpoint exists and returns metadata in the correct format.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement OAuth 2.0 Discovery by adding a new endpoint that serves the OAuth 2.0 authorization server metadata, including rewrites to support the new path, updating middleware to accommodate the discovery endpoint, and creating comprehensive tests to validate the new functionality.

### Why are these changes being made?

These changes are made to support OAuth 2.0 functionality, allowing clients to discover the necessary metadata for authorization dynamically. This implementation is crucial for enabling a standard authorization framework, ensuring easy integration with OAuth 2.0 clients, promoting interoperability, and enhancing security.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->