### PR TITLE
[ON-4700] Fix Circle Progress value > 100

### DIFF
--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsWidget.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsWidget.tsx
@@ -1,4 +1,4 @@
-import { convertKgToTonnes } from "@/util/helpers";
+import { convertKgToTonnes, clamp } from "@/util/helpers";
 import {
   Box,
   Card,
@@ -47,7 +47,7 @@ const EmissionsWidgetCard = ({
         <HStack align="start">
           {value && showProgress ? (
             <ProgressCircleRoot
-              value={Math.round(value)}
+              value={Math.round(clamp(value, 0, 100))}
               size="sm"
               color="interactive.secondary"
               mr="4px"
@@ -84,8 +84,13 @@ const EmissionsWidget = ({
   // Country total is in tonnes, inventory total is in kg
   const percentageOfCountrysEmissions =
     inventory?.totalEmissions && inventory?.totalCountryEmissions
-      ? (inventory.totalEmissions / (inventory.totalCountryEmissions * 1000)) *
-        100
+      ? clamp(
+          (inventory.totalEmissions /
+            (inventory.totalCountryEmissions * 1000)) *
+            100,
+          0,
+          100,
+        )
       : undefined;
   const emissionsPerCapita =
     inventory?.totalEmissions && population?.population

--- a/app/src/components/Cards/SectorCard.tsx
+++ b/app/src/components/Cards/SectorCard.tsx
@@ -117,9 +117,7 @@ export function SectorCard({
               </Heading>
             </Box>
             <Box>
-              <NextLink
-                href={`${pathname}/data/${sector.number}`}
-              >
+              <NextLink href={`${pathname}/data/${sector.number}`}>
                 <Button
                   variant="outline"
                   borderWidth={2}
@@ -178,9 +176,11 @@ export function SectorCard({
                       title={t(subSector.subsectorName ?? "unnamed-sector")}
                       scopes={(sectorScopes || []).join(", ")}
                       isCompleted={subSector.completed}
-                      percentageCompletion={
-                        (subSector.completedCount / subSector.totalCount) * 100
-                      }
+                      percentageCompletion={clamp(
+                        (subSector.completedCount / subSector.totalCount) * 100,
+                        0,
+                        100,
+                      )}
                     />
                   </NextLink>
                 ))}

--- a/app/src/components/Cards/SubSectorCard.tsx
+++ b/app/src/components/Cards/SubSectorCard.tsx
@@ -7,6 +7,7 @@ import {
   ProgressCircleRing,
   ProgressCircleRoot,
 } from "@/components/ui/progress-circle";
+import { clamp } from "@/util/helpers";
 
 interface SubSectorCardProps {
   title: string;
@@ -38,7 +39,7 @@ const SubSectorCard: FC<SubSectorCardProps> = ({
       {percentageCompletion > 0 && percentageCompletion < 100 ? (
         <ProgressCircleRoot
           size="xs"
-          value={percentageCompletion}
+          value={clamp(percentageCompletion, 0, 100)}
           color="background.neutral"
           mr={4}
         >


### PR DESCRIPTION
when value is > 100, the component throws an exception. in the case of the bug report, the Inventory emissions was much larger than the Country's emissions, causing the ratio between them to be > 1.