### PR TITLE
feat: add `.cursor` config for AI-accelerated development

### DIFF
--- a/.cursor/rules/api-routes.mdc
+++ b/.cursor/rules/api-routes.mdc
@@ -1,0 +1,110 @@
+---
+description: API route handler patterns using apiHandler, Swagger JSDoc, and validation
+globs: app/src/app/api/**/*.ts
+alwaysApply: false
+---
+
+# API Route Patterns
+
+## Handler Template
+
+Every API route MUST use `apiHandler` from `@/util/api`. It provides auth, rate limiting, org frozen checks, DB init, and error handling.
+
+```typescript
+import { NextResponse } from "next/server";
+import { apiHandler } from "@/util/api";
+import createHttpError from "http-errors";
+
+export const GET = apiHandler(async (req, { session, params, searchParams }) => {
+  if (!session) throw new createHttpError.Unauthorized("Unauthorized");
+
+  const { inventory } = params;
+  // ... business logic using services from @/backend/
+  return NextResponse.json({ data: result });
+});
+
+export const POST = apiHandler(async (req, { session, params }) => {
+  if (!session) throw new createHttpError.Unauthorized("Unauthorized");
+
+  const body = await req.json();
+  const validated = myZodSchema.parse(body);
+  // ... create logic
+  return NextResponse.json({ data: created }, { status: 201 });
+});
+```
+
+## Handler Signature
+
+```typescript
+type NextHandler = (
+  req: NextRequest,
+  props: {
+    params: Record<string, string>;     // Route params (already resolved)
+    session: AppSession | null;          // NextAuth session or Bearer/PAT/OAuth
+    searchParams: Record<string, string>; // Query string params
+  },
+) => Promise<NextResponse | Response>;
+```
+
+## Swagger JSDoc
+
+Add `@swagger` comments above the import block for OpenAPI generation:
+
+```typescript
+/**
+ * @swagger
+ * /api/v1/inventory/{inventory}:
+ *   get:
+ *     operationId: getInventory
+ *     summary: Get inventory details
+ *     tags:
+ *       - inventory
+ *     parameters:
+ *       - in: path
+ *         name: inventory
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Success
+ */
+```
+
+## Error Handling
+
+Use `http-errors` for HTTP errors — they are automatically caught by `errorHandler`:
+
+```typescript
+import createHttpError from "http-errors";
+
+// 404
+throw new createHttpError.NotFound("Inventory not found");
+// 400
+throw new createHttpError.BadRequest("Invalid input");
+// 403
+throw new createHttpError.Forbidden("Access denied");
+```
+
+For validation, use Zod schemas from `@/util/validation.ts` — `ZodError` is auto-caught as 400.
+
+## File Placement
+
+```
+src/app/api/v1/
+├── route.ts                           # GET /api/v1
+├── inventory/[inventory]/
+│   ├── route.ts                       # GET/PATCH/DELETE /api/v1/inventory/:id
+│   └── activity-value/route.ts        # Nested resources
+├── city/[city]/route.ts
+└── organization/[organization]/route.ts
+```
+
+## Service Layer
+
+Keep route handlers thin. Put business logic in `src/backend/`:
+
+```typescript
+import UserService from "@/backend/UserService";
+import { InventoryService } from "@/backend/InventoryService";
+```

--- a/.cursor/rules/auth-permissions.mdc
+++ b/.cursor/rules/auth-permissions.mdc
@@ -1,0 +1,65 @@
+---
+description: NextAuth authentication and permission patterns
+globs: app/src/lib/auth*,app/src/middleware.ts,app/src/hooks/useUserPermissions*,app/src/hooks/useAdminGuard*
+alwaysApply: false
+---
+
+# Authentication & Permissions
+
+## NextAuth Configuration (src/lib/auth.ts)
+
+- Provider: **Credentials** (email + bcrypt password)
+- Strategy: **JWT** sessions
+- Session type: `AppSession` with `user.id` and `user.role`
+
+```typescript
+import { Auth, AppSession } from "@/lib/auth";
+
+// Server-side (API routes, server components)
+const session = await Auth.getServerSession();
+if (!session) throw new createHttpError.Unauthorized();
+const userId = session.user.id;
+const isAdmin = session.user.role === Roles.Admin;
+```
+
+## API Route Auth
+
+`apiHandler` automatically resolves auth from multiple sources (priority order):
+1. NextAuth session (cookie)
+2. Bearer JWT token (`Authorization: Bearer <token>`)
+3. Personal Access Token (PAT)
+4. OAuth client token (feature-flagged)
+5. Service-to-service (`X-Service-Name` + `X-Service-Key` headers)
+
+The resolved `session` is passed to the handler — no need to call `getServerSession` manually.
+
+## Middleware (src/middleware.ts)
+
+Edge middleware handles:
+- **CORS** for `/api/*` and `/.well-known` routes
+- **i18n** language detection and cookie
+- **Route protection** via `withAuth` — public, auth, and invite matchers define unprotected paths
+
+## Permission Hooks
+
+```tsx
+import { useUserPermissions } from "@/hooks/useUserPermissions";
+import { useAdminGuard } from "@/hooks/useAdminGuard";
+
+// Check user permissions for a resource
+const { hasPermission } = useUserPermissions();
+
+// Redirect non-admins
+useAdminGuard();
+```
+
+## Roles
+
+```typescript
+import { Roles } from "@/util/types";
+// Roles.Admin, Roles.User
+```
+
+## Organization Frozen Check
+
+`apiHandler` blocks mutating methods (POST/PUT/PATCH/DELETE) when the organization is frozen (`active === false`), except for admin users and invite-related endpoints.

--- a/.cursor/rules/chakra-ui-components.mdc
+++ b/.cursor/rules/chakra-ui-components.mdc
@@ -1,0 +1,77 @@
+---
+description: Chakra UI v3 component patterns, theming, and styling conventions
+globs: app/src/components/**/*.tsx
+alwaysApply: false
+---
+
+# Chakra UI v3 Component Patterns
+
+## Theme System
+
+The app uses `createSystem` from Chakra UI v3 with multi-theme support via `next-themes`:
+- Themes: `blue_theme`, `light_brown_theme`, `dark_orange_theme`, `green_theme`, `light_blue_theme`, `violet_theme`
+- Theme config: `src/lib/theme/recipes/app-theme.ts`
+- Semantic tokens change per theme via `conditions`
+
+## Component Template
+
+```tsx
+"use client";
+
+import { Box, Text, Heading, Flex, Stack } from "@chakra-ui/react";
+import { useTranslation } from "@/i18n/client";
+
+interface MyComponentProps {
+  title: string;
+  lng: string;
+}
+
+export function MyComponent({ title, lng }: MyComponentProps) {
+  const { t } = useTranslation(lng, "namespace");
+
+  return (
+    <Box p={6} borderRadius="lg" bg="background.overlay">
+      <Heading size="lg">{title}</Heading>
+      <Text color="content.tertiary">{t("description")}</Text>
+    </Box>
+  );
+}
+```
+
+## Semantic Tokens (use these, not raw colors)
+
+- Backgrounds: `background.default`, `background.overlay`, `background.neutral`
+- Content: `content.primary`, `content.secondary`, `content.tertiary`, `content.link`
+- Border: `border.neutral`, `border.overlay`
+- Interactive: `interactive.primary`, `interactive.secondary`
+- Sentiment: `sentiment.positiveDefault`, `sentiment.negativeDefault`, `sentiment.warningDefault`
+
+## UI Primitives (src/components/ui/)
+
+Use project wrappers instead of raw Chakra:
+- `@/components/ui/button` — Button with loading spinner
+- `@/components/ui/dialog` — Modal dialogs
+- `@/components/ui/field` — Form field with label/error
+- `@/components/ui/data-table` — TanStack-powered data table
+- `@/components/ui/tooltip`, `toaster`, `checkbox`, `switch`, etc.
+
+## File Organization
+
+```
+src/components/
+├── ui/              # Design system primitives (Chakra wrappers)
+├── Navigation/      # Navbar, sidebar, breadcrumbs
+├── Tabs/            # Tab-based views (Activity, etc.)
+├── Modals/          # Modal dialogs
+├── Sections/        # Page sections
+├── Skeletons/       # Loading skeletons
+├── shared/          # Cross-feature shared components
+├── steps/           # Multi-step wizard components
+└── PublicDashboard/ # Public-facing dashboard
+```
+
+## Naming
+
+- **PascalCase** for component names and folders when they're feature buckets
+- **kebab-case** for utility component files (e.g. `form-input.tsx`, `activity-tab.tsx`)
+- Components export as named exports, not default

--- a/.cursor/rules/forms-validation.mdc
+++ b/.cursor/rules/forms-validation.mdc
@@ -1,0 +1,76 @@
+---
+description: react-hook-form and Zod validation patterns for forms
+globs: app/src/components/**/*.tsx,app/src/hooks/**/*.ts,app/src/util/validation.ts
+alwaysApply: false
+---
+
+# Forms & Validation
+
+## Client-Side Forms (react-hook-form)
+
+```tsx
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+const schema = z.object({
+  name: z.string().min(1, "Required"),
+  email: z.string().email("Invalid email"),
+  year: z.number().int().min(2000),
+});
+type FormData = z.infer<typeof schema>;
+
+export function MyForm() {
+  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  });
+
+  const onSubmit = (data: FormData) => { /* ... */ };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <FormInput label="Name" register={register} name="name" errors={errors} />
+      <Button type="submit">Save</Button>
+    </form>
+  );
+}
+```
+
+## Form Input Components
+
+Use `@/components/form-input.tsx` and `@/components/form-select-input.tsx`:
+
+```tsx
+import FormInput from "@/components/form-input";
+import FormSelectInput from "@/components/form-select-input";
+```
+
+## Server-Side Validation (Zod)
+
+All API request validation schemas are in `src/util/validation.ts`:
+
+```typescript
+import { z } from "zod";
+
+export const createCityRequest = z.object({
+  locode: z.string().min(4),
+  name: z.string().min(1),
+  projectId: z.string().uuid().optional(),
+});
+export type CreateCityRequest = z.infer<typeof createCityRequest>;
+```
+
+In API routes, Zod errors are auto-caught by `errorHandler` and returned as 400 with `issues`.
+
+## Activity Forms (Complex Pattern)
+
+Complex dynamic forms use `src/hooks/activity-value-form/use-activity-form.ts` — a large custom hook wrapping `useForm` with methodology-specific logic. Follow this pattern for similarly complex forms.
+
+## Conventions
+
+- Always co-locate the Zod schema with its `type` inference: `type X = z.infer<typeof xSchema>`
+- Server schemas go in `src/util/validation.ts`
+- Client schemas can live in the component file or a nearby `schema.ts`
+- Use `zodResolver` to connect Zod schemas with react-hook-form

--- a/.cursor/rules/i18n.mdc
+++ b/.cursor/rules/i18n.mdc
@@ -1,0 +1,62 @@
+---
+description: Internationalization patterns with i18next and react-i18next
+globs: app/src/i18n/**/*,app/src/app/[lng]/**/*.tsx
+alwaysApply: false
+---
+
+# i18n Patterns
+
+## Client-Side Translation
+
+```tsx
+import { useTranslation } from "@/i18n/client";
+
+export default function MyPage(props: { params: Promise<{ lng: string }> }) {
+  const { lng } = use(props.params);
+  const { t } = useTranslation(lng, "namespace");
+  // namespace maps to src/i18n/locales/en/namespace.json
+
+  return <Text>{t("my-key")}</Text>;
+}
+```
+
+## Namespaces
+
+Each JSON file in `src/i18n/locales/en/` is a namespace:
+- `auth.json` — login, signup, password
+- `dashboard.json` — main dashboard UI
+- `common.json` — shared terms
+- `emails.json` — email templates
+
+## Adding Translations
+
+1. Add the key to the **English** file first: `src/i18n/locales/en/<namespace>.json`
+2. Other languages are auto-translated via CI (`web-translate.yml`)
+3. Use descriptive, kebab-case keys: `"inventory-not-found"`, `"save-changes"`
+
+## Key Format
+
+```json
+{
+  "page-title": "My Page Title",
+  "description": "This is a description with {{count}} items",
+  "nested": {
+    "key": "Nested value"
+  }
+}
+```
+
+## Interpolation
+
+```tsx
+t("description", { count: 5 })
+// "This is a description with 5 items"
+```
+
+## Supported Languages
+
+`en` (fallback), `de`, `es`, `fr`, `pt`
+
+## ESLint
+
+The project uses `eslint-plugin-i18next` — all user-facing strings in TSX must use `t()` instead of hardcoded text.

--- a/.cursor/rules/nextjs-frontend.mdc
+++ b/.cursor/rules/nextjs-frontend.mdc
@@ -1,0 +1,72 @@
+---
+description: Next.js App Router patterns for pages, layouts, and client components
+globs: app/src/app/**/*.{ts,tsx}
+alwaysApply: false
+---
+
+# Next.js App Router Patterns
+
+## Page Structure
+
+Pages live under `src/app/[lng]/` with the locale segment. Always receive `params` as a Promise:
+
+```tsx
+// src/app/[lng]/cities/[cityId]/page.tsx
+import { use } from "react";
+import { useTranslation } from "@/i18n/client";
+
+export default function MyPage(props: { params: Promise<{ lng: string; cityId: string }> }) {
+  const { lng, cityId } = use(props.params);
+  const { t } = useTranslation(lng, "namespace");
+
+  return <div>{t("page-title")}</div>;
+}
+```
+
+## Layout Pattern
+
+```tsx
+// layout.tsx — server component wrapping child pages
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ lng: string }>;
+}) {
+  const { lng } = await params;
+  return <section>{children}</section>;
+}
+```
+
+## Client vs Server Components
+
+- Default is **server component** — add `"use client"` only when needed (hooks, browser APIs, event handlers)
+- Keep server components for data fetching and layout
+- Extract interactive parts into small client components
+
+## Provider Stack (src/app/providers.tsx)
+
+Providers wrap in this order: `ThemeProvider` → `ChakraProvider` → `OrganizationContextProvider` → `SessionProvider` → `Redux Provider`
+
+## Route Organization
+
+```
+src/app/
+├── [lng]/                  # Locale-prefixed UI pages
+│   ├── auth/               # Login, signup, password reset
+│   ├── admin/              # Admin panel
+│   ├── cities/[cityId]/    # City-specific pages
+│   ├── onboarding/         # Onboarding flows
+│   ├── organization/       # Org management
+│   └── public/             # Public dashboards
+├── api/v1/                 # REST API routes
+└── docs/                   # Swagger UI
+```
+
+## Imports Order
+
+1. React/Next.js (`react`, `next/...`)
+2. External libraries (`@chakra-ui`, `zod`, etc.)
+3. Internal modules (`@/components`, `@/hooks`, `@/util`, `@/services`)
+4. Relative imports (`./`, `../`)

--- a/.cursor/rules/project-architecture.mdc
+++ b/.cursor/rules/project-architecture.mdc
@@ -1,0 +1,72 @@
+---
+description: CityCatalyst project architecture, monorepo structure, and core conventions
+alwaysApply: true
+---
+
+# CityCatalyst Architecture
+
+## Monorepo Structure
+
+```
+CityCatalyst/
+├── app/                    # Next.js 15 (App Router) — main product
+│   ├── src/app/            # Pages & API routes (locale: [lng])
+│   ├── src/components/     # React components (Chakra UI v3)
+│   ├── src/services/       # RTK Query API, logger, PDF
+│   ├── src/backend/        # Server services (UserService, InventoryService...)
+│   ├── src/models/         # Sequelize models (PostgreSQL)
+│   ├── src/hooks/          # Custom React hooks
+│   ├── src/util/           # Shared utilities, validation (Zod), types
+│   ├── src/lib/            # Auth, theme, highlight, custom errors
+│   ├── src/i18n/           # i18next config + locales/{en,de,es,fr,pt}
+│   ├── src/features/       # Redux slices
+│   ├── migrations/         # Sequelize migrations (.cjs)
+│   └── seeders/            # Sequelize seeders (.cjs)
+├── global-api/             # Python FastAPI — data services
+├── climate-advisor/        # Python FastAPI — RAG chat agent (LangChain)
+├── hiap/                   # Python FastAPI — prioritization (ML/LLM)
+├── hiap-meed/              # Python FastAPI — MEED scoring
+├── k8s/                    # Shared Kubernetes manifests
+└── .github/workflows/      # CI/CD (GitHub Actions)
+```
+
+## Tech Stack (app/)
+
+| Layer | Technology |
+|-------|-----------|
+| Framework | Next.js 15 (App Router) |
+| UI | Chakra UI v3 + Emotion + next-themes |
+| State | Redux Toolkit + RTK Query |
+| Auth | NextAuth v4 (credentials, JWT) |
+| DB/ORM | PostgreSQL + Sequelize v6 |
+| Forms | react-hook-form + Zod |
+| i18n | i18next + react-i18next |
+| Charts | Nivo |
+| Testing | Jest (unit/API) + Playwright (E2E) |
+
+## Path Alias
+
+`@/` maps to `app/src/` — always use `@/` for imports inside `app/`.
+
+## Key Conventions
+
+- API routes live under `src/app/api/v1/` and use `apiHandler` wrapper from `@/util/api`
+- Pages use `[lng]` locale segment: `src/app/[lng]/...`
+- Backend services in `src/backend/` (e.g. `UserService`, `InventoryService`)
+- Validation schemas in `src/util/validation.ts` using Zod
+- Types in `src/util/types.ts`, enums in `src/util/enums.ts`
+- Feature flags in `src/util/feature-flags.ts`
+- Error handling centralized in `errorHandler` within `src/util/api.ts`
+- Logger: `import { logger } from "@/services/logger"` (pino)
+
+## Domain Glossary
+
+- **GPC**: Global Protocol for Community-Scale GHG Emissions
+- **GHGI**: Greenhouse Gas Inventory
+- **Inventory**: A city's emissions data for a specific year
+- **Sector/SubSector/SubCategory**: GPC hierarchy for emissions classification
+- **ActivityValue/GasValue**: Emissions data entries
+- **InventoryValue**: Aggregated emissions per sub-category
+- **HIAP**: High Impact Action Prioritization
+- **CCRA**: Climate Change Risk Assessment
+- **Locode**: UN/LOCODE city identifier

--- a/.cursor/rules/python-fastapi.mdc
+++ b/.cursor/rules/python-fastapi.mdc
@@ -1,0 +1,72 @@
+---
+description: Python FastAPI patterns for global-api, climate-advisor, hiap, hiap-meed services
+globs: global-api/**/*.py,climate-advisor/**/*.py,hiap/**/*.py,hiap-meed/**/*.py
+alwaysApply: false
+---
+
+# Python FastAPI Services
+
+## Services Overview
+
+| Service | Path | DB | Key Libs |
+|---------|------|------|----------|
+| global-api | `global-api/` | PostgreSQL (SQLAlchemy + Alembic) | GeoPandas, OSMnx, rioxarray |
+| climate-advisor | `climate-advisor/service/` | PostgreSQL + pgvector | LangChain, LangGraph, OpenAI |
+| hiap | `hiap/` | — | LangChain, ChromaDB, XGBoost, scikit-learn |
+| hiap-meed | `hiap-meed/` | — | FastAPI minimal |
+
+## global-api Conventions
+
+- **ORM**: SQLAlchemy with Alembic migrations (`global-api/migrations/`)
+- **Entry**: `global-api/main.py` with Uvicorn
+- **Linting**: black, flake8, mypy
+- **Tests**: pytest + pytest-cov
+- **Deps**: `global-api/requirements.txt`
+
+## climate-advisor Conventions
+
+- **Architecture**: RAG agents with LangChain/LangGraph
+- **Vector store**: pgvector (PostgreSQL extension)
+- **Auth**: JWT validation + service-to-service via `X-Service-Name`/`X-Service-Key`
+- **Streaming**: SSE (Server-Sent Events)
+- **Deps**: `climate-advisor/service/requirements.txt`
+
+## hiap / hiap-meed Conventions
+
+- **Package manager**: `uv` with `pyproject.toml` + `uv.lock`
+- **Tests**: pytest
+- **Deployment**: Kubernetes (`k8s/` subdirectory)
+
+## Common Patterns
+
+```python
+from fastapi import FastAPI, HTTPException, Depends
+from pydantic import BaseModel
+
+app = FastAPI()
+
+class MyRequest(BaseModel):
+    name: str
+    value: float
+
+@app.post("/v1/endpoint")
+async def my_endpoint(request: MyRequest):
+    try:
+        result = process(request)
+        return {"data": result}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+```
+
+## Running Locally
+
+```bash
+# global-api
+cd global-api && pip install -r requirements.txt && python main.py
+
+# hiap
+cd hiap && uv sync && uv run uvicorn app.main:app --reload
+
+# hiap-meed
+cd hiap-meed && uv sync && uv run uvicorn app.main:app --reload
+```

--- a/.cursor/rules/rtk-query.mdc
+++ b/.cursor/rules/rtk-query.mdc
@@ -1,0 +1,81 @@
+---
+description: Redux Toolkit Query patterns for API data fetching and state management
+globs: app/src/services/api.ts,app/src/features/**/*.ts,app/src/lib/store.ts
+alwaysApply: false
+---
+
+# RTK Query & Redux Patterns
+
+## API Definition (src/services/api.ts)
+
+The main API is defined with `createApi` using `fetchBaseQuery` to `/api/v1/`:
+
+```typescript
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+
+export const api = createApi({
+  reducerPath: "api",
+  tagTypes: ["UserInfo", "InventoryProgress", "CityData", /* ... */],
+  baseQuery: fetchBaseQuery({ baseUrl: "/api/v1/", credentials: "include" }),
+  endpoints: (builder) => ({
+    // Query example
+    getInventory: builder.query<InventoryResponse, string>({
+      query: (inventoryId) => `inventory/${inventoryId}`,
+      providesTags: (_result, _err, id) => [{ type: "InventoryValue", id }],
+    }),
+    // Mutation example
+    updateInventory: builder.mutation<InventoryResponse, { id: string; body: UpdateBody }>({
+      query: ({ id, body }) => ({ url: `inventory/${id}`, method: "PATCH", body }),
+      invalidatesTags: (_result, _err, { id }) => [{ type: "InventoryValue", id }],
+    }),
+  }),
+});
+```
+
+## Adding a New Endpoint
+
+1. Add the endpoint inside `endpoints: (builder) => ({...})` in `src/services/api.ts`
+2. Add appropriate `tagTypes` if introducing a new cache domain
+3. Use `providesTags` on queries and `invalidatesTags` on mutations for cache sync
+4. Export the auto-generated hook: `export const { useGetInventoryQuery } = api;`
+
+## Using in Components
+
+```tsx
+import { api } from "@/services/api";
+
+function MyComponent({ inventoryId }: { inventoryId: string }) {
+  const { data, isLoading, error } = api.useGetInventoryQuery(inventoryId);
+  const [updateInventory] = api.useUpdateInventoryMutation();
+
+  if (isLoading) return <Skeleton />;
+  if (error) return <ErrorState />;
+  return <div>{data?.inventoryName}</div>;
+}
+```
+
+## Redux Slices (src/features/)
+
+Small RTK slices for local UI state:
+
+```typescript
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+const citySlice = createSlice({
+  name: "city",
+  initialState: { selectedCity: null as string | null },
+  reducers: {
+    setCity: (state, action: PayloadAction<string>) => {
+      state.selectedCity = action.payload;
+    },
+  },
+});
+```
+
+## Store (src/lib/store.ts)
+
+The store combines RTK Query reducers + slices. When adding new API definitions, register their `reducerPath` and `middleware`.
+
+## Tag Types (existing)
+
+`UserInfo`, `UserPermissions`, `InventoryProgress`, `UserInventories`, `SubSectorValue`, `InventoryValue`, `ActivityValue`, `UserData`, `FileData`, `CityData`, `ReportResults`, `EmissionsFactor`, `Organization`, `Project`, `Theme`, `DataSource`, `VersionHistory`, `HIAP`, `Module`, `PersonalAccessToken`, `OAuthClient`

--- a/.cursor/rules/sequelize-database.mdc
+++ b/.cursor/rules/sequelize-database.mdc
@@ -1,0 +1,110 @@
+---
+description: Sequelize model, migration, and seed patterns for PostgreSQL
+globs: app/src/models/**/*.ts,app/migrations/**/*.cjs,app/seeders/**/*.cjs
+alwaysApply: false
+---
+
+# Sequelize Database Patterns
+
+## Model Definition
+
+Models are defined as classes extending `Model` in `src/models/`:
+
+```typescript
+// src/models/MyEntity.ts
+import { DataTypes, Model, Sequelize } from "sequelize";
+
+export interface MyEntityAttributes {
+  entityId: string;
+  name: string;
+  createdAt?: Date;
+}
+export interface MyEntityCreationAttributes extends MyEntityAttributes {}
+
+export class MyEntity
+  extends Model<MyEntityAttributes, MyEntityCreationAttributes>
+  implements MyEntityAttributes
+{
+  declare entityId: string;
+  declare name: string;
+  declare createdAt: Date;
+
+  static initModel(sequelize: Sequelize): typeof MyEntity {
+    MyEntity.init(
+      {
+        entityId: { type: DataTypes.UUID, primaryKey: true, defaultValue: DataTypes.UUIDV4 },
+        name: { type: DataTypes.STRING(255), allowNull: false },
+      },
+      { sequelize, tableName: "MyEntity", timestamps: true },
+    );
+    return MyEntity;
+  }
+}
+```
+
+## Registering Models
+
+After creating a model, register it in `src/models/init-models.ts`:
+
+1. Import the model class and its attribute types
+2. Add to `initModels()` function with `_MyEntity.initModel(sequelize)`
+3. Define associations if needed (belongsTo, hasMany, etc.)
+4. Re-export attribute types
+
+## Database Access
+
+```typescript
+import { db } from "@/models";
+
+// Direct model usage
+const inventory = await db.models.Inventory.findByPk(id);
+const cities = await db.models.City.findAll({ where: { projectId } });
+
+// With associations
+const data = await db.models.Inventory.findByPk(id, {
+  include: [{ model: db.models.City, as: "city" }],
+});
+```
+
+## Migration Template
+
+Migrations are `.cjs` files in `app/migrations/`:
+
+```javascript
+// migrations/YYYYMMDDHHMMSS-add-my-entity.cjs
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable("MyEntity", {
+      entity_id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        primaryKey: true,
+      },
+      name: { type: Sequelize.STRING(255), allowNull: false },
+      created_at: { type: Sequelize.DATE, defaultValue: Sequelize.fn("NOW") },
+    });
+  },
+  async down(queryInterface) {
+    await queryInterface.dropTable("MyEntity");
+  },
+};
+```
+
+## Commands
+
+```bash
+npm run db:migrate          # Run pending migrations
+npm run db:migrate:undo     # Undo last migration
+npm run db:gen-migration    # Generate migration file
+npm run db:seed             # Run seeders
+```
+
+## Key Models (domain)
+
+Core: `Organization`, `Project`, `City`, `User`, `Inventory`
+GPC: `Sector`, `SubSector`, `SubCategory`, `Scope`, `ReportingLevel`
+Data: `InventoryValue`, `ActivityValue`, `GasValue`, `EmissionsFactor`, `DataSource`
+Planning: `ActionPlan`, `HighImpactActionRanking`

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -1,0 +1,71 @@
+---
+description: Jest API testing and Playwright E2E testing patterns
+globs: app/tests/**/*.jest.ts,app/tests/**/*.spec.ts
+alwaysApply: false
+---
+
+# Testing Patterns
+
+## Jest (Unit/API Tests)
+
+Test files MUST be named `*.jest.ts` (not `*.test.ts`). Located in `app/tests/`.
+
+### API Test Template
+
+```typescript
+import { setupTests, teardownTests, mockRequest, expectStatusCode, testUserData } from "../helpers";
+import { db } from "@/models";
+import { GET, POST } from "@/app/api/v1/my-route/route";
+
+describe("My Route", () => {
+  beforeAll(async () => {
+    setupTests();
+    await db.initialize();
+  });
+  afterAll(() => {
+    teardownTests();
+  });
+
+  describe("GET /api/v1/my-route", () => {
+    it("should return data", async () => {
+      const req = mockRequest();
+      const res = await GET(req, { params: Promise.resolve({}) });
+      expectStatusCode(res, 200);
+      const data = await res.json();
+      expect(data).toBeDefined();
+    });
+  });
+});
+```
+
+### Test Helpers (tests/helpers.ts)
+
+- `setupTests()` — loads env, mocks `Auth.getServerSession` with test user
+- `teardownTests()` — restores session spy
+- `mockRequest(body?, searchParams?, headers?)` — creates mock `NextRequest`
+- `mockRequestFormData(formData)` — for file uploads
+- `expectStatusCode(response, code)` — asserts with helpful error messages
+- `testUserID`, `testCityID`, `testUserData` — test fixtures
+
+### Running Tests
+
+```bash
+npm run jest                    # All Jest tests
+npx jest --testPathPattern=path/to/test.jest.ts  # Single test
+```
+
+## Playwright (E2E Tests)
+
+Located in `app/tests/` with `.spec.ts` extension.
+
+```bash
+npm run e2e:test               # Run E2E suite
+npx playwright test tests/path/to/test.spec.ts   # Single test
+```
+
+## Important Notes
+
+- Jest uses ESM with `ts-jest` — config in `app/jest.config.ts`
+- `@/` paths work in tests via `moduleNameMapper`
+- DB is initialized per test suite, not per test
+- Session is mocked — tests don't need a running auth server

--- a/.cursor/skills/add-rtk-endpoint/SKILL.md
+++ b/.cursor/skills/add-rtk-endpoint/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: add-rtk-endpoint
+description: Add a new RTK Query endpoint to CityCatalyst's API service. Use when the user asks to add data fetching, create a query hook, add a mutation, or connect frontend to a new API endpoint.
+---
+
+# Add RTK Query Endpoint
+
+## Workflow
+
+### Step 1: Define Types
+
+Add response/request types to `app/src/util/types.ts` (or import from models):
+
+```typescript
+export interface WidgetResponse {
+  widgetId: string;
+  name: string;
+  inventoryId: string;
+}
+```
+
+### Step 2: Add Endpoint
+
+In `app/src/services/api.ts`, inside `endpoints: (builder) => ({...})`:
+
+**Query (GET):**
+```typescript
+getWidget: builder.query<WidgetResponse, string>({
+  query: (widgetId) => `widget/${widgetId}`,
+  providesTags: (_result, _err, id) => [{ type: "Widget", id }],
+}),
+
+getWidgets: builder.query<WidgetResponse[], string>({
+  query: (inventoryId) => `inventory/${inventoryId}/widgets`,
+  providesTags: (result) =>
+    result
+      ? [...result.map(({ widgetId }) => ({ type: "Widget" as const, id: widgetId })), "Widget"]
+      : ["Widget"],
+}),
+```
+
+**Mutation (POST/PATCH/DELETE):**
+```typescript
+createWidget: builder.mutation<WidgetResponse, { inventoryId: string; body: CreateWidgetRequest }>({
+  query: ({ inventoryId, body }) => ({
+    url: `inventory/${inventoryId}/widgets`,
+    method: "POST",
+    body,
+  }),
+  invalidatesTags: ["Widget"],
+}),
+
+deleteWidget: builder.mutation<void, string>({
+  query: (widgetId) => ({
+    url: `widget/${widgetId}`,
+    method: "DELETE",
+  }),
+  invalidatesTags: (_result, _err, id) => [{ type: "Widget", id }],
+}),
+```
+
+### Step 3: Add Tag Type (if new)
+
+Add to the `tagTypes` array at the top of `createApi`:
+
+```typescript
+tagTypes: [
+  // ... existing tags
+  "Widget",
+],
+```
+
+### Step 4: Use in Component
+
+```tsx
+import { api } from "@/services/api";
+
+function WidgetList({ inventoryId }: { inventoryId: string }) {
+  const { data, isLoading } = api.useGetWidgetsQuery(inventoryId);
+  const [createWidget, { isLoading: isCreating }] = api.useCreateWidgetMutation();
+
+  const handleCreate = async () => {
+    await createWidget({ inventoryId, body: { name: "New Widget" } });
+    // Cache auto-invalidates via tags — no manual refetch needed
+  };
+
+  if (isLoading) return <Skeleton />;
+  return (
+    <>
+      {data?.map((w) => <WidgetCard key={w.widgetId} widget={w} />)}
+      <Button onClick={handleCreate} loading={isCreating}>Add</Button>
+    </>
+  );
+}
+```
+
+## Tag Strategy
+
+- **`providesTags`** on queries: declare what cache entries this query provides
+- **`invalidatesTags`** on mutations: declare which cache entries to invalidate after mutation
+- Use `{ type: "Tag", id: specificId }` for granular invalidation
+- Use `"Tag"` (string only) to invalidate ALL entries of that type
+
+## Existing Tag Types
+
+`UserInfo`, `UserPermissions`, `InventoryProgress`, `UserInventories`, `SubSectorValue`, `InventoryValue`, `ActivityValue`, `UserData`, `FileData`, `CityData`, `ReportResults`, `EmissionsFactor`, `Organization`, `Project`, `Theme`, `DataSource`, `VersionHistory`, `HIAP`, `Module`, `PersonalAccessToken`, `OAuthClient`

--- a/.cursor/skills/create-api-endpoint/SKILL.md
+++ b/.cursor/skills/create-api-endpoint/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: create-api-endpoint
+description: Create a new REST API endpoint in CityCatalyst. Use when the user asks to create, add, or implement a new API route, endpoint, or backend handler.
+---
+
+# Create API Endpoint
+
+## Workflow
+
+### Step 1: Create Route Handler
+
+Create the route file at `app/src/app/api/v1/<resource>/route.ts` (or nested path).
+
+```typescript
+/**
+ * @swagger
+ * /api/v1/<resource>:
+ *   get:
+ *     operationId: get<Resource>
+ *     summary: <Description>
+ *     tags:
+ *       - <resource>
+ *     responses:
+ *       200:
+ *         description: Success
+ */
+import { NextResponse } from "next/server";
+import { apiHandler } from "@/util/api";
+import createHttpError from "http-errors";
+
+export const GET = apiHandler(async (req, { session, params, searchParams }) => {
+  if (!session) throw new createHttpError.Unauthorized("Unauthorized");
+  // Business logic here — delegate to src/backend/ services
+  return NextResponse.json({ data: result });
+});
+```
+
+### Step 2: Add Validation Schema (if POST/PATCH)
+
+Add Zod schema to `app/src/util/validation.ts`:
+
+```typescript
+export const create<Resource>Request = z.object({
+  name: z.string().min(1),
+  // ... fields
+});
+export type Create<Resource>Request = z.infer<typeof create<Resource>Request>;
+```
+
+### Step 3: Add Service Logic (if complex)
+
+Create or extend a service in `app/src/backend/`:
+
+```typescript
+// app/src/backend/<Resource>Service.ts
+import { db } from "@/models";
+
+export class <Resource>Service {
+  static async getById(id: string) {
+    return db.models.<Resource>.findByPk(id);
+  }
+}
+```
+
+### Step 4: Add RTK Query Endpoint
+
+In `app/src/services/api.ts`, add inside `endpoints`:
+
+```typescript
+get<Resource>: builder.query<ResponseType, string>({
+  query: (id) => `<resource>/${id}`,
+  providesTags: (_r, _e, id) => [{ type: "<Resource>", id }],
+}),
+```
+
+Add tag type to `tagTypes` array if new.
+
+### Step 5: Add i18n Keys
+
+Add user-facing strings to `app/src/i18n/locales/en/<namespace>.json`.
+
+### Step 6: Write Tests
+
+Create `app/tests/api/<resource>.jest.ts`:
+
+```typescript
+import { setupTests, teardownTests, mockRequest, expectStatusCode } from "../helpers";
+import { db } from "@/models";
+import { GET } from "@/app/api/v1/<resource>/route";
+
+describe("<Resource> API", () => {
+  beforeAll(async () => {
+    setupTests();
+    await db.initialize();
+  });
+  afterAll(() => teardownTests());
+
+  it("GET returns data", async () => {
+    const req = mockRequest();
+    const res = await GET(req, { params: Promise.resolve({}) });
+    expectStatusCode(res, 200);
+  });
+});
+```
+
+## Checklist
+
+- [ ] Route handler uses `apiHandler` wrapper
+- [ ] Swagger JSDoc added above imports
+- [ ] Auth check (`if (!session)`) for protected routes
+- [ ] Validation with Zod for request bodies
+- [ ] Business logic delegated to service layer
+- [ ] Error handling uses `http-errors` (not raw try/catch)
+- [ ] RTK Query endpoint added with proper tags
+- [ ] i18n keys for user-facing messages
+- [ ] Jest test created with `*.jest.ts` naming

--- a/.cursor/skills/create-component/SKILL.md
+++ b/.cursor/skills/create-component/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: create-component
+description: Create a new React component in CityCatalyst using Chakra UI v3, i18n, and project conventions. Use when the user asks to create, add, or build a new UI component, page section, or widget.
+---
+
+# Create Component
+
+## Workflow
+
+### Step 1: Determine Location
+
+| Type | Path |
+|------|------|
+| Design primitive | `app/src/components/ui/` |
+| Feature component | `app/src/components/<FeatureName>/` |
+| Page section | `app/src/components/Sections/` |
+| Modal/Dialog | `app/src/components/Modals/` |
+| Shared/reusable | `app/src/components/shared/` |
+| Page component | `app/src/app/[lng]/<route>/page.tsx` |
+
+### Step 2: Create Component File
+
+```tsx
+"use client"; // Only if using hooks, event handlers, or browser APIs
+
+import { Box, Text, Heading, Flex } from "@chakra-ui/react";
+import { useTranslation } from "@/i18n/client";
+
+interface MyComponentProps {
+  lng: string;
+  inventoryId: string;
+}
+
+export function MyComponent({ lng, inventoryId }: MyComponentProps) {
+  const { t } = useTranslation(lng, "namespace");
+
+  return (
+    <Box p={6} borderRadius="lg" bg="background.overlay">
+      <Heading size="lg">{t("title")}</Heading>
+    </Box>
+  );
+}
+```
+
+### Step 3: Add Data Fetching (if needed)
+
+```tsx
+import { api } from "@/services/api";
+
+export function MyComponent({ inventoryId }: Props) {
+  const { data, isLoading, error } = api.useGetInventoryQuery(inventoryId);
+
+  if (isLoading) return <Skeleton height="200px" />;
+  if (error) return <Text color="sentiment.negativeDefault">{t("error")}</Text>;
+
+  return <Box>{data?.inventoryName}</Box>;
+}
+```
+
+### Step 4: Add i18n Keys
+
+Add to `app/src/i18n/locales/en/<namespace>.json`:
+
+```json
+{
+  "title": "My Component Title",
+  "description": "Component description"
+}
+```
+
+### Step 5: Add Form (if needed)
+
+```tsx
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import FormInput from "@/components/form-input";
+```
+
+## Conventions
+
+- Use **semantic tokens** for colors (`background.overlay`, `content.primary`), never raw colors
+- Use **named exports** (not default)
+- Props interface defined above the component
+- Pass `lng` down for i18n — it comes from `[lng]` route param
+- Use project UI wrappers from `@/components/ui/` (button, dialog, field, etc.)
+- Loading states: use `Skeleton` from Chakra
+- Error states: show user-friendly translated messages
+- All user-facing text must use `t()` from i18next

--- a/.cursor/skills/create-migration/SKILL.md
+++ b/.cursor/skills/create-migration/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: create-migration
+description: Create a Sequelize database migration and model for CityCatalyst. Use when the user asks to add a database table, column, index, modify the schema, or create a new model.
+---
+
+# Create Database Migration
+
+## Workflow
+
+### Step 1: Generate Migration File
+
+```bash
+cd app && npm run db:gen-migration -- --name add-my-entity
+```
+
+This creates `app/migrations/YYYYMMDDHHMMSS-add-my-entity.cjs`.
+
+### Step 2: Write Migration
+
+```javascript
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable("MyEntity", {
+      entity_id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        primaryKey: true,
+      },
+      name: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+      },
+      inventory_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: "Inventory", key: "inventory_id" },
+        onDelete: "CASCADE",
+      },
+      created: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.fn("NOW"),
+      },
+      last_updated: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.fn("NOW"),
+      },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable("MyEntity");
+  },
+};
+```
+
+For column additions:
+
+```javascript
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn("ExistingTable", "new_column", {
+      type: Sequelize.STRING(255),
+      allowNull: true,
+    });
+  },
+  async down(queryInterface) {
+    await queryInterface.removeColumn("ExistingTable", "new_column");
+  },
+};
+```
+
+### Step 3: Create Model (if new table)
+
+Create `app/src/models/MyEntity.ts` following the model pattern in the sequelize-database rule.
+
+### Step 4: Register Model
+
+In `app/src/models/init-models.ts`:
+
+1. Import at the top:
+```typescript
+import type { MyEntityAttributes, MyEntityCreationAttributes } from "./MyEntity";
+import { MyEntity as _MyEntity } from "./MyEntity";
+```
+
+2. In `initModels()`, add `_MyEntity.initModel(sequelize)`
+
+3. Add associations if needed:
+```typescript
+_MyEntity.belongsTo(_Inventory, { as: "inventory", foreignKey: "inventoryId" });
+_Inventory.hasMany(_MyEntity, { as: "myEntities", foreignKey: "inventoryId" });
+```
+
+4. Re-export types at the bottom.
+
+### Step 5: Run Migration
+
+```bash
+cd app && npm run db:migrate
+```
+
+### Step 6: Verify
+
+```bash
+cd app && npm run db:migrate:undo   # Test rollback
+cd app && npm run db:migrate        # Re-apply
+```
+
+## Checklist
+
+- [ ] Migration file is `.cjs` (CommonJS)
+- [ ] `up` and `down` are both implemented (reversible)
+- [ ] UUIDs use `Sequelize.UUIDV4` as default
+- [ ] Foreign keys have `references` and `onDelete`
+- [ ] Model class has `Attributes` and `CreationAttributes` interfaces
+- [ ] Model registered in `init-models.ts`
+- [ ] Associations defined bidirectionally

--- a/.cursor/skills/full-feature/SKILL.md
+++ b/.cursor/skills/full-feature/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: full-feature
+description: End-to-end feature development workflow for CityCatalyst covering database, API, frontend, and tests. Use when the user asks to build a complete feature, implement a full user story, or create an end-to-end functionality.
+---
+
+# Full Feature Development
+
+## Overview
+
+A complete feature in CityCatalyst touches up to 7 layers. Follow this order to avoid dependency issues.
+
+## Workflow
+
+### Phase 1: Database Layer
+
+1. **Migration**: Create migration file in `app/migrations/` (see [create-migration skill](../create-migration/SKILL.md))
+2. **Model**: Create Sequelize model in `app/src/models/`
+3. **Register**: Add to `app/src/models/init-models.ts`
+4. **Run**: `cd app && npm run db:migrate`
+
+### Phase 2: Backend API
+
+5. **Validation**: Add Zod schemas to `app/src/util/validation.ts`
+6. **Service** (optional): Create `app/src/backend/<Feature>Service.ts` for complex logic
+7. **Route handler**: Create `app/src/app/api/v1/<feature>/route.ts` with `apiHandler`
+8. **Swagger**: Add `@swagger` JSDoc above imports
+9. **Test**: Create `app/tests/api/<feature>.jest.ts`
+
+### Phase 3: Frontend Data Layer
+
+10. **RTK Query**: Add endpoints to `app/src/services/api.ts`
+    - Query with `providesTags`
+    - Mutation with `invalidatesTags`
+    - Add new tag type to `tagTypes` if needed
+
+### Phase 4: Frontend UI
+
+11. **i18n**: Add keys to `app/src/i18n/locales/en/<namespace>.json`
+12. **Component(s)**: Create in `app/src/components/<Feature>/`
+13. **Page** (if new route): Create `app/src/app/[lng]/<route>/page.tsx`
+14. **Hook** (if complex logic): Create `app/src/hooks/use<Feature>.ts`
+15. **Navigation**: Update sidebar/nav if adding a new page
+
+### Phase 5: Quality
+
+16. **Types**: Ensure all types are in `app/src/util/types.ts` or co-located
+17. **Lint**: `cd app && npm run lint`
+18. **Format**: `cd app && npm run prettier`
+19. **Test**: `cd app && npm run jest`
+
+## File Mapping
+
+```
+Feature: "Widget Management"
+
+app/
+├── migrations/20260410-add-widget.cjs          # DB migration
+├── src/models/Widget.ts                         # Sequelize model
+├── src/models/init-models.ts                    # Register model
+├── src/util/validation.ts                       # + createWidgetRequest schema
+├── src/backend/WidgetService.ts                 # Business logic
+├── src/app/api/v1/widget/route.ts               # API handler (GET, POST)
+├── src/app/api/v1/widget/[widget]/route.ts      # API handler (GET, PATCH, DELETE)
+├── src/services/api.ts                          # + RTK Query endpoints
+├── src/i18n/locales/en/widget.json              # i18n keys
+├── src/components/Widget/widget-list.tsx         # List component
+├── src/components/Widget/widget-form.tsx         # Form component
+├── src/app/[lng]/cities/[cityId]/widget/page.tsx # Page
+├── src/hooks/useWidget.ts                        # Custom hook (optional)
+└── tests/api/widget.jest.ts                      # API tests
+```
+
+## Quick Reference
+
+| Need | Location | Pattern |
+|------|----------|---------|
+| Auth check | `if (!session) throw createHttpError.Unauthorized()` | All protected routes |
+| DB query | `db.models.Widget.findAll(...)` | Sequelize |
+| Validate | `schema.parse(body)` | Zod (auto-caught as 400) |
+| API error | `throw createHttpError.NotFound(...)` | http-errors |
+| Data fetch | `api.useGetWidgetQuery(id)` | RTK Query hook |
+| Translation | `t("widget.title")` | i18next |
+| Styling | `bg="background.overlay"` | Chakra semantic tokens |

--- a/.gitignore
+++ b/.gitignore
@@ -161,5 +161,3 @@ climate-advisor/scripts/setup_local_db.py
 sdk/
 climate-advisor/service/tests/output/
 
-# cursor
-.cursor

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -1,30 +1,417 @@
-# AGENTS.md
+# AGENTS.md — CityCatalyst
 
-## Build, Lint, and Test Commands
+> Comprehensive reference for AI coding agents working on the CityCatalyst web application.
+> This file covers architecture, patterns, conventions, and the full codebase map.
 
-- Build: `npm run build`
-- Lint: `npm run lint`
-- Format: `npm run prettier`
-- Run all tests: `npm run test` (Jest + Playwright)
-- Run unit/API tests: `npm run jest`
-- Run E2E tests: `npm run e2e:test`
-- Run a single Jest test: `npx jest --testPathPattern=path/to/testfile.test.js`
-- Run a single Playwright test: `npx playwright test tests/path/to/testfile.spec.ts`
+---
 
-## Code Style Guidelines
+## Commands
 
-- Use semicolons (Prettier enforced)
-- Use ES module imports (`import ... from ...`)
-- Prefer named exports over default unless necessary
-- Use TypeScript types and interfaces for all function signatures and props
-- Follow Next.js and i18next ESLint rules
-- Use PascalCase for components/classes, camelCase for variables/functions
-- Handle errors with try/catch and meaningful messages
-- Prefer explicit return types for functions
-- Organize imports: external first, then internal, then styles/assets
-- Avoid unused variables and imports
-- Use descriptive names for files, functions, and variables
-- Keep functions small and focused
-- Document complex logic with comments
+```bash
+# Development
+npm run dev                     # Next.js dev server (http://localhost:3000)
+npm run build                   # Production build
+
+# Quality
+npm run lint                    # ESLint (Next.js core-web-vitals + i18next)
+npm run prettier                # Prettier --write (semi: true)
+npm run openapi:lint            # Spectral lint for OpenAPI spec
+
+# Testing
+npm run jest                    # All Jest tests (unit + API)
+npm run e2e:test                # All Playwright E2E tests
+npx jest --testPathPattern=path/to/file.jest.ts   # Single Jest test
+npx playwright test tests/path/to/file.spec.ts    # Single Playwright test
+
+# Database (PostgreSQL via Sequelize CLI)
+npm run db:migrate              # Run pending migrations
+npm run db:migrate:undo         # Undo last migration
+npm run db:gen-migration -- --name <name>  # Generate timestamped migration
+npm run db:seed                 # Run all seeders
+npm run sync-catalogue          # Sync GPC catalogue from Global API
+
+# i18n
+npm run i18n:update             # Auto-translate EN keys to de, es, pt
+```
+
+---
+
+## Architecture
+
+```
+app/src/
+├── app/                        # Next.js 15 App Router
+│   ├── [lng]/                  # Locale-prefixed pages (en, de, es, fr, pt)
+│   │   ├── auth/               # Login, signup, password reset, invite acceptance
+│   │   ├── admin/              # OEF admin panel
+│   │   ├── cities/[cityId]/    # City pages: GHGI inventory, dashboard, settings
+│   │   ├── onboarding/         # City/org onboarding flows
+│   │   ├── organization/       # Org management, projects, billing
+│   │   └── public/             # Public dashboards (unauthenticated)
+│   ├── api/v1/                 # REST API (all routes use apiHandler wrapper)
+│   └── docs/                   # Swagger UI (auto-generated OpenAPI)
+│
+├── backend/                    # Server-side business logic (services)
+│   ├── permissions/            # Permission system (PermissionService, RoleChecker)
+│   ├── hiap/                   # HIAP prioritization orchestration
+│   ├── ccra/                   # Climate risk assessment services
+│   └── llm/                    # LLM abstraction (OpenAI adapter, config)
+│
+├── components/                 # React components (Chakra UI v3)
+│   ├── ui/                     # Design system primitives (button, dialog, field, data-table)
+│   ├── Navigation/             # Navbar, sidebar, breadcrumbs
+│   ├── Tabs/                   # Tab views (Activity, SubSector)
+│   ├── Modals/                 # Dialogs (activity-modal, invite, delete)
+│   ├── Sections/               # Page sections
+│   ├── Skeletons/              # Loading states
+│   ├── steps/                  # Multi-step wizards (GHGI, JourneyNavigator)
+│   ├── shared/                 # Cross-feature shared components
+│   ├── ChatBot/                # AI chat interface
+│   ├── PublicDashboard/        # Public-facing dashboards
+│   └── admin/                  # Admin-specific components
+│
+├── features/                   # Redux slices
+│   └── city/                   # citySlice, openClimateCitySlice, inventoryDataSlice
+│
+├── hooks/                      # Custom React hooks (see list below)
+├── i18n/                       # i18next config + locales/{en,de,es,fr,pt}/*.json
+│
+├── lib/                        # Core infrastructure
+│   ├── auth.ts                 # NextAuth config (credentials, JWT, AppSession)
+│   ├── auth/                   # PAT validator
+│   ├── theme/                  # Chakra v3 theme system (recipes, custom-colors)
+│   ├── custom-errors/          # ManualInputValidationError, CustomOrganizationError, CustomInviteError
+│   ├── emails/                 # React Email templates (registration, invites, HIAP, etc.)
+│   ├── mcp/                    # MCP server + tools (cities, emissions, action-plans, risk-assessment)
+│   └── highlight.ts            # Highlight.io integration
+│
+├── models/                     # Sequelize v6 models (PostgreSQL)
+│   ├── init-models.ts          # Model registration + associations
+│   ├── index.ts                # DB connection (DATABASE_* env vars)
+│   └── *.ts                    # Individual model files
+│
+├── services/                   # Client-side services
+│   ├── api.ts                  # RTK Query API (createApi, ~2000 lines, main data layer)
+│   ├── logger.ts               # Pino logger
+│   ├── chatService.ts          # Chat SSE service
+│   └── PDFExportService.ts     # PDF generation
+│
+└── util/                       # Shared utilities
+    ├── api.ts                  # apiHandler, errorHandler, auth resolution, rate limiter
+    ├── types.ts                # Central TypeScript types/interfaces for API contracts
+    ├── validation.ts           # Zod schemas for request validation
+    ├── enums.ts                # InventoryTypeEnum, GlobalWarmingPotentialTypeEnum, ImportStatusEnum
+    ├── constants.ts            # Sector definitions, GPC config
+    ├── feature-flags.ts        # FeatureFlags enum + hasFeatureFlag/hasServerFeatureFlag
+    ├── helpers.ts              # General helpers
+    ├── routes.ts               # Route path utilities
+    ├── translate.ts            # Translation helpers
+    ├── geojson.ts              # GeoJSON utilities
+    ├── csv.ts                  # CSV export helpers
+    ├── rate-limiter.ts         # In-memory rate limiter (200 req/min)
+    ├── permission-errors.ts    # Permission error utilities
+    ├── check-user-session.ts   # Session check helpers
+    ├── big_int.ts              # BigInt utilities
+    ├── ccra-constants.ts       # CCRA scoring constants
+    ├── form-schema/            # Activity form schema definitions
+    └── GHGI/                   # GPC reference resolver + data tables
+```
+
+---
+
+## Key Backend Services (`src/backend/`)
+
+| Service | Responsibility |
+|---------|---------------|
+| `UserService` | User CRUD, invites, org/project scoping |
+| `InventoryService` | Inventory lookups by city, locode, permissions |
+| `ActivityService` | Activity/gas value CRUD, emissions factors, versioning |
+| `CalculationService` | Emissions math using methodology-specific formulas |
+| `DataSourceService` | Data source management per inventory |
+| `GPCService` | Resolves GPC reference numbers to sector/subsector/subcategory |
+| `PermissionService` | `canAccessInventory`, `canCreateCity`, role-based checks |
+| `EmailService` | All email flows (invites, password, projects) via React Email |
+| `NotificationService` | Nodemailer singleton, admin notifications |
+| `AdminService` | Bulk inventory creation, OpenClimate wiring |
+| `ResultsService` | Emissions results aggregation, forecasts |
+| `PopulationService` | Population data for city/year |
+| `HiapService` | HIAP orchestration (S3, rankings, bulk jobs) |
+| `HiapApiService` | HTTP client to external HIAP API |
+| `ActionPlanService` | Action plan creation and management |
+| `CcraService` | Climate risk normalization and scoring |
+| `CcraApiService` | CCRA API client (Global API) |
+| `ECRFDownloadService` | eCRF Excel template export |
+| `ECRFImportService` | eCRF import parsing |
+| `FileParserService` | XLSX/CSV parsing |
+| `FileUploadService` | Generic file upload (S3 provider) |
+| `FileValidatorService` | Import validation (size, format, CIRIS) |
+| `AIInterpretationService` | LLM column mapping for tabular imports |
+| `InventoryExtractionService` | LLM extraction from PDF documents |
+| `CDPService` | CDP Green Star API client |
+| `CityBoundaryService` | City GeoJSON from Global API |
+| `UnitConversionService` | Unit conversion tables |
+| `VersionHistoryService` | Inventory version diff/history |
+| `ModuleService` | Module access management |
+| `ModuleDashboardService` | Dashboard aggregation (GHGI/HIAP/CCRA) |
+
+---
+
+## Custom Hooks (`src/hooks/`)
+
+| Hook | Purpose |
+|------|---------|
+| `useLogin` | Wraps NextAuth `signIn("credentials")`, analytics, redirect |
+| `useUserPermissions` | Check user permissions for resources |
+| `useAdminGuard` | Redirect non-admin users |
+| `useModuleAccess` | Check if current project has a module enabled |
+| `useModuleAccessLayout` | Module access for layout gating |
+| `useRouteParams` | Extract typed route params |
+| `use-latest-inventory` | Get the latest inventory for a city |
+| `use-inventory-organization` | Get org context for an inventory |
+| `use-organizational-context` | Org context provider (Context + localStorage) |
+| `useChat` | Chat with AI assistant |
+| `useSSEStream` | Server-Sent Events streaming |
+| `useFuzzySearch` | Client-side fuzzy search |
+| `usePollUntil` | Polling with stop condition |
+| `useScrollSpy` | Scroll position tracking |
+| `useEnterSubmit` | Submit form on Enter |
+| `use-copy-to-clipboard` | Clipboard copy helper |
+| `use-action-plan` | Action plan management |
+| `use-activity-form` | Complex activity value form (react-hook-form wrapper) |
+| `use-activity-validation` | Activity data validation |
+| `use-emission-factors` | Emission factor fetching for forms |
+| `Toasts` | Toast notification helpers |
+
+---
+
+## API Route Pattern (Critical)
+
+Every API route MUST use `apiHandler` from `@/util/api`. It provides:
+- **Auth resolution** (NextAuth session → Bearer JWT → PAT → OAuth → service-to-service)
+- **DB initialization** (`db.initialize()` on first request)
+- **Organization frozen check** (blocks mutations on frozen orgs)
+- **Rate limiting** (200 req/min per IP, disabled during Playwright)
+- **Centralized error handling** via `errorHandler`
+- **Request logging** (method, path, status, user, duration)
+
+### Handler Signature
+
+```typescript
+export const GET = apiHandler(async (req, { session, params, searchParams }) => {
+  // session: AppSession | null (already resolved from any auth method)
+  // params: Record<string, string> (route params, already awaited)
+  // searchParams: Record<string, string> (query string)
+  if (!session) throw new createHttpError.Unauthorized("Unauthorized");
+  return NextResponse.json({ data: result });
+});
+```
+
+### Error Handling Hierarchy
+
+| Error Type | HTTP Status | Behavior |
+|-----------|-------------|----------|
+| `createHttpError.*` (http-errors) | Varies (400, 401, 403, 404, 500) | Returns `{ error: { message, code?, data? } }` |
+| `ZodError` | 400 | Returns `{ error: { message, issues } }` |
+| `ManualInputValidationError` | 400 | Returns `{ error: { type, message, issues } }` |
+| `CustomOrganizationError` / `CustomInviteError` | 409 | Returns `err.data` |
+| `SyntaxError` (bad JSON) | 400 | Returns `{ error: { message } }` |
+| `SequelizeUniqueConstraintError` | 400 | Returns "Entity exists already." |
+| `OpenAI.APIError` | Forwarded | Forwards OpenAI error shape |
+| Any other error | 500 | Returns "Internal server error" (logged) |
+
+### Swagger JSDoc
+
+Add `@swagger` comments above imports for OpenAPI generation:
+
+```typescript
+/**
+ * @swagger
+ * /api/v1/my-resource:
+ *   get:
+ *     operationId: getMyResource
+ *     summary: Description
+ *     tags:
+ *       - my-resource
+ *     responses:
+ *       200:
+ *         description: Success
+ */
+```
+
+---
+
+## RTK Query (`src/services/api.ts`)
+
+Main client-side data layer. Uses `fetchBaseQuery` with `baseUrl: "/api/v1/"` and `credentials: "include"`.
+
+### Existing Tag Types
+
+```
+UserInfo, UserPermissions, InventoryProgress, UserInventories, SubSectorValue,
+InventoryValue, ActivityValue, UserData, FileData, CityData, ReportResults,
+YearlyReportResults, SectorBreakdown, Inventory, CitiesAndInventories, Inventories,
+Invites, Organizations, OrganizationInvite, Projects, Organization, Project,
+ProjectUsers, UserAccessStatus, Cities, Hiap, HiapJobs, Themes, Client,
+CityDashboard, Modules, GHGIDashboard, HiapDashboard, Authz, CCRADashboard,
+ProjectModules, ActionPlan, VersionHistory, PersonalAccessToken, AdminModules
+```
+
+### Pattern for Adding Endpoints
+
+```typescript
+// Query
+getMyResource: builder.query<ResponseType, string>({
+  query: (id) => `my-resource/${id}`,
+  transformResponse: (response: { data: ResponseType }) => response.data,
+  providesTags: (_r, _e, id) => [{ type: "MyResource", id }],
+}),
+
+// Mutation
+createMyResource: builder.mutation<ResponseType, RequestBody>({
+  query: (body) => ({ url: "my-resource", method: "POST", body }),
+  invalidatesTags: ["MyResource"],
+}),
+```
+
+Most API responses wrap data in `{ data: ... }` — use `transformResponse` to unwrap.
+
+---
+
+## Database (Sequelize v6 + PostgreSQL)
+
+### Core Models
+
+**Tenancy**: `Organization` → `Project` → `City` → `Inventory`
+**Users**: `User`, `CityUser`, `CityInvite`, `OrganizationAdmin`, `ProjectAdmin`, `OrganizationInvite`, `ProjectInvite`
+**GPC Hierarchy**: `Sector` → `SubSector` → `SubCategory` → `Scope`, `ReportingLevel`
+**Emissions Data**: `InventoryValue`, `ActivityValue`, `GasValue`, `ActivityData`, `EmissionsFactor`, `FormulaInput`
+**Data Sources**: `DataSource` (DataSourceI18n), `DataSourceActivityData`, `DataSourceEmissionsFactor`, `DataSourceGHGs`, `DataSourceMethodology`, `DataSourceReportingLevel`, `DataSourceFormulaInput`
+**Catalogue**: `Catalogue`, `Methodology`, `GHGs`, `GasToCO2Eq`
+**Planning**: `ActionPlan`, `HighImpactActionRanking`, `HighImpactActionRanked`, `UnrankedActionSelection`
+**Product**: `Module`, `ProjectModules`, `Version`, `ImportedInventoryFile`, `UserFile`, `Theme`
+**OAuth**: `OAuthClient`, `OAuthClientI18N`, `OAuthClientAuthz`, `PersonalAccessToken`
+
+### Conventions
+
+- Primary keys: UUIDs with `DataTypes.UUIDV4` default
+- Timestamps: `created` / `lastUpdated` (not `createdAt` / `updatedAt`)
+- Migrations: `.cjs` files, always implement both `up()` and `down()`
+- Registration: Every model must be registered in `init-models.ts`
+
+---
+
+## i18n (i18next)
+
+- Client hook: `useTranslation` from `@/i18n/client` (not raw `react-i18next`)
+- Always pass `lng` from the `[lng]` route param
+- Namespaces map to JSON files: `src/i18n/locales/en/<namespace>.json`
+- Only add keys to the **English** file — CI auto-translates to de, es, fr, pt
+- All user-facing strings must use `t()` (ESLint `i18next` rule enforced)
+- Key format: kebab-case (`"inventory-not-found"`, `"save-changes"`)
+
+---
+
+## Authentication
+
+- **NextAuth v4** with Credentials provider (email + bcrypt)
+- **JWT** session strategy — `AppSession` extends user with `id` and `role`
+- **Roles**: `Roles.Admin` (OEF admin), `Roles.User` (regular)
+- **Server-side**: `Auth.getServerSession()` or use `session` from `apiHandler`
+- **Client-side**: `SessionProvider` in providers, `useSession()` hook
+- **Middleware** (`src/middleware.ts`): CORS for API, i18n redirects, `withAuth` for protected pages
+
+---
+
+## Feature Flags (`src/util/feature-flags.ts`)
+
+```
+ENTERPRISE_MODE, PROJECT_OVERVIEW_ENABLED, ACCOUNT_SETTINGS_ENABLED,
+UPLOAD_OWN_DATA_ENABLED, JN_ENABLED, OAUTH_ENABLED, ANALYTICS_ENABLED,
+CCRA_MODULE, CA_SERVICE_INTEGRATION, HIGHLIGHT_ENABLED
+```
+
+- Parsed from `NEXT_PUBLIC_FEATURE_FLAGS` env (comma-separated)
+- QA override via `localStorage` key `qa_feature_flags`
+- Use `hasFeatureFlag(flag)` on client, `hasServerFeatureFlag(flag)` on server
+
+---
+
+## Testing
+
+### Jest (API + Unit)
+
+- File naming: `*.jest.ts` (NOT `*.test.ts`)
+- Location: `app/tests/`
+- Config: `jest.config.ts` (ESM via `ts-jest`, `@/` paths via `moduleNameMapper`)
+- Helpers (`tests/helpers.ts`):
+  - `setupTests()` — loads env, mocks `Auth.getServerSession` with test user
+  - `teardownTests()` — restores mock
+  - `mockRequest(body?, searchParams?, headers?)` — creates `NextRequest`
+  - `mockRequestFormData(formData)` — for file uploads
+  - `expectStatusCode(response, code)` — assertion with helpful error messages
+  - `testUserID`, `testCityID`, `testUserData` — fixtures
+
+### Playwright (E2E)
+
+- File naming: `*.spec.ts`
+- Config: `playwright.config.ts`
+- Runs against a real dev/test server
+
+---
+
+## Code Style
+
+- **Semicolons**: Yes (Prettier enforced)
+- **Imports**: ES modules (`import ... from ...`)
+- **Exports**: Prefer named exports over default
+- **Types**: TypeScript types/interfaces for all function signatures and props
+- **Naming**: PascalCase (components/classes), camelCase (variables/functions)
+- **Files**: kebab-case for utilities and component files, PascalCase for feature folders
+- **Path alias**: Always use `@/` (maps to `src/`)
+- **Import order**: external → internal (`@/`) → relative (`./`)
+- **Functions**: Small, focused, explicit return types preferred
+- **Errors**: Use `http-errors` on server, meaningful messages always
+- **Logging**: `import { logger } from "@/services/logger"` (Pino)
+- **Styling**: Chakra v3 semantic tokens (never raw colors)
+- **Strings**: All user-facing text via `t()` from i18next
+
+---
+
+## Domain Glossary
+
+| Term | Meaning |
+|------|---------|
+| GPC | Global Protocol for Community-Scale Greenhouse Gas Emissions |
+| GHGI | Greenhouse Gas Inventory — a city's emissions profile |
+| Inventory | A specific city's emissions data for a given year |
+| Sector | Top-level GPC category (Stationary Energy, Transportation, Waste, IPPU, AFOLU) |
+| SubSector | Second-level GPC category within a sector |
+| SubCategory | Third-level GPC category (most granular) |
+| Scope | Emissions scope (1: direct, 2: indirect energy, 3: other indirect) |
+| ActivityValue | An individual emissions data entry (e.g., fuel consumption) |
+| GasValue | Gas-specific emissions for an activity (CO2, CH4, N2O, etc.) |
+| InventoryValue | Aggregated emissions per sub-category |
+| EmissionsFactor | Factor to convert activity data to emissions |
+| DataSource | External data provider for emissions factors/activity data |
+| HIAP | High Impact Action Prioritization — ranking climate actions |
+| CCRA | Climate Change Risk Assessment |
+| Locode | UN/LOCODE city identifier (e.g., "BR RIO") |
+| eCRF | Electronic Common Reporting Framework (GPC Excel format) |
+| AR5/AR6 | IPCC Assessment Report versions for Global Warming Potential values |
+| GWP | Global Warming Potential — converts gases to CO2 equivalent |
+
+---
+
+## Sibling Services (same monorepo, different stacks)
+
+| Service | Path | Stack | Purpose |
+|---------|------|-------|---------|
+| global-api | `global-api/` | Python FastAPI + SQLAlchemy + Alembic | Data services, GIS |
+| climate-advisor | `climate-advisor/` | Python FastAPI + LangChain + pgvector | RAG chat agent |
+| hiap | `hiap/` | Python FastAPI + XGBoost + ChromaDB | Action prioritization ML |
+| hiap-meed | `hiap-meed/` | Python FastAPI | MEED scoring pipeline |
+| api-demo | `api-demo/` | Static HTML + nginx | OAuth demo SPA |
+
+---
 
 _This file is for agentic coding agents. Follow these rules for consistency and reliability._


### PR DESCRIPTION
## Summary

Adds a comprehensive `.cursor/` configuration (11 rules + 5 skills) and a vastly expanded `AGENTS.md` to accelerate AI-assisted development across the CityCatalyst codebase. Every rule is built from actual codebase patterns — not generic boilerplate.

### What's included

**11 Context-Aware Rules** (`.cursor/rules/`) — activate automatically based on the file being edited:

| Rule | Glob | What it teaches the AI |
|------|------|----------------------|
| `project-architecture` | *always on* | Monorepo structure, full tech stack, path aliases, domain glossary (GPC, GHGI, HIAP, CCRA) |
| `api-routes` | `app/src/app/api/**` | `apiHandler` wrapper, Swagger JSDoc, `http-errors`, Zod validation, service delegation |
| `nextjs-frontend` | `app/src/app/**/*.tsx` | App Router patterns, `[lng]` locale segment, `use(props.params)`, client vs server components |
| `sequelize-database` | `app/src/models/**`, `migrations/**` | Model classes, migration `.cjs` templates, `init-models.ts` registration, associations |
| `rtk-query` | `app/src/services/api.ts`, `features/**` | `createApi`, `tagTypes`, `providesTags`/`invalidatesTags`, hooks, existing tag list |
| `chakra-ui-components` | `app/src/components/**` | Chakra v3 semantic tokens, UI primitives (`@/components/ui/`), file organization |
| `forms-validation` | components + hooks + validation | react-hook-form + `zodResolver`, FormInput components, server vs client schemas |
| `auth-permissions` | auth + middleware files | NextAuth credentials/JWT, `apiHandler` auth resolution (5 methods), roles, org frozen check |
| `i18n` | i18n + `[lng]/**` | `useTranslation` from `@/i18n/client`, namespaces, kebab-case keys, ESLint enforcement |
| `testing` | `app/tests/**` | `*.jest.ts` naming, `setupTests`/`mockRequest`/`expectStatusCode`, Playwright patterns |
| `python-fastapi` | `global-api/**`, `climate-advisor/**`, `hiap/**` | FastAPI patterns per service, deps, local dev commands |

**5 Workflow Skills** (`.cursor/skills/`) — step-by-step guides the AI can follow for common tasks:

| Skill | When triggered |
|-------|---------------|
| `create-api-endpoint` | "Create a new API route" → handler + validation + Swagger + service + RTK + test |
| `create-component` | "Build a component" → Chakra + i18n + data fetching + semantic tokens |
| `create-migration` | "Add a table/column" → migration `.cjs` + model + `init-models.ts` + rollback |
| `add-rtk-endpoint` | "Connect frontend to API" → query/mutation + tags + `transformResponse` |
| `full-feature` | "Implement this feature" → DB → API → Frontend → Tests (7-phase pipeline) |

**Expanded `AGENTS.md`** (from 30 lines → 300+ lines):
- Full architecture tree with every directory explained
- Complete backend service catalog (30+ services)
- All custom hooks with descriptions
- API route handler signature and error handling hierarchy table
- RTK Query tag types list and endpoint patterns
- Database model inventory (tenancy, GPC, emissions, planning, OAuth)
- Feature flags reference
- Testing conventions and helpers
- Domain glossary (GPC, GHGI, Scope, ActivityValue, eCRF, GWP, etc.)

**`.gitignore` change**: Removed `.cursor` from ignore list so the configuration is shared across the team.

## Why this matters

Without these rules, AI agents have to explore the codebase every time to discover patterns like `apiHandler`, `*.jest.ts` naming, Chakra semantic tokens, or the `[lng]` locale segment. With them, the AI generates code that matches project conventions on the first try — no rewriting needed.

## Test plan

- [ ] Open any `.tsx` file in `app/src/components/` → verify Chakra UI rule activates in Cursor
- [ ] Open any file in `app/src/app/api/` → verify API route rule activates
- [ ] Ask Cursor to "create a new API endpoint" → verify it follows the `create-api-endpoint` skill
- [ ] Ask Cursor to "add a database table" → verify it follows the `create-migration` skill
- [ ] Ask Cursor a general architecture question → verify `project-architecture` rule provides context
- [ ] Confirm `AGENTS.md` renders correctly and covers all major project areas