### PR TITLE
fix: adds sengment id directly to i18n str function

### DIFF
--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionBySectorChart.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionBySectorChart.tsx
@@ -273,7 +273,7 @@ const EmissionBySectorChart: React.FC<EmissionBySectorChartProps> = ({
                     flex={1}
                     color="content.secondary"
                   >
-                    {tDashboard(shortSectorNameToKebabCase(segment.id))}
+                    {tDashboard(segment.id)}
                   </Text>
                   <Text
                     fontSize="body.md"


### PR DESCRIPTION
Changes
- Removes `shortSectorNameToKebabCase()` causing the translation string to have an duplicate -short suffix at the end
<img width="619" height="706" alt="image" src="https://github.com/user-attachments/assets/835a2679-b4ca-4a6d-bb78-d0fdcb965ac5" />
