### PR TITLE
fix: show correct emission factors for masses from ipcc

### DIFF
--- a/app/src/hooks/activity-value-form/use-emission-factors.ts
+++ b/app/src/hooks/activity-value-form/use-emission-factors.ts
@@ -66,7 +66,9 @@ const reduceEmissionsToUniqueSourcesAndUnits = (
             gasValues: uniqBy(
               source.gasValuesByGas[currentValue].gasValues,
               "emissionsPerActivity",
-            ).filter((factor) => ["kg/m3", "kg/kWh"].includes(factor.units)), // filter only emissions that have kg/m3 or kg/kWh as the unit
+            ).filter((factor) =>
+              ["kg/m3", "kg/kWh", "kg/kg"].includes(factor.units),
+            ), // filter only emissions that have kg/m3, kg/kWh, or kg/kg as the unit
           },
         };
       },


### PR DESCRIPTION
Changes
- Modifies emission factors filter (FE) to include kg/kg units
- Sets fallback units for emission factors
- Dynamilly renders units from emission factors data

<img width="1240" height="578" alt="image" src="https://github.com/user-attachments/assets/98e88bbd-9ac1-419f-8f71-409c824e5d14" /><!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Update the calculation and display logic for emission factors to dynamically determine and show correct units based on IPCC methodology, including support for "kg/kg" units.

### Why are these changes being made?
These changes ensure that the emission factors are displayed with the appropriate units according to the methodology by removing hardcoded unit assignments and enabling dynamic detection, which improves accuracy and flexibility in the emission factor module. The addition of "kg/kg" further supports broader applicability in various scenarios, aligning with user needs and IPCC standards.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->