### PR TITLE
fix: remove console.log from TooltipCard component

### DIFF
--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsForecast/TooltipCard.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsForecast/TooltipCard.tsx
@@ -25,7 +25,6 @@ interface TooltipCardProps {
 }
 
 const TooltipCard = ({ point, data, forecast, t }: TooltipCardProps) => {
-  console.log("Rendering TooltipCard for point:", point);
   const year = point.data.x;
   const sumOfYs = data.reduce((sum, series) => {
     const yearData = series.data.find(({ x }) => x === year);


### PR DESCRIPTION
## Summary

- Remove a debug `console.log` statement from the `TooltipCard` component that was causing console spam during chart interactions

## Changes

- Removed `console.log("Rendering TooltipCard for point:", point)` from `app/src/app/[lng]/[inventory]/InventoryResultTab/EmissionsForecast/TooltipCard.tsx`
- No functional changes — tooltip rendering remains identical

## Test plan

- [ ] Navigate to the emissions forecast chart
- [ ] Hover over data points to trigger tooltips
- [ ] Verify tooltips still render correctly with all expected data
- [ ] Verify browser console is no longer spammed during tooltip interactions

Made with [Cursor](https://cursor.com)