### PR TITLE
ON-5428: implement hard-filter pipeline with mock-first data clients and paired artifacts

### DIFF
--- a/hiap-meed/.env.example
+++ b/hiap-meed/.env.example
@@ -9,4 +9,10 @@ ARTIFACT_LOG_JSONL=true
 # output folder for file logs and request artifacts
 LOG_DIR=logs
 
+# legal hard-filter data source: mock | stub | api
+HIAP_MEED_LEGAL_DATA_SOURCE=mock
+
+# action catalog source: mock | stub | api
+HIAP_MEED_ACTION_DATA_SOURCE=mock
+
 

--- a/hiap-meed/.env.example
+++ b/hiap-meed/.env.example
@@ -9,10 +9,13 @@ ARTIFACT_LOG_JSONL=true
 # output folder for file logs and request artifacts
 LOG_DIR=logs
 
-# legal hard-filter data source: mock | stub | api
+# city data source: mock | api
+HIAP_MEED_CITY_DATA_SOURCE=mock
+
+# legal hard-filter data source: mock | api
 HIAP_MEED_LEGAL_DATA_SOURCE=mock
 
-# action catalog source: mock | stub | api
+# action catalog source: mock | api
 HIAP_MEED_ACTION_DATA_SOURCE=mock
 
 

--- a/hiap-meed/AGENTS.md
+++ b/hiap-meed/AGENTS.md
@@ -228,9 +228,6 @@ def setup_logger() -> None:
         datefmt="%Y-%m-%d %H:%M:%S",
         force=True,
     )
-
-
-__all__ = ["setup_logger"]
 ```
 
 - Log key steps and important parameters, do not log secrets.
@@ -259,6 +256,7 @@ __all__ = ["setup_logger"]
 
 - Strictly use **absolute imports**, for example `from app.utils.foo import bar`. Do not use relative imports.
 - Always run scripts as modules using `python -m ...` from the project root.
+- Do not define module-level `__all__` export lists. With absolute imports, explicit symbol imports at the call site are clearer and avoid hidden export contracts.
 - **Never use wildcard imports** (`from module import *`). Always explicitly name the functions, classes, or objects you are importing.
   - Bad: `from app.utils.helpers import *`
   - Good: `from app.utils.helpers import parse_config, validate_input`
@@ -330,6 +328,7 @@ When making changes:
 ## Quick checklist for contributions
 
 - [ ] `__init__.py` present in all code folders (empty or docstring-only — no imports or re-exports)
+- [ ] No module-level `__all__` export lists
 - [ ] No duplication (helpers in utils where appropriate)
 - [ ] Clear separation of concerns (services vs utils vs scripts)
 - [ ] Runnable scripts: docstring, argparse, `__main__`

--- a/hiap-meed/AGENTS.md
+++ b/hiap-meed/AGENTS.md
@@ -208,6 +208,13 @@ if __name__ == "__main__":
     - side effects (filesystem/DB/network, mutations, logging, caching)
     - raised exceptions (when non-obvious)
 
+### Logical block comments inside functions
+
+- Use short `#` comments to mark **logical blocks** in non-trivial functions (for example: `# Step 1: validate input`, `# Apply hard legal gate`).
+- Prefer comments that explain **why/intent**, not line-by-line restatements of obvious code.
+- Keep comments concise and stable; avoid noisy or redundant comments.
+- Add these comments when they materially improve scanability for future maintainers.
+
 ### Logging is required
 
 - Use Python’s `logging` module, do not use `print`, except in rare CLI UX cases where it is explicitly intended.

--- a/hiap-meed/AGENTS.md
+++ b/hiap-meed/AGENTS.md
@@ -210,10 +210,11 @@ if __name__ == "__main__":
 
 ### Logical block comments inside functions
 
-- Use short `#` comments to mark **logical blocks** in non-trivial functions (for example: `# Step 1: validate input`, `# Apply hard legal gate`).
+- Always use short `#` comments to mark **logical blocks** in non-trivial functions (for example: `# Step 1: validate input`, `# Apply hard legal gate`).
+- In orchestration-style functions, clearly separate fetch, transform, scoring, artifact/logging, and response assembly sections with these comments.
 - Prefer comments that explain **why/intent**, not line-by-line restatements of obvious code.
 - Keep comments concise and stable; avoid noisy or redundant comments.
-- Add these comments when they materially improve scanability for future maintainers.
+- Treat these comments as required readability scaffolding, not an optional style preference.
 
 ### Logging is required
 

--- a/hiap-meed/Dockerfile
+++ b/hiap-meed/Dockerfile
@@ -15,6 +15,9 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Copy the application package
 COPY app/ ./app/
 
+# TODO: Remove this once we have a real data source
+COPY data/ ./data/
+
 # Make the run.sh file executable
 RUN chmod +x app/run.sh
 

--- a/hiap-meed/Implementation-plan-hard-filter.md
+++ b/hiap-meed/Implementation-plan-hard-filter.md
@@ -1,0 +1,237 @@
+# Implementation plan: Hard Filter block (`hiap-meed/app/modules/prioritizer/blocks/hard_filter.py`)
+
+## Goal
+
+Extend the Hard Filter block to match the architecture and Notion “Data Reviews” intent:
+
+- **Gate 1**: Explicit city exclusions (provided as free text by the frontend; **stubbed for now**)
+- **Gate 2**: **Hard legal requirements** (if not satisfied → remove before scoring)
+
+Inputs and behaviors must align with:
+
+- `hiap-meed/docs/detailed-block-architecture.md` (Hard Filter Architecture)
+- Notion “Data Reviews” page: `https://www.notion.so/openearth/Data-Reviews-2eceb557728b808e9537da57340bf43a`
+  - Especially the “Regulations and Mandates” section and the child page “How Legal Signals, Policy Signals, and Socioeconomic Indicators Work in HIAP Ranking”.
+
+## Current state (repo)
+
+- The frontend request payload provides exclusions as `FrontendCityInput.excludedActionsFreeText` (free text).
+- `hard_filter.run(actions, excluded_actions_free_text)` now receives free text directly.
+- The Hard Filter block is already split into two explicit sub-filters:
+  - `_apply_free_text_exclusion_filter(...)`
+  - `_apply_legal_hard_filter(...)`
+- Free-text exclusions are currently **stubbed**:
+  - `_resolve_excluded_action_ids_from_text(...)` returns an empty set, so no actions are excluded yet from free text.
+- Legal hard filtering is currently **stubbed**:
+  - `_apply_legal_hard_filter(...)` does not discard actions yet and marks evidence with `legal_filter_status = "not_applied_stub"`.
+- `HardFilterResult` currently has no explicit bucket for “discarded due to legal mismatch”.
+- The orchestrator calls hard filter before scoring and attaches `hard_filter_result.evidence[action_id]` into the final response evidence.
+
+Relevant files:
+
+- `hiap-meed/app/modules/prioritizer/blocks/hard_filter.py`
+- `hiap-meed/app/modules/prioritizer/internal_models.py`
+- `hiap-meed/app/modules/prioritizer/orchestrator.py`
+- `hiap-meed/app/services/data_clients.py`
+- `hiap-meed/tests/integration/test_prioritize_smoke.py`
+
+## Available legal data in this repo (mock + models)
+
+Mock payload:
+
+- `hiap-meed/data/mock/actions_legal_api_mock.json`
+  - `legal_requirements[]`: `{ action_id, requirements[] }`
+  - Requirement fields include:
+    - `strength`: `mandatory | required | recommended | optional | informational`
+    - `alignment_status`: `aligns | not_aligned | no_evidence`
+    - plus `signal_code`, `signal_name`, `operator`, values, evidence IDs, scope metadata
+
+DTOs already exist in:
+
+- `hiap-meed/app/modules/prioritizer/models.py`
+  - `LegalRequirement`, `LegalRequirementsByAction`, `ActionsLegalApiResponse`
+
+Note: Notion uses a conceptual `hard | soft | constraint` strength scale. The repo mock uses the 5-level scale above. This plan maps those to “hard gate” behavior without introducing new external dependencies.
+
+## Target behavior specification (repo-aligned, next increment)
+
+### Hard legal requirement mapping (to implement next)
+
+Define “hard legal requirements” as:
+
+- `strength in {"mandatory", "required"}`
+
+Hard legal gate evaluation per action:
+
+- **Pass (clean)**: all hard requirements have `alignment_status == "aligns"`
+- **Pass (unknown flagged)**: one or more hard requirements have `alignment_status == "no_evidence"` and none are `not_aligned`
+  - Result: action is **kept**, but the unknown requirement(s) are surfaced in `HardFilterResult.evidence` for frontend flagging
+- **Fail**: any hard requirement has `alignment_status == "not_aligned"`
+  - Result: action is **discarded** (not sent to scoring blocks)
+
+Handling missing legal data:
+
+- If no legal requirements are available for an action (no record), treat as **no hard requirements** and **pass**.
+  - Rationale: prevents missing upstream enrichment from blocking the pipeline during development.
+
+### Evidence contract (Hard Filter)
+
+`HardFilterResult.evidence[action_id]` should be expanded to be explicit and UI-friendly:
+
+- For excluded actions:
+  - `discard_reason`: `"excluded"`
+  - `matched_excluded_action_id`: `<action_id>`
+- For legal discards:
+  - `discard_reason`: `"legal_hard_requirement_failed"`
+  - `failed_requirements`: list of (signal_code, strength, alignment_status, required_value, legal_signal_value, evidence_ids, evidence_count, location_scope, location_name)
+  - Summary fields (always included when legal requirements are provided to the block):
+    - `hard_requirements_checked_count`: number of hard requirements evaluated
+      - Useful for debugging “why did this get blocked?” and for monitoring coverage (how many actions actually have hard legal gates configured).
+    - `hard_requirements_failed_count`: number of hard requirements with `alignment_status == "not_aligned"`
+      - Useful for UI messaging (“blocked by 1 hard legal condition”) and for QA to spot overly strict or misconfigured requirements.
+- For actions that pass:
+  - `discard_reason`: `None`
+  - Legal trace fields (always included when legal requirements are provided to the block):
+    - `hard_requirements_checked_count`: number of hard requirements evaluated
+      - Useful to distinguish “no requirements configured” vs “requirements configured and passed”.
+    - `unknown_requirements`: list of hard requirements with `alignment_status == "no_evidence"`
+      - Useful for frontend flagging (“legal unknown”) and user workflows to request missing evidence.
+    - `hard_requirements_unknown_count`: number of hard requirements with `alignment_status == "no_evidence"`
+      - Useful for summary UI and monitoring/QA (legal signal coverage by theme/action family).
+
+Note:
+- Non-blocking legal constraints / implementation notes (Notion “constraint”) are intentionally **not** emitted by the Hard Filter block in this plan.
+- They should be derived and attached later in the **Feasibility** stage as feasibility evidence (and potentially as a feasibility modifier), because they do not determine eligibility.
+
+## Internal contracts to introduce / update
+
+### 1) Add internal legal requirement model
+
+Add a small internal model in `hiap-meed/app/modules/prioritizer/internal_models.py` used between orchestrator and block:
+
+- `HardFilterLegalRequirement`
+  - `signal_code: str`
+  - `signal_name: str`
+  - `operator: str`
+  - `required_value: str | None`
+  - `legal_signal_value: str | None`
+  - `strength: str`
+  - `alignment_status: str`
+  - `location_scope: str | None`
+  - `location_name: str | None`
+  - `evidence_ids: list[str] = Field(default_factory=list)`
+  - `evidence_count: int = 0`
+
+Motivation:
+
+- Keep blocks dependent on **internal contracts** (consistent with existing `Action`, `CityData`, `HardFilterResult`).
+- Avoid importing external DTOs directly into block logic.
+
+### 2) Extend `HardFilterResult`
+
+Update `HardFilterResult` in `internal_models.py`:
+
+- Add `discarded_legal: list[Action] = Field(default_factory=list)`
+
+Counts should be surfaced in orchestrator metadata similarly to `discarded_excluded`.
+
+## Block API changes
+
+### Update `hard_filter.run()` signature
+
+Proposed signature:
+
+```python
+def run(
+    actions: list[Action],
+    excluded_actions_free_text: str | None,
+    legal_requirements_by_action_id: dict[str, list[HardFilterLegalRequirement]] | None = None,
+) -> HardFilterResult:
+    ...
+```
+
+Notes:
+
+- `excluded_actions_free_text` is the frontend source input.
+- `excluded_action_ids` is an **internal, resolved** exclusion set produced inside the block.
+  - Source of truth from frontend is `excludedActionsFreeText` (free text).
+  - Current implementation plan: resolve free text → IDs is a **stub** returning an empty set (no exclusions).
+  - Future implementation plan: semantic matching over action name/description (and/or a curated mapping table) to derive a concrete `excluded_action_ids` set.
+
+Backward compatibility note:
+
+- Call sites can pass `None` during rollout; in that case legal gate is skipped (no legal discards).
+
+## Pipeline plumbing plan
+
+The orchestrator currently does not fetch legal data. To enable real legal hard filtering:
+
+### 1) Add legal client interface + stub
+
+In `hiap-meed/app/services/data_clients.py`:
+
+- Add `LegalDataApiClient` with method:
+  - `get_action_legal_requirements(self, locode: str) -> dict[str, list[HardFilterLegalRequirement]]`
+- Add `StubLegalDataApiClient` returning `{}` by default (keeps pipeline working without legal enrichment)
+- Add a file-backed mock implementation that reads:
+  - `hiap-meed/data/mock/actions_legal_api_mock.json`
+  - Parses it (using `ActionsLegalApiResponse` from `hiap-meed/app/modules/prioritizer/models.py`)
+  - Converts it into the internal mapping:
+    - `dict[action_id -> list[HardFilterLegalRequirement]]`
+- Add an API-backed implementation `ApiLegalDataApiClient` (placeholder for now):
+  - For now it can return `{}` (no legal enrichment), but it must exist so the service can already be configured to use the `api` code path.
+  - Later it will implement the real HTTP call and parse the upstream payload into the same internal mapping shape.
+- Add dependency provider `get_legal_data_api_client()` that selects mock vs stub vs api via env var, e.g.:
+  - `HIAP_MEED_LEGAL_DATA_SOURCE=mock|stub|api` (default `mock` for local dev until real API integration is ready)
+  - Use `pathlib.Path` to locate the mock file via a repo-root-relative path derived from `__file__`.
+
+### 2) Inject legal client into API route
+
+In `hiap-meed/app/modules/prioritizer/api.py`:
+
+- Add dependency injection for legal client
+- Pass into `run_prioritization(...)`
+
+### 3) Update orchestrator to fetch + pass legal requirements
+
+In `hiap-meed/app/modules/prioritizer/orchestrator.py`:
+
+- Fetch legal requirements:
+  - `legal_requirements_by_action_id = legal_data_api_client.get_action_legal_requirements(request.locode)`
+- Call hard filter with legal requirements
+- Update artifact event + response metadata counts:
+  - add `discarded_legal`
+
+## Test plan (integration)
+
+Update `hiap-meed/tests/integration/test_prioritize_smoke.py`:
+
+- Add `MockLegalDataApiClient` and override the new dependency (same pattern as city/actions).
+- Add a new test verifying hard legal discards (once legal data wiring is added):
+  - Arrange two actions: `A_ok`, `A_blocked`
+  - Provide legal requirements:
+    - for `A_blocked`: one requirement with `strength="mandatory"` and `alignment_status="not_aligned"`
+    - for `A_ok`: either no hard requirements or all `aligns`
+  - Assert:
+    - response `ranked_action_ids` excludes `A_blocked`
+    - `metadata.counts.discarded_legal == 1`
+
+- Add a second test where `alignment_status="no_evidence"` is **kept** and `metadata.counts.discarded_legal == 0`, while `hard_filter` evidence for that action includes `unknown_requirements`.
+
+## Documentation updates (after implementation)
+
+After code is implemented and tests pass:
+
+- Update `hiap-meed/docs/detailed-block-architecture.md`:
+  - Implementation status table:
+    - Hard Filter | Legal requirement check → **Implemented**
+
+## Rollout steps (suggested)
+
+1. Add internal model + `HardFilterResult.discarded_legal`.
+2. Implement legal gate in `hard_filter.py` with `legal_requirements_by_action_id` input.
+3. Add legal client interface + stub + DI wiring.
+4. Update orchestrator to fetch/pass legal data and report counts.
+5. Add integration test(s).
+6. Update architecture doc status.
+

--- a/hiap-meed/Implementation-plan-hard-filter.md
+++ b/hiap-meed/Implementation-plan-hard-filter.md
@@ -22,9 +22,9 @@ Inputs and behaviors must align with:
   - `_apply_legal_hard_filter(...)`
 - Free-text exclusions are currently **stubbed**:
   - `_resolve_excluded_action_ids_from_text(...)` returns an empty set, so no actions are excluded yet from free text.
-- Legal hard filtering is currently **stubbed**:
-  - `_apply_legal_hard_filter(...)` does not discard actions yet and marks evidence with `legal_filter_status = "not_applied_stub"`.
-- `HardFilterResult` currently has no explicit bucket for “discarded due to legal mismatch”.
+- Legal hard filtering is currently **implemented**:
+  - `_apply_legal_hard_filter(...)` evaluates legal requirements and discards actions that fail hard legal constraints (for example `not_aligned` hard requirements).
+- `HardFilterResult` now includes an explicit `discarded_legal` bucket for actions discarded due to legal mismatch.
 - The orchestrator calls hard filter before scoring and attaches `hard_filter_result.evidence[action_id]` into the final response evidence.
 
 Relevant files:
@@ -100,6 +100,7 @@ Handling missing legal data:
       - Useful for summary UI and monitoring/QA (legal signal coverage by theme/action family).
 
 Note:
+
 - Non-blocking legal constraints / implementation notes (Notion “constraint”) are intentionally **not** emitted by the Hard Filter block in this plan.
 - They should be derived and attached later in the **Feasibility** stage as feasibility evidence (and potentially as a feasibility modifier), because they do not determine eligibility.
 
@@ -234,4 +235,3 @@ After code is implemented and tests pass:
 4. Update orchestrator to fetch/pass legal data and report counts.
 5. Add integration test(s).
 6. Update architecture doc status.
-

--- a/hiap-meed/README.md
+++ b/hiap-meed/README.md
@@ -35,14 +35,19 @@ API_PORT=8000
 LOG_LEVEL=INFO
 LOG_DIR=logs
 ARTIFACT_LOG_JSONL=true
+HIAP_MEED_LEGAL_DATA_SOURCE=mock
+HIAP_MEED_ACTION_DATA_SOURCE=mock
 ```
 
 Variables:
+
 - `API_HOST`: server bind host (default `0.0.0.0`)
 - `API_PORT`: server bind port (default `8000`)
 - `LOG_LEVEL`: Python logging level (for example `DEBUG`, `INFO`)
 - `LOG_DIR`: output folder for file logs and request artifacts
 - `ARTIFACT_LOG_JSONL`: if `true`, writes per-request JSONL artifacts
+- `HIAP_MEED_LEGAL_DATA_SOURCE`: legal input source (`mock`, `stub`, or `api`)
+- `HIAP_MEED_ACTION_DATA_SOURCE`: action catalog source (`mock`, `stub`, or `api`)
 
 ### 2. Install dependencies
 
@@ -61,6 +66,7 @@ uv run python -m app.main
 ```
 
 Verify the service:
+
 - Health check: `curl http://localhost:8000/health`
 - OpenAPI docs: `http://localhost:8000/docs`
 - Prioritization endpoint: `POST /v1/prioritize`
@@ -71,6 +77,7 @@ The repository now includes explicit Pydantic contracts for upcoming request and
 upstream response integrations in `app/modules/prioritizer/models.py`.
 
 Key models:
+
 - Frontend request envelope: `PrioritizerApiRequest`
 - Frontend city input row: `FrontendCityInput`
 - Global city API response: `CityApiResponse`
@@ -79,6 +86,7 @@ Key models:
 - Global policy alignment API response: `ActionsPolicySignalsApiResponse`
 
 Design note:
+
 - For the upcoming frontend contract, single-city and multi-city payloads both
   use `cityDataList`; single-city is represented as a list with one item.
 
@@ -87,18 +95,27 @@ Design note:
 Run commands from a Bash shell (Git Bash, WSL, Linux, macOS).
 
 Request body:
+
 - The endpoint accepts the frontend envelope `PrioritizerApiRequest` (see `app/modules/prioritizer/models.py`).
 - Single-city and multi-city payloads both use `requestData.cityDataList`.
 
 Exclusions:
+
 - The frontend provides exclusions as `excludedActionsFreeText` (free text).
 - Current behavior: this is a **stub** and does not exclude actions yet (the text is attached to metadata for downstream flagging).
 
+Hard legal requirements:
+
+- The hard filter now enforces legal requirements with `strength` in `mandatory|required`.
+- Actions with hard `alignment_status="not_aligned"` are discarded before scoring.
+- Actions with hard `alignment_status="no_evidence"` are kept and surfaced in hard-filter evidence.
+
 Response fields:
+
 - `results` (`array`): one entry per requested city.
   - `locode` (`string`)
   - `ranked_action_ids` (`string[]`): ordered action IDs.
-  - `metadata` (`object`): request ID, timings, counts, and frontend trace fields.
+  - `metadata` (`object`): request ID, timings, counts, hard-filter evidence, and frontend trace fields.
 
 Example JSON request bodies (using mock data from `data/`):
 
@@ -165,6 +182,7 @@ Example response:
           "total_actions": 2,
           "valid_actions": 2,
           "discarded_excluded": 0,
+          "discarded_legal": 0,
           "ranked_actions": 2
         },
         "frontend_request_id": "1234567890",
@@ -177,26 +195,30 @@ Example response:
 ```
 
 Common validation errors:
+
 - Missing request body -> HTTP `422`.
 - Missing `requestData.cityDataList` or empty `cityDataList` -> HTTP `422`.
 - Missing `locode` or empty `locode` in a city entry -> HTTP `422`.
 
-Note: current data clients are in-memory stubs. Real upstream API calls are not wired yet. When they are wired, the data clients will use a synchronous HTTP client (e.g. `httpx.Client`). FastAPI runs synchronous routes in a threadpool, so the event loop stays free to handle concurrent requests.
+Note: city data is currently an in-memory stub. Action and legal clients can use `mock` (file-backed), `stub` (empty), or `api` (placeholder returning empty data) based on `HIAP_MEED_ACTION_DATA_SOURCE` and `HIAP_MEED_LEGAL_DATA_SOURCE`. Real upstream HTTP wiring is still pending for all clients; when wired, clients should use a synchronous HTTP client (e.g. `httpx.Client`). FastAPI runs synchronous routes in a threadpool, so the event loop stays free to handle concurrent requests.
 
 ### 5. Logging and artifacts
 
 The service writes:
+
 - Console logs (stdout/stderr)
 - File logs at `LOG_DIR/app.log`
-- Per-request artifacts at `LOG_DIR/requests/{internal_request_id}.jsonl` when `ARTIFACT_LOG_JSONL=true`
+- Per-request artifacts at `LOG_DIR/requests/{UTC_TIMESTAMP}Z_{internal_request_id}.jsonl` when `ARTIFACT_LOG_JSONL=true`
 
 What `app.log` contains:
+
 - Service startup and runtime logs
 - Endpoint activity (for example health checks and prioritization completion)
 - Validation errors and unexpected exceptions with stack traces
 - Cross-request aggregated logs (all requests in one rolling file path)
 
-What each `requests/{internal_request_id}.jsonl` file contains:
+What each `requests/{UTC_TIMESTAMP}Z_{internal_request_id}.jsonl` file contains:
+
 - One JSON line per pipeline event for that single request
 - Event metadata such as timestamp, request ID, event type, and payload
 - Timing/count summaries for fetch/filter/score steps
@@ -213,6 +235,7 @@ ls -1 logs/requests/
 ```
 
 Typical per-request artifact events:
+
 - `fetch_city.completed`
 - `fetch_actions.completed`
 - `validate_weights.completed`
@@ -228,6 +251,10 @@ From the `hiap-meed` directory:
 docker build -t hiap-meed-app .
 docker run -it --rm -p 8000:8000 --env-file .env hiap-meed-app
 ```
+
+The Docker image includes both `app/` and `data/`, so mock payloads under
+`data/mock` are available in-container at `/app/data/mock`.
+Data folder needs to be removed once real APIs are available.
 
 ## Testing
 

--- a/hiap-meed/README.md
+++ b/hiap-meed/README.md
@@ -65,6 +65,23 @@ Verify the service:
 - OpenAPI docs: `http://localhost:8000/docs`
 - Prioritization endpoint: `POST /v1/prioritize`
 
+### External API contracts (modeled, integration pending)
+
+The repository now includes explicit Pydantic contracts for upcoming request and
+upstream response integrations in `app/modules/prioritizer/models.py`.
+
+Key models:
+- Frontend request envelope: `PrioritizerApiRequest`
+- Frontend city input row: `FrontendCityInput`
+- Global city API response: `CityApiResponse`
+- Global actions API response: `ActionsApiResponse`
+- Global legal alignment API response: `ActionsLegalApiResponse`
+- Global policy alignment API response: `ActionsPolicySignalsApiResponse`
+
+Design note:
+- For the upcoming frontend contract, single-city and multi-city payloads both
+  use `cityDataList`; single-city is represented as a list with one item.
+
 ### 4. Call the prioritization endpoint
 
 Run commands from a Bash shell (Git Bash, WSL, Linux, macOS).

--- a/hiap-meed/README.md
+++ b/hiap-meed/README.md
@@ -86,114 +86,100 @@ Design note:
 
 Run commands from a Bash shell (Git Bash, WSL, Linux, macOS).
 
-Request body fields:
-- `locode` (required, `string`): City identifier used to fetch city context.
-- `excluded_action_ids` (optional, `string[]`, default `[]`): Action IDs to remove before scoring.
-- `weights_override` (optional, `object`): Custom weights with keys `impact`, `alignment`, `feasibility`.
-- `top_n` (optional, `integer >= 1`): Limits response to first `N` ranked actions.
+Request body:
+- The endpoint accepts the frontend envelope `PrioritizerApiRequest` (see `app/modules/prioritizer/models.py`).
+- Single-city and multi-city payloads both use `requestData.cityDataList`.
 
-Weight behavior:
-- If `weights_override` is omitted, defaults are used: `impact=0.55`, `alignment=0.22`, `feasibility=0.23`.
-- Unknown keys are rejected.
-- Negative values are rejected.
-- Weight sum must be exactly `1.0`; otherwise the request fails with HTTP `422`.
+Exclusions:
+- The frontend provides exclusions as `excludedActionsFreeText` (free text).
+- Current behavior: this is a **stub** and does not exclude actions yet (the text is attached to metadata for downstream flagging).
 
 Response fields:
-- `ranked_action_ids` (`string[]`): Ordered action IDs from highest to lowest priority.
-- `metadata` (`object`): Request ID, resolved weights, timing, and action counts.
+- `results` (`array`): one entry per requested city.
+  - `locode` (`string`)
+  - `ranked_action_ids` (`string[]`): ordered action IDs.
+  - `metadata` (`object`): request ID, timings, counts, and frontend trace fields.
 
 Example JSON request bodies (using mock data from `data/`):
 
 ```json
 {
-  "locode": "CL ARI",
-  "excluded_action_ids": [
-    "c40_0023",
-    "c40_0037",
-    "icare_0001"
-  ],
-  "top_n": 10
-}
-```
-
-```json
-{
-  "locode": "CL IQQ",
-  "excluded_action_ids": [
-    "c40_0010",
-    "icare_0016"
-  ],
-  "weights_override": {
-    "impact": 0.5,
-    "alignment": 0.3,
-    "feasibility": 0.2
+  "meta": {
+    "requestId": "1234567890",
+    "generatedAtUtc": "2026-02-26T11:43:40.011939+00:00",
+    "backendConsumer": "hiap-meed",
+    "upstreamProvider": "city_catalyst_frontend",
+    "apiContext": {
+      "endpoint": "POST /prioritizer/v1/start_prioritization",
+      "locodes": ["CL IQQ"]
+    },
+    "totalRecords": 1
   },
-  "top_n": 5
+  "requestData": {
+    "requestedLanguages": ["en"],
+    "cityDataList": [
+      {
+        "locode": "CL IQQ",
+        "countryCode": "CL",
+        "populationSize": 125000,
+        "excludedActionsFreeText": "Do not include new fossil fuel-based infrastructure ...",
+        "cityStrategicPreferenceSectors": ["transportation"],
+        "cityStrategicPreferenceOther": "Prioritize near-term air quality improvements ...",
+        "cityEmissionsData": {
+          "inventoryYear": null,
+          "gpcData": {}
+        }
+      }
+    ]
+  }
 }
-```
-
-Minimal payload:
-
-```bash
-curl -X POST http://localhost:8000/v1/prioritize \
-  -H 'Content-Type: application/json' \
-  -d '{"locode":"CL IQQ","excluded_action_ids":[]}'
-```
-
-Payload with `top_n`:
-
-```bash
-curl -X POST http://localhost:8000/v1/prioritize \
-  -H 'Content-Type: application/json' \
-  -d '{"locode":"CL IQQ","excluded_action_ids":[],"top_n":5}'
-```
-
-Payload with exclusions and custom weights:
-
-```bash
-curl -X POST http://localhost:8000/v1/prioritize \
-  -H 'Content-Type: application/json' \
-  -d '{"locode":"CL IQQ","excluded_action_ids":["c40_0020"],"weights_override":{"impact":0.5,"alignment":0.3,"feasibility":0.2},"top_n":10}'
 ```
 
 Example response:
 
 ```json
 {
-  "ranked_action_ids": ["c40_0010", "c40_0030"],
-  "metadata": {
-    "request_id": "d1db6269-4cf9-4d62-8f4c-8f4ce631fbd2",
-    "locode": "CL IQQ",
-    "weights": {
-      "impact": 0.5,
-      "alignment": 0.3,
-      "feasibility": 0.2
-    },
-    "timings": {
-      "fetch_city": 0.001,
-      "fetch_actions": 0.001,
-      "validate_weights": 0.0,
-      "hard_filter": 0.0,
-      "impact": 0.0,
-      "alignment": 0.0,
-      "feasibility": 0.0,
-      "final_scoring": 0.0
-    },
-    "counts": {
-      "total_actions": 2,
-      "valid_actions": 2,
-      "discarded_excluded": 0,
-      "ranked_actions": 2
+  "results": [
+    {
+      "locode": "CL IQQ",
+      "ranked_action_ids": ["c40_0010", "c40_0030"],
+      "metadata": {
+        "internal_request_id": "d1db6269-4cf9-4d62-8f4c-8f4ce631fbd2",
+        "locode": "CL IQQ",
+        "weights": {
+          "impact": 0.55,
+          "alignment": 0.22,
+          "feasibility": 0.23
+        },
+        "timings": {
+          "fetch_city": 0.001,
+          "fetch_actions": 0.001,
+          "validate_weights": 0.0,
+          "hard_filter": 0.0,
+          "impact": 0.0,
+          "alignment": 0.0,
+          "feasibility": 0.0,
+          "final_scoring": 0.0
+        },
+        "counts": {
+          "total_actions": 2,
+          "valid_actions": 2,
+          "discarded_excluded": 0,
+          "ranked_actions": 2
+        },
+        "frontend_request_id": "1234567890",
+        "requested_languages": ["en"],
+        "excluded_actions_free_text": "Do not include new fossil fuel-based infrastructure ..."
+      }
     }
-  }
+  ]
 }
 ```
 
 Common validation errors:
 - Missing request body -> HTTP `422`.
-- Missing `locode` or empty `locode` -> HTTP `422`.
-- `top_n < 1` -> HTTP `422`.
-- Invalid `weights_override` keys/values -> HTTP `422` with error payload.
+- Missing `requestData.cityDataList` or empty `cityDataList` -> HTTP `422`.
+- Missing `locode` or empty `locode` in a city entry -> HTTP `422`.
 
 Note: current data clients are in-memory stubs. Real upstream API calls are not wired yet. When they are wired, the data clients will use a synchronous HTTP client (e.g. `httpx.Client`). FastAPI runs synchronous routes in a threadpool, so the event loop stays free to handle concurrent requests.
 
@@ -202,7 +188,7 @@ Note: current data clients are in-memory stubs. Real upstream API calls are not 
 The service writes:
 - Console logs (stdout/stderr)
 - File logs at `LOG_DIR/app.log`
-- Per-request artifacts at `LOG_DIR/requests/{request_id}.jsonl` when `ARTIFACT_LOG_JSONL=true`
+- Per-request artifacts at `LOG_DIR/requests/{internal_request_id}.jsonl` when `ARTIFACT_LOG_JSONL=true`
 
 What `app.log` contains:
 - Service startup and runtime logs
@@ -210,7 +196,7 @@ What `app.log` contains:
 - Validation errors and unexpected exceptions with stack traces
 - Cross-request aggregated logs (all requests in one rolling file path)
 
-What each `requests/{request_id}.jsonl` file contains:
+What each `requests/{internal_request_id}.jsonl` file contains:
 - One JSON line per pipeline event for that single request
 - Event metadata such as timestamp, request ID, event type, and payload
 - Timing/count summaries for fetch/filter/score steps

--- a/hiap-meed/README.md
+++ b/hiap-meed/README.md
@@ -35,6 +35,7 @@ API_PORT=8000
 LOG_LEVEL=INFO
 LOG_DIR=logs
 ARTIFACT_LOG_JSONL=true
+HIAP_MEED_CITY_DATA_SOURCE=mock
 HIAP_MEED_LEGAL_DATA_SOURCE=mock
 HIAP_MEED_ACTION_DATA_SOURCE=mock
 ```
@@ -45,9 +46,10 @@ Variables:
 - `API_PORT`: server bind port (default `8000`)
 - `LOG_LEVEL`: Python logging level (for example `DEBUG`, `INFO`)
 - `LOG_DIR`: output folder for file logs and request artifacts
-- `ARTIFACT_LOG_JSONL`: if `true`, writes per-request JSONL artifacts
-- `HIAP_MEED_LEGAL_DATA_SOURCE`: legal input source (`mock`, `stub`, or `api`)
-- `HIAP_MEED_ACTION_DATA_SOURCE`: action catalog source (`mock`, `stub`, or `api`)
+- `ARTIFACT_LOG_JSONL`: if `true`, writes per-request artifact files
+- `HIAP_MEED_CITY_DATA_SOURCE`: city input source (`mock` or `api`)
+- `HIAP_MEED_LEGAL_DATA_SOURCE`: legal input source (`mock` or `api`)
+- `HIAP_MEED_ACTION_DATA_SOURCE`: action catalog source (`mock` or `api`)
 
 ### 2. Install dependencies
 
@@ -200,7 +202,7 @@ Common validation errors:
 - Missing `requestData.cityDataList` or empty `cityDataList` -> HTTP `422`.
 - Missing `locode` or empty `locode` in a city entry -> HTTP `422`.
 
-Note: city data is currently an in-memory stub. Action and legal clients can use `mock` (file-backed), `stub` (empty), or `api` (placeholder returning empty data) based on `HIAP_MEED_ACTION_DATA_SOURCE` and `HIAP_MEED_LEGAL_DATA_SOURCE`. Real upstream HTTP wiring is still pending for all clients; when wired, clients should use a synchronous HTTP client (e.g. `httpx.Client`). FastAPI runs synchronous routes in a threadpool, so the event loop stays free to handle concurrent requests.
+Note: city, action, and legal clients now resolve to `mock` (file-backed) or `api` (placeholder until real upstream wiring is added). Default source for all three is `mock`, so local and Docker runs use checked-in mock payloads by default. Real upstream HTTP wiring is still pending; when wired, clients should use a synchronous HTTP client (e.g. `httpx.Client`). FastAPI runs synchronous routes in a threadpool, so the event loop stays free to handle concurrent requests.
 
 ### 5. Logging and artifacts
 
@@ -208,7 +210,7 @@ The service writes:
 
 - Console logs (stdout/stderr)
 - File logs at `LOG_DIR/app.log`
-- Per-request artifacts at `LOG_DIR/requests/{UTC_TIMESTAMP}Z_{internal_request_id}.jsonl` when `ARTIFACT_LOG_JSONL=true`
+- Per-request artifacts at `LOG_DIR/requests/{UTC_TIMESTAMP}Z_{internal_request_id}/` when `ARTIFACT_LOG_JSONL=true`
 
 What `app.log` contains:
 
@@ -217,12 +219,13 @@ What `app.log` contains:
 - Validation errors and unexpected exceptions with stack traces
 - Cross-request aggregated logs (all requests in one rolling file path)
 
-What each `requests/{UTC_TIMESTAMP}Z_{internal_request_id}.jsonl` file contains:
+What each `requests/{UTC_TIMESTAMP}Z_{internal_request_id}/` run folder contains:
 
-- One JSON line per pipeline event for that single request
-- Event metadata such as timestamp, request ID, event type, and payload
-- Timing/count summaries for fetch/filter/score steps
-- Request-scoped traceability (one file per request ID)
+- `summary.jsonl`: one JSON line per high-level pipeline event for that request
+- `NNN_<step>.json`: concise per-step detail files (fetch, filter, score, response)
+- Event metadata such as timestamp, request ID, event index, event/step type, and payload
+- `event_index` is shared between a summary event and its matching detail file, so `summary.jsonl` and `NNN_<step>.json` are directly pairable
+- Timing/count summaries plus request-scoped traceability in a single run directory
 
 Inspect logs:
 
@@ -240,7 +243,9 @@ Typical per-request artifact events:
 - `fetch_actions.completed`
 - `validate_weights.completed`
 - `hard_filter.completed`
-- `block_scores.completed`
+- `pillar_scores.completed`
+- `final_scoring.completed`
+- `run_summary.completed`
 - `response.completed`
 
 ### 6. Docker
@@ -251,6 +256,20 @@ From the `hiap-meed` directory:
 docker build -t hiap-meed-app .
 docker run -it --rm -p 8000:8000 --env-file .env hiap-meed-app
 ```
+
+To persist file logs and per-request artifacts on your machine (under `logs/`, including `logs/requests/`), bind-mount the host `logs` directory to `/app/logs` in the container (this matches default `LOG_DIR=logs`):
+
+```bash
+docker run -it --rm -p 8000:8000 --env-file .env -v ./logs:/app/logs hiap-meed-app
+```
+
+On **Windows Command Prompt**, from the `hiap-meed` directory:
+
+```cmd
+docker run -it --rm -p 8000:8000 --env-file .env -v "%cd%\logs:/app/logs" hiap-meed-app
+```
+
+If you change `LOG_DIR` in `.env`, adjust the container path in `-v` so it matches `/app/<LOG_DIR>`.
 
 The Docker image includes both `app/` and `data/`, so mock payloads under
 `data/mock` are available in-container at `/app/data/mock`.

--- a/hiap-meed/app/modules/prioritizer/api.py
+++ b/hiap-meed/app/modules/prioritizer/api.py
@@ -18,8 +18,10 @@ from app.modules.prioritizer.orchestrator import run_prioritization
 from app.services.data_clients import (
     ActionDataApiClient,
     CityDataApiClient,
+    LegalDataApiClient,
     get_action_data_api_client,
     get_city_data_api_client,
+    get_legal_data_api_client,
 )
 
 
@@ -38,6 +40,7 @@ def prioritize(
     request: PrioritizerApiRequest,
     city_data_api_client: CityDataApiClient = Depends(get_city_data_api_client),
     action_data_api_client: ActionDataApiClient = Depends(get_action_data_api_client),
+    legal_data_api_client: LegalDataApiClient = Depends(get_legal_data_api_client),
 ) -> PrioritizerApiResponse:
     """
     Prioritize actions from the CityCatalyst frontend request envelope.
@@ -59,6 +62,7 @@ def prioritize(
                 requested_languages=list(request.requestData.requestedLanguages),
                 city_data_api_client=city_data_api_client,
                 action_data_api_client=action_data_api_client,
+                legal_data_api_client=legal_data_api_client,
             )
             results.append(
                 PrioritizerApiCityResult(
@@ -94,6 +98,7 @@ def _run_for_city_input(
     requested_languages: list[str],
     city_data_api_client: CityDataApiClient,
     action_data_api_client: ActionDataApiClient,
+    legal_data_api_client: LegalDataApiClient,
 ) -> PrioritizationResponse:
     """
     Translate a single frontend city payload into a pipeline run.
@@ -112,12 +117,13 @@ def _run_for_city_input(
     internal_request_id = uuid4()
     result = run_prioritization(
         locode=city_input.locode,
-        weights_override=None,
+        weights_override=city_input.weightsOverride,
         top_n=None,
         excluded_actions_free_text=city_input.excludedActionsFreeText,
         internal_request_id=internal_request_id,
         city_data_api_client=city_data_api_client,
         action_data_api_client=action_data_api_client,
+        legal_data_api_client=legal_data_api_client,
     )
 
     # Attach minimal frontend context for traceability/debugging.

--- a/hiap-meed/app/modules/prioritizer/api.py
+++ b/hiap-meed/app/modules/prioritizer/api.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 import logging
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from app.modules.prioritizer.models import PrioritizationRequest, PrioritizationResponse
+from app.modules.prioritizer.models import (
+    FrontendCityInput,
+    PrioritizationResponse,
+    PrioritizerApiCityResult,
+    PrioritizerApiRequest,
+    PrioritizerApiResponse,
+)
 from app.modules.prioritizer.orchestrator import run_prioritization
 from app.services.data_clients import (
     ActionDataApiClient,
@@ -22,43 +28,100 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["prioritization"])
 
 
-def _error_payload(request_id: UUID, message: str) -> dict[str, str]:
+def _error_payload(request_id: str, message: str) -> dict[str, str]:
     """Build a consistent JSON error body including the request ID."""
-    return {"request_id": str(request_id), "error": message}
+    return {"request_id": request_id, "error": message}
 
 
-@router.post("/v1/prioritize", response_model=PrioritizationResponse)
+@router.post("/v1/prioritize", response_model=PrioritizerApiResponse)
 def prioritize(
-    request: PrioritizationRequest,
+    request: PrioritizerApiRequest,
     city_data_api_client: CityDataApiClient = Depends(get_city_data_api_client),
     action_data_api_client: ActionDataApiClient = Depends(get_action_data_api_client),
-) -> PrioritizationResponse:
+) -> PrioritizerApiResponse:
     """
-    Run prioritization for one city and return ordered action IDs.
+    Prioritize actions from the CityCatalyst frontend request envelope.
 
     This endpoint is synchronous because the orchestrator and data clients
     are synchronous; FastAPI runs sync routes in a threadpool to avoid
     blocking the event loop.
     """
-    request_id = uuid4()
+
+    # Get the request trace ID from the request envelope.
+    request_trace_id = request.meta.requestId
+
     try:
-        return run_prioritization(
-            request=request,
-            request_id=request_id,
-            city_data_api_client=city_data_api_client,
-            action_data_api_client=action_data_api_client,
-        )
+        results: list[PrioritizerApiCityResult] = []
+        for city_input in request.requestData.cityDataList:
+            per_city_result = _run_for_city_input(
+                city_input=city_input,
+                frontend_request_id=request.meta.requestId,
+                requested_languages=list(request.requestData.requestedLanguages),
+                city_data_api_client=city_data_api_client,
+                action_data_api_client=action_data_api_client,
+            )
+            results.append(
+                PrioritizerApiCityResult(
+                    locode=city_input.locode,
+                    ranked_action_ids=per_city_result.ranked_action_ids,
+                    metadata=per_city_result.metadata,
+                )
+            )
+
+        return PrioritizerApiResponse(results=results)
     except ValueError as error:
         logger.warning(
-            "Invalid prioritization request request_id=%s error=%s", request_id, error
+            "Invalid prioritization request request_id=%s error=%s",
+            request_trace_id,
+            error,
         )
         raise HTTPException(
             status_code=422,
-            detail=_error_payload(request_id, str(error)),
+            detail=_error_payload(request_trace_id, str(error)),
         ) from error
     except Exception as error:
-        logger.exception("Prioritization failed request_id=%s", request_id)
+        logger.exception("Prioritization failed request_id=%s", request_trace_id)
         raise HTTPException(
             status_code=500,
-            detail=_error_payload(request_id, "Internal server error"),
+            detail=_error_payload(request_trace_id, "Internal server error"),
         ) from error
+
+
+def _run_for_city_input(
+    *,
+    city_input: FrontendCityInput,
+    frontend_request_id: str,
+    requested_languages: list[str],
+    city_data_api_client: CityDataApiClient,
+    action_data_api_client: ActionDataApiClient,
+) -> PrioritizationResponse:
+    """
+    Translate a single frontend city payload into a pipeline run.
+
+    Current behavior:
+    - `excludedActionsFreeText` is treated as a **stub** and does not exclude actions.
+      The text is attached to metadata so downstream consumers (e.g. frontend)
+      can flag it or implement a manual review flow.
+
+    Future behavior:
+    - Resolve free-text exclusions into concrete action exclusions via semantic
+      matching over action name/description and/or a curated mapping table.
+    """
+
+    # Create internal request ID used for orchestrator artifacts/tracing.
+    internal_request_id = uuid4()
+    result = run_prioritization(
+        locode=city_input.locode,
+        weights_override=None,
+        top_n=None,
+        excluded_actions_free_text=city_input.excludedActionsFreeText,
+        internal_request_id=internal_request_id,
+        city_data_api_client=city_data_api_client,
+        action_data_api_client=action_data_api_client,
+    )
+
+    # Attach minimal frontend context for traceability/debugging.
+    result.metadata["frontend_request_id"] = frontend_request_id
+    result.metadata["requested_languages"] = requested_languages
+    result.metadata["excluded_actions_free_text"] = city_input.excludedActionsFreeText
+    return result

--- a/hiap-meed/app/modules/prioritizer/api.py
+++ b/hiap-meed/app/modules/prioritizer/api.py
@@ -49,7 +49,9 @@ def prioritize(
             action_data_api_client=action_data_api_client,
         )
     except ValueError as error:
-        logger.warning("Invalid prioritization request request_id=%s error=%s", request_id, error)
+        logger.warning(
+            "Invalid prioritization request request_id=%s error=%s", request_id, error
+        )
         raise HTTPException(
             status_code=422,
             detail=_error_payload(request_id, str(error)),
@@ -60,6 +62,3 @@ def prioritize(
             status_code=500,
             detail=_error_payload(request_id, "Internal server error"),
         ) from error
-
-
-__all__ = ["router", "get_action_data_api_client", "get_city_data_api_client"]

--- a/hiap-meed/app/modules/prioritizer/blocks/alignment.py
+++ b/hiap-meed/app/modules/prioritizer/blocks/alignment.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from app.modules.prioritizer.models import Action, BlockScoreResult, CityData
+from app.modules.prioritizer.internal_models import Action, BlockScoreResult, CityData
 
 
 def run(actions: list[Action], city: CityData) -> BlockScoreResult:
@@ -31,6 +31,3 @@ def run(actions: list[Action], city: CityData) -> BlockScoreResult:
         score_by_action_id=score_by_action_id,
         evidence_by_action_id=evidence_by_action_id,
     )
-
-
-__all__ = ["run"]

--- a/hiap-meed/app/modules/prioritizer/blocks/feasibility.py
+++ b/hiap-meed/app/modules/prioritizer/blocks/feasibility.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from app.modules.prioritizer.models import Action, BlockScoreResult, CityData
+from app.modules.prioritizer.internal_models import Action, BlockScoreResult, CityData
 
 
 def run(actions: list[Action], city: CityData) -> BlockScoreResult:
@@ -27,6 +27,3 @@ def run(actions: list[Action], city: CityData) -> BlockScoreResult:
         score_by_action_id=score_by_action_id,
         evidence_by_action_id=evidence_by_action_id,
     )
-
-
-__all__ = ["run"]

--- a/hiap-meed/app/modules/prioritizer/blocks/final_scoring.py
+++ b/hiap-meed/app/modules/prioritizer/blocks/final_scoring.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from app.modules.prioritizer.models import Action, ScoredAction
+from app.modules.prioritizer.internal_models import Action, ScoredAction
 
 
 def run(
@@ -51,6 +51,3 @@ def run(
         item.rank = index
 
     return scored_actions
-
-
-__all__ = ["run"]

--- a/hiap-meed/app/modules/prioritizer/blocks/hard_filter.py
+++ b/hiap-meed/app/modules/prioritizer/blocks/hard_filter.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from app.modules.prioritizer.models import Action, HardFilterResult
+from app.modules.prioritizer.internal_models import Action, HardFilterResult
 
 
 def run(actions: list[Action], excluded_action_ids: set[str]) -> HardFilterResult:
@@ -34,6 +34,3 @@ def run(actions: list[Action], excluded_action_ids: set[str]) -> HardFilterResul
         discarded_excluded=discarded_excluded,
         evidence=evidence,
     )
-
-
-__all__ = ["run"]

--- a/hiap-meed/app/modules/prioritizer/blocks/hard_filter.py
+++ b/hiap-meed/app/modules/prioritizer/blocks/hard_filter.py
@@ -5,13 +5,31 @@ from __future__ import annotations
 from app.modules.prioritizer.internal_models import Action, HardFilterResult
 
 
-def run(actions: list[Action], excluded_action_ids: set[str]) -> HardFilterResult:
+def _resolve_excluded_action_ids_from_text(
+    *, actions: list[Action], excluded_actions_free_text: str | None
+) -> set[str]:
     """
-    Filter out excluded actions before scoring.
+    Resolve free-text exclusion guidance into concrete action IDs.
 
-    Inputs:
-    - `actions`: Full action list from data client.
-    - `excluded_action_ids`: Action IDs to exclude from ranking.
+    Current behavior is a stub: it always returns an empty set.
+    Future behavior will semantically match free text against action metadata.
+    """
+
+    del actions
+    del excluded_actions_free_text
+    return set()
+
+
+def _apply_free_text_exclusion_filter(
+    *, actions: list[Action], excluded_action_ids: set[str]
+) -> tuple[list[Action], list[Action], dict[str, dict[str, object]]]:
+    """
+    Apply action exclusion by resolved action IDs.
+
+    Returns:
+    - actions that remain eligible
+    - actions discarded by exclusion
+    - evidence keyed by action ID
     """
 
     valid_actions: list[Action] = []
@@ -28,6 +46,43 @@ def run(actions: list[Action], excluded_action_ids: set[str]) -> HardFilterResul
             continue
         valid_actions.append(action)
         evidence[action.action_id] = {"discard_reason": None}
+
+    return valid_actions, discarded_excluded, evidence
+
+
+def _apply_legal_hard_filter(
+    *, actions: list[Action], evidence: dict[str, dict[str, object]]
+) -> list[Action]:
+    """
+    Apply legal hard-requirement filtering to currently eligible actions.
+
+    Current behavior is a stub: no additional legal exclusions are applied yet.
+    """
+
+    for action in actions:
+        action_evidence = evidence.setdefault(action.action_id, {"discard_reason": None})
+        action_evidence["legal_filter_status"] = "not_applied_stub"
+    return actions
+
+
+def run(actions: list[Action], excluded_actions_free_text: str | None) -> HardFilterResult:
+    """
+    Filter out ineligible actions before scoring.
+
+    Inputs:
+    - `actions`: Full action list from data client.
+    - `excluded_actions_free_text`: Frontend free-text exclusion guidance.
+    """
+
+    excluded_action_ids = _resolve_excluded_action_ids_from_text(
+        actions=actions,
+        excluded_actions_free_text=excluded_actions_free_text,
+    )
+    valid_actions, discarded_excluded, evidence = _apply_free_text_exclusion_filter(
+        actions=actions,
+        excluded_action_ids=excluded_action_ids,
+    )
+    valid_actions = _apply_legal_hard_filter(actions=valid_actions, evidence=evidence)
 
     return HardFilterResult(
         valid_actions=valid_actions,

--- a/hiap-meed/app/modules/prioritizer/blocks/hard_filter.py
+++ b/hiap-meed/app/modules/prioritizer/blocks/hard_filter.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from app.modules.prioritizer.internal_models import Action, HardFilterResult
+from app.modules.prioritizer.internal_models import (
+    Action,
+    HardFilterLegalRequirement,
+    HardFilterResult,
+)
+
+HARD_REQUIREMENT_STRENGTHS = {"mandatory", "required"}
 
 
 def _resolve_excluded_action_ids_from_text(
@@ -36,6 +42,7 @@ def _apply_free_text_exclusion_filter(
     discarded_excluded: list[Action] = []
     evidence: dict[str, dict[str, object]] = {}
 
+    # First gate: explicit exclusions resolved from frontend free text.
     for action in actions:
         if action.action_id in excluded_action_ids:
             discarded_excluded.append(action)
@@ -51,21 +58,90 @@ def _apply_free_text_exclusion_filter(
 
 
 def _apply_legal_hard_filter(
-    *, actions: list[Action], evidence: dict[str, dict[str, object]]
-) -> list[Action]:
+    *,
+    actions: list[Action],
+    evidence: dict[str, dict[str, object]],
+    legal_requirements_by_action_id: dict[str, list[HardFilterLegalRequirement]] | None,
+) -> tuple[list[Action], list[Action]]:
     """
     Apply legal hard-requirement filtering to currently eligible actions.
 
-    Current behavior is a stub: no additional legal exclusions are applied yet.
+    Rules:
+    - Hard requirements are those with strength `mandatory` or `required`.
+    - Discard action when any hard requirement is `not_aligned`.
+    - Keep action when hard requirements are all `aligns` or `no_evidence`.
     """
 
+    # Treat missing legal payload as "no hard legal requirements configured".
+    if legal_requirements_by_action_id is None:
+        legal_requirements_by_action_id = {}
+
+    valid_actions: list[Action] = []
+    discarded_legal: list[Action] = []
+
     for action in actions:
-        action_evidence = evidence.setdefault(action.action_id, {"discard_reason": None})
-        action_evidence["legal_filter_status"] = "not_applied_stub"
-    return actions
+        # Reuse hard-filter evidence so the caller gets one combined trace per action.
+        action_evidence = evidence.setdefault(
+            action.action_id, {"discard_reason": None}
+        )
+        requirements = legal_requirements_by_action_id.get(action.action_id, [])
+        # Hard gate only evaluates mandatory/required strengths.
+        hard_requirements = [
+            requirement
+            for requirement in requirements
+            if requirement.strength.lower() in HARD_REQUIREMENT_STRENGTHS
+        ]
+
+        failed_requirements: list[dict[str, object]] = []
+        unknown_requirements: list[dict[str, object]] = []
+
+        # Split hard requirements into blocking failures and non-blocking unknowns
+        for requirement in hard_requirements:
+            requirement_summary = {
+                "signal_code": requirement.signal_code,
+                "signal_name": requirement.signal_name,
+                "strength": requirement.strength,
+                "alignment_status": requirement.alignment_status,
+                "operator": requirement.operator,
+                "required_value": requirement.required_value,
+                "legal_signal_value": requirement.legal_signal_value,
+                "evidence_ids": list(requirement.evidence_ids),
+                "evidence_count": requirement.evidence_count,
+                "location_scope": requirement.location_scope,
+                "location_name": requirement.location_name,
+            }
+            alignment_status = requirement.alignment_status.lower()
+            if alignment_status == "not_aligned":
+                failed_requirements.append(requirement_summary)
+            elif alignment_status == "no_evidence":
+                unknown_requirements.append(requirement_summary)
+
+        # Always expose summary counters for observability and UI status labels.
+        action_evidence["hard_requirements_checked_count"] = len(hard_requirements)
+        action_evidence["hard_requirements_failed_count"] = len(failed_requirements)
+        action_evidence["hard_requirements_unknown_count"] = len(unknown_requirements)
+        action_evidence["unknown_requirements"] = unknown_requirements
+
+        # Any failed hard requirement blocks the action from scoring.
+        if failed_requirements:
+            action_evidence["discard_reason"] = "legal_hard_requirement_failed"
+            action_evidence["failed_requirements"] = failed_requirements
+            discarded_legal.append(action)
+            continue
+
+        # Actions with no hard failures continue to scoring.
+        valid_actions.append(action)
+
+    return valid_actions, discarded_legal
 
 
-def run(actions: list[Action], excluded_actions_free_text: str | None) -> HardFilterResult:
+def run(
+    actions: list[Action],
+    excluded_actions_free_text: str | None,
+    legal_requirements_by_action_id: (
+        dict[str, list[HardFilterLegalRequirement]] | None
+    ) = None,
+) -> HardFilterResult:
     """
     Filter out ineligible actions before scoring.
 
@@ -74,18 +150,26 @@ def run(actions: list[Action], excluded_actions_free_text: str | None) -> HardFi
     - `excluded_actions_free_text`: Frontend free-text exclusion guidance.
     """
 
+    # Step 1: resolve free-text exclusions into concrete action IDs (stub for now).
     excluded_action_ids = _resolve_excluded_action_ids_from_text(
         actions=actions,
         excluded_actions_free_text=excluded_actions_free_text,
     )
+    # Step 2: apply explicit action exclusions and initialize evidence entries.
     valid_actions, discarded_excluded, evidence = _apply_free_text_exclusion_filter(
         actions=actions,
         excluded_action_ids=excluded_action_ids,
     )
-    valid_actions = _apply_legal_hard_filter(actions=valid_actions, evidence=evidence)
+    # Step 3: apply hard legal gate to the remaining candidates.
+    valid_actions, discarded_legal = _apply_legal_hard_filter(
+        actions=valid_actions,
+        evidence=evidence,
+        legal_requirements_by_action_id=legal_requirements_by_action_id,
+    )
 
     return HardFilterResult(
         valid_actions=valid_actions,
         discarded_excluded=discarded_excluded,
+        discarded_legal=discarded_legal,
         evidence=evidence,
     )

--- a/hiap-meed/app/modules/prioritizer/blocks/impact.py
+++ b/hiap-meed/app/modules/prioritizer/blocks/impact.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from app.modules.prioritizer.models import Action, BlockScoreResult
+from app.modules.prioritizer.internal_models import Action, BlockScoreResult
 
 
 def _read_gpc_refs(impact_row: dict[str, object]) -> list[str]:
@@ -52,6 +52,3 @@ def run(actions: list[Action]) -> BlockScoreResult:
         score_by_action_id=score_by_action_id,
         evidence_by_action_id=evidence_by_action_id,
     )
-
-
-__all__ = ["run"]

--- a/hiap-meed/app/modules/prioritizer/config.py
+++ b/hiap-meed/app/modules/prioritizer/config.py
@@ -57,6 +57,3 @@ def validate_weights(weights: Mapping[str, float] | None) -> dict[str, float]:
         raise ValueError(f"Weight sum must be 1.0, got {total}")
 
     return resolved
-
-
-__all__ = ["DEFAULT_WEIGHTS", "validate_weights"]

--- a/hiap-meed/app/modules/prioritizer/internal_models.py
+++ b/hiap-meed/app/modules/prioritizer/internal_models.py
@@ -1,0 +1,121 @@
+"""Internal prioritizer contracts used between pipeline blocks."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class CityData(BaseModel):
+    """
+    Internal city representation consumed by alignment/feasibility blocks.
+
+    This model is intentionally snake_case and independent from external
+    upstream response DTOs.
+    """
+
+    comuna_name: str
+    locode: str = Field(min_length=1)
+    country_code: str | None = None
+    region_name: str
+    comuna_code: str
+    region_code: str
+    population_size: int | None = None
+    population_density: float | None = None
+    area: float | None = None
+    comuna: str | None = None
+    city_context: list[dict[str, Any]] = Field(default_factory=list)
+    as_of: datetime | None = None
+    source: str | None = None
+    raw: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _backfill_city_context(cls, values: Any) -> Any:
+        """Build a minimal context list from known city indicators if absent."""
+        if not isinstance(values, dict):
+            return values
+        if values.get("city_context"):
+            return values
+
+        indicators = (
+            "unemployment_rate",
+            "renter_share",
+            "transport_logistics_employment",
+            "electricity_access",
+            "industry_construction_employment",
+            "median_household_income",
+            "public_transport_share",
+            "poverty_rate",
+            "home_ownership",
+        )
+        context_rows: list[dict[str, Any]] = []
+        for indicator_name in indicators:
+            indicator_value = values.get(indicator_name)
+            if isinstance(indicator_value, dict):
+                context_rows.append({"attribute_name": indicator_name, **indicator_value})
+        if context_rows:
+            values["city_context"] = context_rows
+        return values
+
+
+class Action(BaseModel):
+    """Internal action representation consumed by scoring blocks."""
+
+    action_id: str = Field(min_length=1)
+    action_name: str
+    action_type: str | None = None
+    description: str | None = None
+    action_category: str | None = None
+    action_subcategory: str | None = None
+    investment_cost: str | None = None
+    implementation_timeline: str | None = None
+    biome: str | None = None
+    mitigation_impact: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    impacts: list[dict[str, Any]] = Field(default_factory=list)
+    as_of: datetime | None = None
+    source: str | None = None
+    raw: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _backfill_impacts(self) -> Action:
+        """Flatten `mitigation_impact` object into legacy `impacts` row list."""
+        if self.impacts or not self.mitigation_impact:
+            return self
+        flattened: list[dict[str, Any]] = []
+        for impact_type, impact_data in self.mitigation_impact.items():
+            if not isinstance(impact_data, dict):
+                continue
+            flattened.append({"impact_type": impact_type, **impact_data})
+        self.impacts = flattened
+        return self
+
+
+class BlockScoreResult(BaseModel):
+    """Per-block action scores and optional explainability metadata."""
+
+    score_by_action_id: dict[str, float] = Field(default_factory=dict)
+    evidence_by_action_id: dict[str, dict[str, object]] | None = None
+
+
+class HardFilterResult(BaseModel):
+    """Result of hard filtering before scoring blocks run."""
+
+    valid_actions: list[Action] = Field(default_factory=list)
+    discarded_excluded: list[Action] = Field(default_factory=list)
+    evidence: dict[str, dict[str, object]] = Field(default_factory=dict)
+
+
+class ScoredAction(BaseModel):
+    """Action scores after weighted aggregation and ranking."""
+
+    action: Action
+    impact_score: float
+    alignment_score: float
+    feasibility_score: float
+    final_score: float
+    rank: int
+    evidence: dict[str, object] = Field(default_factory=dict)
+

--- a/hiap-meed/app/modules/prioritizer/internal_models.py
+++ b/hiap-meed/app/modules/prioritizer/internal_models.py
@@ -105,7 +105,24 @@ class HardFilterResult(BaseModel):
 
     valid_actions: list[Action] = Field(default_factory=list)
     discarded_excluded: list[Action] = Field(default_factory=list)
+    discarded_legal: list[Action] = Field(default_factory=list)
     evidence: dict[str, dict[str, object]] = Field(default_factory=dict)
+
+
+class HardFilterLegalRequirement(BaseModel):
+    """Internal legal requirement contract consumed by hard-filter logic."""
+
+    signal_code: str
+    signal_name: str
+    operator: str
+    required_value: str | None = None
+    legal_signal_value: str | None = None
+    strength: str
+    alignment_status: str
+    location_scope: str | None = None
+    location_name: str | None = None
+    evidence_ids: list[str] = Field(default_factory=list)
+    evidence_count: int = 0
 
 
 class ScoredAction(BaseModel):

--- a/hiap-meed/app/modules/prioritizer/models.py
+++ b/hiap-meed/app/modules/prioritizer/models.py
@@ -75,6 +75,7 @@ class FrontendCityInput(BaseModel):
     countryCode: str = Field(min_length=2, max_length=2)
     populationSize: int | None = None
     excludedActionsFreeText: str | None = None
+    weightsOverride: dict[str, float] | None = None
     cityStrategicPreferenceSectors: list[str] = Field(default_factory=list)
     cityStrategicPreferenceOther: str | None = None
     cityEmissionsData: FrontendCityEmissionsData
@@ -265,28 +266,24 @@ class ActionsLegalApiResponse(BaseModel):
     legal_requirements: list[LegalRequirementsByAction] = Field(default_factory=list)
 
 
-# ============================================================================
-# TOP-LEVEL PRIORITIZATION ENDPOINT CONTRACTS
-# ----------------------------------------------------------------------------
-# Composition:
-# - PrioritizationRequest: input contract for `POST /v1/prioritize`
-# - PrioritizationResponse: output contract for `POST /v1/prioritize`
-# ============================================================================
-
-
-class PrioritizationRequest(BaseModel):
-    """Current top-level request payload for `/v1/prioritize`."""
-
-    locode: str = Field(min_length=1)
-    excluded_action_ids: list[str] = Field(default_factory=list)
-    weights_override: dict[str, float] | None = None
-    top_n: int | None = Field(default=None, ge=1)
-
-
 class PrioritizationResponse(BaseModel):
-    """Current top-level response payload for `/v1/prioritize`."""
+    """Per-city prioritization output used by the API response."""
 
     ranked_action_ids: list[str] = Field(default_factory=list)
     metadata: dict[str, object] = Field(default_factory=dict)
+
+
+class PrioritizerApiCityResult(BaseModel):
+    """One city result entry returned by the prioritization endpoint."""
+
+    locode: str = Field(min_length=1)
+    ranked_action_ids: list[str] = Field(default_factory=list)
+    metadata: dict[str, object] = Field(default_factory=dict)
+
+
+class PrioritizerApiResponse(BaseModel):
+    """Top-level response for the frontend prioritization request envelope."""
+
+    results: list[PrioritizerApiCityResult] = Field(default_factory=list)
 
 

--- a/hiap-meed/app/modules/prioritizer/models.py
+++ b/hiap-meed/app/modules/prioritizer/models.py
@@ -1,93 +1,281 @@
 """
-Pydantic models for the MEED prioritizer.
-
-This module intentionally keeps the domain surface small for the initial phase:
-- `CityData` from city identity + city context inputs
-- `Action` from action catalog + impact rows
+Pydantic models for external API payloads and top-level endpoint contracts.
 """
 
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, Field
 
 
-class CityData(BaseModel):
-    """
-    City identity and socio-economic context.
+# ============================================================================
+# FRONTEND REQUEST ENVELOPE MODELS (CityCatalyst -> hiap-meed)
+# ----------------------------------------------------------------------------
+# Composition:
+# - PrioritizerApiRequest
+#   - meta: FrontendRequestMeta
+#     - apiContext: FrontendApiContext
+#   - requestData: PrioritizerRequestData
+#     - cityDataList: list[FrontendCityInput]
+#       - cityEmissionsData: FrontendCityEmissionsData
+#         - gpcData: dict[str, GpcDataEntry]
+#           - activities: list[GpcActivity]
+# ============================================================================
 
-    Inputs:
-    - City identity fields from the upstream city endpoint.
-    - `city_context` row-like records aligned with `city_context.csv` fields.
-    """
+
+class FrontendApiContext(BaseModel):
+    """Frontend request API context metadata."""
+
+    endpoint: str
+    locodes: list[str] = Field(default_factory=list)
+
+
+class FrontendRequestMeta(BaseModel):
+    """Metadata envelope for prioritizer requests sent by CityCatalyst."""
+
+    requestId: str
+    generatedAtUtc: str
+    backendConsumer: str
+    upstreamProvider: str
+    apiContext: FrontendApiContext
+    totalRecords: int
+
+
+class GpcActivity(BaseModel):
+    """Single activity record for one GPC key."""
+
+    activityName: str
+    totalEmissions: float | None = None
+    totalEmissionsUnit: str | None = None
+    activityValue: float | None = None
+    activityUnit: str | None = None
+    dataSource: str | None = None
+    notationKey: str | None = None
+
+
+class GpcDataEntry(BaseModel):
+    """One GPC reference key payload containing optional activities."""
+
+    notationKey: str | None = None
+    activities: list[GpcActivity] = Field(default_factory=list)
+
+
+class FrontendCityEmissionsData(BaseModel):
+    """City emissions payload provided by frontend request."""
+
+    inventoryYear: int | None = None
+    gpcData: dict[str, GpcDataEntry] = Field(default_factory=dict)
+
+
+class FrontendCityInput(BaseModel):
+    """Single city payload within frontend prioritizer request."""
+
+    locode: str = Field(min_length=1)
+    countryCode: str = Field(min_length=2, max_length=2)
+    populationSize: int | None = None
+    excludedActionsFreeText: str | None = None
+    cityStrategicPreferenceSectors: list[str] = Field(default_factory=list)
+    cityStrategicPreferenceOther: str | None = None
+    cityEmissionsData: FrontendCityEmissionsData
+
+
+class PrioritizerRequestData(BaseModel):
+    """RequestData section of frontend prioritizer request payload."""
+
+    requestedLanguages: list[str] = Field(default_factory=lambda: ["en"])
+    cityDataList: list[FrontendCityInput] = Field(min_length=1)
+
+
+class PrioritizerApiRequest(BaseModel):
+    """Frontend -> hiap-meed request envelope for single or multi-city prioritization."""
+
+    meta: FrontendRequestMeta
+    requestData: PrioritizerRequestData
+
+
+# ============================================================================
+# UPSTREAM RESPONSE MODELS (global-api -> hiap-meed)
+# ----------------------------------------------------------------------------
+# Composition:
+# - CityApiResponse
+#   - meta: UpstreamMeta
+#     - api_context: UpstreamApiContext
+#   - city: CityApiItem
+# - CitiesApiResponse
+#   - meta: UpstreamMeta
+#   - cities: list[CityApiItem]
+# - ActionsApiResponse
+#   - meta: UpstreamMeta
+#   - actions: list[ActionApiItem]
+# - ActionsPolicySignalsApiResponse
+#   - meta: UpstreamMeta
+#   - policy_signals: list[PolicySignalByAction]
+#     - policy_signals: list[PolicySignal]
+# - ActionsLegalApiResponse
+#   - meta: ActionsLegalApiMeta (extends UpstreamMeta)
+#   - legal_requirements: list[LegalRequirementsByAction]
+#     - requirements: list[LegalRequirement]
+# ============================================================================
+
+
+class UpstreamApiContext(BaseModel):
+    """Common API context metadata returned by upstream APIs."""
+
+    endpoint: str
+    locode: str | None = None
+
+
+class UpstreamMeta(BaseModel):
+    """Common metadata envelope returned by upstream APIs."""
+
+    generated_at_utc: str
+    backend_consumer: str
+    upstream_provider: str
+    api_context: UpstreamApiContext
+    total_records: int
+
+
+class CityIndicator(BaseModel):
+    """Single city indicator object used in city API payload."""
+
+    attribute_value: float | str | None = None
+    attribute_units: str | None = None
+    attribute_category: str | None = None
+
+
+class CityApiItem(BaseModel):
+    """City item shape returned by upstream `GET /v1/cities/{locode}`."""
 
     comuna_name: str
-    locode: str = Field(min_length=1)
+    locode: str
+    countryCode: str | None = None
     region_name: str
     comuna_code: str
     region_code: str
-    comuna: str | None = None
-    city_context: list[dict[str, Any]] = Field(default_factory=list)
-    as_of: datetime | None = None
-    source: str | None = None
-    raw: dict[str, Any] = Field(default_factory=dict)
+    populationSize: int | None = None
+    populationDensity: float | None = None
+    area: float | None = None
+    unemployment_rate: CityIndicator | None = None
+    renter_share: CityIndicator | None = None
+    transport_logistics_employment: CityIndicator | None = None
+    electricity_access: CityIndicator | None = None
+    industry_construction_employment: CityIndicator | None = None
+    median_household_income: CityIndicator | None = None
+    public_transport_share: CityIndicator | None = None
+    poverty_rate: CityIndicator | None = None
+    home_ownership: CityIndicator | None = None
 
 
-class Action(BaseModel):
-    """
-    Action catalog record with embedded impact rows.
+class ActionApiItem(BaseModel):
+    """Action item shape returned by upstream `GET /v1/actions`."""
 
-    Inputs:
-    - Action identity and attributes from the upstream actions endpoint.
-    - `impacts` row-like records aligned with `actions_mitigation_impact.csv`.
-    """
-
-    action_id: str = Field(min_length=1)
-    action_name: str
-    action_type: str | None = None
+    actionId: str
+    actionName: str
     description: str | None = None
-    action_category: str | None = None
-    action_subcategory: str | None = None
-    investment_cost: str | None = None
-    implementation_timeline: str | None = None
-    biome: str | None = None
-    impacts: list[dict[str, Any]] = Field(default_factory=list)
-    as_of: datetime | None = None
-    source: str | None = None
-    raw: dict[str, Any] = Field(default_factory=dict)
+    actionCategory: str | None = None
+    actionSubcategory: str | None = None
+    costInvestmentNeeded: str | None = None
+    timelineForImplementation: str | None = None
+    mitigationImpact: dict[str, dict[str, Any]] = Field(default_factory=dict)
 
 
-class BlockScoreResult(BaseModel):
-    """Per-block action scores and optional explainability metadata."""
+class CityApiResponse(BaseModel):
+    """Response model for `GET /v1/cities/{locode}`."""
 
-    score_by_action_id: dict[str, float] = Field(default_factory=dict)
-    evidence_by_action_id: dict[str, dict[str, object]] | None = None
-
-
-class HardFilterResult(BaseModel):
-    """Result of hard filtering before scoring blocks run."""
-
-    valid_actions: list[Action] = Field(default_factory=list)
-    discarded_excluded: list[Action] = Field(default_factory=list)
-    evidence: dict[str, dict[str, object]] = Field(default_factory=dict)
+    meta: UpstreamMeta
+    city: CityApiItem
 
 
-class ScoredAction(BaseModel):
-    """Action scores after weighted aggregation and ranking."""
+class CitiesApiResponse(BaseModel):
+    """Response model for city list endpoints."""
 
-    action: Action
-    impact_score: float
-    alignment_score: float
-    feasibility_score: float
-    final_score: float
-    rank: int
-    evidence: dict[str, object] = Field(default_factory=dict)
+    meta: UpstreamMeta
+    cities: list[CityApiItem] = Field(default_factory=list)
+
+
+class ActionsApiResponse(BaseModel):
+    """Response model for `GET /v1/actions`."""
+
+    meta: UpstreamMeta
+    actions: list[ActionApiItem] = Field(default_factory=list)
+
+
+class PolicySignal(BaseModel):
+    """Single policy signal evidence item for one action."""
+
+    location_scope: str
+    location_name: str
+    signal_type: str
+    signal_relation: str
+    signal_strength: str
+    evidence_ids: list[str] = Field(default_factory=list)
+    evidence_count: int = 0
+
+
+class PolicySignalByAction(BaseModel):
+    """Policy signal collection grouped by action ID."""
+
+    action_id: str
+    policy_signals: list[PolicySignal] = Field(default_factory=list)
+    policy_support_score: float | None = None
+
+
+class ActionsPolicySignalsApiResponse(BaseModel):
+    """Response model for city-scoped policy alignment endpoint."""
+
+    meta: UpstreamMeta
+    policy_signals: list[PolicySignalByAction] = Field(default_factory=list)
+
+
+class LegalRequirement(BaseModel):
+    """Single legal requirement alignment check for one action."""
+
+    signal_code: str
+    signal_name: str
+    operator: str
+    required_value: str | None = None
+    legal_signal_value: str | None = None
+    strength: str
+    alignment_status: str
+    location_scope: str | None = None
+    location_name: str | None = None
+    evidence_ids: list[str] = Field(default_factory=list)
+    evidence_count: int = 0
+
+
+class LegalRequirementsByAction(BaseModel):
+    """Legal requirements grouped by action ID."""
+
+    action_id: str
+    requirements: list[LegalRequirement] = Field(default_factory=list)
+
+
+class ActionsLegalApiMeta(UpstreamMeta):
+    """Metadata for actions/legal response including test descriptors."""
+
+    test_cases: dict[str, str] = Field(default_factory=dict)
+    strength_scale: list[str] = Field(default_factory=list)
+
+
+class ActionsLegalApiResponse(BaseModel):
+    """Response model for city-scoped legal alignment endpoint."""
+
+    meta: ActionsLegalApiMeta
+    legal_requirements: list[LegalRequirementsByAction] = Field(default_factory=list)
+
+
+# ============================================================================
+# TOP-LEVEL PRIORITIZATION ENDPOINT CONTRACTS
+# ----------------------------------------------------------------------------
+# Composition:
+# - PrioritizationRequest: input contract for `POST /v1/prioritize`
+# - PrioritizationResponse: output contract for `POST /v1/prioritize`
+# ============================================================================
 
 
 class PrioritizationRequest(BaseModel):
-    """Request payload for the prioritization endpoint."""
+    """Current top-level request payload for `/v1/prioritize`."""
 
     locode: str = Field(min_length=1)
     excluded_action_ids: list[str] = Field(default_factory=list)
@@ -96,18 +284,9 @@ class PrioritizationRequest(BaseModel):
 
 
 class PrioritizationResponse(BaseModel):
-    """Response payload with ordered action IDs and execution metadata."""
+    """Current top-level response payload for `/v1/prioritize`."""
 
     ranked_action_ids: list[str] = Field(default_factory=list)
     metadata: dict[str, object] = Field(default_factory=dict)
 
 
-__all__ = [
-    "Action",
-    "BlockScoreResult",
-    "CityData",
-    "HardFilterResult",
-    "PrioritizationRequest",
-    "PrioritizationResponse",
-    "ScoredAction",
-]

--- a/hiap-meed/app/modules/prioritizer/orchestrator.py
+++ b/hiap-meed/app/modules/prioritizer/orchestrator.py
@@ -169,4 +169,3 @@ def run_prioritization(
     return PrioritizationResponse(ranked_action_ids=ranked_action_ids, metadata=metadata)
 
 
-__all__ = ["run_prioritization"]

--- a/hiap-meed/app/modules/prioritizer/orchestrator.py
+++ b/hiap-meed/app/modules/prioritizer/orchestrator.py
@@ -13,7 +13,7 @@ from app.modules.prioritizer.blocks import (
     impact,
 )
 from app.modules.prioritizer.config import validate_weights
-from app.modules.prioritizer.models import PrioritizationRequest, PrioritizationResponse
+from app.modules.prioritizer.models import PrioritizationResponse
 from app.services.data_clients import ActionDataApiClient, CityDataApiClient
 from app.utils.artifacts import ArtifactWriter
 from app.utils.timing import time_block
@@ -35,8 +35,12 @@ def _safe_block_evidence(
 
 
 def run_prioritization(
-    request: PrioritizationRequest,
-    request_id: UUID,
+    *,
+    locode: str,
+    weights_override: dict[str, float] | None,
+    top_n: int | None,
+    excluded_actions_free_text: str | None,
+    internal_request_id: UUID,
     city_data_api_client: CityDataApiClient,
     action_data_api_client: ActionDataApiClient,
 ) -> PrioritizationResponse:
@@ -48,16 +52,17 @@ def run_prioritization(
     - Metadata with timings, counts, and resolved weights.
     """
 
-    artifact_writer = ArtifactWriter(request_id=request_id)
+    artifact_writer = ArtifactWriter(request_id=internal_request_id)
     timings: dict[str, float] = {}
 
     with time_block("fetch_city") as block:
-        city = city_data_api_client.get_city(request.locode)
+        city = city_data_api_client.get_city(locode)
+
     timings["fetch_city"] = block.elapsed_seconds
     artifact_writer.write_event(
         "fetch_city.completed",
         {
-            "locode": request.locode,
+            "locode": locode,
             "city_context_rows": len(city.city_context),
             "elapsed_seconds": block.elapsed_seconds,
         },
@@ -72,7 +77,7 @@ def run_prioritization(
     )
 
     with time_block("validate_weights") as block:
-        weights = validate_weights(request.weights_override)
+        weights = validate_weights(weights_override)
     timings["validate_weights"] = block.elapsed_seconds
     artifact_writer.write_event(
         "validate_weights.completed",
@@ -82,7 +87,7 @@ def run_prioritization(
     with time_block("hard_filter") as block:
         hard_filter_result = hard_filter.run(
             actions=actions,
-            excluded_action_ids=set(request.excluded_action_ids),
+            excluded_actions_free_text=excluded_actions_free_text,
         )
     timings["hard_filter"] = block.elapsed_seconds
     artifact_writer.write_event(
@@ -122,7 +127,7 @@ def run_prioritization(
             alignment_scores=alignment_result.score_by_action_id,
             feasibility_scores=feasibility_result.score_by_action_id,
             weights=weights,
-            top_n=request.top_n,
+            top_n=top_n,
         )
     timings["final_scoring"] = block.elapsed_seconds
 
@@ -130,8 +135,12 @@ def run_prioritization(
         action_id = scored_action.action.action_id
         scored_action.evidence = {
             "hard_filter": hard_filter_result.evidence.get(action_id, {}),
-            "impact": _safe_block_evidence(impact_result.evidence_by_action_id, action_id),
-            "alignment": _safe_block_evidence(alignment_result.evidence_by_action_id, action_id),
+            "impact": _safe_block_evidence(
+                impact_result.evidence_by_action_id, action_id
+            ),
+            "alignment": _safe_block_evidence(
+                alignment_result.evidence_by_action_id, action_id
+            ),
             "feasibility": _safe_block_evidence(
                 feasibility_result.evidence_by_action_id,
                 action_id,
@@ -141,8 +150,8 @@ def run_prioritization(
     ranked_action_ids = [item.action.action_id for item in scored_actions]
 
     metadata: dict[str, object] = {
-        "request_id": str(request_id),
-        "locode": request.locode,
+        "internal_request_id": str(internal_request_id),
+        "locode": locode,
         "weights": weights,
         "timings": timings,
         "counts": {
@@ -161,11 +170,11 @@ def run_prioritization(
     )
 
     logger.info(
-        "Prioritization complete request_id=%s locode=%s ranked_actions=%s",
-        request_id,
-        request.locode,
+        "Prioritization complete internal_request_id=%s locode=%s ranked_actions=%s",
+        internal_request_id,
+        locode,
         len(ranked_action_ids),
     )
-    return PrioritizationResponse(ranked_action_ids=ranked_action_ids, metadata=metadata)
-
-
+    return PrioritizationResponse(
+        ranked_action_ids=ranked_action_ids, metadata=metadata
+    )

--- a/hiap-meed/app/modules/prioritizer/orchestrator.py
+++ b/hiap-meed/app/modules/prioritizer/orchestrator.py
@@ -14,7 +14,11 @@ from app.modules.prioritizer.blocks import (
 )
 from app.modules.prioritizer.config import validate_weights
 from app.modules.prioritizer.models import PrioritizationResponse
-from app.services.data_clients import ActionDataApiClient, CityDataApiClient
+from app.services.data_clients import (
+    ActionDataApiClient,
+    CityDataApiClient,
+    LegalDataApiClient,
+)
 from app.utils.artifacts import ArtifactWriter
 from app.utils.timing import time_block
 
@@ -43,6 +47,7 @@ def run_prioritization(
     internal_request_id: UUID,
     city_data_api_client: CityDataApiClient,
     action_data_api_client: ActionDataApiClient,
+    legal_data_api_client: LegalDataApiClient,
 ) -> PrioritizationResponse:
     """
     Run the end-to-end prioritization workflow for one city request.
@@ -76,6 +81,19 @@ def run_prioritization(
         {"total_actions": len(actions), "elapsed_seconds": block.elapsed_seconds},
     )
 
+    with time_block("fetch_legal_requirements") as block:
+        legal_requirements_by_action_id = legal_data_api_client.get_action_legal_requirements(
+            locode
+        )
+    timings["fetch_legal_requirements"] = block.elapsed_seconds
+    artifact_writer.write_event(
+        "fetch_legal_requirements.completed",
+        {
+            "actions_with_legal_requirements": len(legal_requirements_by_action_id),
+            "elapsed_seconds": block.elapsed_seconds,
+        },
+    )
+
     with time_block("validate_weights") as block:
         weights = validate_weights(weights_override)
     timings["validate_weights"] = block.elapsed_seconds
@@ -88,6 +106,7 @@ def run_prioritization(
         hard_filter_result = hard_filter.run(
             actions=actions,
             excluded_actions_free_text=excluded_actions_free_text,
+            legal_requirements_by_action_id=legal_requirements_by_action_id,
         )
     timings["hard_filter"] = block.elapsed_seconds
     artifact_writer.write_event(
@@ -95,6 +114,7 @@ def run_prioritization(
         {
             "valid_actions": len(hard_filter_result.valid_actions),
             "discarded_excluded": len(hard_filter_result.discarded_excluded),
+            "discarded_legal": len(hard_filter_result.discarded_legal),
             "elapsed_seconds": block.elapsed_seconds,
         },
     )
@@ -154,10 +174,12 @@ def run_prioritization(
         "locode": locode,
         "weights": weights,
         "timings": timings,
+        "hard_filter_evidence_by_action_id": hard_filter_result.evidence,
         "counts": {
             "total_actions": len(actions),
             "valid_actions": len(hard_filter_result.valid_actions),
             "discarded_excluded": len(hard_filter_result.discarded_excluded),
+            "discarded_legal": len(hard_filter_result.discarded_legal),
             "ranked_actions": len(ranked_action_ids),
         },
     }

--- a/hiap-meed/app/modules/prioritizer/orchestrator.py
+++ b/hiap-meed/app/modules/prioritizer/orchestrator.py
@@ -13,6 +13,7 @@ from app.modules.prioritizer.blocks import (
     impact,
 )
 from app.modules.prioritizer.config import validate_weights
+from app.modules.prioritizer.internal_models import Action
 from app.modules.prioritizer.models import PrioritizationResponse
 from app.services.data_clients import (
     ActionDataApiClient,
@@ -24,6 +25,35 @@ from app.utils.timing import time_block
 
 
 logger = logging.getLogger(__name__)
+
+
+def _sorted_action_ids(actions: list[Action]) -> list[str]:
+    """Return all action IDs in deterministic sorted order."""
+    action_ids = [action.action_id for action in actions]
+    return sorted(action_ids)
+
+
+def _score_stats(score_by_action_id: dict[str, float]) -> dict[str, float | int | bool]:
+    """Return compact score distribution stats for one block."""
+    if not score_by_action_id:
+        return {"actions": 0, "all_scores_zero": True}
+    scores = list(score_by_action_id.values())
+    return {
+        "actions": len(scores),
+        "all_scores_zero": all(score == 0.0 for score in scores),
+        "min_score": min(scores),
+        "max_score": max(scores),
+    }
+
+
+def _all_block_evidence(
+    evidence_by_action_id: dict[str, dict[str, object]] | None,
+) -> dict[str, dict[str, object]]:
+    """Return full block evidence keyed by action ID in deterministic order."""
+    if not evidence_by_action_id:
+        return {}
+    sorted_ids = sorted(evidence_by_action_id.keys())
+    return {action_id: evidence_by_action_id[action_id] for action_id in sorted_ids}
 
 
 def _safe_block_evidence(
@@ -57,82 +87,217 @@ def run_prioritization(
     - Metadata with timings, counts, and resolved weights.
     """
 
+    # Phase 0: initialize request-scoped artifact writer and timing accumulator.
     artifact_writer = ArtifactWriter(request_id=internal_request_id)
     timings: dict[str, float] = {}
 
+    # Phase 1: fetch city context used by alignment and feasibility blocks.
     with time_block("fetch_city") as block:
         city = city_data_api_client.get_city(locode)
 
+    # Emit high-level and step-detail artifacts for city fetch.
     timings["fetch_city"] = block.elapsed_seconds
-    artifact_writer.write_event(
-        "fetch_city.completed",
+    fetch_city_payload = {
+        "locode": locode,
+        "city_context_rows": len(city.city_context),
+        "elapsed_seconds": block.elapsed_seconds,
+    }
+    fetch_city_event_index = artifact_writer.write_event(
+        "fetch_city.completed", fetch_city_payload
+    )
+    artifact_writer.write_step_detail(
+        "fetch_city",
         {
-            "locode": locode,
-            "city_context_rows": len(city.city_context),
-            "elapsed_seconds": block.elapsed_seconds,
+            **fetch_city_payload,
+            "comuna_name": city.comuna_name,
+            "region_name": city.region_name,
         },
+        event_index=fetch_city_event_index,
+        event_type="fetch_city.completed",
     )
 
+    # Phase 2: fetch action catalog that enters hard filtering.
     with time_block("fetch_actions") as block:
         actions = action_data_api_client.list_actions()
+    # Emit high-level and step-detail artifacts for action fetch.
     timings["fetch_actions"] = block.elapsed_seconds
-    artifact_writer.write_event(
-        "fetch_actions.completed",
-        {"total_actions": len(actions), "elapsed_seconds": block.elapsed_seconds},
+    fetch_actions_payload = {
+        "total_actions": len(actions),
+        "elapsed_seconds": block.elapsed_seconds,
+    }
+    fetch_actions_event_index = artifact_writer.write_event(
+        "fetch_actions.completed", fetch_actions_payload
+    )
+    artifact_writer.write_step_detail(
+        "fetch_actions",
+        {
+            **fetch_actions_payload,
+            "action_ids": _sorted_action_ids(actions),
+        },
+        event_index=fetch_actions_event_index,
+        event_type="fetch_actions.completed",
     )
 
+    # Phase 3: fetch legal requirements used by hard legal filtering.
     with time_block("fetch_legal_requirements") as block:
         legal_requirements_by_action_id = legal_data_api_client.get_action_legal_requirements(
             locode
         )
+    # Emit high-level and step-detail artifacts for legal requirement fetch.
     timings["fetch_legal_requirements"] = block.elapsed_seconds
-    artifact_writer.write_event(
-        "fetch_legal_requirements.completed",
+    fetch_legal_payload = {
+        "actions_with_legal_requirements": len(legal_requirements_by_action_id),
+        "elapsed_seconds": block.elapsed_seconds,
+    }
+    fetch_legal_event_index = artifact_writer.write_event(
+        "fetch_legal_requirements.completed", fetch_legal_payload
+    )
+    artifact_writer.write_step_detail(
+        "fetch_legal_requirements",
         {
-            "actions_with_legal_requirements": len(legal_requirements_by_action_id),
-            "elapsed_seconds": block.elapsed_seconds,
+            **fetch_legal_payload,
+            "action_ids_with_requirements": sorted(
+                legal_requirements_by_action_id.keys()
+            ),
         },
+        event_index=fetch_legal_event_index,
+        event_type="fetch_legal_requirements.completed",
     )
 
+    # Phase 4: validate and resolve ranking weights for this run.
     with time_block("validate_weights") as block:
         weights = validate_weights(weights_override)
+    # Emit high-level and step-detail artifacts for weight resolution.
     timings["validate_weights"] = block.elapsed_seconds
-    artifact_writer.write_event(
-        "validate_weights.completed",
-        {"weights": weights, "elapsed_seconds": block.elapsed_seconds},
+    validate_weights_payload = {
+        "weights": weights,
+        "weights_override_provided": weights_override is not None,
+        "elapsed_seconds": block.elapsed_seconds,
+    }
+    validate_weights_event_index = artifact_writer.write_event(
+        "validate_weights.completed", validate_weights_payload
+    )
+    artifact_writer.write_step_detail(
+        "validate_weights",
+        validate_weights_payload,
+        event_index=validate_weights_event_index,
+        event_type="validate_weights.completed",
     )
 
+    # Phase 5: run hard filter to remove excluded and legally blocked actions.
     with time_block("hard_filter") as block:
         hard_filter_result = hard_filter.run(
             actions=actions,
             excluded_actions_free_text=excluded_actions_free_text,
             legal_requirements_by_action_id=legal_requirements_by_action_id,
         )
+    # Build discard diagnostics and emit hard-filter artifacts.
     timings["hard_filter"] = block.elapsed_seconds
-    artifact_writer.write_event(
-        "hard_filter.completed",
+    discarded_excluded_ids = [item.action_id for item in hard_filter_result.discarded_excluded]
+    discarded_legal_ids = [item.action_id for item in hard_filter_result.discarded_legal]
+    hard_filter_payload = {
+        "valid_actions": len(hard_filter_result.valid_actions),
+        "discarded_excluded": len(discarded_excluded_ids),
+        "discarded_legal": len(discarded_legal_ids),
+        "elapsed_seconds": block.elapsed_seconds,
+    }
+    hard_filter_event_index = artifact_writer.write_event(
+        "hard_filter.completed", hard_filter_payload
+    )
+    artifact_writer.write_step_detail(
+        "hard_filter",
         {
-            "valid_actions": len(hard_filter_result.valid_actions),
-            "discarded_excluded": len(hard_filter_result.discarded_excluded),
-            "discarded_legal": len(hard_filter_result.discarded_legal),
-            "elapsed_seconds": block.elapsed_seconds,
+            **hard_filter_payload,
+            "discarded_excluded_action_ids": sorted(discarded_excluded_ids),
+            "discarded_legal_action_ids": sorted(discarded_legal_ids),
+            "discarded_legal_reasons_by_action_id": {
+                action_id: {
+                    "discard_reason": hard_filter_result.evidence.get(action_id, {}).get(
+                        "discard_reason"
+                    ),
+                    "failed_requirements_count": hard_filter_result.evidence.get(
+                        action_id, {}
+                    ).get("hard_requirements_failed_count", 0),
+                }
+                for action_id in sorted(discarded_legal_ids)
+            },
+            "valid_action_ids": _sorted_action_ids(hard_filter_result.valid_actions),
         },
+        event_index=hard_filter_event_index,
+        event_type="hard_filter.completed",
     )
 
+    # Phase 6: run Impact block scoring on hard-filtered actions.
     with time_block("impact") as block:
         impact_result = impact.run(hard_filter_result.valid_actions)
+    # Emit impact score stats and detailed evidence artifacts.
     timings["impact"] = block.elapsed_seconds
+    impact_payload = {
+        **_score_stats(impact_result.score_by_action_id),
+        "elapsed_seconds": block.elapsed_seconds,
+    }
+    impact_event_index = artifact_writer.write_event("impact.completed", impact_payload)
+    artifact_writer.write_step_detail(
+        "impact",
+        {
+            **impact_payload,
+            "evidence_by_action_id": _all_block_evidence(
+                impact_result.evidence_by_action_id
+            ),
+        },
+        event_index=impact_event_index,
+        event_type="impact.completed",
+    )
 
+    # Phase 7: run Alignment block scoring on hard-filtered actions.
     with time_block("alignment") as block:
         alignment_result = alignment.run(hard_filter_result.valid_actions, city)
+    # Emit alignment score stats and detailed evidence artifacts.
     timings["alignment"] = block.elapsed_seconds
+    alignment_payload = {
+        **_score_stats(alignment_result.score_by_action_id),
+        "elapsed_seconds": block.elapsed_seconds,
+    }
+    alignment_event_index = artifact_writer.write_event(
+        "alignment.completed", alignment_payload
+    )
+    artifact_writer.write_step_detail(
+        "alignment",
+        {
+            **alignment_payload,
+            "evidence_by_action_id": _all_block_evidence(
+                alignment_result.evidence_by_action_id
+            ),
+        },
+        event_index=alignment_event_index,
+        event_type="alignment.completed",
+    )
 
+    # Phase 8: run Feasibility block scoring on hard-filtered actions.
     with time_block("feasibility") as block:
         feasibility_result = feasibility.run(hard_filter_result.valid_actions, city)
+    # Emit feasibility score stats and detailed evidence artifacts.
     timings["feasibility"] = block.elapsed_seconds
-
+    feasibility_payload = {
+        **_score_stats(feasibility_result.score_by_action_id),
+        "elapsed_seconds": block.elapsed_seconds,
+    }
+    feasibility_event_index = artifact_writer.write_event(
+        "feasibility.completed", feasibility_payload
+    )
+    artifact_writer.write_step_detail(
+        "feasibility",
+        {
+            **feasibility_payload,
+            "evidence_by_action_id": _all_block_evidence(
+                feasibility_result.evidence_by_action_id
+            ),
+        },
+        event_index=feasibility_event_index,
+        event_type="feasibility.completed",
+    )
     artifact_writer.write_event(
-        "block_scores.completed",
+        "pillar_scores.completed",
         {
             "impact_actions": len(impact_result.score_by_action_id),
             "alignment_actions": len(alignment_result.score_by_action_id),
@@ -140,6 +305,7 @@ def run_prioritization(
         },
     )
 
+    # Phase 9: aggregate pillar scores into final ranking.
     with time_block("final_scoring") as block:
         scored_actions = final_scoring.run(
             actions=hard_filter_result.valid_actions,
@@ -149,8 +315,37 @@ def run_prioritization(
             weights=weights,
             top_n=top_n,
         )
+    # Emit final-scoring artifacts, including top ranked rows.
     timings["final_scoring"] = block.elapsed_seconds
+    final_scoring_payload = {
+        "ranked_actions": len(scored_actions),
+        "top_n": top_n,
+        "elapsed_seconds": block.elapsed_seconds,
+    }
+    final_scoring_event_index = artifact_writer.write_event(
+        "final_scoring.completed", final_scoring_payload
+    )
+    artifact_writer.write_step_detail(
+        "final_scoring",
+        {
+            **final_scoring_payload,
+            "top_ranked_actions": [
+                {
+                    "rank": item.rank,
+                    "action_id": item.action.action_id,
+                    "final_score": item.final_score,
+                    "impact_score": item.impact_score,
+                    "alignment_score": item.alignment_score,
+                    "feasibility_score": item.feasibility_score,
+                }
+                for item in scored_actions[:20]
+            ],
+        },
+        event_index=final_scoring_event_index,
+        event_type="final_scoring.completed",
+    )
 
+    # Phase 10: attach per-block evidence into each ranked action object.
     for scored_action in scored_actions:
         action_id = scored_action.action.action_id
         scored_action.evidence = {
@@ -167,6 +362,7 @@ def run_prioritization(
             ),
         }
 
+    # Phase 11: build response metadata with counts and timings.
     ranked_action_ids = [item.action.action_id for item in scored_actions]
 
     metadata: dict[str, object] = {
@@ -183,11 +379,36 @@ def run_prioritization(
             "ranked_actions": len(ranked_action_ids),
         },
     }
-    artifact_writer.write_event(
+    # Emit final response and run-summary artifacts.
+    response_event_index = artifact_writer.write_event(
         "response.completed",
         {
             "ranked_action_ids": ranked_action_ids,
             "counts": metadata["counts"],
+        },
+    )
+    artifact_writer.write_step_detail(
+        "response",
+        {
+            "locode": locode,
+            "counts": metadata["counts"],
+            "timings": timings,
+            "weights": weights,
+            "ranked_action_ids": ranked_action_ids,
+            "discarded_excluded_action_ids": sorted(discarded_excluded_ids),
+            "discarded_legal_action_ids": sorted(discarded_legal_ids),
+        },
+        event_index=response_event_index,
+        event_type="response.completed",
+    )
+    artifact_writer.write_event(
+        "run_summary.completed",
+        {
+            "locode": locode,
+            "counts": metadata["counts"],
+            "timings": timings,
+            "discarded_excluded_action_ids": sorted(discarded_excluded_ids),
+            "discarded_legal_action_ids": sorted(discarded_legal_ids),
         },
     )
 

--- a/hiap-meed/app/services/data_clients.py
+++ b/hiap-meed/app/services/data_clients.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from app.modules.prioritizer.models import Action, CityData
+from app.modules.prioritizer.internal_models import Action, CityData
 
 
 class CityDataApiClient:
@@ -69,13 +69,3 @@ def get_city_data_api_client() -> CityDataApiClient:
 def get_action_data_api_client() -> ActionDataApiClient:
     """FastAPI dependency provider for action data client."""
     return _default_action_client
-
-
-__all__ = [
-    "ActionDataApiClient",
-    "CityDataApiClient",
-    "StubActionDataApiClient",
-    "StubCityDataApiClient",
-    "get_action_data_api_client",
-    "get_city_data_api_client",
-]

--- a/hiap-meed/app/services/data_clients.py
+++ b/hiap-meed/app/services/data_clients.py
@@ -2,9 +2,20 @@
 
 from __future__ import annotations
 
+import json
+import logging
+import os
 from dataclasses import dataclass, field
+from pathlib import Path
 
-from app.modules.prioritizer.internal_models import Action, CityData
+from app.modules.prioritizer.internal_models import (
+    Action,
+    CityData,
+    HardFilterLegalRequirement,
+)
+from app.modules.prioritizer.models import ActionsApiResponse, ActionsLegalApiResponse
+
+logger = logging.getLogger(__name__)
 
 
 class CityDataApiClient:
@@ -20,6 +31,16 @@ class ActionDataApiClient:
 
     def list_actions(self) -> list[Action]:
         """Fetch action catalog records."""
+        raise NotImplementedError
+
+
+class LegalDataApiClient:
+    """Minimal interface for legal requirement retrieval."""
+
+    def get_action_legal_requirements(
+        self, locode: str
+    ) -> dict[str, list[HardFilterLegalRequirement]]:
+        """Fetch legal requirements grouped by action ID for one city."""
         raise NotImplementedError
 
 
@@ -57,8 +78,135 @@ class StubActionDataApiClient:
         return list(self.actions)
 
 
+@dataclass
+class MockActionDataApiClient:
+    """
+    File-backed action client loading the checked-in mock actions API payload.
+
+    The mock data is currently city-agnostic and returned as one shared action list.
+    """
+
+    mock_file_path: Path
+
+    def list_actions(self) -> list[Action]:
+        """Load and map mock action catalog rows into internal action models."""
+        payload = json.loads(self.mock_file_path.read_text(encoding="utf-8"))
+        response = ActionsApiResponse.model_validate(payload)
+        actions: list[Action] = []
+        for action in response.actions:
+            actions.append(
+                Action(
+                    action_id=action.actionId,
+                    action_name=action.actionName,
+                    description=action.description,
+                    action_category=action.actionCategory,
+                    action_subcategory=action.actionSubcategory,
+                    investment_cost=action.costInvestmentNeeded,
+                    implementation_timeline=action.timelineForImplementation,
+                    mitigation_impact=action.mitigationImpact,
+                    raw=action.model_dump(),
+                )
+            )
+        return actions
+
+
+@dataclass
+class StubLegalDataApiClient:
+    """In-memory fallback legal client for local development and tests."""
+
+    requirements_by_locode: dict[str, dict[str, list[HardFilterLegalRequirement]]] = field(
+        default_factory=dict
+    )
+
+    def get_action_legal_requirements(
+        self, locode: str
+    ) -> dict[str, list[HardFilterLegalRequirement]]:
+        """Return preloaded legal requirements for a locode, or an empty map."""
+        return dict(self.requirements_by_locode.get(locode, {}))
+
+
+@dataclass
+class MockLegalDataApiClient:
+    """
+    File-backed legal client loading the checked-in mock legal API payload.
+
+    The mock data is city-agnostic in this scaffold and returned for any locode.
+    """
+
+    mock_file_path: Path
+
+    def get_action_legal_requirements(
+        self, locode: str
+    ) -> dict[str, list[HardFilterLegalRequirement]]:
+        """Load mock legal requirements grouped by action ID."""
+        del locode
+        payload = json.loads(self.mock_file_path.read_text(encoding="utf-8"))
+        response = ActionsLegalApiResponse.model_validate(payload)
+        requirements_by_action_id: dict[str, list[HardFilterLegalRequirement]] = {}
+        for action_group in response.legal_requirements:
+            requirements_by_action_id[action_group.action_id] = [
+                HardFilterLegalRequirement(
+                    signal_code=requirement.signal_code,
+                    signal_name=requirement.signal_name,
+                    operator=requirement.operator,
+                    required_value=requirement.required_value,
+                    legal_signal_value=requirement.legal_signal_value,
+                    strength=requirement.strength,
+                    alignment_status=requirement.alignment_status,
+                    location_scope=requirement.location_scope,
+                    location_name=requirement.location_name,
+                    evidence_ids=requirement.evidence_ids,
+                    evidence_count=requirement.evidence_count,
+                )
+                for requirement in action_group.requirements
+            ]
+        return requirements_by_action_id
+
+
+class ApiLegalDataApiClient:
+    """
+    Placeholder legal client for future upstream HTTP integration.
+
+    Current behavior returns an empty map to avoid blocking the pipeline.
+    """
+
+    def get_action_legal_requirements(
+        self, locode: str
+    ) -> dict[str, list[HardFilterLegalRequirement]]:
+        """Return no legal requirements until HTTP integration is implemented."""
+        del locode
+        return {}
+
+
+class ApiActionDataApiClient:
+    """
+    Placeholder action client for future upstream HTTP integration.
+
+    Current behavior returns an empty list to avoid blocking the pipeline.
+    """
+
+    def list_actions(self) -> list[Action]:
+        """Return no actions until HTTP integration is implemented."""
+        return []
+
+
 _default_city_client = StubCityDataApiClient()
 _default_action_client = StubActionDataApiClient()
+_default_api_action_client = ApiActionDataApiClient()
+_default_mock_action_client = MockActionDataApiClient(
+    mock_file_path=Path(__file__).resolve().parents[2]
+    / "data"
+    / "mock"
+    / "actions_api_mock.json"
+)
+_default_stub_legal_client = StubLegalDataApiClient()
+_default_api_legal_client = ApiLegalDataApiClient()
+_default_mock_legal_client = MockLegalDataApiClient(
+    mock_file_path=Path(__file__).resolve().parents[2]
+    / "data"
+    / "mock"
+    / "actions_legal_api_mock.json"
+)
 
 
 def get_city_data_api_client() -> CityDataApiClient:
@@ -67,5 +215,44 @@ def get_city_data_api_client() -> CityDataApiClient:
 
 
 def get_action_data_api_client() -> ActionDataApiClient:
-    """FastAPI dependency provider for action data client."""
+    """FastAPI dependency provider for action catalog client."""
+    source = os.getenv("HIAP_MEED_ACTION_DATA_SOURCE", "mock").strip().lower()
+    if source == "mock":
+        if not _default_mock_action_client.mock_file_path.exists():
+            logger.warning(
+                "Mock actions file not found at `%s`; using stub action client",
+                _default_mock_action_client.mock_file_path,
+            )
+            return _default_action_client
+        return _default_mock_action_client
+    if source == "api":
+        return _default_api_action_client
+    if source == "stub":
+        return _default_action_client
+
+    logger.warning(
+        "Unknown HIAP_MEED_ACTION_DATA_SOURCE=`%s`; falling back to stub", source
+    )
     return _default_action_client
+
+
+def get_legal_data_api_client() -> LegalDataApiClient:
+    """FastAPI dependency provider for legal requirement client."""
+    source = os.getenv("HIAP_MEED_LEGAL_DATA_SOURCE", "mock").strip().lower()
+    if source == "mock":
+        if not _default_mock_legal_client.mock_file_path.exists():
+            logger.warning(
+                "Mock legal file not found at `%s`; using stub legal client",
+                _default_mock_legal_client.mock_file_path,
+            )
+            return _default_stub_legal_client
+        return _default_mock_legal_client
+    if source == "api":
+        return _default_api_legal_client
+    if source == "stub":
+        return _default_stub_legal_client
+
+    logger.warning(
+        "Unknown HIAP_MEED_LEGAL_DATA_SOURCE=`%s`; falling back to stub", source
+    )
+    return _default_stub_legal_client

--- a/hiap-meed/app/services/data_clients.py
+++ b/hiap-meed/app/services/data_clients.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 from app.modules.prioritizer.internal_models import (
@@ -13,7 +13,11 @@ from app.modules.prioritizer.internal_models import (
     CityData,
     HardFilterLegalRequirement,
 )
-from app.modules.prioritizer.models import ActionsApiResponse, ActionsLegalApiResponse
+from app.modules.prioritizer.models import (
+    ActionsApiResponse,
+    ActionsLegalApiResponse,
+    CitiesApiResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,37 +49,33 @@ class LegalDataApiClient:
 
 
 @dataclass
-class StubCityDataApiClient:
-    """
-    In-memory fallback city client for local development and tests.
+class MockCityDataApiClient:
+    """File-backed city client loading checked-in mock city API payload."""
 
-    If no city is preloaded for a locode, a minimal placeholder city is returned.
-    """
-
-    cities_by_locode: dict[str, CityData] = field(default_factory=dict)
+    mock_file_path: Path
 
     def get_city(self, locode: str) -> CityData:
-        city = self.cities_by_locode.get(locode)
-        if city is not None:
-            return city
-        return CityData(
-            comuna_name=locode,
-            locode=locode,
-            region_name="unknown",
-            comuna_code="unknown",
-            region_code="unknown",
-            city_context=[],
-        )
+        """Load one city record from mock data by locode."""
+        payload = json.loads(self.mock_file_path.read_text(encoding="utf-8"))
+        response = CitiesApiResponse.model_validate(payload)
+        requested_locode = locode.strip().upper()
+        for city in response.cities:
+            if city.locode.strip().upper() != requested_locode:
+                continue
+            return CityData(
+                comuna_name=city.comuna_name,
+                locode=city.locode,
+                country_code=city.countryCode,
+                region_name=city.region_name,
+                comuna_code=city.comuna_code,
+                region_code=city.region_code,
+                population_size=city.populationSize,
+                population_density=city.populationDensity,
+                area=city.area,
+                raw=city.model_dump(),
+            )
 
-
-@dataclass
-class StubActionDataApiClient:
-    """In-memory fallback action client for local development and tests."""
-
-    actions: list[Action] = field(default_factory=list)
-
-    def list_actions(self) -> list[Action]:
-        return list(self.actions)
+        raise ValueError(f"Locode `{locode}` not found in city mock data")
 
 
 @dataclass
@@ -111,21 +111,6 @@ class MockActionDataApiClient:
 
 
 @dataclass
-class StubLegalDataApiClient:
-    """In-memory fallback legal client for local development and tests."""
-
-    requirements_by_locode: dict[str, dict[str, list[HardFilterLegalRequirement]]] = field(
-        default_factory=dict
-    )
-
-    def get_action_legal_requirements(
-        self, locode: str
-    ) -> dict[str, list[HardFilterLegalRequirement]]:
-        """Return preloaded legal requirements for a locode, or an empty map."""
-        return dict(self.requirements_by_locode.get(locode, {}))
-
-
-@dataclass
 class MockLegalDataApiClient:
     """
     File-backed legal client loading the checked-in mock legal API payload.
@@ -139,7 +124,7 @@ class MockLegalDataApiClient:
         self, locode: str
     ) -> dict[str, list[HardFilterLegalRequirement]]:
         """Load mock legal requirements grouped by action ID."""
-        del locode
+        _ = locode  # Locode is unused because mock legal payload is city-agnostic.
         payload = json.loads(self.mock_file_path.read_text(encoding="utf-8"))
         response = ActionsLegalApiResponse.model_validate(payload)
         requirements_by_action_id: dict[str, list[HardFilterLegalRequirement]] = {}
@@ -174,7 +159,7 @@ class ApiLegalDataApiClient:
         self, locode: str
     ) -> dict[str, list[HardFilterLegalRequirement]]:
         """Return no legal requirements until HTTP integration is implemented."""
-        del locode
+        _ = locode  # Locode is unused until the real upstream API call is wired.
         return {}
 
 
@@ -190,8 +175,32 @@ class ApiActionDataApiClient:
         return []
 
 
-_default_city_client = StubCityDataApiClient()
-_default_action_client = StubActionDataApiClient()
+class ApiCityDataApiClient:
+    """
+    Placeholder city client for future upstream HTTP integration.
+
+    Current behavior returns a minimal placeholder city until HTTP wiring exists.
+    """
+
+    def get_city(self, locode: str) -> CityData:
+        """Return minimal city data until HTTP integration is implemented."""
+        return CityData(
+            comuna_name=locode,
+            locode=locode,
+            region_name="unknown",
+            comuna_code="unknown",
+            region_code="unknown",
+            city_context=[],
+        )
+
+
+_default_api_city_client = ApiCityDataApiClient()
+_default_mock_city_client = MockCityDataApiClient(
+    mock_file_path=Path(__file__).resolve().parents[2]
+    / "data"
+    / "mock"
+    / "cities_api_mock.json"
+)
 _default_api_action_client = ApiActionDataApiClient()
 _default_mock_action_client = MockActionDataApiClient(
     mock_file_path=Path(__file__).resolve().parents[2]
@@ -199,7 +208,6 @@ _default_mock_action_client = MockActionDataApiClient(
     / "mock"
     / "actions_api_mock.json"
 )
-_default_stub_legal_client = StubLegalDataApiClient()
 _default_api_legal_client = ApiLegalDataApiClient()
 _default_mock_legal_client = MockLegalDataApiClient(
     mock_file_path=Path(__file__).resolve().parents[2]
@@ -211,48 +219,61 @@ _default_mock_legal_client = MockLegalDataApiClient(
 
 def get_city_data_api_client() -> CityDataApiClient:
     """FastAPI dependency provider for city data client."""
-    return _default_city_client
+    source = os.getenv("HIAP_MEED_CITY_DATA_SOURCE", "mock").strip().lower()
+    if source == "api":
+        return _default_api_city_client
+
+    if not _default_mock_city_client.mock_file_path.exists():
+        logger.warning(
+            "Mock city file not found at `%s`; using API city client",
+            _default_mock_city_client.mock_file_path,
+        )
+        return _default_api_city_client
+
+    if source not in {"mock", "api"}:
+        logger.warning(
+            "Unknown HIAP_MEED_CITY_DATA_SOURCE=`%s`; using mock city client", source
+        )
+    return _default_mock_city_client
 
 
 def get_action_data_api_client() -> ActionDataApiClient:
     """FastAPI dependency provider for action catalog client."""
     source = os.getenv("HIAP_MEED_ACTION_DATA_SOURCE", "mock").strip().lower()
-    if source == "mock":
-        if not _default_mock_action_client.mock_file_path.exists():
-            logger.warning(
-                "Mock actions file not found at `%s`; using stub action client",
-                _default_mock_action_client.mock_file_path,
-            )
-            return _default_action_client
-        return _default_mock_action_client
     if source == "api":
         return _default_api_action_client
-    if source == "stub":
-        return _default_action_client
 
-    logger.warning(
-        "Unknown HIAP_MEED_ACTION_DATA_SOURCE=`%s`; falling back to stub", source
-    )
-    return _default_action_client
+    if not _default_mock_action_client.mock_file_path.exists():
+        logger.warning(
+            "Mock actions file not found at `%s`; using API action client",
+            _default_mock_action_client.mock_file_path,
+        )
+        return _default_api_action_client
+
+    if source not in {"mock", "api"}:
+        logger.warning(
+            "Unknown HIAP_MEED_ACTION_DATA_SOURCE=`%s`; using mock action client",
+            source,
+        )
+    return _default_mock_action_client
 
 
 def get_legal_data_api_client() -> LegalDataApiClient:
     """FastAPI dependency provider for legal requirement client."""
     source = os.getenv("HIAP_MEED_LEGAL_DATA_SOURCE", "mock").strip().lower()
-    if source == "mock":
-        if not _default_mock_legal_client.mock_file_path.exists():
-            logger.warning(
-                "Mock legal file not found at `%s`; using stub legal client",
-                _default_mock_legal_client.mock_file_path,
-            )
-            return _default_stub_legal_client
-        return _default_mock_legal_client
     if source == "api":
         return _default_api_legal_client
-    if source == "stub":
-        return _default_stub_legal_client
 
-    logger.warning(
-        "Unknown HIAP_MEED_LEGAL_DATA_SOURCE=`%s`; falling back to stub", source
-    )
-    return _default_stub_legal_client
+    if not _default_mock_legal_client.mock_file_path.exists():
+        logger.warning(
+            "Mock legal file not found at `%s`; using API legal client",
+            _default_mock_legal_client.mock_file_path,
+        )
+        return _default_api_legal_client
+
+    if source not in {"mock", "api"}:
+        logger.warning(
+            "Unknown HIAP_MEED_LEGAL_DATA_SOURCE=`%s`; using mock legal client",
+            source,
+        )
+    return _default_mock_legal_client

--- a/hiap-meed/app/services/data_clients.py
+++ b/hiap-meed/app/services/data_clients.py
@@ -62,18 +62,24 @@ class MockCityDataApiClient:
         for city in response.cities:
             if city.locode.strip().upper() != requested_locode:
                 continue
-            return CityData(
-                comuna_name=city.comuna_name,
-                locode=city.locode,
-                country_code=city.countryCode,
-                region_name=city.region_name,
-                comuna_code=city.comuna_code,
-                region_code=city.region_code,
-                population_size=city.populationSize,
-                population_density=city.populationDensity,
-                area=city.area,
-                raw=city.model_dump(),
+            # Keep full indicator fields so CityData can backfill city_context.
+            city_raw = city.model_dump()
+            city_for_validation = dict(city_raw)
+            city_for_validation.update(
+                {
+                    "comuna_name": city.comuna_name,
+                    "locode": city.locode,
+                    "country_code": city.countryCode,
+                    "region_name": city.region_name,
+                    "comuna_code": city.comuna_code,
+                    "region_code": city.region_code,
+                    "population_size": city.populationSize,
+                    "population_density": city.populationDensity,
+                    "area": city.area,
+                    "raw": city_raw,
+                }
             )
+            return CityData.model_validate(city_for_validation)
 
         raise ValueError(f"Locode `{locode}` not found in city mock data")
 

--- a/hiap-meed/app/utils/artifacts.py
+++ b/hiap-meed/app/utils/artifacts.py
@@ -27,7 +27,12 @@ class ArtifactWriter:
         self.request_id = request_id
         self.enabled = _artifacts_enabled()
         log_dir = Path(os.getenv("LOG_DIR", "logs"))
-        self.path = log_dir / "requests" / f"{request_id}.jsonl"
+        created_at_utc = datetime.now(UTC)
+        timestamp_prefix = created_at_utc.strftime("%Y%m%d-%H%M%S")
+        # Keep request ID in the file name so traces remain easy to correlate.
+        self.path = (
+            log_dir / "requests" / f"{timestamp_prefix}Z_{request_id}.jsonl"
+        )
 
     def write_event(self, event_type: str, payload: Mapping[str, object]) -> None:
         """Append a single JSON event line. Failures are logged and ignored."""

--- a/hiap-meed/app/utils/artifacts.py
+++ b/hiap-meed/app/utils/artifacts.py
@@ -47,6 +47,3 @@ class ArtifactWriter:
                 handle.write("\n")
         except Exception:
             logger.exception("Failed to write artifact event `%s`", event_type)
-
-
-__all__ = ["ArtifactWriter"]

--- a/hiap-meed/app/utils/artifacts.py
+++ b/hiap-meed/app/utils/artifacts.py
@@ -1,4 +1,4 @@
-"""Per-request JSONL artifact writer."""
+"""Per-request artifact writer for summary JSONL and step detail JSON files."""
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ def _artifacts_enabled() -> bool:
 
 
 class ArtifactWriter:
-    """Best-effort JSONL artifact writer for one request."""
+    """Best-effort artifact writer for one request."""
 
     def __init__(self, request_id: UUID) -> None:
         self.request_id = request_id
@@ -29,19 +29,36 @@ class ArtifactWriter:
         log_dir = Path(os.getenv("LOG_DIR", "logs"))
         created_at_utc = datetime.now(UTC)
         timestamp_prefix = created_at_utc.strftime("%Y%m%d-%H%M%S")
-        # Keep request ID in the file name so traces remain easy to correlate.
-        self.path = (
-            log_dir / "requests" / f"{timestamp_prefix}Z_{request_id}.jsonl"
+        # Group all artifacts for one run under a single folder.
+        self._run_dir = (
+            log_dir
+            / "requests"
+            / f"{timestamp_prefix}Z_{request_id}"
         )
+        self.path = self._run_dir / "summary.jsonl"
+        self._event_counter = 0
 
-    def write_event(self, event_type: str, payload: Mapping[str, object]) -> None:
-        """Append a single JSON event line. Failures are logged and ignored."""
+    def _next_event_counter(self) -> int:
+        """Return a monotonically increasing per-request event counter."""
+        self._event_counter += 1
+        return self._event_counter
+
+    def _safe_file_stem(self, name: str) -> str:
+        """Convert event/step name to a filename-safe stem."""
+        lowered = name.strip().lower()
+        sanitized = lowered.replace(".", "_").replace(" ", "_").replace("/", "_")
+        return sanitized or "step"
+
+    def write_event(self, event_type: str, payload: Mapping[str, object]) -> int | None:
+        """Append one summary event and return its event index."""
         if not self.enabled:
-            return
+            return None
 
+        event_index = self._next_event_counter()
         event = {
             "timestamp": datetime.now(UTC).isoformat(),
             "request_id": str(self.request_id),
+            "event_index": event_index,
             "event_type": event_type,
             "payload": dict(payload),
         }
@@ -52,3 +69,41 @@ class ArtifactWriter:
                 handle.write("\n")
         except Exception:
             logger.exception("Failed to write artifact event `%s`", event_type)
+        return event_index
+
+    def write_step_detail(
+        self,
+        step_name: str,
+        payload: Mapping[str, object],
+        *,
+        event_index: int | None = None,
+        event_type: str | None = None,
+    ) -> None:
+        """Write detail for one pipeline step, optionally linked to summary event."""
+        if not self.enabled:
+            return
+
+        if event_index is None:
+            event_index = self._next_event_counter()
+        else:
+            self._event_counter = max(self._event_counter, event_index)
+
+        detail = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "request_id": str(self.request_id),
+            "event_index": event_index,
+            "step_name": step_name,
+            "payload": dict(payload),
+        }
+        if event_type is not None:
+            detail["event_type"] = event_type
+        safe_step_name = self._safe_file_stem(step_name)
+        detail_path = self._run_dir / f"{event_index:03d}_{safe_step_name}.json"
+        try:
+            detail_path.parent.mkdir(parents=True, exist_ok=True)
+            detail_path.write_text(
+                json.dumps(detail, ensure_ascii=True, indent=2),
+                encoding="utf-8",
+            )
+        except Exception:
+            logger.exception("Failed to write step detail `%s`", step_name)

--- a/hiap-meed/app/utils/logging_config.py
+++ b/hiap-meed/app/utils/logging_config.py
@@ -21,7 +21,3 @@ def setup_logger() -> None:
         handlers=[stream_handler, file_handler],
         force=True,
     )
-
-
-__all__ = ["setup_logger"]
-

--- a/hiap-meed/app/utils/timing.py
+++ b/hiap-meed/app/utils/timing.py
@@ -26,6 +26,3 @@ def time_block(name: str) -> Iterator[TimedBlock]:
         yield block
     finally:
         block.elapsed_seconds = perf_counter() - block._start_time
-
-
-__all__ = ["TimedBlock", "time_block"]

--- a/hiap-meed/data/mock/README.md
+++ b/hiap-meed/data/mock/README.md
@@ -3,6 +3,11 @@
 This is a mock request for the prioritizer API.
 It simulates a request from CityCatalyst frontend containing information provided by the city user via the frontend.
 
+This payload shape is modeled by:
+- `PrioritizerApiRequest` (envelope)
+- `PrioritizerRequestData` (`requestData`)
+- `FrontendCityInput` (`cityDataList[]`)
+
 This includes:
 
 - locode (city identifier for the prioritization request)
@@ -12,11 +17,24 @@ This includes:
 - city strategic preference sector (list of sectors to prioritize)
 - city emissions data (emissions data for the city from CityCatalyst)
 
+Single-city and multi-city requests use the same structure (`cityDataList`).
+A single-city request is represented by exactly one item in `cityDataList`.
+
+# prioritizer_bulk_request_mock.json:
+
+This is the multi-city variant of the same frontend request contract. It uses
+the same envelope and schema as `prioritizer_request_mock.json` but includes
+more than one item in `cityDataList`.
+
 # city_api_mock.json:
 
 This is a mock response from the city context data API.
 It simulates a response from the city context data API containing information about the city.
 The upstream provider is the global-api.
+
+This payload shape is modeled by:
+- `CityApiResponse` (envelope)
+- `CityData` (`city`)
 
 It is being used to fetch basic city context data and also more specific city context data like unemployment rate, renter share, transport logistics employment, electricity access, industry construction employment, median household income, public transport share, poverty rate and home ownership.
 
@@ -30,6 +48,10 @@ The upstream provider is the global-api.
 
 It is being used to fetch the list of actions and their associated mitigation and impact data.
 
+This payload shape is modeled by:
+- `ActionsApiResponse` (envelope)
+- `Action` (`actions[]`)
+
 # city_policy_signals_api_mock.json:
 
 Mock for GET /v1/cities/{locode}/policy-signals.
@@ -41,6 +63,11 @@ It includes:
 - each signal: location_scope, location_name, signal_type, signal_relation, signal_strength, evidence_ids, evidence_count
 - policy_support_score: 0–1 score per action (relation × strength × scope multiplier, normalized)
 - meta.locode, meta.comuna_name, meta.region_name
+
+This payload shape is modeled by:
+- `ActionsPolicySignalsApiResponse` (envelope)
+- `PolicySignalByAction` (`policy_signals[]`)
+- `PolicySignal` (nested signal rows)
 
 # policy_framework_api_mock.json:
 
@@ -74,6 +101,11 @@ It includes:
 - legal_requirements: array of { action_id, requirements: [...] }
 - each requirement: signal_code, signal_name, required_value, legal_signal_value, strength, alignment_status, location_scope, location_name, evidence_ids, evidence_count
 - meta.locode: null for now; can filter by city when city-scoped legal data exists
+
+This payload shape is modeled by:
+- `ActionsLegalApiResponse` (envelope)
+- `LegalRequirementsByAction` (`legal_requirements[]`)
+- `LegalRequirement` (nested requirement rows)
 
 # actions_legal_api_mock_test_cases.json:
 

--- a/hiap-meed/data/mock/prioritizer_bulk_request_mock.json
+++ b/hiap-meed/data/mock/prioritizer_bulk_request_mock.json
@@ -6,8 +6,7 @@
     "upstreamProvider": "city_catalyst_frontend",
     "apiContext": {
       "endpoint": "POST /prioritizer/v1/start_prioritization_bulk",
-      "locodes": ["CL IQQ", "CL ARI"],
-      "emissionsStructure": "gpc_reference_number_keyed"
+      "locodes": ["CL IQQ", "CL ARI"]
     },
     "totalRecords": 2
   },

--- a/hiap-meed/data/mock/prioritizer_bulk_request_mock.json
+++ b/hiap-meed/data/mock/prioritizer_bulk_request_mock.json
@@ -18,6 +18,11 @@
         "countryCode": "CL",
         "populationSize": 125000,
         "excludedActionsFreeText": "Do not include new fossil fuel-based infrastructure or actions that significantly increase household costs for vulnerable communities.",
+        "weightsOverride": {
+          "impact": 0.5,
+          "alignment": 0.3,
+          "feasibility": 0.2
+        },
         "cityStrategicPreferenceSectors": ["transportation"],
         "cityStrategicPreferenceOther": "Prioritize near-term air quality improvements, reliable and affordable mobility, and climate resilience benefits for low-income neighborhoods.",
         "cityEmissionsData": {
@@ -55,6 +60,11 @@
         "countryCode": "CL",
         "populationSize": 250000,
         "excludedActionsFreeText": "Avoid actions with high implementation complexity in the first phase; prioritize feasible measures with quick delivery.",
+        "weightsOverride": {
+          "impact": 0.6,
+          "alignment": 0.2,
+          "feasibility": 0.2
+        },
         "cityStrategicPreferenceSectors": [
           "stationary_energy",
           "transportation",

--- a/hiap-meed/data/mock/prioritizer_request_mock.json
+++ b/hiap-meed/data/mock/prioritizer_request_mock.json
@@ -26,15 +26,71 @@
         "cityStrategicPreferenceSectors": ["transportation"],
         "cityStrategicPreferenceOther": "Prioritize near-term air quality improvements, reliable and affordable mobility, and climate resilience benefits for low-income neighborhoods.",
         "cityEmissionsData": {
-          "inventoryYear": null,
+          "inventoryYear": 2022,
           "gpcData": {
             "I.1.1": {
               "notationKey": null,
-              "activities": []
+              "activities": [
+                {
+                  "activityName": "Kerosene (paraffin)",
+                  "totalEmissions": 599.532,
+                  "totalEmissionsUnit": "t CO2e",
+                  "activityValue": 8352484.555,
+                  "activityUnit": "MJ",
+                  "dataSource": null,
+                  "notationKey": null
+                },
+                {
+                  "activityName": "Natural gas",
+                  "totalEmissions": 818452.245,
+                  "totalEmissionsUnit": "t CO2e",
+                  "activityValue": 14280609148.0,
+                  "activityUnit": "MJ",
+                  "dataSource": null,
+                  "notationKey": null
+                },
+                {
+                  "activityName": "Wood or wood waste",
+                  "totalEmissions": 42200.983,
+                  "totalEmissionsUnit": "t CO2e",
+                  "activityValue": 360130991.6,
+                  "activityUnit": "MJ",
+                  "dataSource": null,
+                  "notationKey": null
+                }
+              ]
             },
             "I.1.2": {
               "notationKey": null,
-              "activities": []
+              "activities": [
+                {
+                  "activityName": "Electricity use in single family home",
+                  "totalEmissions": 2955600.0,
+                  "totalEmissionsUnit": "t CO2e",
+                  "activityValue": null,
+                  "activityUnit": null,
+                  "dataSource": "Mock data",
+                  "notationKey": null
+                },
+                {
+                  "activityName": "Heating in multi family home",
+                  "totalEmissions": 1438300.0,
+                  "totalEmissionsUnit": "t CO2e",
+                  "activityValue": null,
+                  "activityUnit": null,
+                  "dataSource": "Mock data",
+                  "notationKey": null
+                },
+                {
+                  "activityName": "All energy usage types in informal housing",
+                  "totalEmissions": 3524785.0,
+                  "totalEmissionsUnit": "t CO2e",
+                  "activityValue": null,
+                  "activityUnit": null,
+                  "dataSource": "Mock data",
+                  "notationKey": null
+                }
+              ]
             },
             "I.1.3": {
               "notationKey": null,
@@ -42,11 +98,89 @@
             },
             "II.1.1": {
               "notationKey": null,
-              "activities": []
+              "activities": [
+                {
+                  "activityName": "Biodiesels (Single unit truck)",
+                  "totalEmissions": 1943.87,
+                  "totalEmissionsUnit": "t CO2e",
+                  "activityValue": 27028397.55,
+                  "activityUnit": "MJ",
+                  "dataSource": null,
+                  "notationKey": null
+                },
+                {
+                  "activityName": "Diesel oil (Single unit truck)",
+                  "totalEmissions": 24808.289,
+                  "totalEmissionsUnit": "t CO2e",
+                  "activityValue": 347138314.3,
+                  "activityUnit": "MJ",
+                  "dataSource": null,
+                  "notationKey": null
+                },
+                {
+                  "activityName": "Gas oil (Single unit truck)",
+                  "totalEmissions": 836.075,
+                  "totalEmissionsUnit": "t CO2e",
+                  "activityValue": 11395082.09,
+                  "activityUnit": "MJ",
+                  "dataSource": null,
+                  "notationKey": null
+                }
+              ]
             },
             "III.1.1": {
-              "notationKey": null,
+              "notationKey": "IE",
               "activities": []
+            },
+            "III.2.1": {
+              "notationKey": "NE",
+              "activities": []
+            },
+            "III.4.1": {
+              "notationKey": null,
+              "activities": [
+                {
+                  "activityName": "Domestic wastewater",
+                  "totalEmissions": 144817.556,
+                  "totalEmissionsUnit": "t CO2e",
+                  "activityValue": null,
+                  "activityUnit": null,
+                  "dataSource": null,
+                  "notationKey": null
+                },
+                {
+                  "activityName": "Industrial wastewater",
+                  "totalEmissions": 91786.748,
+                  "totalEmissionsUnit": "t CO2e",
+                  "activityValue": null,
+                  "activityUnit": null,
+                  "dataSource": null,
+                  "notationKey": null
+                }
+              ]
+            },
+            "V.1": {
+              "notationKey": null,
+              "activities": [
+                {
+                  "activityName": "Buffalo",
+                  "totalEmissions": 0.489,
+                  "totalEmissionsUnit": "t CO2e",
+                  "activityValue": null,
+                  "activityUnit": null,
+                  "dataSource": null,
+                  "notationKey": null
+                },
+                {
+                  "activityName": "Cattle",
+                  "totalEmissions": 129.168,
+                  "totalEmissionsUnit": "t CO2e",
+                  "activityValue": null,
+                  "activityUnit": null,
+                  "dataSource": null,
+                  "notationKey": null
+                }
+              ]
             },
             "VI.1": {
               "notationKey": null,

--- a/hiap-meed/data/mock/prioritizer_request_mock.json
+++ b/hiap-meed/data/mock/prioritizer_request_mock.json
@@ -1,0 +1,55 @@
+{
+  "meta": {
+    "requestId": "1234567890",
+    "generatedAtUtc": "2026-02-26T11:43:40.011939+00:00",
+    "backendConsumer": "hiap-meed",
+    "upstreamProvider": "city_catalyst_frontend",
+    "apiContext": {
+      "endpoint": "POST /prioritizer/v1/start_prioritization",
+      "locodes": ["CL IQQ"]
+    },
+    "totalRecords": 1
+  },
+  "requestData": {
+    "requestedLanguages": ["en"],
+    "cityDataList": [
+      {
+        "locode": "CL IQQ",
+        "countryCode": "CL",
+        "populationSize": 125000,
+        "excludedActionsFreeText": "Do not include new fossil fuel-based infrastructure or actions that significantly increase household costs for vulnerable communities.",
+        "cityStrategicPreferenceSectors": ["transportation"],
+        "cityStrategicPreferenceOther": "Prioritize near-term air quality improvements, reliable and affordable mobility, and climate resilience benefits for low-income neighborhoods.",
+        "cityEmissionsData": {
+          "inventoryYear": null,
+          "gpcData": {
+            "I.1.1": {
+              "notationKey": null,
+              "activities": []
+            },
+            "I.1.2": {
+              "notationKey": null,
+              "activities": []
+            },
+            "I.1.3": {
+              "notationKey": null,
+              "activities": []
+            },
+            "II.1.1": {
+              "notationKey": null,
+              "activities": []
+            },
+            "III.1.1": {
+              "notationKey": null,
+              "activities": []
+            },
+            "VI.1": {
+              "notationKey": null,
+              "activities": []
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/hiap-meed/data/mock/prioritizer_request_mock.json
+++ b/hiap-meed/data/mock/prioritizer_request_mock.json
@@ -18,6 +18,11 @@
         "countryCode": "CL",
         "populationSize": 125000,
         "excludedActionsFreeText": "Do not include new fossil fuel-based infrastructure or actions that significantly increase household costs for vulnerable communities.",
+        "weightsOverride": {
+          "impact": 0.5,
+          "alignment": 0.3,
+          "feasibility": 0.2
+        },
         "cityStrategicPreferenceSectors": ["transportation"],
         "cityStrategicPreferenceOther": "Prioritize near-term air quality improvements, reliable and affordable mobility, and climate resilience benefits for low-income neighborhoods.",
         "cityEmissionsData": {

--- a/hiap-meed/docs/detailed-block-architecture.md
+++ b/hiap-meed/docs/detailed-block-architecture.md
@@ -5,7 +5,7 @@
 | Block | Sub-feature | Status |
 |---|---|---|
 | Hard Filter | Exclusion by `action_id` | Implemented |
-| Hard Filter | Legal requirement check | Not started |
+| Hard Filter | Legal requirement check | Implemented |
 | Impact | GPC reference evidence collection | Implemented (stub: score = 0.0) |
 | Impact | Activity relevance × reduction band × timeline | Not started |
 | Alignment | Attribute-presence evidence | Implemented (stub: score = 0.0) |

--- a/hiap-meed/docs/service-architecture.md
+++ b/hiap-meed/docs/service-architecture.md
@@ -28,7 +28,7 @@ graph TD
 
     GlobalAPI["Global API (upstream data service)"]
 
-    CC -->|"POST /v1/prioritize JSON body: locode, weights, top_n"| Router
+    CC -->|"POST /v1/prioritize JSON body: PrioritizerApiRequest (meta + requestData.cityDataList)"| Router
     Router --> Orch
 
     Orch -->|"getCityContext(locode)"| CityClient
@@ -51,8 +51,8 @@ graph TD
     Align --> WS
     Feas --> WS
 
-    WS -->|"PrioritizationResponse"| Router
-    Router -->|"JSON response ranked_action_ids + metadata"| CC
+    WS -->|"PrioritizationResponse (per city)"| Router
+    Router -->|"JSON response PrioritizerApiResponse (results[])"| CC
 ```
 
 ---
@@ -85,16 +85,16 @@ sequenceDiagram
     participant Orch as Orchestrator
     participant GlobalAPI as Global API
 
-    CC->>API: POST /v1/prioritize {locode, weights, top_n}
+    CC->>API: POST /v1/prioritize PrioritizerApiRequest (meta + requestData.cityDataList)
     Note over API: FastAPI validates request body (Pydantic)
-    API->>Orch: run_prioritization(request, clients)
+    API->>Orch: run_prioritization(locode, clients)
     Orch->>GlobalAPI: getCityContext(locode)
     GlobalAPI-->>Orch: CityData
     Orch->>GlobalAPI: listActions()
     GlobalAPI-->>Orch: Action[]
     Note over Orch: Hard Filter → Impact / Alignment / Feasibility → Weighted Sum
-    Orch-->>API: PrioritizationResponse
-    API-->>CC: 200 {ranked_action_ids, metadata}
+    Orch-->>API: PrioritizationResponse (per city)
+    API-->>CC: 200 PrioritizerApiResponse (results[])
 ```
 
 ---

--- a/hiap-meed/docs/service-architecture.md
+++ b/hiap-meed/docs/service-architecture.md
@@ -70,7 +70,7 @@ This is the right choice as long as the orchestrator and data clients are synchr
 | Client                | Method             | Status         | Target upstream |
 | --------------------- | ------------------ | -------------- | --------------- |
 | `CityDataApiClient`   | `get_city(locode)` | In-memory stub | Global API      |
-| `ActionDataApiClient` | `list_actions()`   | In-memory stub | Global API      |
+| `ActionDataApiClient` | `list_actions()`   | Mock/stub/api switch (`HIAP_MEED_ACTION_DATA_SOURCE`) | Global API      |
 
 Stubs are injected via FastAPI's `Depends()` pattern, which makes swapping real implementations straightforward without changing route or orchestrator code.
 

--- a/hiap-meed/docs/service-architecture.md
+++ b/hiap-meed/docs/service-architecture.md
@@ -67,9 +67,9 @@ This is the right choice as long as the orchestrator and data clients are synchr
 
 ## Data client layer (current state)
 
-| Client                | Method             | Status         | Target upstream |
-| --------------------- | ------------------ | -------------- | --------------- |
-| `CityDataApiClient`   | `get_city(locode)` | In-memory stub | Global API      |
+| Client                | Method             | Status                                                | Target upstream |
+| --------------------- | ------------------ | ----------------------------------------------------- | --------------- |
+| `CityDataApiClient`   | `get_city(locode)` | In-memory stub                                        | Global API      |
 | `ActionDataApiClient` | `list_actions()`   | Mock/stub/api switch (`HIAP_MEED_ACTION_DATA_SOURCE`) | Global API      |
 
 Stubs are injected via FastAPI's `Depends()` pattern, which makes swapping real implementations straightforward without changing route or orchestrator code.
@@ -87,7 +87,7 @@ sequenceDiagram
 
     CC->>API: POST /v1/prioritize PrioritizerApiRequest (meta + requestData.cityDataList)
     Note over API: FastAPI validates request body (Pydantic)
-    API->>Orch: run_prioritization(locode, clients)
+    API->>Orch: run_prioritization(locode, clients, per_city_options...)
     Orch->>GlobalAPI: getCityContext(locode)
     GlobalAPI-->>Orch: CityData
     Orch->>GlobalAPI: listActions()

--- a/hiap-meed/future-work.md
+++ b/hiap-meed/future-work.md
@@ -1,0 +1,39 @@
+# Future work (HIAP-MEED)
+
+This file tracks agreed future enhancements that are **out of scope for the current Hard Filter implementation**.
+
+## Legal constraints and soft requirements (Feasibility stage)
+
+Source: Notion “How Legal Signals, Policy Signals, and Socioeconomic Indicators Work in HIAP Ranking”  
+`https://www.notion.so/openearth/How-Legal-Signals-Policy-Signals-and-Socioeconomic-Indicators-Work-in-HIAP-Ranking-319eb557728b80d4bf84edb7edd0449a?source=copy_link`
+
+### 1) Non-blocking legal constraints → feasibility evidence
+
+- **Intent**: requirements that do not gate eligibility (Notion “constraint”) should appear as **implementation notes**.
+- **Where**: implement in `hiap-meed/app/modules/prioritizer/blocks/feasibility.py` (or a dedicated legal-feasibility helper called by that block).
+- **Output**: feasibility evidence should include:
+  - a structured list of constraint requirement rows (signal, operator, scope, evidence IDs)
+  - a derived human-readable note list suitable for UI display (“permit may apply”, “public procurement required”, etc.)
+- **Hard Filter should not emit these**, because constraints do not determine eligibility.
+
+### 2) Soft legal requirements → feasibility modifier (later)
+
+- **Intent**: Notion “soft” requirements can increase feasibility when satisfied and do nothing when not satisfied.
+- **Where**: feasibility block (not hard filter).
+- **Note**: exact strength enums may differ in the repo mock vs Notion; preserve semantics.
+
+## Free-text exclusions → semantic matching (Hard Filter stage)
+
+Source: Notion “Data Reviews” (exclusion intent)  
+`https://www.notion.so/openearth/Data-Reviews-2eceb557728b808e9537da57340bf43a?source=copy_link`
+
+- **Current**: `excludedActionsFreeText` is accepted but is a stub (no actions excluded).
+- **Future**: implement `_resolve_excluded_action_ids_from_text(...)` in
+  - `hiap-meed/app/modules/prioritizer/blocks/hard_filter.py`
+- **Approach** (initial):
+  - semantic matching / fuzzy matching over `Action.action_name` and `Action.description`
+  - produce a resolved `excluded_action_ids` set + evidence on matched actions and rationale
+- **Guardrails**:
+  - never exclude unless confidence is high and the UI can show “why”
+  - consider a “preview only” mode if/when the frontend needs human confirmation
+

--- a/hiap-meed/tests/conftest.py
+++ b/hiap-meed/tests/conftest.py
@@ -8,6 +8,12 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 
+@pytest.fixture(autouse=True)
+def disable_artifact_logging(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable per-request artifact JSONL writes during pytest runs."""
+    monkeypatch.setenv("ARTIFACT_LOG_JSONL", "false")
+
+
 @pytest.fixture
 def client():
     """FastAPI test client fixture."""

--- a/hiap-meed/tests/integration/test_prioritize_e2e_mock_api_data.py
+++ b/hiap-meed/tests/integration/test_prioritize_e2e_mock_api_data.py
@@ -1,0 +1,99 @@
+"""Dedicated end-to-end prioritize test using checked-in mock API payloads."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.modules.prioritizer.api import (
+    get_action_data_api_client,
+    get_city_data_api_client,
+    get_legal_data_api_client,
+)
+from app.modules.prioritizer.internal_models import CityData
+from app.services.data_clients import (
+    CityDataApiClient,
+    MockActionDataApiClient,
+    MockLegalDataApiClient,
+)
+
+
+def _mock_data_dir() -> Path:
+    """Return the checked-in mock data directory path."""
+    return Path(__file__).resolve().parents[2] / "data" / "mock"
+
+
+@dataclass
+class MockCityDataApiClient(CityDataApiClient):
+    """File-backed city client loading the checked-in city mock payload."""
+
+    mock_file_path: Path
+
+    def get_city(self, locode: str) -> CityData:
+        """Load one city and enforce that requested locode matches the mock record."""
+        payload = json.loads(self.mock_file_path.read_text(encoding="utf-8"))
+        city = CityData.model_validate(payload["city"])
+        if locode != city.locode:
+            raise ValueError(f"Unknown locode: {locode}")
+        return city
+
+
+@pytest.mark.integration
+def test_prioritize_e2e_with_mock_api_payloads() -> None:
+    """Prioritize endpoint returns expected hard-filtered ranking for mock payloads."""
+    mock_data_dir = _mock_data_dir()
+    request_payload = json.loads(
+        (mock_data_dir / "prioritizer_request_mock.json").read_text(encoding="utf-8")
+    )
+
+    mock_city_client = MockCityDataApiClient(mock_file_path=mock_data_dir / "city_api_mock.json")
+    mock_action_client = MockActionDataApiClient(
+        mock_file_path=mock_data_dir / "actions_api_mock.json"
+    )
+    mock_legal_client = MockLegalDataApiClient(
+        mock_file_path=mock_data_dir / "actions_legal_api_mock.json"
+    )
+
+    app.dependency_overrides[get_city_data_api_client] = lambda: mock_city_client
+    app.dependency_overrides[get_action_data_api_client] = lambda: mock_action_client
+    app.dependency_overrides[get_legal_data_api_client] = lambda: mock_legal_client
+    try:
+        with TestClient(app) as test_client:
+            response = test_client.post("/v1/prioritize", json=request_payload)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["results"]) == 1
+        result = body["results"][0]
+        metadata = result["metadata"]
+
+        expected_discarded_legal_ids = {"c40_0012", "c40_0034", "c40_0037", "c40_0029"}
+        ranked_action_ids = result["ranked_action_ids"]
+
+        assert result["locode"] == "CL IQQ"
+        assert metadata["weights"] == {"impact": 0.5, "alignment": 0.3, "feasibility": 0.2}
+        assert metadata["counts"]["total_actions"] == 155
+        assert metadata["counts"]["discarded_excluded"] == 0
+        assert metadata["counts"]["discarded_legal"] == len(expected_discarded_legal_ids)
+        assert metadata["counts"]["valid_actions"] == 151
+        assert metadata["counts"]["ranked_actions"] == 151
+        assert not expected_discarded_legal_ids.intersection(ranked_action_ids)
+
+        expected_ranked_ids = sorted(
+            action.action_id
+            for action in mock_action_client.list_actions()
+            if action.action_id not in expected_discarded_legal_ids
+        )
+        assert ranked_action_ids == expected_ranked_ids
+
+        blocked_evidence = metadata["hard_filter_evidence_by_action_id"]["c40_0012"]
+        unknown_evidence = metadata["hard_filter_evidence_by_action_id"]["c40_0013"]
+        assert blocked_evidence["discard_reason"] == "legal_hard_requirement_failed"
+        assert unknown_evidence["hard_requirements_unknown_count"] == 1
+    finally:
+        app.dependency_overrides.clear()

--- a/hiap-meed/tests/integration/test_prioritize_smoke.py
+++ b/hiap-meed/tests/integration/test_prioritize_smoke.py
@@ -40,7 +40,7 @@ class MockActionDataApiClient(ActionDataApiClient):
 
 @pytest.mark.integration
 def test_prioritize_smoke() -> None:
-    """Excluded actions are removed and remaining actions are ranked."""
+    """Frontend envelope request returns deterministic ranked action IDs."""
     city = CityData(
         comuna_name="Santiago",
         locode="CL-SCL",
@@ -90,55 +90,44 @@ def test_prioritize_smoke() -> None:
             response = test_client.post(
                 "/v1/prioritize",
                 json={
-                    "locode": "CL-SCL",
-                    "excluded_action_ids": ["c40_0020"],
-                    "top_n": 5,
+                    "meta": {
+                        "requestId": "1234567890",
+                        "generatedAtUtc": "2026-02-26T11:43:40.011939+00:00",
+                        "backendConsumer": "hiap-meed",
+                        "upstreamProvider": "city_catalyst_frontend",
+                        "apiContext": {
+                            "endpoint": "POST /prioritizer/v1/start_prioritization",
+                            "locodes": ["CL-SCL"],
+                        },
+                        "totalRecords": 1,
+                    },
+                    "requestData": {
+                        "requestedLanguages": ["en"],
+                        "cityDataList": [
+                            {
+                                "locode": "CL-SCL",
+                                "countryCode": "CL",
+                                "populationSize": 1000,
+                                "excludedActionsFreeText": "Do not include ... (stub)",
+                                "cityStrategicPreferenceSectors": [],
+                                "cityStrategicPreferenceOther": None,
+                                "cityEmissionsData": {"inventoryYear": None, "gpcData": {}},
+                            }
+                        ],
+                    },
                 },
             )
         assert response.status_code == 200
         body = response.json()
 
-        assert body["ranked_action_ids"] == ["c40_0010"]
-        assert "metadata" in body
-        assert "timings" in body["metadata"]
-        assert "counts" in body["metadata"]
-        assert body["metadata"]["counts"]["discarded_excluded"] == 1
-    finally:
-        app.dependency_overrides.clear()
-
-
-@pytest.mark.integration
-def test_prioritize_rejects_non_unit_weight_sum() -> None:
-    """Non-unit weight sums return 422 and do not get normalized."""
-    city = CityData(
-        comuna_name="Santiago",
-        locode="CL-SCL",
-        region_name="Metropolitana",
-        comuna_code="13101",
-        region_code="13",
-        city_context=[],
-    )
-    actions = [Action(action_id="c40_0010", action_name="Retrofit buildings")]
-    mock_city_client = MockCityDataApiClient(city=city)
-    mock_action_client = MockActionDataApiClient(actions=actions)
-
-    app.dependency_overrides[get_city_data_api_client] = lambda: mock_city_client
-    app.dependency_overrides[get_action_data_api_client] = lambda: mock_action_client
-    try:
-        with TestClient(app) as test_client:
-            response = test_client.post(
-                "/v1/prioritize",
-                json={
-                    "locode": "CL-SCL",
-                    "weights_override": {
-                        "impact": 0.5,
-                        "alignment": 0.3,
-                        "feasibility": 0.3,
-                    },
-                },
-            )
-        assert response.status_code == 422
-        detail = response.json()["detail"]
-        assert "Weight sum must be 1.0" in detail["error"]
+        assert "results" in body
+        assert len(body["results"]) == 1
+        result = body["results"][0]
+        assert result["locode"] == "CL-SCL"
+        assert result["ranked_action_ids"] == ["c40_0010", "c40_0020"]
+        assert "metadata" in result
+        assert "timings" in result["metadata"]
+        assert "counts" in result["metadata"]
+        assert result["metadata"]["counts"]["discarded_excluded"] == 0
     finally:
         app.dependency_overrides.clear()

--- a/hiap-meed/tests/integration/test_prioritize_smoke.py
+++ b/hiap-meed/tests/integration/test_prioritize_smoke.py
@@ -11,9 +11,18 @@ from app.main import app
 from app.modules.prioritizer.api import (
     get_action_data_api_client,
     get_city_data_api_client,
+    get_legal_data_api_client,
 )
-from app.modules.prioritizer.internal_models import Action, CityData
-from app.services.data_clients import ActionDataApiClient, CityDataApiClient
+from app.modules.prioritizer.internal_models import (
+    Action,
+    CityData,
+    HardFilterLegalRequirement,
+)
+from app.services.data_clients import (
+    ActionDataApiClient,
+    CityDataApiClient,
+    LegalDataApiClient,
+)
 
 
 @dataclass
@@ -36,6 +45,20 @@ class MockActionDataApiClient(ActionDataApiClient):
 
     def list_actions(self) -> list[Action]:
         return list(self.actions)
+
+
+@dataclass
+class MockLegalDataApiClient(LegalDataApiClient):
+    """In-memory legal client for hard filter integration tests."""
+
+    requirements_by_action_id: dict[str, list[HardFilterLegalRequirement]]
+
+    def get_action_legal_requirements(
+        self, locode: str
+    ) -> dict[str, list[HardFilterLegalRequirement]]:
+        """Return legal requirements for the requested city test case."""
+        del locode
+        return dict(self.requirements_by_action_id)
 
 
 @pytest.mark.integration
@@ -82,9 +105,11 @@ def test_prioritize_smoke() -> None:
     ]
     mock_city_client = MockCityDataApiClient(city=city)
     mock_action_client = MockActionDataApiClient(actions=actions)
+    mock_legal_client = MockLegalDataApiClient(requirements_by_action_id={})
 
     app.dependency_overrides[get_city_data_api_client] = lambda: mock_city_client
     app.dependency_overrides[get_action_data_api_client] = lambda: mock_action_client
+    app.dependency_overrides[get_legal_data_api_client] = lambda: mock_legal_client
     try:
         with TestClient(app) as test_client:
             response = test_client.post(
@@ -129,5 +154,174 @@ def test_prioritize_smoke() -> None:
         assert "timings" in result["metadata"]
         assert "counts" in result["metadata"]
         assert result["metadata"]["counts"]["discarded_excluded"] == 0
+        assert result["metadata"]["counts"]["discarded_legal"] == 0
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.integration
+def test_prioritize_discards_hard_legal_mismatch() -> None:
+    """Actions failing hard legal requirements are removed before ranking."""
+    city = CityData(
+        comuna_name="Santiago",
+        locode="CL-SCL",
+        region_name="Metropolitana",
+        comuna_code="13101",
+        region_code="13",
+        city_context=[],
+    )
+    actions = [
+        Action(action_id="A_ok", action_name="Aligned action"),
+        Action(action_id="A_blocked", action_name="Blocked action"),
+    ]
+    requirements_by_action_id = {
+        "A_blocked": [
+            HardFilterLegalRequirement(
+                signal_code="MUNI_ENV_STANDARDS",
+                signal_name="Municipal environmental standards",
+                operator="equals",
+                required_value="apply_standards",
+                legal_signal_value="restricted",
+                strength="mandatory",
+                alignment_status="not_aligned",
+                location_scope="National",
+                location_name="Chile",
+                evidence_ids=["ev_1"],
+                evidence_count=1,
+            )
+        ]
+    }
+    mock_city_client = MockCityDataApiClient(city=city)
+    mock_action_client = MockActionDataApiClient(actions=actions)
+    mock_legal_client = MockLegalDataApiClient(
+        requirements_by_action_id=requirements_by_action_id
+    )
+
+    app.dependency_overrides[get_city_data_api_client] = lambda: mock_city_client
+    app.dependency_overrides[get_action_data_api_client] = lambda: mock_action_client
+    app.dependency_overrides[get_legal_data_api_client] = lambda: mock_legal_client
+    try:
+        with TestClient(app) as test_client:
+            response = test_client.post(
+                "/v1/prioritize",
+                json={
+                    "meta": {
+                        "requestId": "req-legal-discard",
+                        "generatedAtUtc": "2026-02-26T11:43:40.011939+00:00",
+                        "backendConsumer": "hiap-meed",
+                        "upstreamProvider": "city_catalyst_frontend",
+                        "apiContext": {
+                            "endpoint": "POST /prioritizer/v1/start_prioritization",
+                            "locodes": ["CL-SCL"],
+                        },
+                        "totalRecords": 1,
+                    },
+                    "requestData": {
+                        "requestedLanguages": ["en"],
+                        "cityDataList": [
+                            {
+                                "locode": "CL-SCL",
+                                "countryCode": "CL",
+                                "populationSize": 1000,
+                                "excludedActionsFreeText": None,
+                                "cityStrategicPreferenceSectors": [],
+                                "cityStrategicPreferenceOther": None,
+                                "cityEmissionsData": {"inventoryYear": None, "gpcData": {}},
+                            }
+                        ],
+                    },
+                },
+            )
+
+        assert response.status_code == 200
+        result = response.json()["results"][0]
+        assert result["ranked_action_ids"] == ["A_ok"]
+        assert result["metadata"]["counts"]["discarded_legal"] == 1
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.integration
+def test_prioritize_keeps_no_evidence_hard_legal_requirements() -> None:
+    """No-evidence hard requirements keep actions but expose unknown requirement evidence."""
+    city = CityData(
+        comuna_name="Santiago",
+        locode="CL-SCL",
+        region_name="Metropolitana",
+        comuna_code="13101",
+        region_code="13",
+        city_context=[],
+    )
+    actions = [Action(action_id="A_unknown", action_name="Unknown legal evidence action")]
+    requirements_by_action_id = {
+        "A_unknown": [
+            HardFilterLegalRequirement(
+                signal_code="PLANS_ALIGNMENT",
+                signal_name="Plans alignment requirement",
+                operator="equals",
+                required_value="comply",
+                legal_signal_value=None,
+                strength="required",
+                alignment_status="no_evidence",
+                location_scope=None,
+                location_name=None,
+                evidence_ids=[],
+                evidence_count=0,
+            )
+        ]
+    }
+    mock_city_client = MockCityDataApiClient(city=city)
+    mock_action_client = MockActionDataApiClient(actions=actions)
+    mock_legal_client = MockLegalDataApiClient(
+        requirements_by_action_id=requirements_by_action_id
+    )
+
+    app.dependency_overrides[get_city_data_api_client] = lambda: mock_city_client
+    app.dependency_overrides[get_action_data_api_client] = lambda: mock_action_client
+    app.dependency_overrides[get_legal_data_api_client] = lambda: mock_legal_client
+    try:
+        with TestClient(app) as test_client:
+            response = test_client.post(
+                "/v1/prioritize",
+                json={
+                    "meta": {
+                        "requestId": "req-legal-no-evidence",
+                        "generatedAtUtc": "2026-02-26T11:43:40.011939+00:00",
+                        "backendConsumer": "hiap-meed",
+                        "upstreamProvider": "city_catalyst_frontend",
+                        "apiContext": {
+                            "endpoint": "POST /prioritizer/v1/start_prioritization",
+                            "locodes": ["CL-SCL"],
+                        },
+                        "totalRecords": 1,
+                    },
+                    "requestData": {
+                        "requestedLanguages": ["en"],
+                        "cityDataList": [
+                            {
+                                "locode": "CL-SCL",
+                                "countryCode": "CL",
+                                "populationSize": 1000,
+                                "excludedActionsFreeText": None,
+                                "cityStrategicPreferenceSectors": [],
+                                "cityStrategicPreferenceOther": None,
+                                "cityEmissionsData": {"inventoryYear": None, "gpcData": {}},
+                            }
+                        ],
+                    },
+                },
+            )
+
+        assert response.status_code == 200
+        result = response.json()["results"][0]
+        assert result["ranked_action_ids"] == ["A_unknown"]
+        assert result["metadata"]["counts"]["discarded_legal"] == 0
+
+        unknown_evidence = result["metadata"]["hard_filter_evidence_by_action_id"][
+            "A_unknown"
+        ]
+        assert unknown_evidence["discard_reason"] is None
+        assert unknown_evidence["hard_requirements_unknown_count"] == 1
+        assert len(unknown_evidence["unknown_requirements"]) == 1
     finally:
         app.dependency_overrides.clear()

--- a/hiap-meed/tests/integration/test_prioritize_smoke.py
+++ b/hiap-meed/tests/integration/test_prioritize_smoke.py
@@ -12,7 +12,7 @@ from app.modules.prioritizer.api import (
     get_action_data_api_client,
     get_city_data_api_client,
 )
-from app.modules.prioritizer.models import Action, CityData
+from app.modules.prioritizer.internal_models import Action, CityData
 from app.services.data_clients import ActionDataApiClient, CityDataApiClient
 
 

--- a/hiap-meed/tests/integration/test_prioritize_smoke.py
+++ b/hiap-meed/tests/integration/test_prioritize_smoke.py
@@ -62,6 +62,76 @@ class MockLegalDataApiClient(LegalDataApiClient):
 
 
 @pytest.mark.integration
+@pytest.mark.parametrize(
+    "weights_override",
+    [
+        {"impact": 0.6, "alignment": 0.2, "feasibility": 0.1},
+        {"impact": 0.55, "alignment": 0.22, "feasibility": 0.23, "unknown": 0.0},
+    ],
+)
+def test_prioritize_rejects_invalid_weights_override(
+    weights_override: dict[str, float],
+) -> None:
+    """Invalid `weightsOverride` values are rejected with HTTP 422."""
+    city = CityData(
+        comuna_name="Santiago",
+        locode="CL-SCL",
+        region_name="Metropolitana",
+        comuna_code="13101",
+        region_code="13",
+        city_context=[],
+    )
+    actions = [Action(action_id="A_ok", action_name="Action")]
+    mock_city_client = MockCityDataApiClient(city=city)
+    mock_action_client = MockActionDataApiClient(actions=actions)
+    mock_legal_client = MockLegalDataApiClient(requirements_by_action_id={})
+
+    app.dependency_overrides[get_city_data_api_client] = lambda: mock_city_client
+    app.dependency_overrides[get_action_data_api_client] = lambda: mock_action_client
+    app.dependency_overrides[get_legal_data_api_client] = lambda: mock_legal_client
+    try:
+        with TestClient(app) as test_client:
+            response = test_client.post(
+                "/v1/prioritize",
+                json={
+                    "meta": {
+                        "requestId": "req-invalid-weights",
+                        "generatedAtUtc": "2026-02-26T11:43:40.011939+00:00",
+                        "backendConsumer": "hiap-meed",
+                        "upstreamProvider": "city_catalyst_frontend",
+                        "apiContext": {
+                            "endpoint": "POST /prioritizer/v1/start_prioritization",
+                            "locodes": ["CL-SCL"],
+                        },
+                        "totalRecords": 1,
+                    },
+                    "requestData": {
+                        "requestedLanguages": ["en"],
+                        "cityDataList": [
+                            {
+                                "locode": "CL-SCL",
+                                "countryCode": "CL",
+                                "populationSize": 1000,
+                                "excludedActionsFreeText": None,
+                                "weightsOverride": weights_override,
+                                "cityStrategicPreferenceSectors": [],
+                                "cityStrategicPreferenceOther": None,
+                                "cityEmissionsData": {
+                                    "inventoryYear": None,
+                                    "gpcData": {},
+                                },
+                            }
+                        ],
+                    },
+                },
+            )
+        assert response.status_code == 422
+        assert response.json()["detail"]["request_id"] == "req-invalid-weights"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.integration
 def test_prioritize_smoke() -> None:
     """Frontend envelope request returns deterministic ranked action IDs."""
     city = CityData(

--- a/hiap-meed/tests/unit/test_data_clients.py
+++ b/hiap-meed/tests/unit/test_data_clients.py
@@ -1,0 +1,38 @@
+"""Unit tests for action data source selection and mock loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.services.data_clients import (
+    MockActionDataApiClient,
+    StubActionDataApiClient,
+    get_action_data_api_client,
+)
+
+
+@pytest.mark.unit
+def test_mock_action_client_loads_actions_from_file() -> None:
+    """Mock action client reads and maps actions from the checked-in mock payload."""
+    mock_file_path = (
+        Path(__file__).resolve().parents[2] / "data" / "mock" / "actions_api_mock.json"
+    )
+    client = MockActionDataApiClient(mock_file_path=mock_file_path)
+
+    actions = client.list_actions()
+
+    assert len(actions) > 0
+    assert actions[0].action_id
+    assert actions[0].action_name
+
+
+@pytest.mark.unit
+def test_get_action_data_client_uses_stub_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Action dependency provider returns stub client when env source is stub."""
+    monkeypatch.setenv("HIAP_MEED_ACTION_DATA_SOURCE", "stub")
+
+    client = get_action_data_api_client()
+
+    assert isinstance(client, StubActionDataApiClient)

--- a/hiap-meed/tests/unit/test_data_clients.py
+++ b/hiap-meed/tests/unit/test_data_clients.py
@@ -1,4 +1,4 @@
-"""Unit tests for action data source selection and mock loading."""
+"""Unit tests for data source selection and mock loading."""
 
 from __future__ import annotations
 
@@ -8,8 +8,9 @@ import pytest
 
 from app.services.data_clients import (
     MockActionDataApiClient,
-    StubActionDataApiClient,
+    MockCityDataApiClient,
     get_action_data_api_client,
+    get_city_data_api_client,
 )
 
 
@@ -29,10 +30,36 @@ def test_mock_action_client_loads_actions_from_file() -> None:
 
 
 @pytest.mark.unit
-def test_get_action_data_client_uses_stub_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Action dependency provider returns stub client when env source is stub."""
-    monkeypatch.setenv("HIAP_MEED_ACTION_DATA_SOURCE", "stub")
+def test_get_action_data_client_uses_mock_for_unknown_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Action dependency provider defaults unknown source values to mock data."""
+    monkeypatch.setenv("HIAP_MEED_ACTION_DATA_SOURCE", "unexpected")
 
     client = get_action_data_api_client()
 
-    assert isinstance(client, StubActionDataApiClient)
+    assert isinstance(client, MockActionDataApiClient)
+
+
+@pytest.mark.unit
+def test_mock_city_client_loads_city_from_file() -> None:
+    """Mock city client returns expected city metadata for known locode."""
+    mock_file_path = (
+        Path(__file__).resolve().parents[2] / "data" / "mock" / "cities_api_mock.json"
+    )
+    client = MockCityDataApiClient(mock_file_path=mock_file_path)
+
+    city = client.get_city("CL IQQ")
+
+    assert city.comuna_name == "Iquique"
+    assert city.region_name == "Tarapacá"
+
+
+@pytest.mark.unit
+def test_get_city_data_client_defaults_to_mock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """City dependency provider defaults to mock data source."""
+    monkeypatch.delenv("HIAP_MEED_CITY_DATA_SOURCE", raising=False)
+
+    client = get_city_data_api_client()
+
+    assert isinstance(client, MockCityDataApiClient)

--- a/hiap-meed/tests/unit/test_data_clients.py
+++ b/hiap-meed/tests/unit/test_data_clients.py
@@ -53,6 +53,10 @@ def test_mock_city_client_loads_city_from_file() -> None:
 
     assert city.comuna_name == "Iquique"
     assert city.region_name == "Tarapacá"
+    assert city.city_context
+    assert any(
+        row.get("attribute_name") == "unemployment_rate" for row in city.city_context
+    )
 
 
 @pytest.mark.unit

--- a/hiap-meed/tests/unit/test_prioritizer_blocks.py
+++ b/hiap-meed/tests/unit/test_prioritizer_blocks.py
@@ -1,0 +1,145 @@
+"""Unit tests for prioritizer pipeline blocks using mock API payloads."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.modules.prioritizer.blocks import (
+    alignment,
+    feasibility,
+    final_scoring,
+    hard_filter,
+    impact,
+)
+from app.modules.prioritizer.internal_models import Action, CityData
+from app.services.data_clients import MockActionDataApiClient, MockLegalDataApiClient
+
+
+def _mock_data_dir() -> Path:
+    """Return the checked-in mock data directory path."""
+    return Path(__file__).resolve().parents[2] / "data" / "mock"
+
+
+def _load_mock_actions() -> list[Action]:
+    """Load actions from the mock actions API payload."""
+    action_client = MockActionDataApiClient(
+        mock_file_path=_mock_data_dir() / "actions_api_mock.json"
+    )
+    return action_client.list_actions()
+
+
+def _load_mock_city() -> CityData:
+    """Load city context from the mock city API payload."""
+    payload = json.loads((_mock_data_dir() / "city_api_mock.json").read_text(encoding="utf-8"))
+    return CityData.model_validate(payload["city"])
+
+
+def _load_mock_legal_requirements() -> dict[str, object]:
+    """Load legal requirements from the mock legal API payload."""
+    legal_client = MockLegalDataApiClient(
+        mock_file_path=_mock_data_dir() / "actions_legal_api_mock.json"
+    )
+    return legal_client.get_action_legal_requirements(locode="CL IQQ")
+
+
+@pytest.mark.unit
+def test_hard_filter_block_with_mock_api_data() -> None:
+    """Hard filter removes known not-aligned actions from mock legal data."""
+    actions = _load_mock_actions()
+    legal_requirements = _load_mock_legal_requirements()
+
+    result = hard_filter.run(
+        actions=actions,
+        excluded_actions_free_text="Exclude fossil-heavy actions (stub behavior today).",
+        legal_requirements_by_action_id=legal_requirements,
+    )
+
+    discarded_legal_ids = {action.action_id for action in result.discarded_legal}
+    expected_discarded_legal_ids = {"c40_0012", "c40_0034", "c40_0037", "c40_0029"}
+    assert discarded_legal_ids == expected_discarded_legal_ids
+    assert len(result.discarded_excluded) == 0
+    assert len(result.valid_actions) == len(actions) - len(expected_discarded_legal_ids)
+
+    assert result.evidence["c40_0012"]["discard_reason"] == "legal_hard_requirement_failed"
+    assert result.evidence["c40_0013"]["hard_requirements_unknown_count"] == 1
+
+
+@pytest.mark.unit
+def test_impact_block_with_mock_api_data() -> None:
+    """Impact block returns zero scores plus emissions evidence for mock actions."""
+    actions = _load_mock_actions()
+
+    result = impact.run(actions=actions)
+
+    assert len(result.score_by_action_id) == len(actions)
+    assert all(score == 0.0 for score in result.score_by_action_id.values())
+    assert result.evidence_by_action_id is not None
+
+    first_action_evidence = result.evidence_by_action_id["c40_0010"]
+    assert first_action_evidence["emissions_impact_rows"] == 1
+    assert first_action_evidence["has_any_gpc_reference"] is False
+    assert first_action_evidence["sample_gpc_reference_numbers"] == []
+
+
+@pytest.mark.unit
+def test_alignment_block_with_mock_api_data() -> None:
+    """Alignment block returns zero scores with attribute-presence evidence."""
+    actions = _load_mock_actions()
+    city = _load_mock_city()
+
+    result = alignment.run(actions=actions, city=city)
+
+    assert len(result.score_by_action_id) == len(actions)
+    assert all(score == 0.0 for score in result.score_by_action_id.values())
+    assert result.evidence_by_action_id is not None
+
+    first_action_evidence = result.evidence_by_action_id["c40_0010"]
+    assert first_action_evidence["has_action_type"] is False
+    assert first_action_evidence["has_action_category"] is True
+    assert first_action_evidence["has_action_subcategory"] is True
+
+
+@pytest.mark.unit
+def test_feasibility_block_with_mock_api_data() -> None:
+    """Feasibility block returns zero scores and city-context row counts."""
+    actions = _load_mock_actions()
+    city = _load_mock_city()
+
+    result = feasibility.run(actions=actions, city=city)
+
+    assert len(result.score_by_action_id) == len(actions)
+    assert all(score == 0.0 for score in result.score_by_action_id.values())
+    assert result.evidence_by_action_id is not None
+
+    expected_context_rows = len(city.city_context)
+    assert expected_context_rows > 0
+    assert result.evidence_by_action_id["c40_0010"]["city_context_rows"] == expected_context_rows
+
+
+@pytest.mark.unit
+def test_final_scoring_block_with_mock_api_data() -> None:
+    """Final scoring applies weights, tie-break sorting, and top_n truncation."""
+    actions = _load_mock_actions()
+    action_by_id = {action.action_id: action for action in actions}
+    selected_actions = [
+        action_by_id["c40_0013"],
+        action_by_id["c40_0012"],
+        action_by_id["c40_0010"],
+    ]
+
+    scored_actions = final_scoring.run(
+        actions=selected_actions,
+        impact_scores={"c40_0013": 0.6, "c40_0012": 0.4, "c40_0010": 0.4},
+        alignment_scores={"c40_0013": 0.2, "c40_0012": 0.6, "c40_0010": 0.6},
+        feasibility_scores={"c40_0013": 0.1, "c40_0012": 0.1, "c40_0010": 0.1},
+        weights={"impact": 0.5, "alignment": 0.3, "feasibility": 0.2},
+        top_n=2,
+    )
+
+    ranked_ids = [item.action.action_id for item in scored_actions]
+    assert ranked_ids == ["c40_0010", "c40_0012"]
+    assert [item.rank for item in scored_actions] == [1, 2]
+    assert scored_actions[0].final_score == pytest.approx(scored_actions[1].final_score)


### PR DESCRIPTION
## Summary
- Implement the MEED prioritizer hard-filter and scoring pipeline stages with improved tracing artifacts and run summaries.
- Switch city/action/legal data clients to mock-first behavior (with API placeholders) so local and Docker runs consistently use checked-in mock API payloads.
- Update tests and docs for mock-backed behavior, request artifact output structure, and Docker log volume usage.

## Test plan
- [x] `uv run pytest -c pytest.ini`
- [x] `uv run pytest tests/integration/test_prioritize_e2e_mock_api_data.py -q`
- [x] Verified per-request artifacts are written under `logs/requests/<timestamp>_<request_id>/` with paired summary/detail event indexes.