### PR TITLE
fix: increases close delay for module card tooltip

### DIFF
--- a/app/src/components/HomePageJN/ModuleCard.tsx
+++ b/app/src/components/HomePageJN/ModuleCard.tsx
@@ -91,10 +91,7 @@ export function ModuleCard({
                 alt={`${name} module logo`}
               />
               {status && status !== "active" && (
-                <Tag
-                  size="sm"
-                  colorPalette={statusColorMap[status] || "gray"}
-                >
+                <Tag size="sm" colorPalette={statusColorMap[status] || "gray"}>
                   {t(statusLabelMap[status] || status)}
                 </Tag>
               )}
@@ -103,7 +100,7 @@ export function ModuleCard({
             <Tooltip
               content={getTranslationInLanguage(description)}
               showArrow
-              closeDelay={1000}
+              closeDelay={8000}
               contentProps={{
                 bg: "content.secondary",
                 color: "background.default",


### PR DESCRIPTION
## Changes
- Increases close delay for module card tool tips.

## Motivation
- Info buttons are the primary contextual help mechanism. When they close quickly, users lose their most accessible learning path