### PR TITLE
fix: sanitize error responses to prevent internal detail leakage

### DIFF
--- a/app/src/util/api.ts
+++ b/app/src/util/api.ts
@@ -466,17 +466,14 @@ function errorHandler(err: unknown, _req: NextRequest) {
       { status: 400 },
     );
   } else if (err instanceof OpenAI.APIError) {
-    const { name, status, headers, message } = err;
-    return NextResponse.json({ name, status, headers, message }, { status });
-  } else {
-    let errorMessage = "Unknown error";
-    if ((err as Object).hasOwnProperty("message")) {
-      errorMessage = (err as Error).message;
-    } else if (err instanceof Error) {
-      errorMessage = (err as Object).toString();
-    }
+    const { name, status, message } = err;
     return NextResponse.json(
-      { error: { message: "Internal server error", error: errorMessage } },
+      { error: { name, message } },
+      { status: status ?? 500 },
+    );
+  } else {
+    return NextResponse.json(
+      { error: { message: "Internal server error" } },
       { status: 500 },
     );
   }


### PR DESCRIPTION
## Summary

- Sanitize the fallback 500 error response in `apiHandler` to stop
  leaking internal error details to API clients
- Remove leaked `headers` from OpenAI API error responses

## Motivation

The `errorHandler` in `app/src/util/api.ts` has a fallback branch for unrecognized errors that was extracting `err.message` and returning it in the JSON body alongside `"Internal server error"`. This could expose:

- Database/driver error messages (e.g. connection strings, table names)
- Stack trace fragments
- Internal service details

The OpenAI error branch was also forwarding `headers` from the upstream OpenAI API response, which could contain rate limit details or other internal metadata that clients should not see.

## Changes

- **Fallback 500**: return only `{ error: { message: "Internal server error" } }`
  without the raw error string (the full error is still logged server-side
  via `logger.error(err)` on line 422)
- **OpenAI errors**: return `{ error: { name, message } }` without `headers`

## Test plan

- [ ] Trigger a 500 error and verify the response body contains only
      the generic message, not internal details
- [ ] Verify server logs still contain the full error for debugging
- [ ] Run existing API tests (`npm run ci:test`)