### PR TITLE
fix(api, ui): 0% of sector emissions on report sector table

### DIFF
--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/ByScopeView.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/ByScopeView.tsx
@@ -95,19 +95,23 @@ const ByScopeView: React.FC<ByScopeViewProps> = ({
         </Table.Cell>
       ))}
       <Table.Cell>
-        <BodyMedium
-          color="content.link"
-          textDecoration={"underline"}
-          textTransform={"uppercase"}
-          fontWeight={"bold"}
-          onClick={(e) => {
-            e.stopPropagation();
-            setSelectedSourceId(item.datasource_id || "");
-            onSourceDrawerOpen();
-          }}
-        >
-          {item.datasource_name || tDashboard("N/A")}
-        </BodyMedium>
+        {item.datasource_name ? (
+          <BodyMedium
+            color="content.link"
+            textDecoration={"underline"}
+            textTransform={"uppercase"}
+            fontWeight={"bold"}
+            onClick={(e) => {
+              e.stopPropagation();
+              setSelectedSourceId(item.datasource_id || "");
+              onSourceDrawerOpen();
+            }}
+          >
+            {item.datasource_name}
+          </BodyMedium>
+        ) : (
+          <BodyMedium color="content.secondary">{tDashboard("n-a")}</BodyMedium>
+        )}
       </Table.Cell>
       <Table.Cell></Table.Cell>
     </Table.Row>

--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/ByScopeView.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/ByScopeView.tsx
@@ -140,7 +140,7 @@ const ByScopeView: React.FC<ByScopeViewProps> = ({
     const isExpanded = expandedSubsectors.has(subsector);
 
     return (
-      <Box key={subsector}>
+      <React.Fragment key={subsector}>
         <Table.Row
           cursor="pointer"
           onClick={() => toggleSubsector(subsector)}
@@ -188,7 +188,7 @@ const ByScopeView: React.FC<ByScopeViewProps> = ({
           activities.map((item, index) =>
             renderActivityRow(item, `${item.activityTitle}-${index}`),
           )}
-      </Box>
+      </React.Fragment>
     );
   };
 

--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/ByScopeView.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/ByScopeView.tsx
@@ -196,28 +196,30 @@ const ByScopeView: React.FC<ByScopeViewProps> = ({
     <Box py={4}>
       <Table.Root variant="line">
         <Table.Header textTransform="uppercase">
-          <Table.ColumnHeader>
-            <ButtonSmall>{tData("subsector")}</ButtonSmall>
-          </Table.ColumnHeader>
-          <Table.ColumnHeader>
-            <ButtonSmall>{tDashboard("total-emissions")}</ButtonSmall>
-          </Table.ColumnHeader>
-          <Table.ColumnHeader>
-            <ButtonSmall>{tDashboard("%-of-sector-emissions")}</ButtonSmall>
-          </Table.ColumnHeader>
-          {scopes.map((s) => (
-            <Table.ColumnHeader key={s}>
-              <ButtonSmall>
-                {tDashboard("emissions-scope")} {s}
-              </ButtonSmall>
+          <Table.Row>
+            <Table.ColumnHeader>
+              <ButtonSmall>{tData("subsector")}</ButtonSmall>
             </Table.ColumnHeader>
-          ))}
-          <Table.ColumnHeader>
-            <ButtonSmall>{tDashboard("source")}</ButtonSmall>
-          </Table.ColumnHeader>
-          <Table.ColumnHeader>
-            {/* this is where the chevron is */}
-          </Table.ColumnHeader>
+            <Table.ColumnHeader>
+              <ButtonSmall>{tDashboard("total-emissions")}</ButtonSmall>
+            </Table.ColumnHeader>
+            <Table.ColumnHeader>
+              <ButtonSmall>{tDashboard("%-of-sector-emissions")}</ButtonSmall>
+            </Table.ColumnHeader>
+            {scopes.map((s) => (
+              <Table.ColumnHeader key={s}>
+                <ButtonSmall>
+                  {tDashboard("emissions-scope")} {s}
+                </ButtonSmall>
+              </Table.ColumnHeader>
+            ))}
+            <Table.ColumnHeader>
+              <ButtonSmall>{tDashboard("source")}</ButtonSmall>
+            </Table.ColumnHeader>
+            <Table.ColumnHeader>
+              {/* this is where the chevron is */}
+            </Table.ColumnHeader>
+          </Table.Row>
         </Table.Header>
         <Table.Body>
           {Object.entries(groupedData).map(([subsector, activities]) =>

--- a/app/src/backend/ResultsService.ts
+++ b/app/src/backend/ResultsService.ts
@@ -407,21 +407,19 @@ export const getEmissionsBreakdownBatch = async (
       (e) => `${e.subsector_name}-${e.datasource_id}`,
     );
 
-    const totalEmissions = bigIntToDecimal(
-      emissionsForSector.reduce((sum, item) => {
-        // Sum the co2eq from all activities for this inventory value
-        if (item.activities.length > 0) {
-          const activitySum = item.activities.reduce(
-            (activitySum, activity) =>
-              activitySum + BigInt(activity.co2eq || 0n),
-            0n,
-          );
-          return sum + activitySum;
-        } else {
-          return sum + (item.co2eq || 0n);
-        }
-      }, 0n),
-    );
+    const totalEmissions = emissionsForSector.reduce((sum, item) => {
+      // Sum the co2eq from all activities for this inventory value
+      if (item.activities.length > 0) {
+        const activitySum = item.activities.reduce(
+          (activitySum, activity) =>
+            activitySum.plus(bigIntToDecimal(activity.co2eq ?? 0n)),
+          new Decimal(0),
+        );
+        return sum.plus(activitySum);
+      } else {
+        return sum.plus(bigIntToDecimal(item.co2eq ?? 0n));
+      }
+    }, new Decimal(0));
 
     const resultsByScope = Object.entries(bySubSectorAndDataSource).map(
       ([_subsectorAndDataSource, scopeValues]) => {

--- a/app/src/backend/ResultsService.ts
+++ b/app/src/backend/ResultsService.ts
@@ -429,7 +429,7 @@ export const getEmissionsBreakdownBatch = async (
         const byScope = groupBy(scopeValues, "scope_name");
 
         const scopes: { [key: string]: Decimal } = {};
-        let totalSectorEmissions = new Decimal(0);
+        let totalSubSectorEmissions = new Decimal(0);
 
         // Aggregate emissions by scope
         Object.entries(byScope).forEach(([scopeName, scopeItems]) => {
@@ -448,7 +448,8 @@ export const getEmissionsBreakdownBatch = async (
             }
           }, new Decimal(0));
           scopes[scopeName] = scopeEmissions;
-          totalSectorEmissions = totalSectorEmissions.plus(scopeEmissions);
+          totalSubSectorEmissions =
+            totalSubSectorEmissions.plus(scopeEmissions);
           return scopeEmissions;
         });
 
@@ -457,11 +458,16 @@ export const getEmissionsBreakdownBatch = async (
           (scopeValue) => scopeValue.activities,
         );
 
+        const percentage = calculatePercentage(
+          totalSubSectorEmissions,
+          totalEmissions,
+        );
+
         return {
           activityTitle: scopeValues[0].subsector_name,
           scopes,
-          totalEmissions: totalSectorEmissions,
-          percentage: calculatePercentage(totalSectorEmissions, totalEmissions),
+          totalEmissions: totalSubSectorEmissions,
+          percentage,
           datasource_id: scopeValues[0].datasource_id,
           datasource_name: scopeValues[0].datasource_name,
           activities,


### PR DESCRIPTION
Also fixes that some of the rows in the table weren't full width by using React.Fragment instead of <> or <Box>, so the key attribute can be supplied to it but the rows are direct children of the table body.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Replace `Box` components with `React.Fragment` in `ByScopeView.tsx` and refactor emission calculations to improve accuracy and replace `bigIntToDecimal` conversions with `Decimal` in `ResultsService.ts` for calculating subsector emissions percentage accurately in reports.

### Why are these changes being made?

The `React.Fragment` usage instead of `Box` is intended to eliminate redundant DOM nodes and improve rendering performance. The refactoring in `ResultsService.ts` is aimed at fixing issues where emission percentages were inaccurately calculated due to improper usage of `bigIntToDecimal`, allowing for more precise financial calculations using `Decimal`. This approach is favored to ensure data integrity and consistency across reports, presenting the right emissions data for decision-making.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->