### PR TITLE
Fix: Safari Bug Fixes - page titles, navbar module name, readable project name, and i18n updates

### DIFF
--- a/app/src/app/[lng]/cities/[cityId]/GHGI/GHGIClientLayout.tsx
+++ b/app/src/app/[lng]/cities/[cityId]/GHGI/GHGIClientLayout.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import React from "react";
+import { useModuleAccessLayout } from "@/hooks/useModuleAccessLayout";
+import { Modules } from "@/util/constants";
+
+const GHGI_MODULE_ID = Modules.GHGI.id;
+
+export default function GHGIClientLayout(props: {
+  children: React.ReactNode;
+  params: Promise<{ lng: string; cityId: string }>;
+}) {
+  return useModuleAccessLayout({
+    params: props.params,
+    moduleId: GHGI_MODULE_ID,
+    children: props.children,
+  });
+}

--- a/app/src/app/[lng]/cities/[cityId]/GHGI/layout.tsx
+++ b/app/src/app/[lng]/cities/[cityId]/GHGI/layout.tsx
@@ -1,18 +1,19 @@
-"use client";
-
+import type { Metadata } from "next";
 import React from "react";
-import { useModuleAccessLayout } from "@/hooks/useModuleAccessLayout";
-import { Modules } from "@/util/constants";
+import GHGIClientLayout from "./GHGIClientLayout";
 
-const GHGI_MODULE_ID = Modules.GHGI.id;
+// TODO: translate page titles using i18n once a RSC-safe locale helper is available
+export const metadata: Metadata = {
+  title: "GHG Inventories",
+};
 
 export default function GHGILayout(props: {
   children: React.ReactNode;
   params: Promise<{ lng: string; cityId: string }>;
 }) {
-  return useModuleAccessLayout({
-    params: props.params,
-    moduleId: GHGI_MODULE_ID,
-    children: props.children,
-  });
+  return (
+    <GHGIClientLayout params={props.params}>
+      {props.children}
+    </GHGIClientLayout>
+  );
 }

--- a/app/src/app/[lng]/cities/[cityId]/HIAP/HIAPClientLayout.tsx
+++ b/app/src/app/[lng]/cities/[cityId]/HIAP/HIAPClientLayout.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import React from "react";
+import { useModuleAccessLayout } from "@/hooks/useModuleAccessLayout";
+import { Modules } from "@/util/constants";
+
+const HIAP_MODULE_ID = Modules.HIAP.id;
+
+export default function HIAPClientLayout(props: {
+  children: React.ReactNode;
+  params: Promise<{ lng: string; cityId: string }>;
+}) {
+  return useModuleAccessLayout({
+    params: props.params,
+    moduleId: HIAP_MODULE_ID,
+    children: props.children,
+  });
+}

--- a/app/src/app/[lng]/cities/[cityId]/HIAP/layout.tsx
+++ b/app/src/app/[lng]/cities/[cityId]/HIAP/layout.tsx
@@ -1,18 +1,19 @@
-"use client";
-
+import type { Metadata } from "next";
 import React from "react";
-import { useModuleAccessLayout } from "@/hooks/useModuleAccessLayout";
-import { Modules } from "@/util/constants";
+import HIAPClientLayout from "./HIAPClientLayout";
 
-const HIAP_MODULE_ID = Modules.HIAP.id;
+// TODO: translate page titles using i18n once a RSC-safe locale helper is available
+export const metadata: Metadata = {
+  title: "High Impact Action Plan",
+};
 
 export default function HIAPLayout(props: {
   children: React.ReactNode;
   params: Promise<{ lng: string; cityId: string }>;
 }) {
-  return useModuleAccessLayout({
-    params: props.params,
-    moduleId: HIAP_MODULE_ID,
-    children: props.children,
-  });
+  return (
+    <HIAPClientLayout params={props.params}>
+      {props.children}
+    </HIAPClientLayout>
+  );
 }

--- a/app/src/app/[lng]/cities/[cityId]/dashboard/layout.tsx
+++ b/app/src/app/[lng]/cities/[cityId]/dashboard/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import React from "react";
+
+// TODO: translate page titles using i18n once a RSC-safe locale helper is available
+export const metadata: Metadata = {
+  title: "Dashboard",
+};
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/src/app/[lng]/layout.tsx
+++ b/app/src/app/[lng]/layout.tsx
@@ -14,7 +14,10 @@ import { HighlightInit } from "@highlight-run/next/client";
 import HighlightIdentifier from "@/components/HighlightIo/HighlightIdentifier";
 import { hasServerFeatureFlag, FeatureFlags } from "@/util/feature-flags";
 export const metadata: Metadata = {
-  title: "CityCatalyst",
+  title: {
+    default: "CityCatalyst",
+    template: "CityCatalyst - %s",
+  },
   description: "Make building a climate inventory a breeze",
 };
 

--- a/app/src/components/HomePage/JNDrawer.tsx
+++ b/app/src/components/HomePage/JNDrawer.tsx
@@ -627,7 +627,7 @@ const JNDrawer = ({
               <NavigationLinks
                 items={[
                   {
-                    label: "home",
+                    label: "citycatalyst",
                     icon: BiHomeAlt,
                     href: `/${lng}/cities/${selectedCity}`,
                   },

--- a/app/src/components/navigation-bar.tsx
+++ b/app/src/components/navigation-bar.tsx
@@ -6,6 +6,7 @@ import { languages } from "@/i18n/settings";
 import {
   Box,
   Heading,
+  HStack,
   Icon,
   IconButton,
   Link,
@@ -109,6 +110,15 @@ export function NavigationBar({
     api.useGetUserInfoQuery();
   const router = useRouter();
 
+  // Derive the active module name from the current pathname
+  const moduleName = useMemo(() => {
+    if (!pathname) return null;
+    if (pathname.includes("/GHGI")) return t("page-title-ghg-inventories");
+    if (pathname.includes("/HIAP")) return t("page-title-hiap");
+    if (pathname.includes("/dashboard")) return t("page-title-dashboard");
+    return null;
+  }, [pathname, t]);
+
   // Memoize city and inventory IDs to ensure they update when route changes
   const currentInventoryId = useMemo(
     () => inventoryIdFromRoute ?? userInfo?.defaultInventoryId,
@@ -191,7 +201,7 @@ export function NavigationBar({
                 />
               </Link>
             ) : (
-              <>
+              <HStack display="flex" alignItems="center" gap={2}>
                 {!isAuth && (
                   <Link width={9} height={9} href={homePath}>
                     <Image
@@ -207,7 +217,19 @@ export function NavigationBar({
                     {t("title")}
                   </Heading>
                 </Link>
-              </>
+                {moduleName && (
+                  <>
+                    <Separator
+                      orientation="vertical"
+                      height="5"
+                      borderColor="base.light"
+                    />
+                    <Heading size="lg" color="base.light" fontWeight="normal">
+                      {moduleName}
+                    </Heading>
+                  </>
+                )}
+              </HStack>
             )}
           </Box>
           <Box flex={1} />

--- a/app/src/components/steps/GHGI/set-inventory-details-step.tsx
+++ b/app/src/components/steps/GHGI/set-inventory-details-step.tsx
@@ -215,22 +215,9 @@ export default function SetInventoryDetailsStep({
               lineHeight="24px"
               letterSpacing="wide"
               color="content.tertiary"
+              fontFamily="body"
             >
-              <Trans i18nKey="inventory-goal-description" t={t}>
-                Want to learn more about these inventory formats?{" "}
-                <Link
-                  href="https://ghgprotocol.org/ghg-protocol-cities"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  fontFamily="heading"
-                  fontWeight="bold"
-                  color="content.link"
-                  textDecorationLine="underline"
-                >
-                  Learn more
-                </Link>{" "}
-                about the GPC Framework.
-              </Trans>
+              {t("inventory-goal-description-ghgi")}
             </Text>
           </Box>
           <Box>
@@ -311,23 +298,20 @@ export default function SetInventoryDetailsStep({
               fontStyle="normal"
               lineHeight="24px"
               letterSpacing="wide"
+              fontFamily="body"
               color="content.tertiary"
             >
-              <Trans i18nKey="gwp-description" t={t}>
-                Want to learn more about these inventory formats?{" "}
-                <Link
-                  href="https://ghgprotocol.org/sites/default/files/2024-08/Global-Warming-Potential-Values%20(August%202024).pdf"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  fontFamily="heading"
-                  fontWeight="bold"
-                  color="content.link"
-                  textDecorationLine="underline"
-                >
-                  Learn more
-                </Link>{" "}
-                about the GPC Framework.
-              </Trans>
+              {t("gwp-description-ghgi")}
+            </Text>
+            <Text
+              fontSize="body.md"
+              fontStyle="normal"
+              lineHeight="16px"
+              letterSpacing="wide"
+              color="content.tertiary"
+              w="421px"
+            >
+              {t("gwp-description-ghgi-tip")}
             </Text>
           </Box>
           <Box>

--- a/app/src/components/steps/select-city-steps.tsx
+++ b/app/src/components/steps/select-city-steps.tsx
@@ -124,11 +124,14 @@ export default function SelectCityStep({
     return createListCollection({
       items:
         projectsList?.map((project) => ({
-          label: project.name,
+          label:
+            project.name === "cc_project_default"
+              ? t("citycatalyst-demo")
+              : project.name,
           value: project.projectId,
         })) ?? [],
     });
-  }, [projectsList]);
+  }, [projectsList, t]);
 
   useEffect(() => {
     if (year && ocCityData) {

--- a/app/src/i18n/locales/de/chat.json
+++ b/app/src/i18n/locales/de/chat.json
@@ -1,7 +1,7 @@
 {
   "ask-ai-expert": "Fragen Sie einen KI-Experten",
   "ai-expert": "KI-Experte",
-  "ask-ai": "KI fragen",
+  "ask-ai": "Clima AI fragen",
   "ask-assistant": "Fragen Sie den Assistenten etwas...",
   "initial-message": "Hallo! Ich bin Clima, Ihr virtueller Assistent. Ich bin hier, um Sie durch den Prozess der genauen Messung und Berichterstattung der Treibhausgasemissionen Ihrer Stadt zu führen. Wie kann ich Ihnen heute helfen?",
   "regenerate": "Regenerieren",

--- a/app/src/i18n/locales/de/dashboard.json
+++ b/app/src/i18n/locales/de/dashboard.json
@@ -297,5 +297,6 @@
   "status-early-access": "Frühzeitiger Zugang",
   "status-beta": "Betaversion",
   "status-active": "Aktiv",
-  "legend": "Legende"
+  "legend": "Legende",
+  "citycatalyst": "CityCatalyst"
 }

--- a/app/src/i18n/locales/de/navigation.json
+++ b/app/src/i18n/locales/de/navigation.json
@@ -4,5 +4,8 @@
   "cities": "Städte",
   "settings": "Einstellungen",
   "account-settings": "Kontoeinstellungen",
-  "account-frozen-warning-text": "Ihr Konto ist eingefroren. Bitte wenden Sie sich an einen Administrator oder an <bold>{{ email }}</bold>, um es zu reaktivieren"
+  "account-frozen-warning-text": "Ihr Konto ist eingefroren. Bitte wenden Sie sich an einen Administrator oder an <bold>{{ email }}</bold>, um es zu reaktivieren",
+  "page-title-ghg-inventories": "GHG Inventories",
+  "page-title-hiap": "High Impact Action Plan",
+  "page-title-dashboard": "Dashboard"
 }

--- a/app/src/i18n/locales/de/onboarding.json
+++ b/app/src/i18n/locales/de/onboarding.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "onboarding-heading": "Beginnen Sie Ihr Emissions-Inventar!",
   "onboarding-details": "Wir müssen die Stadt und das Jahr bestätigen, für die Sie das Inventar erstellen möchten.<br/>Sie sind einen Schritt näher an Ihrem GPC Emissions-Inventar!",
   "start-button": "Emissions-Inventar beginnen",
@@ -152,5 +152,9 @@
   "total-co2e": "Gesamte CO2e",
   "map-rows-description-pdf": "Extrahierte Zeilen sind bereits auf Bestandsfelder abgebildet. Überprüfen Sie die untenstehenden Daten und fahren Sie mit dem letzten Schritt fort.",
   "upload-failed": "Upload fehlgeschlagen",
-  "failed-to-upload-file": "Datei konnte nicht hochgeladen werden"
+  "failed-to-upload-file": "Datei konnte nicht hochgeladen werden",
+  "citycatalyst-demo": "CityCatalyst Demo",
+  "inventory-goal-description-ghgi": "The GPC provides a robust framework for accounting and reporting city-wide greenhouse gas emissions.",
+  "gwp-description-ghgi": "Global warming potential (GWP) is a measure of how much heat a greenhouse gas traps in the atmosphere over a specific time period, relative to carbon dioxide.",
+  "gwp-description-ghgi-tip": "We recommend using AR6 (latest version) for your inventory calculations. If your city has previous inventories, use the same version as before."
 }

--- a/app/src/i18n/locales/de/onboarding.json
+++ b/app/src/i18n/locales/de/onboarding.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "onboarding-heading": "Beginnen Sie Ihr Emissions-Inventar!",
   "onboarding-details": "Wir müssen die Stadt und das Jahr bestätigen, für die Sie das Inventar erstellen möchten.<br/>Sie sind einen Schritt näher an Ihrem GPC Emissions-Inventar!",
   "start-button": "Emissions-Inventar beginnen",

--- a/app/src/i18n/locales/de/organization.json
+++ b/app/src/i18n/locales/de/organization.json
@@ -20,5 +20,6 @@
   "organization-load-failed": "Organisation konnte nicht geladen werden",
   "discover-cities-description": "Entdecken Sie die Städte, die in diesem Projekt vorgestellt werden. Klicken Sie auf jede Stadt, um ihr Dashboard und die verfügbaren Module anzuzeigen.",
   "country-name": "Name des Landes",
-  "city-name": "Name der Stadt"
+  "city-name": "Name der Stadt",
+  "citycatalyst-demo": "CityCatalyst Demo"
 }

--- a/app/src/i18n/locales/en/chat.json
+++ b/app/src/i18n/locales/en/chat.json
@@ -1,7 +1,7 @@
 {
   "ask-ai-expert": "Ask An AI Expert",
   "ai-expert": "AI Expert",
-  "ask-ai": "Ask AI",
+  "ask-ai": "Ask Clima AI",
   "ask-assistant": "Ask assistant anything...",
   "initial-message": "Hello! I'm Clima, your virtual assistant. I'm here to guide you through the process of accurately measuring and reporting your city's greenhouse gas emissions. How can I assist you today?",
   "regenerate": "Regenerate",

--- a/app/src/i18n/locales/en/dashboard.json
+++ b/app/src/i18n/locales/en/dashboard.json
@@ -303,5 +303,6 @@
   "no-history": "No version history entries found.",
   "subcategory": "Sub-category",
   "inventory-versions-restore-failed": "Failed to restore version",
-  "legend": "Legend"
+  "legend": "Legend",
+  "citycatalyst": "CityCatalyst"
 }

--- a/app/src/i18n/locales/en/navigation.json
+++ b/app/src/i18n/locales/en/navigation.json
@@ -4,6 +4,8 @@
   "cities": "cities",
   "settings": "Settings",
   "account-settings": "Account Settings",
-  "account-frozen-warning-text": "Your account is frozen. Please reach out to an admin or to <bold>{{ email }}</bold> to reactivate it"
-
+  "account-frozen-warning-text": "Your account is frozen. Please reach out to an admin or to <bold>{{ email }}</bold> to reactivate it",
+  "page-title-ghg-inventories": "GHG Inventories",
+  "page-title-hiap": "High Impact Action Plan",
+  "page-title-dashboard": "Dashboard"
 }

--- a/app/src/i18n/locales/en/onboarding.json
+++ b/app/src/i18n/locales/en/onboarding.json
@@ -150,5 +150,6 @@
   "loading-validation-results": "Loading validation results...",
   "no-field-mappings": "No field mappings available",
   "upload-failed": "Upload failed",
-  "failed-to-upload-file": "Failed to upload file"
+  "failed-to-upload-file": "Failed to upload file",
+  "citycatalyst-demo": "CityCatalyst Demo"
 }

--- a/app/src/i18n/locales/en/onboarding.json
+++ b/app/src/i18n/locales/en/onboarding.json
@@ -151,5 +151,8 @@
   "no-field-mappings": "No field mappings available",
   "upload-failed": "Upload failed",
   "failed-to-upload-file": "Failed to upload file",
-  "citycatalyst-demo": "CityCatalyst Demo"
+  "citycatalyst-demo": "CityCatalyst Demo",
+  "inventory-goal-description-ghgi": "The GPC provides a robust framework for accounting and reporting city-wide greenhouse gas emissions.",
+  "gwp-description-ghgi": "Global warming potential (GWP) is a measure of how much heat a greenhouse gas traps in the atmosphere over a specific time period, relative to carbon dioxide.",
+  "gwp-description-ghgi-tip": "We recommend using AR6 (latest version) for your inventory calculations. If your city has previous inventories, use the same version as before."
 }

--- a/app/src/i18n/locales/es/chat.json
+++ b/app/src/i18n/locales/es/chat.json
@@ -1,7 +1,7 @@
 {
   "ask-ai-expert": "Preguntale al Experto de IA",
   "ai-expert": "Experto IA",
-  "ask-ai": "Preguntale a la IA",
+  "ask-ai": "Preguntale a Clima AI",
   "ask-assistant": "Pregúntale lo que quieras al asistente…",
   "initial-message": "Hola! Soy Clima, tu asistente virtual. Estoy aquí para guiarte a través del proceso de medición y reporte de las emisiones GEI de tu ciudad. ¿Cómo te puedo ayudar hoy?",
   "regenerate": "Regenerar",

--- a/app/src/i18n/locales/es/dashboard.json
+++ b/app/src/i18n/locales/es/dashboard.json
@@ -300,5 +300,6 @@
   "status-early-access": "Acceso Anticipado",
   "status-beta": "Beta",
   "status-active": "Activo",
-  "legend": "Leyenda"
+  "legend": "Leyenda",
+  "citycatalyst": "CityCatalyst"
 }

--- a/app/src/i18n/locales/es/navigation.json
+++ b/app/src/i18n/locales/es/navigation.json
@@ -4,5 +4,8 @@
   "cities": "ciudades",
   "settings": "Ajustes",
   "account-settings": "Ajustes de la Cuenta",
-  "account-frozen-warning-text": "Su cuenta está congelada. Por favor, póngase en contacto con un administrador o con <bold>{{ email }}</bold> para reactivarla"
+  "account-frozen-warning-text": "Su cuenta está congelada. Por favor, póngase en contacto con un administrador o con <bold>{{ email }}</bold> para reactivarla",
+  "page-title-ghg-inventories": "GHG Inventories",
+  "page-title-hiap": "High Impact Action Plan",
+  "page-title-dashboard": "Dashboard"
 }

--- a/app/src/i18n/locales/es/onboarding.json
+++ b/app/src/i18n/locales/es/onboarding.json
@@ -153,5 +153,9 @@
   "total-co2e": "Total de CO2e",
   "map-rows-description-pdf": "Las filas extraídas ya están asignadas a los campos del inventario. Revisa los datos a continuación y continúa hasta el último paso.",
   "upload-failed": "Error al subir",
-  "failed-to-upload-file": "No se pudo subir el archivo"
+  "failed-to-upload-file": "No se pudo subir el archivo",
+  "citycatalyst-demo": "CityCatalyst Demo",
+  "inventory-goal-description-ghgi": "El GPC proporciona un marco sólido para contabilizar e informar las emisiones de gases de efecto invernadero a escala municipal.",
+  "gwp-description-ghgi": "El potencial de calentamiento global (GWP) mide cuánto calor atrapa un gas de efecto invernadero en la atmósfera durante un período específico, en relación con el dióxido de carbono.",
+  "gwp-description-ghgi-tip": "Recomendamos utilizar AR6 (versión más reciente) para los cálculos de su inventario. Si su ciudad tiene inventarios anteriores, utilice la misma versión que antes."
 }

--- a/app/src/i18n/locales/es/organization.json
+++ b/app/src/i18n/locales/es/organization.json
@@ -20,5 +20,6 @@
   "organization-load-failed": "No se puede cargar la organización",
   "discover-cities-description": "Descubre las ciudades destacadas en este proyecto. Haz clic en cada ciudad para ver su panel de control y los módulos disponibles.",
   "country-name": "Nombre del país",
-  "city-name": "Nombre de la ciudad"
+  "city-name": "Nombre de la ciudad",
+  "citycatalyst-demo": "CityCatalyst Demo"
 }

--- a/app/src/i18n/locales/fr/chat.json
+++ b/app/src/i18n/locales/fr/chat.json
@@ -1,7 +1,7 @@
 {
   "ask-ai-expert": "Demander à un expert en IA",
   "ai-expert": "Expert en IA",
-  "ask-ai": "Demander à l'IA",
+  "ask-ai": "Demander à Clima AI",
   "ask-assistant": "Posez n'importe quelle question à l'assistant...",
   "initial-message": "Bonjour! Je suis Clima, votre assistant virtuel. Je suis ici pour vous guider à travers le processus de mesure précise et de rapport de vos émissions de gaz à effet de serre de votre ville. Comment puis-je vous aider aujourd'hui?",
   "regenerate": "Régénérer",

--- a/app/src/i18n/locales/fr/dashboard.json
+++ b/app/src/i18n/locales/fr/dashboard.json
@@ -297,5 +297,6 @@
   "status-early-access": "Accès Anticipé",
   "status-beta": "Bêta",
   "status-active": "Actif",
-  "legend": "Légende"
+  "legend": "Légende",
+  "citycatalyst": "CityCatalyst"
 }

--- a/app/src/i18n/locales/fr/navigation.json
+++ b/app/src/i18n/locales/fr/navigation.json
@@ -4,5 +4,8 @@
   "cities": "villes",
   "settings": "Paramètres",
   "account-settings": "Paramètres du compte",
-  "account-frozen-warning-text": "Votre compte est gelé. Veuillez contacter un administrateur ou <bold>{{ email }}</bold> pour le réactiver"
+  "account-frozen-warning-text": "Votre compte est gelé. Veuillez contacter un administrateur ou <bold>{{ email }}</bold> pour le réactiver",
+  "page-title-ghg-inventories": "GHG Inventories",
+  "page-title-hiap": "High Impact Action Plan",
+  "page-title-dashboard": "Dashboard"
 }

--- a/app/src/i18n/locales/fr/onboarding.json
+++ b/app/src/i18n/locales/fr/onboarding.json
@@ -150,5 +150,9 @@
   "total-co2e": "Total CO2e",
   "map-rows-description-pdf": "Les rangées extraites sont déjà mappées aux champs d'inventaire. Examinez les données ci-dessous et passez à l'étape finale.",
   "upload-failed": "Échec du téléchargement",
-  "failed-to-upload-file": "Échec de l'envoi du fichier"
+  "failed-to-upload-file": "Échec de l'envoi du fichier",
+  "citycatalyst-demo": "CityCatalyst Demo",
+  "inventory-goal-description-ghgi": "Le GPC fournit un cadre solide pour la comptabilisation et la déclaration des émissions de gaz à effet de serre à l'échelle de la ville.",
+  "gwp-description-ghgi": "Le potentiel de réchauffement global (GWP) mesure la quantité de chaleur qu'un gaz à effet de serre piège dans l'atmosphère sur une période donnée, par rapport au dioxyde de carbone.",
+  "gwp-description-ghgi-tip": "Nous recommandons d'utiliser AR6 (version la plus récente) pour vos calculs d'inventaire. Si votre ville dispose d'inventaires antérieurs, utilisez la même version qu'auparavant."
 }

--- a/app/src/i18n/locales/fr/organization.json
+++ b/app/src/i18n/locales/fr/organization.json
@@ -20,5 +20,6 @@
   "organization-load-failed": "Impossible de charger l'organisation",
   "discover-cities-description": "Découvrez les villes présentées dans ce projet. Cliquez sur chaque ville pour voir son tableau de bord et les modules disponibles.",
   "country-name": "Nom du pays",
-  "city-name": "Nom de la ville"
+  "city-name": "Nom de la ville",
+  "citycatalyst-demo": "CityCatalyst Demo"
 }

--- a/app/src/i18n/locales/pt/chat.json
+++ b/app/src/i18n/locales/pt/chat.json
@@ -1,7 +1,7 @@
 {
   "ask-ai-expert": "Pergunte a um Especialista em IA",
   "ai-expert": "Especialista em IA",
-  "ask-ai": "Pergunte à IA",
+  "ask-ai": "Pergunte ao Clima AI",
   "ask-assistant": "Pergunte qualquer coisa ao assistente...",
   "initial-message": "Olá! Sou Clima, sua assistente virtual. Estou aqui para guiá-lo no processo de medir e reportar com precisão as emissões de gases de efeito estufa da sua cidade. Como posso ajudá-lo hoje?",
   "regenerate": "Regenerar",

--- a/app/src/i18n/locales/pt/dashboard.json
+++ b/app/src/i18n/locales/pt/dashboard.json
@@ -298,5 +298,6 @@
   "status-early-access": "Acesso Antecipado",
   "status-beta": "Beta",
   "status-active": "Ativo",
-  "legend": "Legenda"
+  "legend": "Legenda",
+  "citycatalyst": "CityCatalyst"
 }

--- a/app/src/i18n/locales/pt/navigation.json
+++ b/app/src/i18n/locales/pt/navigation.json
@@ -4,5 +4,8 @@
   "cities": "cidades",
   "settings": "Configurações",
   "account-settings": "Configurações da Conta",
-  "account-frozen-warning-text": "Sua conta está congelada. Por favor, entre em contato com um administrador ou com <bold>{{ email }}</bold> para reativá-la"
+  "account-frozen-warning-text": "Sua conta está congelada. Por favor, entre em contato com um administrador ou com <bold>{{ email }}</bold> para reativá-la",
+  "page-title-ghg-inventories": "GHG Inventories",
+  "page-title-hiap": "High Impact Action Plan",
+  "page-title-dashboard": "Dashboard"
 }

--- a/app/src/i18n/locales/pt/onboarding.json
+++ b/app/src/i18n/locales/pt/onboarding.json
@@ -152,5 +152,9 @@
   "total-co2e": "Total de CO2e",
   "map-rows-description-pdf": "As linhas extraídas já estão mapeadas para os campos do inventário. Reveja os dados abaixo e continue para a etapa final.",
   "upload-failed": "Falha no upload",
-  "failed-to-upload-file": "Falha ao enviar o arquivo"
+  "failed-to-upload-file": "Falha ao enviar o arquivo",
+  "citycatalyst-demo": "CityCatalyst Demo",
+  "inventory-goal-description-ghgi": "O GPC fornece um quadro robusto para contabilizar e reportar as emissões de gases de efeito estufa em toda a cidade.",
+  "gwp-description-ghgi": "O potencial de aquecimento global (GWP) mede a quantidade de calor que um gás de efeito estufa retém na atmosfera durante um período específico, em relação ao dióxido de carbono.",
+  "gwp-description-ghgi-tip": "Recomendamos usar o AR6 (versão mais recente) para os cálculos do seu inventário. Se a sua cidade tiver inventários anteriores, use a mesma versão de antes."
 }

--- a/app/src/i18n/locales/pt/organization.json
+++ b/app/src/i18n/locales/pt/organization.json
@@ -20,5 +20,6 @@
   "organization-load-failed": "Não foi possível carregar a organização",
   "discover-cities-description": "Descubra as cidades destacadas neste projeto. Clique em cada cidade para visualizar o seu painel e os módulos disponíveis.",
   "country-name": "Nome do país",
-  "city-name": "Nome da cidade"
+  "city-name": "Nome da cidade",
+  "citycatalyst-demo": "CityCatalyst Demo"
 }

--- a/app/src/lib/theme/recipes/app-theme.ts
+++ b/app/src/lib/theme/recipes/app-theme.ts
@@ -71,6 +71,9 @@ export const appTheme = createSystem(defaultConfig, {
               _violet_theme: "{colors.violet_theme.content.tertiary}",
             },
           },
+          "tertiary-light": {
+            value: "#4B4C63",
+          },
           secondary: {
             value: {
               base: "{colors.blue_theme.content.secondary}",


### PR DESCRIPTION
## Summary

Improves page-level polish across the app: browser tab titles now reflect the active module, the navbar shows the module name next to the CityCatalyst logo, the default project name is humanised, and several i18n gaps are filled.

## Changes

- **Tab titles**: each city module (GHGI, HIAP, Dashboard) now exports `metadata` so the browser tab shows `CityCatalyst - Module Name` via a root layout title template
- **Navbar module label**: `NavigationBar` derives the active module from the current pathname and renders `CityCatalyst | Module Name` next to the logo
- **Readable project name**: `cc_project_default` is translated to "CityCatalyst Demo" in both the dropdown items and the selected value display
- **Theme token**: added `content.tertiary-light` (#4B4C63) as a new semantic colour token
- **i18n**: added missing `citycatalyst-demo`, `inventory-goal-description-ghgi`, `gwp-description-ghgi`, and `gwp-description-ghgi-tip` keys to `de`, `es`, `fr`, and `pt` onboarding locale files; renamed `ask-ai` to "Ask Clima AI" across all locales; 

## Commits (7)

- fix: rename ask ai to ask clima ai
- add translations
- fix: updates inventory settings screen to explain gpc and gwp terminology
- fix: readable default project name
- feat: adds module name to navbar logo section
- feat: adds tab titles
- renames home to CityCatalyst ref: ON-5622
