### PR TITLE
fix(ui): ON-5530 keep inventory details step data alive

### DIFF
--- a/app/e2e/helpers.ts
+++ b/app/e2e/helpers.ts
@@ -151,7 +151,7 @@ export async function createInventoryThroughOnboarding(
 
   // Select year - click the select trigger and then select an option
   const yearSelectTrigger = page
-    .locator('[data-testid="inventory-detils-year"]')
+    .locator('[data-testid="inventory-details-year"]')
     .locator("button");
   await yearSelectTrigger.click();
   await page.waitForTimeout(500); // Wait for dropdown to open

--- a/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/setup/page.tsx
+++ b/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/setup/page.tsx
@@ -134,6 +134,15 @@ export default function OnboardingSetup(props: {
     }
   }, [CCCityData, setValue, setOcCityData]);
 
+  // Inventory details step state
+  const [selectedYearArray, setSelectedYearArray] = useState<string[]>([]);
+  const [selectedInventoryGoalValue, setSelectedInventoryGoalValue] =
+    useState("");
+  const [
+    selectedGlobalWarmingPotentialValue,
+    setSelectedGlobalWarmingPotentialValue,
+  ] = useState("");
+
   const makeErrorToast = (title: string, description?: string) => {
     const { showErrorToast } = UseErrorToast({ description, title });
     showErrorToast();
@@ -204,12 +213,14 @@ export default function OnboardingSetup(props: {
         defaultCityId: cityId,
       }).unwrap();
       setConfirming(false);
-      
+
       // Check if we're in upload mode
       const mode = params.get("mode");
       if (mode === "upload") {
         // Route to import page with the newly created inventory ID
-        router.push(`/${lng}/cities/${cityId}/GHGI/onboarding/import?inventory=${inventory.inventoryId}`);
+        router.push(
+          `/${lng}/cities/${cityId}/GHGI/onboarding/import?inventory=${inventory.inventoryId}`,
+        );
       } else {
         // Default behavior: route to home page
         router.push(`/${lng}/cities/${cityId}/GHGI/${inventory.inventoryId}`);
@@ -275,6 +286,16 @@ export default function OnboardingSetup(props: {
               control={control}
               setValue={setValue}
               years={years}
+              selectedYearArray={selectedYearArray}
+              setSelectedYearArray={setSelectedYearArray}
+              selectedInventoryGoalValue={selectedInventoryGoalValue}
+              selectedGlobalWarmingPotentialValue={
+                selectedGlobalWarmingPotentialValue
+              }
+              setSelectedInventoryGoalValue={setSelectedInventoryGoalValue}
+              setSelectedGlobalWarmingPotentialValue={
+                setSelectedGlobalWarmingPotentialValue
+              }
             />
           )}
           {activeStep === 1 && (

--- a/app/src/components/steps/GHGI/set-inventory-details-step.tsx
+++ b/app/src/components/steps/GHGI/set-inventory-details-step.tsx
@@ -6,7 +6,7 @@ import {
   UseFormRegister,
 } from "react-hook-form";
 import type { GHGIFormInputs } from "@/util/GHGI/types";
-import { FC, useEffect, useState } from "react";
+import { useEffect } from "react";
 import {
   Box,
   createListCollection,
@@ -18,7 +18,7 @@ import {
 } from "@chakra-ui/react";
 import { MdCheck, MdWarning } from "react-icons/md";
 import { Trans } from "react-i18next";
-import { CustomRadio, RadioGroup } from "@/components/ui/custom-radio";
+import { RadioGroup } from "@/components/ui/custom-radio";
 import { InputGroup } from "@/components/ui/input-group";
 import {
   SelectContent,
@@ -29,8 +29,6 @@ import {
   SelectValueText,
 } from "@/components/ui/select";
 import { Field } from "@/components/ui/field";
-import { Button } from "../../ui/button";
-import { InventoryButtonCheckIcon } from "../../icons";
 import CustomSelectableButton from "../../custom-selectable-buttons";
 
 export default function SetInventoryDetailsStep({
@@ -40,6 +38,12 @@ export default function SetInventoryDetailsStep({
   control,
   setValue,
   years,
+  selectedYearArray,
+  setSelectedYearArray,
+  selectedInventoryGoalValue,
+  selectedGlobalWarmingPotentialValue,
+  setSelectedInventoryGoalValue,
+  setSelectedGlobalWarmingPotentialValue,
 }: {
   t: TFunction;
   register: UseFormRegister<GHGIFormInputs>;
@@ -47,14 +51,13 @@ export default function SetInventoryDetailsStep({
   control: Control<GHGIFormInputs>;
   setValue: any;
   years: number[];
+  selectedYearArray?: string[];
+  setSelectedYearArray: (value: string[]) => void;
+  selectedInventoryGoalValue?: string;
+  setSelectedInventoryGoalValue: (value: string) => void;
+  selectedGlobalWarmingPotentialValue?: string;
+  setSelectedGlobalWarmingPotentialValue: (value: string) => void;
 }) {
-  const [selectedInventoryGoalValue, setSelectedInventoryGoalValue] =
-    useState("");
-  const [
-    selectedGlobalWarmingPotentialValue,
-    setSelectedGlobalWarmingPotentialValue,
-  ] = useState("");
-  let year;
   const inventoryGoalOptions: string[] = ["gpc_basic", "gpc_basic_plus"];
   const globalWarmingPotential: string[] = ["ar5", "ar6"];
 
@@ -126,12 +129,12 @@ export default function SetInventoryDetailsStep({
               invalid={!!errors.year}
               errorText={
                 <Box gap="6px" m={0}>
-                  <Icon as={MdWarning} boxSize={4} display="inline" />
                   <Text
                     fontSize="body.md"
                     color="content.tertiary"
                     fontStyle="normal"
                   >
+                    <Icon as={MdWarning} boxSize={4} display="inline" />
                     {errors.year?.message}
                   </Text>
                 </Box>
@@ -139,7 +142,7 @@ export default function SetInventoryDetailsStep({
             >
               <InputGroup
                 endElement={
-                  !!year && (
+                  (selectedYearArray?.length ?? 0) > 0 && (
                     <Icon
                       as={MdCheck}
                       color="semantic.success"
@@ -155,10 +158,12 @@ export default function SetInventoryDetailsStep({
                   size="lg"
                   w="400px"
                   _placeholder={{ color: "content.tertiary" }}
-                  data-testid="inventory-detils-year"
+                  data-testid="inventory-details-year"
                   {...register("year", {
                     required: t("inventory-year-required"),
                   })}
+                  value={selectedYearArray}
+                  onValueChange={({ value }) => setSelectedYearArray(value)}
                 >
                   <SelectLabel />
                   <SelectTrigger shadow="1dp">
@@ -248,7 +253,7 @@ export default function SetInventoryDetailsStep({
                             field={field}
                             key={value}
                             value={value}
-                            inputValue={selectedInventoryGoalValue}
+                            inputValue={selectedInventoryGoalValue ?? ""}
                             inputValueFunction={setSelectedInventoryGoalValue}
                             t={t}
                           />
@@ -347,7 +352,7 @@ export default function SetInventoryDetailsStep({
                           field={field}
                           key={value}
                           value={value}
-                          inputValue={selectedGlobalWarmingPotentialValue}
+                          inputValue={selectedGlobalWarmingPotentialValue ?? ""}
                           inputValueFunction={
                             setSelectedGlobalWarmingPotentialValue
                           }


### PR DESCRIPTION
Step state is hoisted to parent component (onboarding setup page) in order to keep it around between step navigations (going back from the population or confirmation steps).