### PR TITLE
Remove debug console statements from UI components

### DIFF
--- a/app/src/app/[lng]/[inventory]/InventoryResultTab/ByScopeViewSourceDrawer.tsx
+++ b/app/src/app/[lng]/[inventory]/InventoryResultTab/ByScopeViewSourceDrawer.tsx
@@ -33,11 +33,7 @@ const ByScopeViewSourceDrawer: React.FC<ByScopeViewProps> = ({
 
   useEffect(() => {
     if (dataSourceError) {
-      console.error("Failed to fetch data source:", {
-        error: dataSourceError,
-        sourceId,
-        inventoryId,
-      });
+      // Error handling could be implemented here if needed
     }
   }, [dataSourceError, sourceId, inventoryId]);
 

--- a/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
+++ b/app/src/app/[lng]/[inventory]/data/manage-sectors/SectorTabs.tsx
@@ -300,7 +300,6 @@ const SectorTabs: FC<SectorTabsProps> = ({ t, inventoryId }) => {
         title: t("error"),
         description: t("error-updating-notation-keys"),
       });
-      console.log("no notation keys to update");
       return;
     }
 
@@ -320,7 +319,6 @@ const SectorTabs: FC<SectorTabsProps> = ({ t, inventoryId }) => {
           duration: 5000,
         });
     } catch (error) {
-      console.log(error);
       toaster.error({
         title: t("error"),
         description: t("error-updating-notation-keys"),

--- a/app/src/app/[lng]/admin/organization/[id]/modules/page.tsx
+++ b/app/src/app/[lng]/admin/organization/[id]/modules/page.tsx
@@ -36,9 +36,6 @@ const AdminOrganizationModulesPage = (props: {
     hasAccess: boolean,
   ) => {
     // TODO: implement module access update logic
-    console.log(
-      `Toggle ${moduleName} for project ${projectId} to ${hasAccess}`,
-    );
   };
   return (
     <Box>

--- a/app/src/hooks/useChat.ts
+++ b/app/src/hooks/useChat.ts
@@ -73,7 +73,7 @@ export function useChat({ inventoryId, t }: UseChatProps) {
             setAssistantStartedResponding(false);
           },
           onWarning: (warning: string) => {
-            console.warn("Chat warning:", warning);
+            // Warning could be handled here if needed
           },
         }
       : {
@@ -95,7 +95,6 @@ export function useChat({ inventoryId, t }: UseChatProps) {
           onRequiresAction: async (event: any) => {
             // Handle function calls for legacy implementation
             // This would need the full function call handling logic
-            console.log("Requires action:", event);
           },
           onError: (error: string) => {
             // Remove empty assistant message if no response was received


### PR DESCRIPTION
## Summary
- Removed debug console.log/warn/error statements from UI components that were polluting the browser console in production
- Cleaned up 4 components and 1 hook to eliminate 6 console statements total
- No functional changes made - only removed debugging artifacts

## Changes
- **ByScopeViewSourceDrawer.tsx**: Removed console.error from useEffect error handler
- **modules/page.tsx**: Removed console.log from stub handler function
- **SectorTabs.tsx**: Removed 2 console.log statements from notation key update logic
- **useChat.ts**: Removed console.warn and console.log from event handlers

## Test plan
- [ ] Verify components still function correctly without console output
- [ ] Check that error handling still works appropriately without console pollution
- [ ] Confirm no regression in UI functionality