### PR TITLE
feat: add key impacts column to the actions list

### DIFF
--- a/global-api/migrations/versions/2c02fff0607f_add_key_impacts_actions.py
+++ b/global-api/migrations/versions/2c02fff0607f_add_key_impacts_actions.py
@@ -1,0 +1,31 @@
+"""add_key_impacts_actions
+
+Revision ID: 2c02fff0607f
+Revises: d3f9011814f9
+Create Date: 2025-11-17 04:33:26.422483
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ARRAY
+
+
+# revision identifiers, used by Alembic.
+revision: str = '2c02fff0607f'
+down_revision: Union[str, None] = 'd3f9011814f9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'cap_climate_action',
+        sa.Column('key_impacts', ARRAY(sa.String), nullable=True),
+        schema='modelled'
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('cap_climate_action', 'key_impacts', schema='modelled')

--- a/global-api/routes/get_climate_actions.py
+++ b/global-api/routes/get_climate_actions.py
@@ -40,6 +40,7 @@ def db_climate_actions() -> List[Dict[str, Any]]:
                 timeline_for_implementation,
                 dependencies,
                 key_performance_indicators,
+                key_impacts,
                 powers_and_mandates,
                 json_build_object(
                     'droughts', adaptation_effectiveness_droughts,
@@ -103,6 +104,7 @@ def get_climate_actions(
                 "TimelineForImplementation": response.get("timeline_for_implementation"),
                 "Dependencies": dependencies,
                 "KeyPerformanceIndicators": key_performance_indicators,
+                "KeyImpacts": response.get("key_impacts"),
                 "PowersAndMandates": response.get("powers_and_mandates"),
                 "AdaptationEffectivenessPerHazard": response.get("adaptationeffectivenessperhazard"),
                 "biome": response.get("biome"),


### PR DESCRIPTION
- Added key_impacts (VARCHAR[]) to modelled.cap_climate_action via new Alembic migration.
- Extended GET /api/v0/climate_actions to select and return the new KeyImpacts field so can see the data alongside existing attributes.