### PR TITLE
fix(ON-5074): Add CityId and InventoryId to action plan schema

### DIFF
--- a/app/migrations/20251208124249-action-plan-add-inventory-id-city-id.cjs
+++ b/app/migrations/20251208124249-action-plan-add-inventory-id-city-id.cjs
@@ -1,0 +1,26 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Add inventory_id column
+    await queryInterface.addColumn("ActionPlan", "inventory_id", {
+      type: Sequelize.UUID,
+      allowNull: true,
+      comment: "Reference to the inventory",
+    });
+
+    // Add city_id column
+    await queryInterface.addColumn("ActionPlan", "city_id", {
+      type: Sequelize.UUID,
+      allowNull: true,
+      comment: "Reference to the city",
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Remove columns
+    await queryInterface.removeColumn("ActionPlan", "inventory_id");
+    await queryInterface.removeColumn("ActionPlan", "city_id");
+  },
+};

--- a/app/src/backend/hiap/ActionPlanService.ts
+++ b/app/src/backend/hiap/ActionPlanService.ts
@@ -11,6 +11,8 @@ export interface CreateActionPlanInput {
   actionId: string;
   highImpactActionRankedId?: string;
   cityLocode: string;
+  cityId?: string;
+  inventoryId?: string;
   actionName: string;
   language: string;
 
@@ -69,6 +71,7 @@ export interface UpsertActionPlanInput {
   highImpactActionRankedId?: string;
   cityId: string;
   cityLocode: string;
+  inventoryId?: string;
   actionName: string;
   language: string;
   planData: any; // Legacy HIAP API format - will be transformed
@@ -160,6 +163,8 @@ export default class ActionPlanService {
         actionId: input.actionId,
         highImpactActionRankedId: input.highImpactActionRankedId,
         cityLocode: input.cityLocode,
+        cityId: input.cityId,
+        inventoryId: input.inventoryId,
         actionName: input.actionName,
         language: input.language,
         cityName: input.cityName,
@@ -360,6 +365,8 @@ export default class ActionPlanService {
           actionId: input.actionId,
           highImpactActionRankedId: input.highImpactActionRankedId,
           cityLocode: input.cityLocode,
+          cityId: input.cityId,
+          inventoryId: input.inventoryId,
           actionName: input.actionName,
           language: input.language,
           createdBy: input.createdBy,

--- a/app/src/backend/hiap/HiapApiService.ts
+++ b/app/src/backend/hiap/HiapApiService.ts
@@ -127,8 +127,8 @@ const startPrioritizationImpl = async (
   if (!response.ok) {
     const errorText = await response.text();
     logger.error(
-      { 
-        status: response.status, 
+      {
+        status: response.status,
         statusText: response.statusText,
         error: errorText,
         requestBody: body,
@@ -352,6 +352,7 @@ const startActionPlanJobImpl = async ({
         actionId: action.actionId,
         highImpactActionRankedId: action.hiaRankingId, // This should be the ranked ID, not ranking ID
         cityLocode,
+        inventoryId,
         actionName: action.name,
         language: lng,
         planData,
@@ -470,10 +471,12 @@ const startBulkPrioritizationImpl = async (
         prioritizationType: type,
         language: languages,
       },
-      sampleCityData: citiesData[0] ? {
-        cityContextData: citiesData[0].cityContextData,
-        cityEmissionsData: citiesData[0].cityEmissionsData,
-      } : null,
+      sampleCityData: citiesData[0]
+        ? {
+            cityContextData: citiesData[0].cityContextData,
+            cityEmissionsData: citiesData[0].cityEmissionsData,
+          }
+        : null,
     },
     "🔍 DETAILED startBulkPrioritization request payload",
   );
@@ -495,7 +498,7 @@ const startBulkPrioritizationImpl = async (
   if (!response.ok) {
     const errorText = await response.text();
     logger.error(
-      { 
+      {
         status: response.status,
         statusText: response.statusText,
         error: errorText,

--- a/app/src/models/ActionPlan.ts
+++ b/app/src/models/ActionPlan.ts
@@ -6,6 +6,8 @@ export interface ActionPlanAttributes {
   actionId: string;
   highImpactActionRankedId?: string | null;
   cityLocode: string;
+  cityId?: string | null;
+  inventoryId?: string | null;
   actionName: string;
   language: string;
 
@@ -40,6 +42,8 @@ export type ActionPlanId = ActionPlan[ActionPlanPk];
 export type ActionPlanOptionalAttributes =
   | "id"
   | "highImpactActionRankedId"
+  | "cityId"
+  | "inventoryId"
   | "cityName"
   | "createdAtTimestamp"
   | "cityDescription"
@@ -70,6 +74,8 @@ export class ActionPlan
   declare actionId: string;
   declare highImpactActionRankedId?: string | null;
   declare cityLocode: string;
+  declare cityId?: string | null;
+  declare inventoryId?: string | null;
   declare actionName: string;
   declare language: string;
 
@@ -121,6 +127,16 @@ export class ActionPlan
           type: DataTypes.STRING,
           allowNull: false,
           field: "city_locode",
+        },
+        cityId: {
+          type: DataTypes.UUID,
+          allowNull: true,
+          field: "city_id",
+        },
+        inventoryId: {
+          type: DataTypes.UUID,
+          allowNull: true,
+          field: "inventory_id",
         },
         actionName: {
           type: DataTypes.STRING,


### PR DESCRIPTION
changes
- Adds migration to include cityId and inventoryId to database
- Adds Ids to action plan schema
- Updates services
<img width="764" height="260" alt="image" src="https://github.com/user-attachments/assets/0089294b-1f1f-4f99-8fa9-6672983ebe5e" />
