### PR TITLE
Fix cron HIAP auth bypass with empty bearer token

### DIFF
--- a/app/src/app/api/v1/cron/check-hiap-jobs/route.ts
+++ b/app/src/app/api/v1/cron/check-hiap-jobs/route.ts
@@ -61,7 +61,7 @@ export async function GET(req: NextRequest) {
     );
   }
   const token = authorization.replace("Bearer ", "").trim();
-  if (token.length > 0 && token !== process.env.CC_CRON_JOB_API_KEY) {
+  if (token.length === 0 || token !== process.env.CC_CRON_JOB_API_KEY) {
     return NextResponse.json(
       { error: { message: "Unauthorized, API key invalid" } },
       { status: 401 },


### PR DESCRIPTION
## Summary
- Fixed authentication bypass vulnerability in cron endpoint `/api/v1/cron/check-hiap-jobs`
- Empty bearer tokens (`Bearer `) were incorrectly allowed to bypass authentication
- Changed validation logic to properly reject empty tokens with 401 status

## Changes
- Modified the token validation condition in `route.ts` from `token.length > 0 && token !== api_key` to `token.length === 0 || token !== api_key`
- This ensures empty tokens are properly rejected instead of bypassing authentication

## Test plan
- [ ] Empty bearer token (`Authorization: Bearer `) returns 401
- [ ] Missing Authorization header returns 401 
- [ ] Invalid API key returns 401
- [ ] Valid API key allows access to endpoint