### PR TITLE
ON-5593: Hide Ask AI button on onboarding screens

### DIFF
--- a/app/src/components/ChatBot/chat-popover.tsx
+++ b/app/src/components/ChatBot/chat-popover.tsx
@@ -84,8 +84,11 @@ export default function ChatPopover({
 
   const pathname = usePathname();
 
-  // Hide the ChatPopover on auth pages
-  if (pathname.startsWith(`/${lng}/auth`)) {
+  // Hide the ChatPopover on auth and onboarding pages
+  if (
+    pathname.startsWith(`/${lng}/auth`) ||
+    pathname.includes("/onboarding")
+  ) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

Hides the Clima AI assistant button on all onboarding pages. Previously the button was visible during onboarding flows, where it is not relevant and could distract users.

## Changes

- Extend path-based hide logic in `chat-popover.tsx` to return `null` when the current path includes `/onboarding`
- Covers both known onboarding routes (`/cities/:id/GHGI/onboarding/` and `/cities/onboarding/setup/`) and any future onboarding paths

## Commits (1)

- fix: hide Ask AI button on onboarding pages