### PR TITLE
feat: add docker-compose.yml for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: citycatalyst
+      POSTGRES_PASSWORD: development
+      POSTGRES_DB: citycatalyst
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./scripts/init-databases.sql:/docker-entrypoint-initdb.d/init-databases.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U citycatalyst"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  global-api:
+    build: ./global-api
+    ports:
+      - "8000:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DB_HOST: db
+      DB_PORT: "5432"
+      DB_NAME: ccglobal
+      DB_USER: ccglobal
+      DB_PASSWORD: development
+    profiles:
+      - full
+
+volumes:
+  pgdata:

--- a/scripts/init-databases.sql
+++ b/scripts/init-databases.sql
@@ -1,0 +1,6 @@
+-- Creates the additional databases needed by other services.
+-- The primary database (citycatalyst) is created automatically via
+-- POSTGRES_DB in docker-compose.yml.
+
+CREATE USER ccglobal WITH PASSWORD 'development';
+CREATE DATABASE ccglobal OWNER ccglobal;


### PR DESCRIPTION
## Summary

- Add `docker-compose.yml` at the repo root for local development
- Add `scripts/init-databases.sql` to bootstrap both databases in a single Postgres instance

## Motivation

Setting up the local environment currently requires multiple manual steps spread across different READMEs:

1. Run `app/scripts/start-db.sh` for the app database
2. Manually create the `ccglobal` user and database for the global-api
3. Manually configure each service to connect to the right database

There is no unified way to bring up the full local stack. This makes onboarding slow and error-prone — especially for new team members.

## Changes

### `docker-compose.yml`
- **db**: Postgres 16 Alpine with persistent volume, healthcheck, and an init script that creates both `citycatalyst` (primary) and `ccglobal` (global-api) databases
- **global-api**: Builds from `./global-api/Dockerfile`, connects to the `db` service. Behind the `full` profile so it only starts when explicitly requested

### `scripts/init-databases.sql`
- Creates the `ccglobal` user and database on first Postgres startup (the `citycatalyst` database is created automatically via `POSTGRES_DB`)

## Usage

### Database only (most common for app development)
`docker compose up -d`

### Then run the app locally with hot reload
`cd app && npm run dev`

### Full stack (database + global-api)
`docker compose --profile full up -d`


## Test plan
- [ ] `docker compose up -d` starts Postgres and both databases are created
- [ ] `docker compose --profile full up -d` additionally starts the `global-api service`
- [ ] App connects to the database and migrations run successfully
- [ ] `docker compose down -v` cleans up volumes
- [ ] Existing `app/scripts/start-db.sh` still works independently