### PR TITLE
Fix inverted shell condition in HIAP cron job

### DIFF
--- a/k8s/cc-check-hiap-jobs.yml
+++ b/k8s/cc-check-hiap-jobs.yml
@@ -26,12 +26,12 @@ spec:
                 - /bin/sh
                 - -c
                 - |
-                  if [ -n "$(CC_CRON_JOB_API_KEY)" ]; then
+                  if [ -z "$CC_CRON_JOB_API_KEY" ]; then
                     echo "Missing env var CC_CRON_JOB_API_KEY"
                     exit 1
                   fi
                   echo "Checking HIAP jobs at $(date)"
-                  curl -f -L --header "Authorization: Bearer $(CC_CRON_JOB_API_KEY)" -X GET http://cc-web:3000/api/v1/cron/check-hiap-jobs
+                  curl -f -L --header "Authorization: Bearer $CC_CRON_JOB_API_KEY" -X GET http://cc-web:3000/api/v1/cron/check-hiap-jobs
                   EXIT_CODE=$?
                   if [ $EXIT_CODE -eq 0 ]; then
                     echo "Cron job completed successfully"


### PR DESCRIPTION
## Summary
- Fixed inverted shell condition logic that was preventing the HIAP cron job from running when API key was present
- Corrected variable reference syntax in shell script

## Changes
- Changed `-n` to `-z` in shell condition to properly test for empty/missing API key
- Fixed variable reference from `$(CC_CRON_JOB_API_KEY)` to `$CC_CRON_JOB_API_KEY` to avoid command execution
- The cron job now properly exits when API key is missing and proceeds when it's present

## Test plan
- [ ] Deploy to staging environment and verify cron job runs successfully with API key set
- [ ] Verify cron job fails gracefully with appropriate error message when API key is missing

## Tests added
N/A - This is a Kubernetes configuration fix that doesn't require unit tests