### PR TITLE
chore: remove console.log from TooltipCard component

### DIFF
--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsForecast/TooltipCard.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsForecast/TooltipCard.tsx
@@ -25,7 +25,6 @@ interface TooltipCardProps {
 }
 
 const TooltipCard = ({ point, data, forecast, t }: TooltipCardProps) => {
-  console.log("Rendering TooltipCard for point:", point);
   const year = point.data.x;
   const sumOfYs = data.reduce((sum, series) => {
     const yearData = series.data.find(({ x }) => x === year);


### PR DESCRIPTION
Removes debug console.log that was causing console spam during chart tooltip interactions in the emissions forecast section.

[agent gerenated]