### PR TITLE
fix(ui): ON-5532 page freezing when language is changed

### DIFF
--- a/app/src/i18n/client.ts
+++ b/app/src/i18n/client.ts
@@ -9,7 +9,6 @@ import {
   useTranslation as useTranslationOrg,
 } from "react-i18next";
 import { getOptions, languages } from "./settings";
-import { useEffect, useState } from "react";
 
 const runsOnServerSide = typeof window === "undefined";
 
@@ -32,25 +31,9 @@ i18next
   });
 
 export function useTranslation(
-  lng: string,
+  _lng: string,
   ns: string,
   options: UseTranslationOptions<undefined> = {},
 ) {
-  const ret = useTranslationOrg(ns, options);
-  const { i18n } = ret;
-  const isChangedOnServer =
-    runsOnServerSide && lng && i18n.resolvedLanguage !== lng;
-  const [activeLng, setActiveLng] = useState(i18n.resolvedLanguage);
-
-  useEffect(() => {
-    if (isChangedOnServer || activeLng === i18n.resolvedLanguage) return;
-    setActiveLng(i18n.resolvedLanguage);
-  }, [activeLng, i18n.resolvedLanguage, isChangedOnServer]);
-
-  useEffect(() => {
-    if (isChangedOnServer || !lng || i18n.resolvedLanguage === lng) return;
-    i18n.changeLanguage(lng);
-  }, [lng, i18n, isChangedOnServer]);
-
-  return ret;
+  return useTranslationOrg(ns, options);
 }


### PR DESCRIPTION
The useEffect hooks inside of our custom useTranslation hook in `i18n/client.ts` were causing circular state updates. The language changes without them when a different one was selected, so they weren't necessary in the first place.