### PR TITLE
Add catch handler to prevent unhandled promise rejection in HIAP background job

### DIFF
--- a/app/src/backend/hiap/HiapService.ts
+++ b/app/src/backend/hiap/HiapService.ts
@@ -185,7 +185,12 @@ export const startBothActionRankingJobs = async (
       : ACTION_TYPES.Mitigation;
 
   // start the opposite type job in the background
-  startActionRankingJob(inventoryId, locode, langs, oppositeType, user);
+  startActionRankingJob(inventoryId, locode, langs, oppositeType, user).catch((error) => {
+    logger.error(
+      { error, inventoryId, locode, type: oppositeType },
+      "Background action ranking job failed"
+    );
+  });
   // then start the current type job and return the result
   return await startActionRankingJob(inventoryId, locode, langs, type, user);
 };


### PR DESCRIPTION
## Summary
- Fixes unhandled promise rejection in `startBothActionRankingJobs` function
- Adds `.catch()` handler to background job to prevent Node.js process crashes
- Maintains existing functionality while improving error handling

## Changes
- Added error logging to the unawaited `startActionRankingJob` call for the opposite action type
- Uses existing logger to log errors with context (inventoryId, locode, type)
- Primary job execution continues normally even if background job fails

## Test plan
- [ ] Verify background job failures are logged instead of causing unhandled promise rejections
- [ ] Confirm primary job still runs and returns normally
- [ ] Test that error logs include proper context for debugging