### PR TITLE
fix: remove duplicate pytest entry in global-api requirements.txt

### DIFF
--- a/global-api/requirements.txt
+++ b/global-api/requirements.txt
@@ -24,7 +24,6 @@ nest_asyncio==1.6.*
 xlrd==2.0.*
 dns-cache==0.3.*
 openpyxl==3.1.*
-pytest==9.0.2
 pytest-cov==7.0.0
 httpx==0.28.1
 pyproj==3.7.*


### PR DESCRIPTION
## Summary

- Remove duplicate `pytest==9.0.2` entry in `global-api/requirements.txt`

## Problem

`pytest==9.0.2` appeared twice in the file (lines 13 and 27). While `pip install` handles this gracefully, it adds noise and makes dependency management error-prone — if someone updates the version on one line but not the other, pip's behavior becomes unpredictable depending on installation order.

## Changes

- Removed the second `pytest==9.0.2` occurrence (line 27), keeping the one at line 13

## Test plan

- [ ] Run `pip install -r requirements.txt` in the global-api virtualenv — verify no errors
- [ ] Run `pytest` in global-api — verify tests still pass