### PR TITLE
Fix inverted shell condition in HIAP cron job

### DIFF
--- a/k8s/cc-check-hiap-jobs.yml
+++ b/k8s/cc-check-hiap-jobs.yml
@@ -26,12 +26,12 @@ spec:
                 - /bin/sh
                 - -c
                 - |
-                  if [ -n "$(CC_CRON_JOB_API_KEY)" ]; then
+                  if [ -z "$CC_CRON_JOB_API_KEY" ]; then
                     echo "Missing env var CC_CRON_JOB_API_KEY"
                     exit 1
                   fi
                   echo "Checking HIAP jobs at $(date)"
-                  curl -f -L --header "Authorization: Bearer $(CC_CRON_JOB_API_KEY)" -X GET http://cc-web:3000/api/v1/cron/check-hiap-jobs
+                  curl -f -L --header "Authorization: Bearer $CC_CRON_JOB_API_KEY" -X GET http://cc-web:3000/api/v1/cron/check-hiap-jobs
                   EXIT_CODE=$?
                   if [ $EXIT_CODE -eq 0 ]; then
                     echo "Cron job completed successfully"


### PR DESCRIPTION
## Summary
- Fixed inverted shell condition that caused the HIAP cron job to exit when API key was present instead of missing
- Corrected variable reference syntax from command substitution to proper variable expansion

## Changes
- Changed `-n` to `-z` in shell condition to properly test for empty/missing CC_CRON_JOB_API_KEY
- Fixed variable reference from `"$(CC_CRON_JOB_API_KEY)"` to `"$CC_CRON_JOB_API_KEY"` in both the condition check and curl command
- The cron job now correctly exits with error when the API key is missing and proceeds normally when it's present

## Test plan
- [ ] Deploy the updated cron job to verify it runs successfully when CC_CRON_JOB_API_KEY is set
- [ ] Verify it fails appropriately when CC_CRON_JOB_API_KEY is not set or empty
- [ ] Check that the curl command properly uses the API key for authorization