### PR TITLE
fix: prevent i18n language fallback on navigation

### DIFF
--- a/app/src/components/navigation-bar.tsx
+++ b/app/src/components/navigation-bar.tsx
@@ -222,25 +222,6 @@ export function NavigationBar({
             )}
           </Box>
           <Box flex={1} />
-          {showNav && !isPublic && (
-            <>
-              {!isAuth && (
-                <Link width={9} height={9} href={dashboardPath}>
-                  <Image
-                    src="/assets/logo.svg"
-                    width={36}
-                    height={36}
-                    alt="CityCatalyst logo"
-                  />
-                </Link>
-              )}
-              <Link href={dashboardPath}>
-                <Heading size="lg" color="base.light">
-                  {t("title")}
-                </Heading>
-              </Link>
-            </>
-          )}
         </Box>
         <Box flex={1} />
         {showNav && !isPublic && (


### PR DESCRIPTION
Changes
- Make i18next cookie the single source of truth
- Remove referer-based language detection that overwrote cookie
- Redirect to cookie language when URL mismatch occurs
- Use router.replace() instead of history.replaceState() for language switching
- Indentation issues in the navbar