### PR TITLE
ON-5544: Fix markdown rendering in Clima AI chat-bot bubbles

### DIFF
--- a/app/src/components/ChatBot/ChatMessageList.tsx
+++ b/app/src/components/ChatBot/ChatMessageList.tsx
@@ -5,14 +5,139 @@ import {
   Icon,
   IconButton,
   Spacer,
+  Text,
 } from "@chakra-ui/react";
 import { BsStars } from "react-icons/bs";
 import { MdCheckCircle, MdContentCopy } from "react-icons/md";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { Message } from "@/utils/chatUtils";
 import { PulsingAIIcon } from "./PulsingAIIcon";
+
+const markdownComponents: Components = {
+  p: ({ children }) => (
+    <Text mb={3} lineHeight="24px" fontSize="16px" color="inherit" _last={{ mb: 0 }}>
+      {children}
+    </Text>
+  ),
+  h1: ({ children }) => (
+    <Text as="h1" fontWeight="bold" fontSize="xl" mb={3} mt={2} lineHeight="1.4" color="inherit">
+      {children}
+    </Text>
+  ),
+  h2: ({ children }) => (
+    <Text as="h2" fontWeight="bold" fontSize="lg" mb={3} mt={2} lineHeight="1.4" color="inherit">
+      {children}
+    </Text>
+  ),
+  h3: ({ children }) => (
+    <Text as="h3" fontWeight="semibold" fontSize="md" mb={2} mt={2} lineHeight="1.4" color="inherit">
+      {children}
+    </Text>
+  ),
+  ul: ({ children }) => (
+    <Box as="ul" pl={5} mb={3} color="inherit" css={{ listStyleType: "disc" }}>
+      {children}
+    </Box>
+  ),
+  ol: ({ children }) => (
+    <Box as="ol" pl={5} mb={3} color="inherit" css={{ listStyleType: "decimal" }}>
+      {children}
+    </Box>
+  ),
+  li: ({ children }) => (
+    <Box as="li" lineHeight="24px" mb={1} color="inherit">
+      {children}
+    </Box>
+  ),
+  strong: ({ children }) => (
+    <Text as="strong" fontWeight="bold" display="inline" color="inherit">
+      {children}
+    </Text>
+  ),
+  em: ({ children }) => (
+    <Text as="em" fontStyle="italic" display="inline" color="inherit">
+      {children}
+    </Text>
+  ),
+  code: ({ children }) => (
+    <Text
+      as="code"
+      fontFamily="mono"
+      bg="blackAlpha.100"
+      px={1}
+      borderRadius="sm"
+      fontSize="sm"
+      color="inherit"
+    >
+      {children}
+    </Text>
+  ),
+  pre: ({ children }) => (
+    <Box
+      as="pre"
+      bg="blackAlpha.100"
+      p={3}
+      borderRadius="md"
+      mb={3}
+      overflowX="auto"
+      fontSize="sm"
+    >
+      {children}
+    </Box>
+  ),
+  table: ({ children }) => (
+    <Box overflowX="auto" mb={3}>
+      <Box
+        as="table"
+        w="full"
+        fontSize="sm"
+        css={{ borderCollapse: "collapse" }}
+        color="inherit"
+      >
+        {children}
+      </Box>
+    </Box>
+  ),
+  thead: ({ children }) => (
+    <Box as="thead" bg="blackAlpha.100">
+      {children}
+    </Box>
+  ),
+  tbody: ({ children }) => <Box as="tbody">{children}</Box>,
+  tr: ({ children }) => (
+    <Box as="tr" css={{ borderBottom: "1px solid" }} borderColor="border.overlay">
+      {children}
+    </Box>
+  ),
+  th: ({ children }) => (
+    <Box
+      as="th"
+      px={3}
+      py={2}
+      fontWeight="semibold"
+      textAlign="left"
+      color="inherit"
+      css={{ border: "1px solid" }}
+      borderColor="border.overlay"
+    >
+      {children}
+    </Box>
+  ),
+  td: ({ children }) => (
+    <Box
+      as="td"
+      px={3}
+      py={2}
+      color="inherit"
+      css={{ border: "1px solid" }}
+      borderColor="border.overlay"
+    >
+      {children}
+    </Box>
+  ),
+};
 
 interface ChatMessageListProps {
   messages: Message[];
@@ -76,14 +201,17 @@ export function ChatMessageList({ messages, isGenerating, assistantStartedRespon
                   px={6}
                   py={4}
                   bg={isUser ? "content.link" : "base.light"}
-                  whiteSpace="pre-wrap"
+                  whiteSpace={isUser ? "pre-wrap" : undefined}
                   color={isUser ? "base.light" : "content.tertiary"}
                   letterSpacing="0.5px"
                   lineHeight="24px"
                   fontSize="16px"
                 >
                 <>
-                  <ReactMarkdown rehypePlugins={[remarkGfm]}>
+                  <ReactMarkdown
+                    remarkPlugins={[remarkGfm]}
+                    components={isUser ? undefined : markdownComponents}
+                  >
                     {m.text}
                   </ReactMarkdown>
                   {!isUser &&


### PR DESCRIPTION
## Summary

Corrects markdown rendering in the Clima AI assistant chat-bot response bubbles. `remarkGfm` was incorrectly passed as a `rehypePlugin` (breaking GFM features), and `whiteSpace: pre-wrap` on assistant bubbles was causing excessive paragraph spacing between paragraphs.

## Changes

- Fix `remarkGfm` passed as `rehypePlugin` instead of `remarkPlugin`
- Remove `whiteSpace: pre-wrap` from assistant bubbles (root cause of large paragraph gaps)
- Add `markdownComponents` map to properly style `p`, headings, `ul`/`ol`/`li`, `code`, `pre`, and table elements (`table`, `thead`, `tbody`, `tr`, `th`, `td`)

## Commits (1)

- fix: correct markdown rendering in chat-bot message bubbles
