### PR TITLE
fix: remove duplicate NEXT_PUBLIC_FEATURE_FLAGS in env.example

### DIFF
--- a/app/env.example
+++ b/app/env.example
@@ -45,6 +45,5 @@ NEXT_PUBLIC_POSTHOG_HOST="https://eu.i.posthog.com"
 
 # Environment tracking for analytics
 NEXT_PUBLIC_DEPLOYMENT_ENV="development"
-NEXT_PUBLIC_FEATURE_FLAGS="ACCOUNT_SETTINGS_ENABLED, JN_ENABLED"
 HIAP_API_URL="http://localhost:8080"
 CC_CCRA_REPLIT_URL="https://citycatalyst-ccra.replit.app"


### PR DESCRIPTION
## Summary

- Remove duplicate `NEXT_PUBLIC_FEATURE_FLAGS` entry in `app/env.example`

## Problem

`NEXT_PUBLIC_FEATURE_FLAGS` was defined twice:

- **Line 40:** `"ENTERPRISE_MODE,ACCOUNT_SETTINGS_ENABLED,JN_ENABLED,ANALYTICS_ENABLED"`
- **Line 48:** `"ACCOUNT_SETTINGS_ENABLED, JN_ENABLED"`

When a developer copies `env.example` to `.env`, the second definition silently overrides the first. This means `ENTERPRISE_MODE` and `ANALYTICS_ENABLED` would be missing from local environments, which could mask bugs related to those features during development.

## Changes

- Removed the duplicate on line 48, keeping the complete definition under the `# Feature Flags` section

## Test plan

- [ ] Verify `env.example` has a single `NEXT_PUBLIC_FEATURE_FLAGS`
- [ ] Copy to `.env` and confirm all 4 flags are loaded correctly