### PR TITLE
fix(ui): ON-5520 select correct city in journey navigator drawer

### DIFF
--- a/app/src/components/HomePage/JNDrawer.tsx
+++ b/app/src/components/HomePage/JNDrawer.tsx
@@ -204,12 +204,12 @@ const ProjectFilterSection = ({
   t,
   projectsData,
   lng,
-  currentInventoryId,
+  currentCityId,
 }: {
   t: Function;
   projectsData: ProjectWithCitiesResponse;
   lng: string;
-  currentInventoryId?: string;
+  currentCityId?: string;
 }) => {
   const router = useRouter();
   const [selectedProject, setSelectedProject] = useState<string>("");
@@ -219,17 +219,13 @@ const ProjectFilterSection = ({
   const [selectedCity, setSelectedCity] = useState<string>("");
   const [searchTerm, setSearchTerm] = useState<string>("");
 
-  // Initialize with current project and city based on currentInventoryId
+  // Initialize with current project and city based on currentCityId
   useEffect(() => {
-    if (currentInventoryId && projectsData) {
+    if (currentCityId && projectsData) {
       // Find the project and city that contains the current inventory
       for (const project of projectsData) {
         for (const city of project.cities) {
-          if (
-            city.inventories?.some(
-              (inv) => inv.inventoryId === currentInventoryId,
-            )
-          ) {
+          if (city.cityId === currentCityId) {
             setSelectedProject(project.projectId);
             setSelectedCity(city.cityId);
             return;
@@ -237,7 +233,7 @@ const ProjectFilterSection = ({
         }
       }
     }
-  }, [currentInventoryId, projectsData]);
+  }, [currentCityId, projectsData]);
 
   // Transform projectsData into options for the project select
   const projectOptions = projectsData.map((project) => ({
@@ -525,14 +521,14 @@ const JNDrawer = ({
   organizationId,
   onClose,
   onOpenChange,
-  currentInventoryId,
+  currentCityId,
 }: {
   lng: string;
   isOpen: boolean;
   onClose: () => void;
   onOpenChange: (val: OpenChangeDetails) => void;
   organizationId?: string;
-  currentInventoryId?: string;
+  currentCityId?: string;
 }) => {
   const { t } = useTranslation(lng, "dashboard");
   const { data: projectsData, isLoading } = useGetUserProjectsQuery({});
@@ -546,17 +542,13 @@ const JNDrawer = ({
   const { data: projectModules, isLoading: isProjectModulesLoading } =
     useGetProjectModulesQuery(selectedProject!, { skip: !selectedProject });
 
-  // Initialize with current project and city based on currentInventoryId
+  // Initialize with current project and city based on currentCityId
   useEffect(() => {
-    if (currentInventoryId && projectsData) {
+    if (currentCityId && projectsData) {
       // Find the project and city that contains the current inventory
       for (const project of projectsData) {
         for (const city of project.cities) {
-          if (
-            city.inventories?.some(
-              (inv) => inv.inventoryId === currentInventoryId,
-            )
-          ) {
+          if (city.cityId === currentCityId) {
             setSelectedProject(project.projectId);
             setSelectedCity(city.cityId);
             return;
@@ -564,11 +556,7 @@ const JNDrawer = ({
         }
       }
     }
-  }, [currentInventoryId, projectsData]);
-
-  const selectProject = (projectId: string) => {
-    setSelectedProject(projectId);
-  };
+  }, [currentCityId, projectsData]);
 
   // Module filtering by stage - same logic as HomePage
   const modulesByStage = useMemo(() => {
@@ -632,7 +620,7 @@ const JNDrawer = ({
                 t={t}
                 projectsData={projectsData}
                 lng={lng}
-                currentInventoryId={currentInventoryId}
+                currentCityId={currentCityId}
               />
               <Box w="full" border="1px solid" borderColor="border.neutral" />
               {/* Menu items */}

--- a/app/src/components/navigation-bar.tsx
+++ b/app/src/components/navigation-bar.tsx
@@ -106,28 +106,6 @@ export function NavigationBar({
     router.replace(newPath);
   };
 
-  // Checks if language is set in cookie and updates URL if not
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      if (typeof window !== "undefined") {
-        const handlePopState = () => {
-          const cookieLanguage = Cookies.get("i18next");
-          if (cookieLanguage) {
-            const currentPath = window.location.pathname;
-            // Your logic here
-          }
-        };
-
-        window.addEventListener("popstate", handlePopState);
-
-        // Cleanup the event listener on component unmount
-        return () => {
-          window.removeEventListener("popstate", handlePopState);
-        };
-      }
-    }
-  }, []);
-
   const { data: session, status } = useSession();
   const { data: userInfo, isLoading: isUserInfoLoading } =
     api.useGetUserInfoQuery();

--- a/app/src/components/navigation-bar.tsx
+++ b/app/src/components/navigation-bar.tsx
@@ -136,21 +136,21 @@ export function NavigationBar({
   // Memoize city and inventory IDs to ensure they update when route changes
   const currentInventoryId = useMemo(
     () => inventoryIdFromRoute ?? userInfo?.defaultInventoryId,
-    [inventoryIdFromRoute, userInfo?.defaultInventoryId, pathname],
+    [inventoryIdFromRoute, userInfo?.defaultInventoryId],
   );
   const currentCityId = useMemo(
-    () => cityIdFromRoute ?? userInfo?.defaultCityId,
-    [cityIdFromRoute, userInfo?.defaultCityId, pathname],
+    () => cityIdFromRoute ?? userInfo?.defaultCityId ?? undefined,
+    [cityIdFromRoute, userInfo?.defaultCityId],
   );
 
   // Memoize paths to recompute when pathname or IDs change
   const dashboardPath = useMemo(
     () => getDashboardPath(lng, currentCityId ?? "", currentInventoryId ?? ""),
-    [lng, currentCityId, currentInventoryId, pathname],
+    [lng, currentCityId, currentInventoryId],
   );
   const homePath = useMemo(
     () => getHomePath(lng, currentCityId ?? "", currentInventoryId ?? ""),
-    [lng, currentCityId, currentInventoryId, pathname],
+    [lng, currentCityId, currentInventoryId],
   );
   const { setTheme } = useTheme();
 
@@ -526,8 +526,11 @@ export function NavigationBar({
         {hasFeatureFlag(FeatureFlags.JN_ENABLED) && (
           <JNDrawer
             lng={lng}
-            currentInventoryId={currentInventoryId as string}
-            organizationId={(organization?.organizationId ?? userAccessStatus?.organizationId) as string}
+            currentCityId={currentCityId}
+            organizationId={
+              (organization?.organizationId ??
+                userAccessStatus?.organizationId) as string
+            }
             isOpen={isDrawerOpen}
             onClose={() => setIsDrawerOpen(false)}
             onOpenChange={({ open }) => setIsDrawerOpen(open)}


### PR DESCRIPTION
Use current city instead of current inventory because the current inventory defaults to the user's stored default inventory, which is often a different one when e.g. on the journey navigator home page/ city dashboard.