### PR TITLE
fix(ui): add minHeight to heading of ClimateActionCard's action cards

### DIFF
--- a/app/src/components/ClimateActionCard.tsx
+++ b/app/src/components/ClimateActionCard.tsx
@@ -111,6 +111,7 @@ export const ClimateActionCard = ({
           whiteSpace="nowrap"
           lineClamp={2}
           color="content.secondary"
+          minHeight="300px"
         >
           {action.name}
         </TitleLarge>
@@ -255,7 +256,6 @@ const GeneratePlanDialog = ({
     language: action.lang || "en",
   });
 
-  
   const planToDisplay = existingPlan?.planData;
   const hasExistingPlan = !!existingPlan;
 


### PR DESCRIPTION
To fix layout with shorter action titles

<img width="1297" height="807" alt="image" src="https://github.com/user-attachments/assets/8a59823d-680a-4374-b1cf-9ea75d527e57" />
