### PR TITLE
chore: upgrade outdated GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/api-demo-develop.yml
+++ b/.github/workflows/api-demo-develop.yml
@@ -24,13 +24,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/climate-advisor-develop.yml
+++ b/.github/workflows/climate-advisor-develop.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/climate-advisor-tag.yml
+++ b/.github/workflows/climate-advisor-tag.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/climate-advisor-test.yml
+++ b/.github/workflows/climate-advisor-test.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/global-api-develop.yml
+++ b/.github/workflows/global-api-develop.yml
@@ -32,10 +32,10 @@ jobs:
       run:
         working-directory: ./global-api
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
 

--- a/.github/workflows/hiap-develop.yml
+++ b/.github/workflows/hiap-develop.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.12
 

--- a/.github/workflows/hiap-meed-develop.yml
+++ b/.github/workflows/hiap-meed-develop.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.12
 

--- a/.github/workflows/hiap-meed-tag.yml
+++ b/.github/workflows/hiap-meed-tag.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.12
 

--- a/.github/workflows/hiap-meed-test.yml
+++ b/.github/workflows/hiap-meed-test.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.12
 

--- a/.github/workflows/hiap-tag.yml
+++ b/.github/workflows/hiap-tag.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.12
 

--- a/.github/workflows/hiap-test.yml
+++ b/.github/workflows/hiap-test.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.12
 


### PR DESCRIPTION
## Summary

- Upgrade all GitHub Actions maintained by `actions/*` and `docker/*` to their latest major versions across 11 workflow files

## Motivation

Several CI workflows were using outdated action versions:

| Workflow | Action | Old | New |
|----------|--------|-----|-----|
| global-api-develop | actions/checkout | v3 | v4 |
| global-api-develop | actions/setup-python | v2 | v5 |
| api-demo-develop | actions/checkout | v2 | v4 |
| api-demo-develop | docker/setup-buildx-action | v1 | v3 |
| api-demo-develop | docker/login-action | v1 | v3 |
| hiap-* (6 files) | actions/setup-python | v4 | v5 |
| climate-advisor-* (3 files) | actions/setup-python | v4 | v5 |

Old major versions:
- No longer receive security patches
- May run on deprecated Node.js runtimes (Node 12/16)
- Miss performance improvements (e.g. v4 checkout is significantly
  faster with sparse checkout support)

## Changes

11 workflow files updated, no logic changes — only version bumps
on `uses:` directives.

## Test plan

- [ ] Verify `global-api-develop` workflow runs successfully on push
- [ ] Verify `api-demo-develop` workflow builds and deploys correctly
- [ ] Verify hiap workflows (develop/test/tag) pass
- [ ] Verify climate-advisor workflows (develop/test/tag) pass
- [ ] Spot-check that Python version resolution still works with
      setup-python v5