### PR TITLE
fix: remove unnecessary User.findAll() call during login

### DIFF
--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -73,7 +73,6 @@ export const authOptions: NextAuthOptions = {
           if (!db.initialized) {
             await db.initialize();
           }
-          const users = await db.models.User.findAll();
           user = await db.models.User.findOne({
             where: { email: credentials.email.toLowerCase() },
           });


### PR DESCRIPTION
## Summary

- Remove a redundant `User.findAll()` call in the NextAuth `authorize` function (`app/src/lib/auth.ts`)
- The query loaded every user from the database on each login attempt but the result was never consumed — only the subsequent `findOne()` by email was actually used

## Motivation

This is both a **performance** and **security hygiene** issue:
- Every login attempt triggered a full table scan on the `Users` table, adding unnecessary database load that scales linearly with the number of registered users
- No application logic depended on the result — it appears to be leftover debug/development code

## Changes

- Removed the unused `User.findAll()` call (single line removal)
- No behavioral change to the login flow — `findOne()` by email continues to work as before

## Test plan

- [ ] Verify login works correctly with valid credentials
- [ ] Verify login fails gracefully with invalid credentials
- [ ] Verify login fails gracefully with non-existent email
- [ ] Run existing auth-related tests (`npm run ci:test`)