### PR TITLE
ON-5686: Add city context API and prioritization tests

### DIFF
--- a/.github/workflows/hiap-meed-develop.yml
+++ b/.github/workflows/hiap-meed-develop.yml
@@ -125,7 +125,8 @@ jobs:
           kubectl set env deployment/hiap-meed-dev \
             API_HOST=0.0.0.0 \
             API_PORT=8000 \
-            LOG_LEVEL=INFO
+            LOG_LEVEL=INFO \
+            CCGLOBAL_API_BASE_URL=https://ccglobal.openearth.dev
 
           kubectl rollout restart deployment hiap-meed-dev -n default
           kubectl rollout status deployment/hiap-meed-dev -n default

--- a/.github/workflows/hiap-meed-tag.yml
+++ b/.github/workflows/hiap-meed-tag.yml
@@ -127,7 +127,8 @@ jobs:
           kubectl set env deployment/hiap-meed-prod \
             API_HOST=0.0.0.0 \
             API_PORT=8000 \
-            LOG_LEVEL=INFO
+            LOG_LEVEL=INFO \
+            CCGLOBAL_API_BASE_URL=https://api.citycatalyst.io/
 
           kubectl rollout restart deployment hiap-meed-prod -n default
           kubectl rollout status deployment/hiap-meed-prod -n default

--- a/.github/workflows/hiap-meed-test.yml
+++ b/.github/workflows/hiap-meed-test.yml
@@ -111,7 +111,8 @@ jobs:
           kubectl set env deployment/hiap-meed-test \
             API_HOST=0.0.0.0 \
             API_PORT=8000 \
-            LOG_LEVEL=INFO
+            LOG_LEVEL=INFO \
+            CCGLOBAL_API_BASE_URL=https://api.citycatalyst.io/
 
           kubectl rollout restart deployment hiap-meed-test -n default
           kubectl rollout status deployment/hiap-meed-test -n default

--- a/hiap-meed/.env.example
+++ b/hiap-meed/.env.example
@@ -16,6 +16,9 @@ UPSTREAM_HTTP_TIMEOUT_SECONDS=30
 UPSTREAM_HTTP_MAX_RETRIES=2
 UPSTREAM_HTTP_RETRY_BACKOFF_SECONDS=0.5
 
+# shared Global API host used by upstream API-backed clients
+CCGLOBAL_API_BASE_URL=https://ccglobal.openearth.dev
+
 # city data source: mock | api
 HIAP_MEED_CITY_DATA_SOURCE=api
 

--- a/hiap-meed/.env.example
+++ b/hiap-meed/.env.example
@@ -11,8 +11,13 @@ LOG_FILE_ENABLED=true
 # output folder for file logs and request artifacts
 LOG_DIR=logs
 
+# shared upstream HTTP client runtime config
+UPSTREAM_HTTP_TIMEOUT_SECONDS=30
+UPSTREAM_HTTP_MAX_RETRIES=2
+UPSTREAM_HTTP_RETRY_BACKOFF_SECONDS=0.5
+
 # city data source: mock | api
-HIAP_MEED_CITY_DATA_SOURCE=mock
+HIAP_MEED_CITY_DATA_SOURCE=api
 
 # legal hard-filter data source: mock | api
 HIAP_MEED_LEGAL_DATA_SOURCE=mock

--- a/hiap-meed/README.md
+++ b/hiap-meed/README.md
@@ -124,6 +124,14 @@ Design note:
 
 - For the upcoming frontend contract, single-city and multi-city payloads both
   use `cityDataList`; single-city is represented as a list with one item.
+- Boundary validation note: incoming frontend request contracts and upstream/mock
+  response contracts are strict. Unexpected fields and wrong casing are rejected
+  at validation time instead of being silently ignored.
+- Future action API note: the current strict `ActionsApiResponse` contract still
+  matches the checked-in `actions_api_mock.json`, including optional fields such
+  as `biome`. When `GET /api/v1/action-pathways` is integrated, this action
+  contract will need a dedicated update to match that new payload, including
+  removing `biome` and aligning to the new field names and nested shapes.
 - Current implementation note: exclusion preview and prioritization are separate flows. Exclusion preview resolves raw exclusion preferences into proposals for review, while prioritization consumes confirmed `excludedActionIds`. Prioritization uses a dedicated orchestrator for run-level artifact writing, while exclusion preview currently writes its request artifacts directly from the API layer.
 
 ### 4. Call the prioritization endpoint
@@ -447,7 +455,7 @@ Common validation errors:
 - Missing `requestData.cityDataList` or empty `cityDataList` -> HTTP `422`.
 - Missing `locode` or empty `locode` in a city entry -> HTTP `422`.
 
-Note: city, action, legal, and policy-signal clients resolve to `mock` (file-backed) or `api`. The city client now uses a synchronous upstream HTTP integration for `GET /api/v0/city_attributes/{locode}` when `HIAP_MEED_CITY_DATA_SOURCE=api`, which is the default. That shared upstream HTTP path now includes simple retries for transient failures, explicit timeout config, and route-level `404/502/503/504` error mapping. The action, legal, and policy-signal API clients are still placeholders, so their default source remains `mock`. FastAPI runs synchronous routes in a threadpool, so the event loop stays free to handle concurrent requests.
+Note: city, action, legal, and policy-signal clients resolve to `mock` (file-backed) or `api`. The city client now uses a synchronous upstream HTTP integration for `GET /api/v0/city_attributes/{locode}` when `HIAP_MEED_CITY_DATA_SOURCE=api`, which is the default. That shared upstream HTTP path now includes simple retries for transient failures, explicit timeout config, and route-level `404/502/503/504` error mapping. The city upstream response contract is strict: unknown or misnamed fields are rejected instead of being silently dropped. The action, legal, and policy-signal API clients are still placeholders, so their default source remains `mock`. FastAPI runs synchronous routes in a threadpool, so the event loop stays free to handle concurrent requests.
 
 ### 5. Logging and artifacts
 

--- a/hiap-meed/README.md
+++ b/hiap-meed/README.md
@@ -127,9 +127,10 @@ Design note:
 - For the upcoming frontend contract, single-city and multi-city payloads both
   use `cityDataList`; single-city is represented as a list with one item.
 - Boundary validation note: incoming frontend request contracts and upstream/mock
-  response contracts are strict. Unexpected fields and wrong casing are rejected
-  at validation time instead of being silently ignored.
-- Future action API note: the current strict `ActionsApiResponse` contract still
+  response contracts are handled differently by design. Frontend request DTOs
+  reject unexpected fields, while upstream response DTOs ignore unexpected extra
+  fields and still validate the fields we actually use.
+- Future action API note: the current `ActionsApiResponse` contract still
   matches the checked-in `actions_api_mock.json`, including optional fields such
   as `biome`. When `GET /api/v1/action-pathways` is integrated, this action
   contract will need a dedicated update to match that new payload, including
@@ -457,7 +458,7 @@ Common validation errors:
 - Missing `requestData.cityDataList` or empty `cityDataList` -> HTTP `422`.
 - Missing `locode` or empty `locode` in a city entry -> HTTP `422`.
 
-Note: city, action, legal, and policy-signal clients resolve to `mock` (file-backed) or `api`. The city client now uses a synchronous upstream HTTP integration for `GET /api/v0/city_attributes/{locode}` when `HIAP_MEED_CITY_DATA_SOURCE=api`, which is the default. The shared `CCGLOBAL_API_BASE_URL` defaults to `https://ccglobal.openearth.dev` for local/dev use; the hiap-meed GitHub workflows override it per environment, with dev using `https://ccglobal.openearth.dev` and test/prod using `https://api.citycatalyst.io/`. If that host mapping changes, update both the runtime config and the hiap-meed deploy workflows together. The shared upstream HTTP path also includes simple retries for transient failures, explicit timeout config, and route-level `404/502/503/504` error mapping. The city upstream response contract is strict: unknown or misnamed fields are rejected instead of being silently dropped. The action, legal, and policy-signal API clients are still placeholders, so their default source remains `mock`. FastAPI runs synchronous routes in a threadpool, so the event loop stays free to handle concurrent requests.
+Note: city, action, legal, and policy-signal clients resolve to `mock` (file-backed) or `api`. The city client now uses a synchronous upstream HTTP integration for `GET /api/v0/city_attributes/{locode}` when `HIAP_MEED_CITY_DATA_SOURCE=api`, which is the default. The shared `CCGLOBAL_API_BASE_URL` defaults to `https://ccglobal.openearth.dev` for local/dev use; the hiap-meed GitHub workflows override it per environment, with dev using `https://ccglobal.openearth.dev` and test/prod using `https://api.citycatalyst.io/`. If that host mapping changes, update both the runtime config and the hiap-meed deploy workflows together. The shared upstream HTTP path also includes simple retries for transient failures, explicit timeout config, and route-level `404/502/503/504` error mapping. Upstream response DTOs are intentionally additive-tolerant right now: they ignore unexpected extra fields while still validating the fields the pipeline depends on. The action, legal, and policy-signal API clients are still placeholders, so their default source remains `mock`. FastAPI runs synchronous routes in a threadpool, so the event loop stays free to handle concurrent requests.
 
 ### 5. Logging and artifacts
 

--- a/hiap-meed/README.md
+++ b/hiap-meed/README.md
@@ -37,6 +37,7 @@ LOG_LEVEL=INFO
 LOG_DIR=logs
 ARTIFACT_LOG_JSONL=true
 HIAP_MEED_CITY_DATA_SOURCE=api
+CCGLOBAL_API_BASE_URL=https://ccglobal.openearth.dev
 UPSTREAM_HTTP_TIMEOUT_SECONDS=30
 UPSTREAM_HTTP_MAX_RETRIES=2
 UPSTREAM_HTTP_RETRY_BACKOFF_SECONDS=0.5
@@ -64,6 +65,7 @@ Variables:
 - `LOG_DIR`: output folder for file logs and request artifacts
 - `ARTIFACT_LOG_JSONL`: if `true`, writes per-request artifact files
 - `HIAP_MEED_CITY_DATA_SOURCE`: city input source (`mock` or `api`)
+- `CCGLOBAL_API_BASE_URL`: shared Global API base host for upstream API-backed clients (default `https://ccglobal.openearth.dev` for local/dev)
 - `UPSTREAM_HTTP_TIMEOUT_SECONDS`: shared timeout in seconds for upstream HTTP API calls (default `30`)
 - `UPSTREAM_HTTP_MAX_RETRIES`: shared retry count for transient upstream HTTP failures (default `2`)
 - `UPSTREAM_HTTP_RETRY_BACKOFF_SECONDS`: fixed sleep between upstream HTTP retry attempts (default `0.5`)
@@ -455,7 +457,7 @@ Common validation errors:
 - Missing `requestData.cityDataList` or empty `cityDataList` -> HTTP `422`.
 - Missing `locode` or empty `locode` in a city entry -> HTTP `422`.
 
-Note: city, action, legal, and policy-signal clients resolve to `mock` (file-backed) or `api`. The city client now uses a synchronous upstream HTTP integration for `GET /api/v0/city_attributes/{locode}` when `HIAP_MEED_CITY_DATA_SOURCE=api`, which is the default. That shared upstream HTTP path now includes simple retries for transient failures, explicit timeout config, and route-level `404/502/503/504` error mapping. The city upstream response contract is strict: unknown or misnamed fields are rejected instead of being silently dropped. The action, legal, and policy-signal API clients are still placeholders, so their default source remains `mock`. FastAPI runs synchronous routes in a threadpool, so the event loop stays free to handle concurrent requests.
+Note: city, action, legal, and policy-signal clients resolve to `mock` (file-backed) or `api`. The city client now uses a synchronous upstream HTTP integration for `GET /api/v0/city_attributes/{locode}` when `HIAP_MEED_CITY_DATA_SOURCE=api`, which is the default. The shared `CCGLOBAL_API_BASE_URL` defaults to `https://ccglobal.openearth.dev` for local/dev use; the hiap-meed GitHub workflows override it per environment, with dev using `https://ccglobal.openearth.dev` and test/prod using `https://api.citycatalyst.io/`. If that host mapping changes, update both the runtime config and the hiap-meed deploy workflows together. The shared upstream HTTP path also includes simple retries for transient failures, explicit timeout config, and route-level `404/502/503/504` error mapping. The city upstream response contract is strict: unknown or misnamed fields are rejected instead of being silently dropped. The action, legal, and policy-signal API clients are still placeholders, so their default source remains `mock`. FastAPI runs synchronous routes in a threadpool, so the event loop stays free to handle concurrent requests.
 
 ### 5. Logging and artifacts
 

--- a/hiap-meed/README.md
+++ b/hiap-meed/README.md
@@ -36,7 +36,10 @@ API_PORT=8000
 LOG_LEVEL=INFO
 LOG_DIR=logs
 ARTIFACT_LOG_JSONL=true
-HIAP_MEED_CITY_DATA_SOURCE=mock
+HIAP_MEED_CITY_DATA_SOURCE=api
+UPSTREAM_HTTP_TIMEOUT_SECONDS=30
+UPSTREAM_HTTP_MAX_RETRIES=2
+UPSTREAM_HTTP_RETRY_BACKOFF_SECONDS=0.5
 HIAP_MEED_LEGAL_DATA_SOURCE=mock
 HIAP_MEED_ACTION_DATA_SOURCE=mock
 HIAP_MEED_POLICY_SIGNALS_DATA_SOURCE=mock
@@ -61,6 +64,9 @@ Variables:
 - `LOG_DIR`: output folder for file logs and request artifacts
 - `ARTIFACT_LOG_JSONL`: if `true`, writes per-request artifact files
 - `HIAP_MEED_CITY_DATA_SOURCE`: city input source (`mock` or `api`)
+- `UPSTREAM_HTTP_TIMEOUT_SECONDS`: shared timeout in seconds for upstream HTTP API calls (default `30`)
+- `UPSTREAM_HTTP_MAX_RETRIES`: shared retry count for transient upstream HTTP failures (default `2`)
+- `UPSTREAM_HTTP_RETRY_BACKOFF_SECONDS`: fixed sleep between upstream HTTP retry attempts (default `0.5`)
 - `HIAP_MEED_LEGAL_DATA_SOURCE`: legal input source (`mock` or `api`)
 - `HIAP_MEED_ACTION_DATA_SOURCE`: action catalog source (`mock` or `api`)
 - `HIAP_MEED_POLICY_SIGNALS_DATA_SOURCE`: policy-signal input source (`mock` or `api`)
@@ -100,7 +106,7 @@ Verify the service:
 - Explanation translation endpoint: `POST /v1/explanations/translate`
 - Exclusion preview endpoint: `POST /v1/prioritize/exclusions/preview`
 
-### External API contracts (modeled, integration pending)
+### External API contracts
 
 The repository now includes explicit Pydantic contracts for upcoming request and
 upstream response integrations in `app/modules/prioritizer/models.py`.
@@ -441,7 +447,7 @@ Common validation errors:
 - Missing `requestData.cityDataList` or empty `cityDataList` -> HTTP `422`.
 - Missing `locode` or empty `locode` in a city entry -> HTTP `422`.
 
-Note: city, action, legal, and policy-signal clients now resolve to `mock` (file-backed) or `api` (placeholder until real upstream wiring is added). Default source for all four is `mock`, so local and Docker runs use checked-in mock payloads by default. Real upstream HTTP wiring is still pending; when wired, clients should use a synchronous HTTP client (e.g. `httpx.Client`). FastAPI runs synchronous routes in a threadpool, so the event loop stays free to handle concurrent requests.
+Note: city, action, legal, and policy-signal clients resolve to `mock` (file-backed) or `api`. The city client now uses a synchronous upstream HTTP integration for `GET /api/v0/city_attributes/{locode}` when `HIAP_MEED_CITY_DATA_SOURCE=api`, which is the default. That shared upstream HTTP path now includes simple retries for transient failures, explicit timeout config, and route-level `404/502/503/504` error mapping. The action, legal, and policy-signal API clients are still placeholders, so their default source remains `mock`. FastAPI runs synchronous routes in a threadpool, so the event loop stays free to handle concurrent requests.
 
 ### 5. Logging and artifacts
 
@@ -453,6 +459,8 @@ The service writes:
   - `LOG_DIR/requests/prioritization/{UTC_TIMESTAMP}Z_{internal_request_id}/`
   - `LOG_DIR/requests/exclusion_preview/{UTC_TIMESTAMP}Z_{internal_request_id}/`
   when `ARTIFACT_LOG_JSONL=true`
+
+For city fetches, the `fetch_city` step artifact now also records the upstream city endpoint details used for that request, including the resolved URL, the endpoint template, the requested locode, the HTTP status code, and upstream `meta.generated_at_utc` when present.
 
 To disable `app.log` file writes (for example, during tests), set `LOG_FILE_ENABLED=false`.
 

--- a/hiap-meed/app/main.py
+++ b/hiap-meed/app/main.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
         os.getenv("LOG_LEVEL", "INFO"),
         os.getenv("LOG_DIR", "logs"),
         os.getenv("ARTIFACT_LOG_JSONL", "true"),
-        os.getenv("HIAP_MEED_CITY_DATA_SOURCE", "mock"),
+        os.getenv("HIAP_MEED_CITY_DATA_SOURCE", "api"),
         os.getenv("HIAP_MEED_ACTION_DATA_SOURCE", "mock"),
         os.getenv("HIAP_MEED_LEGAL_DATA_SOURCE", "mock"),
     )

--- a/hiap-meed/app/modules/prioritizer/api.py
+++ b/hiap-meed/app/modules/prioritizer/api.py
@@ -44,6 +44,7 @@ from app.services.data_clients import (
     get_legal_data_api_client,
     get_policy_signals_data_api_client,
 )
+from app.services.http_client import UpstreamApiError
 from app.utils.artifacts import ArtifactWriter
 
 
@@ -55,6 +56,22 @@ router = APIRouter(tags=["prioritization"])
 def _error_payload(request_id: str, message: str) -> dict[str, str]:
     """Build a consistent JSON error body including the request ID."""
     return {"request_id": request_id, "error": message}
+
+
+def _upstream_error_payload(
+    request_id: str,
+    error: UpstreamApiError,
+) -> dict[str, str | int]:
+    """Build a consistent JSON error body for upstream dependency failures."""
+    payload: dict[str, str | int] = {
+        "request_id": request_id,
+        "error": error.message,
+    }
+    if error.upstream_status_code is not None:
+        payload["upstream_status_code"] = error.upstream_status_code
+    if error.url is not None:
+        payload["upstream_url"] = error.url
+    return payload
 
 
 def _extract_city_emissions_context(city_input: FrontendCityInput) -> CityEmissionsContext:
@@ -256,6 +273,17 @@ def preview_exclusions(
             status_code=422,
             detail=_error_payload(request_trace_id, str(error)),
         ) from error
+    except UpstreamApiError as error:
+        logger.warning(
+            "Exclusion preview upstream dependency failed request_id=%s status_code=%s error=%s",
+            request_trace_id,
+            error.status_code,
+            error,
+        )
+        raise HTTPException(
+            status_code=error.status_code,
+            detail=_upstream_error_payload(request_trace_id, error),
+        ) from error
     except Exception as error:
         logger.exception("Exclusion preview failed request_id=%s", request_trace_id)
         raise HTTPException(
@@ -365,6 +393,17 @@ def prioritize(
         raise HTTPException(
             status_code=422,
             detail=_error_payload(request_trace_id, str(error)),
+        ) from error
+    except UpstreamApiError as error:
+        logger.warning(
+            "Prioritization upstream dependency failed request_id=%s status_code=%s error=%s",
+            request_trace_id,
+            error.status_code,
+            error,
+        )
+        raise HTTPException(
+            status_code=error.status_code,
+            detail=_upstream_error_payload(request_trace_id, error),
         ) from error
     except Exception as error:
         logger.exception("Prioritization failed request_id=%s", request_trace_id)

--- a/hiap-meed/app/modules/prioritizer/internal_models.py
+++ b/hiap-meed/app/modules/prioritizer/internal_models.py
@@ -16,19 +16,18 @@ class CityData(BaseModel):
     upstream response DTOs.
     """
 
-    comuna_name: str
+    city_name: str
     locode: str = Field(min_length=1)
     country_code: str | None = None
     region_name: str
-    comuna_code: str
     region_code: str
     population_size: int | None = None
     population_density: float | None = None
-    area: float | None = None
-    comuna: str | None = None
+    area_km2: float | None = None
     city_context: list[dict[str, Any]] = Field(default_factory=list)
     as_of: datetime | None = None
     source: str | None = None
+    source_metadata: dict[str, Any] = Field(default_factory=dict)
     raw: dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="before")

--- a/hiap-meed/app/modules/prioritizer/models.py
+++ b/hiap-meed/app/modules/prioritizer/models.py
@@ -547,7 +547,7 @@ class UpstreamApiContext(BaseModel):
 class UpstreamMeta(BaseModel):
     """Common metadata envelope returned by upstream APIs."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     generated_at_utc: str
     api_context: UpstreamApiContext
@@ -559,7 +559,7 @@ class UpstreamMeta(BaseModel):
 class UpstreamDatasource(BaseModel):
     """One datasource entry attached to upstream city metadata."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     datasource_name: str
     publisher_name: str | None = None
@@ -624,7 +624,7 @@ class CityApiItem(BaseModel):
 class ActionImpactEntry(BaseModel):
     """Single impact entry (emissions or co-benefit category) for one action."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     sector_number: str
     subsector_number: list[int] = Field(min_length=1)
@@ -651,7 +651,7 @@ class ActionImpactEntry(BaseModel):
 class ActionCoBenefitEntry(BaseModel):
     """Single co-benefit entry for one action."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     impact_relationship: str | None = None
     impact_text: str | None = None
@@ -662,7 +662,7 @@ class ActionCoBenefitEntry(BaseModel):
 class ActionSocioeconomicIndicatorRule(BaseModel):
     """One socioeconomic fit rule row attached to an action."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     indicator_key: str
     direction: str
@@ -690,7 +690,7 @@ class ActionSocioeconomicIndicatorRule(BaseModel):
 class ActionApiItem(BaseModel):
     """Action item shape returned by upstream `GET /v1/actions`."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     actionId: str
     actionName: str
@@ -758,7 +758,7 @@ class CitiesApiResponse(BaseModel):
 class ActionsApiResponse(BaseModel):
     """Response model for `GET /v1/actions`."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     meta: UpstreamMeta
     actions: list[ActionApiItem] = Field(default_factory=list)
@@ -767,7 +767,7 @@ class ActionsApiResponse(BaseModel):
 class PolicySignal(BaseModel):
     """Single policy signal evidence item for one action."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     location_scope: str
     location_name: str
@@ -781,7 +781,7 @@ class PolicySignal(BaseModel):
 class PolicySignalByAction(BaseModel):
     """Policy signal collection grouped by action ID."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     action_id: str
     policy_signals: list[PolicySignal] = Field(default_factory=list)
@@ -791,7 +791,7 @@ class PolicySignalByAction(BaseModel):
 class ActionsPolicySignalsApiResponse(BaseModel):
     """Response model for city-scoped policy alignment endpoint."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     meta: UpstreamMeta
     policy_signals: list[PolicySignalByAction] = Field(default_factory=list)
@@ -800,7 +800,7 @@ class ActionsPolicySignalsApiResponse(BaseModel):
 class LegalRequirement(BaseModel):
     """Single legal requirement alignment check for one action."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     signal_code: str
     signal_name: str
@@ -818,7 +818,7 @@ class LegalRequirement(BaseModel):
 class LegalRequirementsByAction(BaseModel):
     """Legal requirements grouped by action ID."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     action_id: str
     requirements: list[LegalRequirement] = Field(default_factory=list)
@@ -827,7 +827,7 @@ class LegalRequirementsByAction(BaseModel):
 class ActionsLegalApiMeta(UpstreamMeta):
     """Metadata for actions/legal response including test descriptors."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     test_cases: dict[str, str] = Field(default_factory=dict)
     strength_scale: list[str] = Field(default_factory=list)
@@ -836,7 +836,7 @@ class ActionsLegalApiMeta(UpstreamMeta):
 class ActionsLegalApiResponse(BaseModel):
     """Response model for city-scoped legal alignment endpoint."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     meta: ActionsLegalApiMeta
     legal_requirements: list[LegalRequirementsByAction] = Field(default_factory=list)

--- a/hiap-meed/app/modules/prioritizer/models.py
+++ b/hiap-meed/app/modules/prioritizer/models.py
@@ -537,7 +537,7 @@ class ExclusionPreviewApiResponse(BaseModel):
 class UpstreamApiContext(BaseModel):
     """Common API context metadata returned by upstream APIs."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     endpoint: str
     locode: str | None = None
@@ -575,7 +575,7 @@ class UpstreamDatasource(BaseModel):
 class CityApiMeta(BaseModel):
     """Exact metadata envelope returned by the upstream city attributes API."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     generated_at_utc: str
     api_context: UpstreamApiContext
@@ -585,7 +585,7 @@ class CityApiMeta(BaseModel):
 class CityIndicator(BaseModel):
     """Single city indicator object used in city API payload."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     attribute_value: float | str | None = None
     attribute_units: str | None = None
@@ -597,15 +597,17 @@ class CityIndicator(BaseModel):
 class CityApiItem(BaseModel):
     """City item shape returned by upstream `GET /api/v0/city_attributes/{locode}`."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     city_name: str
     locode: str
     country_code: str | None = None
     region_name: str
     region_code: str
-    population_size: int | None = None
-    population_density: float | None = None
+    population_size: int | None = Field(default=None, validation_alias="populationSize")
+    population_density: float | None = Field(
+        default=None, validation_alias="populationDensity"
+    )
     area_km2: float | None = None
     population: CityIndicator | None = None
     unemployment_rate: CityIndicator | None = None
@@ -738,7 +740,7 @@ class ActionApiItem(BaseModel):
 class CityApiResponse(BaseModel):
     """Response model for `GET /api/v0/city_attributes/{locode}`."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     meta: CityApiMeta
     city: CityApiItem
@@ -747,7 +749,7 @@ class CityApiResponse(BaseModel):
 class CitiesApiResponse(BaseModel):
     """Response model for city list endpoints."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     meta: CityApiMeta
     cities: list[CityApiItem] = Field(default_factory=list)

--- a/hiap-meed/app/modules/prioritizer/models.py
+++ b/hiap-meed/app/modules/prioritizer/models.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.modules.prioritizer.config import resolve_impact_text_multiplier
 from app.modules.prioritizer.utils.co_benefit_taxonomy import ALLOWED_CO_BENEFIT_KEYS
@@ -49,6 +49,8 @@ def _validate_allowed_string_list(
 class FrontendApiContext(BaseModel):
     """Caller request API context metadata."""
 
+    model_config = ConfigDict(extra="forbid")
+
     endpoint: str = Field(description="Caller route or endpoint that originated the request.")
     locodes: list[str] = Field(
         default_factory=list,
@@ -58,6 +60,8 @@ class FrontendApiContext(BaseModel):
 
 class FrontendRequestMeta(BaseModel):
     """Metadata envelope for prioritizer requests sent by the current caller."""
+
+    model_config = ConfigDict(extra="forbid")
 
     requestId: str = Field(description="Caller-generated request identifier.")
     generatedAtUtc: str = Field(
@@ -78,6 +82,8 @@ class FrontendRequestMeta(BaseModel):
 class GpcActivity(BaseModel):
     """Single activity record for one GPC key."""
 
+    model_config = ConfigDict(extra="forbid")
+
     activityType: str | None = None
     totalEmissions: float | None = None
     totalEmissionsUnit: str | None = None
@@ -90,12 +96,16 @@ class GpcActivity(BaseModel):
 class GpcDataEntry(BaseModel):
     """One GPC reference key payload containing optional activities."""
 
+    model_config = ConfigDict(extra="forbid")
+
     notationKey: str | None = None
     activities: list[GpcActivity] = Field(default_factory=list)
 
 
 class FrontendCityEmissionsData(BaseModel):
     """City emissions payload provided by the caller request."""
+
+    model_config = ConfigDict(extra="forbid")
 
     inventoryYear: int | None = Field(
         default=None,
@@ -134,6 +144,8 @@ class FrontendCityEmissionsData(BaseModel):
 
 class FrontendCityInput(BaseModel):
     """Single city payload within frontend prioritizer request."""
+
+    model_config = ConfigDict(extra="forbid")
 
     locode: str = Field(min_length=1, description="UN/LOCODE for the city to rank actions for.")
     countryCode: str = Field(
@@ -236,6 +248,8 @@ class FrontendCityInput(BaseModel):
 class PrioritizerRequestData(BaseModel):
     """RequestData section of the caller prioritizer request payload."""
 
+    model_config = ConfigDict(extra="forbid")
+
     requestedLanguages: list[str] = Field(
         default_factory=lambda: ["en"],
         description="Languages to include in the explanation output. English is always canonical.",
@@ -274,6 +288,8 @@ class PrioritizerRequestData(BaseModel):
 class PrioritizerApiRequest(BaseModel):
     """Caller -> hiap-meed request envelope for single or multi-city prioritization."""
 
+    model_config = ConfigDict(extra="forbid")
+
     meta: FrontendRequestMeta = Field(description="Caller request metadata envelope.")
     requestData: PrioritizerRequestData = Field(
         description="Prioritization request payload."
@@ -297,6 +313,8 @@ class PrioritizerApiRequest(BaseModel):
 class ExplanationTranslationActionInput(BaseModel):
     """One canonical explanation row provided for stateless translation."""
 
+    model_config = ConfigDict(extra="forbid")
+
     actionId: str = Field(
         min_length=1,
         description="Action ID whose canonical explanation should be translated.",
@@ -309,6 +327,8 @@ class ExplanationTranslationActionInput(BaseModel):
 
 class ExplanationTranslationRequestData(BaseModel):
     """RequestData section for explanation translation requests."""
+
+    model_config = ConfigDict(extra="forbid")
 
     sourceLanguage: str = Field(
         default="en",
@@ -375,6 +395,8 @@ class ExplanationTranslationRequestData(BaseModel):
 class ExplanationTranslationApiRequest(BaseModel):
     """Caller -> hiap-meed request envelope for stateless explanation translation."""
 
+    model_config = ConfigDict(extra="forbid")
+
     meta: FrontendRequestMeta = Field(description="Caller request metadata envelope.")
     requestData: ExplanationTranslationRequestData = Field(
         description="Explanation translation request payload."
@@ -400,6 +422,8 @@ class ExplanationTranslationApiRequest(BaseModel):
 
 class ExclusionPreviewCityInput(BaseModel):
     """Single city payload for exclusion-preference preview."""
+
+    model_config = ConfigDict(extra="forbid")
 
     locode: str = Field(min_length=1)
     excludedSectorTags: list[str] = Field(default_factory=list)
@@ -430,11 +454,15 @@ class ExclusionPreviewCityInput(BaseModel):
 class ExclusionPreviewRequestData(BaseModel):
     """RequestData section for exclusion preview requests."""
 
+    model_config = ConfigDict(extra="forbid")
+
     cityDataList: list[ExclusionPreviewCityInput] = Field(min_length=1)
 
 
 class ExclusionPreviewApiRequest(BaseModel):
     """Caller -> hiap-meed request envelope for exclusion preview."""
+
+    model_config = ConfigDict(extra="forbid")
 
     meta: FrontendRequestMeta
     requestData: ExclusionPreviewRequestData
@@ -509,6 +537,8 @@ class ExclusionPreviewApiResponse(BaseModel):
 class UpstreamApiContext(BaseModel):
     """Common API context metadata returned by upstream APIs."""
 
+    model_config = ConfigDict(extra="forbid")
+
     endpoint: str
     locode: str | None = None
     version_label: str | None = None
@@ -516,6 +546,8 @@ class UpstreamApiContext(BaseModel):
 
 class UpstreamMeta(BaseModel):
     """Common metadata envelope returned by upstream APIs."""
+
+    model_config = ConfigDict(extra="forbid")
 
     generated_at_utc: str
     api_context: UpstreamApiContext
@@ -526,6 +558,8 @@ class UpstreamMeta(BaseModel):
 
 class UpstreamDatasource(BaseModel):
     """One datasource entry attached to upstream city metadata."""
+
+    model_config = ConfigDict(extra="forbid")
 
     datasource_name: str
     publisher_name: str | None = None
@@ -541,6 +575,8 @@ class UpstreamDatasource(BaseModel):
 class CityApiMeta(BaseModel):
     """Exact metadata envelope returned by the upstream city attributes API."""
 
+    model_config = ConfigDict(extra="forbid")
+
     generated_at_utc: str
     api_context: UpstreamApiContext
     datasources: list[UpstreamDatasource] = Field(default_factory=list)
@@ -548,6 +584,8 @@ class CityApiMeta(BaseModel):
 
 class CityIndicator(BaseModel):
     """Single city indicator object used in city API payload."""
+
+    model_config = ConfigDict(extra="forbid")
 
     attribute_value: float | str | None = None
     attribute_units: str | None = None
@@ -559,6 +597,8 @@ class CityIndicator(BaseModel):
 class CityApiItem(BaseModel):
     """City item shape returned by upstream `GET /api/v0/city_attributes/{locode}`."""
 
+    model_config = ConfigDict(extra="forbid")
+
     city_name: str
     locode: str
     country_code: str | None = None
@@ -567,6 +607,7 @@ class CityApiItem(BaseModel):
     population_size: int | None = None
     population_density: float | None = None
     area_km2: float | None = None
+    population: CityIndicator | None = None
     unemployment_rate: CityIndicator | None = None
     renter_share: CityIndicator | None = None
     employment_in_transport_and_logistics: CityIndicator | None = None
@@ -580,6 +621,8 @@ class CityApiItem(BaseModel):
 
 class ActionImpactEntry(BaseModel):
     """Single impact entry (emissions or co-benefit category) for one action."""
+
+    model_config = ConfigDict(extra="forbid")
 
     sector_number: str
     subsector_number: list[int] = Field(min_length=1)
@@ -606,6 +649,8 @@ class ActionImpactEntry(BaseModel):
 class ActionCoBenefitEntry(BaseModel):
     """Single co-benefit entry for one action."""
 
+    model_config = ConfigDict(extra="forbid")
+
     impact_relationship: str | None = None
     impact_text: str | None = None
     impact_numeric: int | None = None
@@ -614,6 +659,8 @@ class ActionCoBenefitEntry(BaseModel):
 
 class ActionSocioeconomicIndicatorRule(BaseModel):
     """One socioeconomic fit rule row attached to an action."""
+
+    model_config = ConfigDict(extra="forbid")
 
     indicator_key: str
     direction: str
@@ -641,8 +688,11 @@ class ActionSocioeconomicIndicatorRule(BaseModel):
 class ActionApiItem(BaseModel):
     """Action item shape returned by upstream `GET /v1/actions`."""
 
+    model_config = ConfigDict(extra="forbid")
+
     actionId: str
     actionName: str
+    biome: str | None = None
     activity_type_description: str | None = None
     description: str | None = None
     actionCategory: str | None = None
@@ -688,12 +738,16 @@ class ActionApiItem(BaseModel):
 class CityApiResponse(BaseModel):
     """Response model for `GET /api/v0/city_attributes/{locode}`."""
 
+    model_config = ConfigDict(extra="forbid")
+
     meta: CityApiMeta
     city: CityApiItem
 
 
 class CitiesApiResponse(BaseModel):
     """Response model for city list endpoints."""
+
+    model_config = ConfigDict(extra="forbid")
 
     meta: CityApiMeta
     cities: list[CityApiItem] = Field(default_factory=list)
@@ -702,12 +756,16 @@ class CitiesApiResponse(BaseModel):
 class ActionsApiResponse(BaseModel):
     """Response model for `GET /v1/actions`."""
 
+    model_config = ConfigDict(extra="forbid")
+
     meta: UpstreamMeta
     actions: list[ActionApiItem] = Field(default_factory=list)
 
 
 class PolicySignal(BaseModel):
     """Single policy signal evidence item for one action."""
+
+    model_config = ConfigDict(extra="forbid")
 
     location_scope: str
     location_name: str
@@ -721,6 +779,8 @@ class PolicySignal(BaseModel):
 class PolicySignalByAction(BaseModel):
     """Policy signal collection grouped by action ID."""
 
+    model_config = ConfigDict(extra="forbid")
+
     action_id: str
     policy_signals: list[PolicySignal] = Field(default_factory=list)
     policy_support_score: float | None = Field(default=None, ge=0.0, le=1.0)
@@ -729,12 +789,16 @@ class PolicySignalByAction(BaseModel):
 class ActionsPolicySignalsApiResponse(BaseModel):
     """Response model for city-scoped policy alignment endpoint."""
 
+    model_config = ConfigDict(extra="forbid")
+
     meta: UpstreamMeta
     policy_signals: list[PolicySignalByAction] = Field(default_factory=list)
 
 
 class LegalRequirement(BaseModel):
     """Single legal requirement alignment check for one action."""
+
+    model_config = ConfigDict(extra="forbid")
 
     signal_code: str
     signal_name: str
@@ -752,6 +816,8 @@ class LegalRequirement(BaseModel):
 class LegalRequirementsByAction(BaseModel):
     """Legal requirements grouped by action ID."""
 
+    model_config = ConfigDict(extra="forbid")
+
     action_id: str
     requirements: list[LegalRequirement] = Field(default_factory=list)
 
@@ -759,12 +825,16 @@ class LegalRequirementsByAction(BaseModel):
 class ActionsLegalApiMeta(UpstreamMeta):
     """Metadata for actions/legal response including test descriptors."""
 
+    model_config = ConfigDict(extra="forbid")
+
     test_cases: dict[str, str] = Field(default_factory=dict)
     strength_scale: list[str] = Field(default_factory=list)
 
 
 class ActionsLegalApiResponse(BaseModel):
     """Response model for city-scoped legal alignment endpoint."""
+
+    model_config = ConfigDict(extra="forbid")
 
     meta: ActionsLegalApiMeta
     legal_requirements: list[LegalRequirementsByAction] = Field(default_factory=list)

--- a/hiap-meed/app/modules/prioritizer/models.py
+++ b/hiap-meed/app/modules/prioritizer/models.py
@@ -511,16 +511,39 @@ class UpstreamApiContext(BaseModel):
 
     endpoint: str
     locode: str | None = None
+    version_label: str | None = None
 
 
 class UpstreamMeta(BaseModel):
     """Common metadata envelope returned by upstream APIs."""
 
     generated_at_utc: str
-    backend_consumer: str
-    upstream_provider: str
     api_context: UpstreamApiContext
-    total_records: int
+    backend_consumer: str | None = None
+    upstream_provider: str | None = None
+    total_records: int | None = None
+
+
+class UpstreamDatasource(BaseModel):
+    """One datasource entry attached to upstream city metadata."""
+
+    datasource_name: str
+    publisher_name: str | None = None
+    publisher_url: str | None = None
+    dataset_name: str | None = None
+    dataset_url: str | None = None
+    version_label: str | None = None
+    released_at: str | None = None
+    source_url: str | None = None
+    is_latest: bool | None = None
+
+
+class CityApiMeta(BaseModel):
+    """Exact metadata envelope returned by the upstream city attributes API."""
+
+    generated_at_utc: str
+    api_context: UpstreamApiContext
+    datasources: list[UpstreamDatasource] = Field(default_factory=list)
 
 
 class CityIndicator(BaseModel):
@@ -529,20 +552,21 @@ class CityIndicator(BaseModel):
     attribute_value: float | str | None = None
     attribute_units: str | None = None
     attribute_category: str | None = None
+    datasource: str | None = None
+    version_label: str | None = None
 
 
 class CityApiItem(BaseModel):
-    """City item shape returned by upstream `GET /v1/cities/{locode}`."""
+    """City item shape returned by upstream `GET /api/v0/city_attributes/{locode}`."""
 
-    comuna_name: str
+    city_name: str
     locode: str
-    countryCode: str | None = None
+    country_code: str | None = None
     region_name: str
-    comuna_code: str
     region_code: str
-    populationSize: int | None = None
-    populationDensity: float | None = None
-    area: float | None = None
+    population_size: int | None = None
+    population_density: float | None = None
+    area_km2: float | None = None
     unemployment_rate: CityIndicator | None = None
     renter_share: CityIndicator | None = None
     employment_in_transport_and_logistics: CityIndicator | None = None
@@ -662,16 +686,16 @@ class ActionApiItem(BaseModel):
 
 
 class CityApiResponse(BaseModel):
-    """Response model for `GET /v1/cities/{locode}`."""
+    """Response model for `GET /api/v0/city_attributes/{locode}`."""
 
-    meta: UpstreamMeta
+    meta: CityApiMeta
     city: CityApiItem
 
 
 class CitiesApiResponse(BaseModel):
     """Response model for city list endpoints."""
 
-    meta: UpstreamMeta
+    meta: CityApiMeta
     cities: list[CityApiItem] = Field(default_factory=list)
 
 

--- a/hiap-meed/app/modules/prioritizer/orchestrator.py
+++ b/hiap-meed/app/modules/prioritizer/orchestrator.py
@@ -259,8 +259,10 @@ def run_prioritization(
         "fetch_city",
         {
             "locode": locode,
-            "comuna_name": city.comuna_name,
+            "city_name": city.city_name,
             "region_name": city.region_name,
+            "source": city.source,
+            "source_metadata": city.source_metadata,
             "elapsed_seconds": block.elapsed_seconds,
         },
         event_index=fetch_city_event_index,

--- a/hiap-meed/app/services/city_attributes_api.py
+++ b/hiap-meed/app/services/city_attributes_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from urllib.parse import quote
 
 from pydantic import ValidationError
 
@@ -37,7 +38,8 @@ class CityAttributesApiService:
     def _build_city_url(self, locode: str) -> str:
         """Return the full upstream city attributes URL for one locode."""
         normalized_locode = locode.strip().upper()
-        return f"{self.base_url.rstrip('/')}/api/v0/city_attributes/{normalized_locode}"
+        encoded_locode = quote(normalized_locode, safe="")
+        return f"{self.base_url.rstrip('/')}/api/v0/city_attributes/{encoded_locode}"
 
     def get_city(self, locode: str) -> CityData:
         """Fetch one city payload from the upstream API and map it to `CityData`."""

--- a/hiap-meed/app/services/city_attributes_api.py
+++ b/hiap-meed/app/services/city_attributes_api.py
@@ -1,0 +1,54 @@
+"""Synchronous client for the upstream city attributes API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.modules.prioritizer.internal_models import CityData
+from app.modules.prioritizer.models import CityApiResponse
+from app.services.http_client import get_json_with_retries
+
+CITY_ATTRIBUTES_BASE_URL = "https://ccglobal.openearth.dev"
+CITY_ATTRIBUTES_ENDPOINT_TEMPLATE = "GET /api/v0/city_attributes/{locode}"
+
+
+@dataclass
+class CityAttributesApiService:
+    """Fetch and map city context from the upstream city attributes API."""
+
+    base_url: str = CITY_ATTRIBUTES_BASE_URL
+
+    def _build_city_url(self, locode: str) -> str:
+        """Return the full upstream city attributes URL for one locode."""
+        normalized_locode = locode.strip().upper()
+        return f"{self.base_url.rstrip('/')}/api/v0/city_attributes/{normalized_locode}"
+
+    def get_city(self, locode: str) -> CityData:
+        """Fetch one city payload from the upstream API and map it to `CityData`."""
+        city_url = self._build_city_url(locode)
+
+        # Fetch and validate the upstream response in one small, synchronous path.
+        payload, http_status_code = get_json_with_retries(
+            url=city_url,
+            operation_name="city attributes API call",
+            headers={"accept": "application/json"},
+        )
+        city_response = CityApiResponse.model_validate(payload)
+        city = city_response.city
+
+        # Preserve the full upstream city payload and lightweight fetch metadata.
+        city_raw = city.model_dump()
+        return CityData.model_validate(
+            {
+                **city_raw,
+                "raw": city_raw,
+                "source": "city_attributes_api",
+                "source_metadata": {
+                    "upstream_url": city_url,
+                    "upstream_endpoint": CITY_ATTRIBUTES_ENDPOINT_TEMPLATE,
+                    "requested_locode": locode.strip().upper(),
+                    "http_status_code": http_status_code,
+                    "upstream_generated_at_utc": city_response.meta.generated_at_utc,
+                },
+            }
+        )

--- a/hiap-meed/app/services/city_attributes_api.py
+++ b/hiap-meed/app/services/city_attributes_api.py
@@ -2,21 +2,37 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
+
+from pydantic import ValidationError
 
 from app.modules.prioritizer.internal_models import CityData
 from app.modules.prioritizer.models import CityApiResponse
-from app.services.http_client import get_json_with_retries
+from app.services.http_client import UpstreamApiError, get_json_with_retries
 
-CITY_ATTRIBUTES_BASE_URL = "https://ccglobal.openearth.dev"
+DEFAULT_CITY_ATTRIBUTES_BASE_URL = "https://ccglobal.openearth.dev"
 CITY_ATTRIBUTES_ENDPOINT_TEMPLATE = "GET /api/v0/city_attributes/{locode}"
+
+
+def get_city_attributes_base_url() -> str:
+    """Return the configured shared Global API host."""
+    raw_value = os.getenv("CCGLOBAL_API_BASE_URL")
+    if raw_value is None or not raw_value.strip():
+        return DEFAULT_CITY_ATTRIBUTES_BASE_URL
+    return raw_value.strip()
 
 
 @dataclass
 class CityAttributesApiService:
     """Fetch and map city context from the upstream city attributes API."""
 
-    base_url: str = CITY_ATTRIBUTES_BASE_URL
+    base_url: str | None = None
+
+    def __post_init__(self) -> None:
+        """Resolve the upstream city attributes host from config when omitted."""
+        if self.base_url is None:
+            self.base_url = get_city_attributes_base_url()
 
     def _build_city_url(self, locode: str) -> str:
         """Return the full upstream city attributes URL for one locode."""
@@ -33,22 +49,30 @@ class CityAttributesApiService:
             operation_name="city attributes API call",
             headers={"accept": "application/json"},
         )
-        city_response = CityApiResponse.model_validate(payload)
-        city = city_response.city
+        try:
+            city_response = CityApiResponse.model_validate(payload)
+            city = city_response.city
 
-        # Preserve the full upstream city payload and lightweight fetch metadata.
-        city_raw = city.model_dump()
-        return CityData.model_validate(
-            {
-                **city_raw,
-                "raw": city_raw,
-                "source": "city_attributes_api",
-                "source_metadata": {
-                    "upstream_url": city_url,
-                    "upstream_endpoint": CITY_ATTRIBUTES_ENDPOINT_TEMPLATE,
-                    "requested_locode": locode.strip().upper(),
-                    "http_status_code": http_status_code,
-                    "upstream_generated_at_utc": city_response.meta.generated_at_utc,
-                },
-            }
-        )
+            # Preserve the full upstream city payload and lightweight fetch metadata.
+            city_raw = city.model_dump()
+            return CityData.model_validate(
+                {
+                    **city_raw,
+                    "raw": city_raw,
+                    "source": "city_attributes_api",
+                    "source_metadata": {
+                        "upstream_url": city_url,
+                        "upstream_endpoint": CITY_ATTRIBUTES_ENDPOINT_TEMPLATE,
+                        "requested_locode": locode.strip().upper(),
+                        "http_status_code": http_status_code,
+                        "upstream_generated_at_utc": city_response.meta.generated_at_utc,
+                    },
+                }
+            )
+        except ValidationError as error:
+            raise UpstreamApiError(
+                status_code=502,
+                message="city attributes API returned a payload that failed schema validation",
+                upstream_status_code=http_status_code,
+                url=city_url,
+            ) from error

--- a/hiap-meed/app/services/data_clients.py
+++ b/hiap-meed/app/services/data_clients.py
@@ -8,6 +8,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from app.services.city_attributes_api import CityAttributesApiService
 from app.modules.prioritizer.internal_models import (
     Action,
     CityData,
@@ -51,16 +52,20 @@ class MockCityDataApiClient:
             city_for_validation = dict(city_raw)
             city_for_validation.update(
                 {
-                    "comuna_name": city.comuna_name,
+                    "city_name": city.city_name,
                     "locode": city.locode,
-                    "country_code": city.countryCode,
+                    "country_code": city.country_code,
                     "region_name": city.region_name,
-                    "comuna_code": city.comuna_code,
                     "region_code": city.region_code,
-                    "population_size": city.populationSize,
-                    "population_density": city.populationDensity,
-                    "area": city.area,
+                    "population_size": city.population_size,
+                    "population_density": city.population_density,
+                    "area_km2": city.area_km2,
                     "raw": city_raw,
+                    "source": "mock_city_api",
+                    "source_metadata": {
+                        "mock_file_path": str(self.mock_file_path),
+                        "requested_locode": requested_locode,
+                    },
                 }
             )
             return CityData.model_validate(city_for_validation)
@@ -224,13 +229,13 @@ class ApiCityDataApiClient:
     Current behavior fails fast until real HTTP integration is implemented.
     """
 
+    def __init__(self, service: CityAttributesApiService | None = None) -> None:
+        """Create the city API client with a small synchronous service wrapper."""
+        self._service = service or CityAttributesApiService()
+
     def get_city(self, locode: str) -> CityData:
-        """Raise until city API integration is implemented."""
-        del locode
-        raise NotImplementedError(
-            "ApiCityDataApiClient is not implemented yet. "
-            "Set HIAP_MEED_CITY_DATA_SOURCE=mock for local runs."
-        )
+        """Fetch city context from the upstream city attributes API."""
+        return self._service.get_city(locode)
 
 
 _default_api_city_client = ApiCityDataApiClient()
@@ -265,7 +270,7 @@ _default_mock_policy_signals_client = MockPolicySignalsDataApiClient(
 
 def get_city_data_api_client() -> MockCityDataApiClient | ApiCityDataApiClient:
     """FastAPI dependency provider for city data client."""
-    source = os.getenv("HIAP_MEED_CITY_DATA_SOURCE", "mock").strip().lower()
+    source = os.getenv("HIAP_MEED_CITY_DATA_SOURCE", "api").strip().lower()
     if source == "api":
         return _default_api_city_client
 

--- a/hiap-meed/app/services/data_clients.py
+++ b/hiap-meed/app/services/data_clients.py
@@ -97,6 +97,7 @@ class MockActionDataApiClient:
                 Action(
                     action_id=action.actionId,
                     action_name=action.actionName,
+                    biome=action.biome,
                     activity_type_description=action.activity_type_description,
                     description=action.description,
                     action_category=action.actionCategory,

--- a/hiap-meed/app/services/http_client.py
+++ b/hiap-meed/app/services/http_client.py
@@ -1,0 +1,157 @@
+"""Small shared HTTP helpers for upstream API calls."""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+DEFAULT_UPSTREAM_HTTP_TIMEOUT_SECONDS = 30.0
+DEFAULT_UPSTREAM_HTTP_MAX_RETRIES = 2
+DEFAULT_UPSTREAM_HTTP_RETRY_BACKOFF_SECONDS = 0.5
+RETRYABLE_STATUS_CODES = {429, 502, 503, 504}
+
+
+@dataclass
+class UpstreamApiError(Exception):
+    """Structured error raised when an upstream HTTP call fails."""
+
+    status_code: int
+    message: str
+    upstream_status_code: int | None = None
+    url: str | None = None
+
+    def __str__(self) -> str:
+        """Return the human-readable upstream error message."""
+        return self.message
+
+
+def _get_upstream_http_timeout_seconds() -> float:
+    """Return upstream HTTP timeout from env config."""
+    raw_value = os.getenv("UPSTREAM_HTTP_TIMEOUT_SECONDS")
+    if raw_value is None or not raw_value.strip():
+        return DEFAULT_UPSTREAM_HTTP_TIMEOUT_SECONDS
+    try:
+        parsed = float(raw_value.strip())
+    except ValueError as error:
+        raise ValueError("UPSTREAM_HTTP_TIMEOUT_SECONDS must be a number") from error
+    if parsed <= 0:
+        raise ValueError("UPSTREAM_HTTP_TIMEOUT_SECONDS must be > 0")
+    return parsed
+
+
+def _get_upstream_http_max_retries() -> int:
+    """Return upstream HTTP retry count from env config."""
+    raw_value = os.getenv("UPSTREAM_HTTP_MAX_RETRIES")
+    if raw_value is None or not raw_value.strip():
+        return DEFAULT_UPSTREAM_HTTP_MAX_RETRIES
+    try:
+        parsed = int(raw_value.strip())
+    except ValueError as error:
+        raise ValueError("UPSTREAM_HTTP_MAX_RETRIES must be an integer") from error
+    if parsed < 0:
+        raise ValueError("UPSTREAM_HTTP_MAX_RETRIES must be >= 0")
+    return parsed
+
+
+def _get_upstream_http_retry_backoff_seconds() -> float:
+    """Return upstream HTTP retry backoff from env config."""
+    raw_value = os.getenv("UPSTREAM_HTTP_RETRY_BACKOFF_SECONDS")
+    if raw_value is None or not raw_value.strip():
+        return DEFAULT_UPSTREAM_HTTP_RETRY_BACKOFF_SECONDS
+    try:
+        parsed = float(raw_value.strip())
+    except ValueError as error:
+        raise ValueError(
+            "UPSTREAM_HTTP_RETRY_BACKOFF_SECONDS must be a number"
+        ) from error
+    if parsed < 0:
+        raise ValueError("UPSTREAM_HTTP_RETRY_BACKOFF_SECONDS must be >= 0")
+    return parsed
+
+
+def _map_upstream_http_status_to_api_status(upstream_status_code: int) -> int:
+    """Map upstream HTTP statuses to the status hiap-meed should return."""
+    if upstream_status_code == 404:
+        return 404
+    if upstream_status_code in RETRYABLE_STATUS_CODES:
+        return 503
+    if upstream_status_code == 408:
+        return 504
+    return 502
+
+
+def get_json_with_retries(
+    *,
+    url: str,
+    operation_name: str,
+    headers: dict[str, str] | None = None,
+) -> tuple[dict[str, Any], int]:
+    """GET one JSON payload with simple retries for transient upstream failures."""
+    timeout_seconds = _get_upstream_http_timeout_seconds()
+    max_retries = _get_upstream_http_max_retries()
+    retry_backoff_seconds = _get_upstream_http_retry_backoff_seconds()
+    attempts = max_retries + 1
+
+    for attempt_number in range(1, attempts + 1):
+        try:
+            with httpx.Client(timeout=timeout_seconds) as client:
+                response = client.get(url, headers=headers)
+                response.raise_for_status()
+                try:
+                    payload = response.json()
+                except ValueError as error:
+                    raise UpstreamApiError(
+                        status_code=502,
+                        message=f"{operation_name} returned invalid JSON",
+                        upstream_status_code=response.status_code,
+                        url=url,
+                    ) from error
+            if not isinstance(payload, dict):
+                raise UpstreamApiError(
+                    status_code=502,
+                    message=f"{operation_name} returned a non-object JSON payload",
+                    upstream_status_code=response.status_code,
+                    url=url,
+                )
+            return payload, response.status_code
+        except httpx.TimeoutException as error:
+            if attempt_number < attempts:
+                time.sleep(retry_backoff_seconds)
+                continue
+            raise UpstreamApiError(
+                status_code=504,
+                message=f"{operation_name} timed out",
+                url=url,
+            ) from error
+        except (httpx.ConnectError, httpx.NetworkError) as error:
+            if attempt_number < attempts:
+                time.sleep(retry_backoff_seconds)
+                continue
+            raise UpstreamApiError(
+                status_code=503,
+                message=f"{operation_name} is temporarily unavailable",
+                url=url,
+            ) from error
+        except httpx.HTTPStatusError as error:
+            upstream_status_code = error.response.status_code
+            if (
+                upstream_status_code in RETRYABLE_STATUS_CODES
+                and attempt_number < attempts
+            ):
+                time.sleep(retry_backoff_seconds)
+                continue
+            raise UpstreamApiError(
+                status_code=_map_upstream_http_status_to_api_status(
+                    upstream_status_code
+                ),
+                message=(
+                    f"{operation_name} failed with upstream status "
+                    f"{upstream_status_code}"
+                ),
+                upstream_status_code=upstream_status_code,
+                url=url,
+            ) from error

--- a/hiap-meed/data/mock/README.md
+++ b/hiap-meed/data/mock/README.md
@@ -101,7 +101,7 @@ This mock follows the active upstream city attributes schema:
 - city fields such as `city_name`, `country_code`, `populationSize`, `populationDensity`, and `area_km2`
 - a `population` indicator object in addition to the top-level population fields
 - all 9 socioeconomic indicator keys currently used by Feasibility
-- strict city payload validation, so unexpected keys or wrong casing are rejected
+- the current city response DTOs still accept the camelCase population aliases and ignore unexpected extra keys
 
 # actions_api_mock.json:
 
@@ -119,7 +119,7 @@ Future action API note:
 
 - This mock still matches the current action contract used by this branch.
 - It may include optional fields such as `biome`.
-- When the future `GET /api/v1/action-pathways` payload replaces this mock, the strict action DTOs and this mock file should be updated together, including removing `biome` and aligning to the new payload field names.
+- When the future `GET /api/v1/action-pathways` payload replaces this mock, the action DTOs and this mock file should be updated together, including removing `biome` and aligning to the new payload field names.
 
 # actions_policy_signals_api_mock.json:
 

--- a/hiap-meed/data/mock/README.md
+++ b/hiap-meed/data/mock/README.md
@@ -89,17 +89,17 @@ The upstream provider is the global-api.
 
 This payload shape is modeled by:
 - `CityApiResponse` (envelope)
-- `CityData` (`city`)
+- `CityApiItem` (`city`)
 
 It is being used to fetch basic city context data and also more specific city context data like unemployment rate, renter share, transport logistics employment, electricity access, industry construction employment, median household income, public transport share, poverty rate and home ownership.
 
 The general logic is that this is the baseline and values might be updated by the city user via the frontend request.
 
-Known alignment gap with action socioeconomic rules:
+This mock follows the active upstream city attributes schema:
 
-- City keys currently include `transport_logistics_employment` and `electricity_access`.
-- `actions_api_mock.json` currently includes indicator keys `employment_in_transport_and_logistics` and `electricity_access_rate`.
-- Until these names are aligned (or mapped in code), feasibility socio-economic lookup will treat those indicators as missing.
+- `GET /api/v0/city_attributes/{locode}`
+- snake_case city fields such as `city_name`, `country_code`, `population_size`, `population_density`, and `area_km2`
+- all 9 socioeconomic indicator keys currently used by Feasibility
 
 # actions_api_mock.json:
 

--- a/hiap-meed/data/mock/README.md
+++ b/hiap-meed/data/mock/README.md
@@ -99,7 +99,9 @@ This mock follows the active upstream city attributes schema:
 
 - `GET /api/v0/city_attributes/{locode}`
 - snake_case city fields such as `city_name`, `country_code`, `population_size`, `population_density`, and `area_km2`
+- a `population` indicator object in addition to the top-level population fields
 - all 9 socioeconomic indicator keys currently used by Feasibility
+- strict city payload validation, so unexpected keys or wrong casing are rejected
 
 # actions_api_mock.json:
 
@@ -112,6 +114,12 @@ It is being used to fetch the list of actions and their associated emissions, co
 This payload shape is modeled by:
 - `ActionsApiResponse` (envelope)
 - `Action` (`actions[]`)
+
+Future action API note:
+
+- This mock still matches the current action contract used by this branch.
+- It may include optional fields such as `biome`.
+- When the future `GET /api/v1/action-pathways` payload replaces this mock, the strict action DTOs and this mock file should be updated together, including removing `biome` and aligning to the new payload field names.
 
 # actions_policy_signals_api_mock.json:
 

--- a/hiap-meed/data/mock/README.md
+++ b/hiap-meed/data/mock/README.md
@@ -98,7 +98,7 @@ The general logic is that this is the baseline and values might be updated by th
 This mock follows the active upstream city attributes schema:
 
 - `GET /api/v0/city_attributes/{locode}`
-- snake_case city fields such as `city_name`, `country_code`, `population_size`, `population_density`, and `area_km2`
+- city fields such as `city_name`, `country_code`, `populationSize`, `populationDensity`, and `area_km2`
 - a `population` indicator object in addition to the top-level population fields
 - all 9 socioeconomic indicator keys currently used by Feasibility
 - strict city payload validation, so unexpected keys or wrong casing are rejected
@@ -130,7 +130,7 @@ It includes:
 
 - policy_signals: array of { action_id, policy_signals: [...], policy_support_score }
 - each signal: location_scope, location_name, signal_type, signal_relation, signal_strength, evidence_ids, evidence_count
-- policy_support_score: 0–1 score per action (relation × strength × scope multiplier, normalized)
+- policy_support_score: 0â€“1 score per action (relation Ã— strength Ã— scope multiplier, normalized)
 - meta.locode, meta.comuna_name, meta.region_name
 
 This payload shape is modeled by:
@@ -163,7 +163,7 @@ It includes:
 # actions_legal_api_mock.json:
 
 Mock for GET /v1/actions/legal (or /v1/legal-requirements).
-Returns action_id → legal alignment + evidence per action.
+Returns action_id â†’ legal alignment + evidence per action.
 
 It includes:
 

--- a/hiap-meed/data/mock/cities_api_mock.json
+++ b/hiap-meed/data/mock/cities_api_mock.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "meta": {
     "generated_at_utc": "2026-02-26T11:38:45.183100+00:00",
     "backend_consumer": "hiap-meed",
@@ -29,8 +29,8 @@
       "region_name": "Tarapacá",
       "comuna_code": "CL01101",
       "region_code": "CL01",
-      "populationSize": 214857,
-      "populationDensity": 953.69,
+      "population_size": 214857,
+      "population_density": 953.69,
       "area": 225,
       "unemployment_rate": {
         "attribute_value": 9.44,
@@ -85,8 +85,8 @@
       "region_name": "Tarapacá",
       "comuna_code": "CL01107",
       "region_code": "CL01",
-      "populationSize": 128312,
-      "populationDensity": 224.67,
+      "population_size": 128312,
+      "population_density": 224.67,
       "area": 571,
       "electricity_access": {
         "attribute_value": 100.0,
@@ -141,8 +141,8 @@
       "region_name": "Tarapacá",
       "comuna_code": "CL01402",
       "region_code": "CL01",
-      "populationSize": 1298,
-      "populationDensity": 0.9,
+      "population_size": 1298,
+      "population_density": 0.9,
       "area": 1437,
       "industry_construction_employment": {
         "attribute_value": 0.0,
@@ -192,8 +192,8 @@
       "region_name": "Tarapacá",
       "comuna_code": "CL01403",
       "region_code": "CL01",
-      "populationSize": 1728,
-      "populationDensity": 0.11,
+      "population_size": 1728,
+      "population_density": 0.11,
       "area": 15855,
       "public_transport_share": {
         "attribute_value": 31.84,
@@ -223,8 +223,8 @@
       "region_name": "Tarapacá",
       "comuna_code": "CL01404",
       "region_code": "CL01",
-      "populationSize": 3127,
-      "populationDensity": 0.03,
+      "population_size": 3127,
+      "population_density": 0.03,
       "area": 105061,
       "median_household_income": {
         "attribute_value": 1200000.0,
@@ -279,8 +279,8 @@
       "region_name": "Tarapacá",
       "comuna_code": "CL01405",
       "region_code": "CL01",
-      "populationSize": 10450,
-      "populationDensity": 1.16,
+      "population_size": 10450,
+      "population_density": 1.16,
       "area": 8989,
       "transport_logistics_employment": {
         "attribute_value": 0.0,
@@ -335,8 +335,8 @@
       "region_name": "Antofagasta",
       "comuna_code": "CL02101",
       "region_code": "CL02",
-      "populationSize": 105093,
-      "populationDensity": 180.11,
+      "population_size": 105093,
+      "population_density": 180.11,
       "area": 590,
       "home_ownership": {
         "attribute_value": 40.09,
@@ -391,8 +391,8 @@
       "region_name": "Antofagasta",
       "comuna_code": "CL02102",
       "region_code": "CL02",
-      "populationSize": 12954,
-      "populationDensity": 3.44,
+      "population_size": 12954,
+      "population_density": 3.44,
       "area": 3768,
       "unemployment_rate": {
         "attribute_value": 9.26,
@@ -447,8 +447,8 @@
       "region_name": "Antofagasta",
       "comuna_code": "CL02103",
       "region_code": "CL02",
-      "populationSize": 1867,
-      "populationDensity": 0.15,
+      "population_size": 1867,
+      "population_density": 0.15,
       "area": 12467,
       "public_transport_share": {
         "attribute_value": 34.19,
@@ -478,8 +478,8 @@
       "region_name": "Antofagasta",
       "comuna_code": "CL02104",
       "region_code": "CL02",
-      "populationSize": 13602,
-      "populationDensity": 0.66,
+      "population_size": 13602,
+      "population_density": 0.66,
       "area": 20405,
       "poverty_rate": {
         "attribute_value": 19.53,
@@ -534,8 +534,8 @@
       "region_name": "Arica y Parinacota",
       "comuna_code": "CL15101",
       "region_code": "CL15",
-      "populationSize": 247552,
-      "populationDensity": 515.73,
+      "population_size": 247552,
+      "population_density": 515.73,
       "area": 480,
       "industry_construction_employment": {
         "attribute_value": 22.4,

--- a/hiap-meed/data/mock/cities_api_mock.json
+++ b/hiap-meed/data/mock/cities_api_mock.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "meta": {
     "generated_at_utc": "2026-02-26T11:38:45.183100+00:00",
     "backend_consumer": "hiap-meed",
@@ -29,8 +29,8 @@
       "region_name": "Tarapacá",
       "comuna_code": "CL01101",
       "region_code": "CL01",
-      "population_size": 214857,
-      "population_density": 953.69,
+      "populationSize": 214857,
+      "populationDensity": 953.69,
       "area": 225,
       "unemployment_rate": {
         "attribute_value": 9.44,
@@ -85,8 +85,8 @@
       "region_name": "Tarapacá",
       "comuna_code": "CL01107",
       "region_code": "CL01",
-      "population_size": 128312,
-      "population_density": 224.67,
+      "populationSize": 128312,
+      "populationDensity": 224.67,
       "area": 571,
       "electricity_access": {
         "attribute_value": 100.0,
@@ -141,8 +141,8 @@
       "region_name": "Tarapacá",
       "comuna_code": "CL01402",
       "region_code": "CL01",
-      "population_size": 1298,
-      "population_density": 0.9,
+      "populationSize": 1298,
+      "populationDensity": 0.9,
       "area": 1437,
       "industry_construction_employment": {
         "attribute_value": 0.0,
@@ -192,8 +192,8 @@
       "region_name": "Tarapacá",
       "comuna_code": "CL01403",
       "region_code": "CL01",
-      "population_size": 1728,
-      "population_density": 0.11,
+      "populationSize": 1728,
+      "populationDensity": 0.11,
       "area": 15855,
       "public_transport_share": {
         "attribute_value": 31.84,
@@ -223,8 +223,8 @@
       "region_name": "Tarapacá",
       "comuna_code": "CL01404",
       "region_code": "CL01",
-      "population_size": 3127,
-      "population_density": 0.03,
+      "populationSize": 3127,
+      "populationDensity": 0.03,
       "area": 105061,
       "median_household_income": {
         "attribute_value": 1200000.0,
@@ -279,8 +279,8 @@
       "region_name": "Tarapacá",
       "comuna_code": "CL01405",
       "region_code": "CL01",
-      "population_size": 10450,
-      "population_density": 1.16,
+      "populationSize": 10450,
+      "populationDensity": 1.16,
       "area": 8989,
       "transport_logistics_employment": {
         "attribute_value": 0.0,
@@ -335,8 +335,8 @@
       "region_name": "Antofagasta",
       "comuna_code": "CL02101",
       "region_code": "CL02",
-      "population_size": 105093,
-      "population_density": 180.11,
+      "populationSize": 105093,
+      "populationDensity": 180.11,
       "area": 590,
       "home_ownership": {
         "attribute_value": 40.09,
@@ -391,8 +391,8 @@
       "region_name": "Antofagasta",
       "comuna_code": "CL02102",
       "region_code": "CL02",
-      "population_size": 12954,
-      "population_density": 3.44,
+      "populationSize": 12954,
+      "populationDensity": 3.44,
       "area": 3768,
       "unemployment_rate": {
         "attribute_value": 9.26,
@@ -447,8 +447,8 @@
       "region_name": "Antofagasta",
       "comuna_code": "CL02103",
       "region_code": "CL02",
-      "population_size": 1867,
-      "population_density": 0.15,
+      "populationSize": 1867,
+      "populationDensity": 0.15,
       "area": 12467,
       "public_transport_share": {
         "attribute_value": 34.19,
@@ -478,8 +478,8 @@
       "region_name": "Antofagasta",
       "comuna_code": "CL02104",
       "region_code": "CL02",
-      "population_size": 13602,
-      "population_density": 0.66,
+      "populationSize": 13602,
+      "populationDensity": 0.66,
       "area": 20405,
       "poverty_rate": {
         "attribute_value": 19.53,
@@ -534,8 +534,8 @@
       "region_name": "Arica y Parinacota",
       "comuna_code": "CL15101",
       "region_code": "CL15",
-      "population_size": 247552,
-      "population_density": 515.73,
+      "populationSize": 247552,
+      "populationDensity": 515.73,
       "area": 480,
       "industry_construction_employment": {
         "attribute_value": 22.4,

--- a/hiap-meed/data/mock/city_api_mock.json
+++ b/hiap-meed/data/mock/city_api_mock.json
@@ -29,6 +29,13 @@
     "area_km2": 2646,
     "population_size": 214857,
     "population_density": 953.69,
+    "population": {
+      "attribute_value": 214857,
+      "attribute_units": "persons",
+      "attribute_category": "very high",
+      "datasource": "cl-ine-censo",
+      "version_label": "2024"
+    },
     "unemployment_rate": {
       "attribute_value": 9.44,
       "attribute_units": "percent",

--- a/hiap-meed/data/mock/city_api_mock.json
+++ b/hiap-meed/data/mock/city_api_mock.json
@@ -27,8 +27,8 @@
     "region_code": "CL01",
     "region_name": "Tarapaca",
     "area_km2": 2646,
-    "population_size": 214857,
-    "population_density": 953.69,
+    "populationSize": 214857,
+    "populationDensity": 953.69,
     "population": {
       "attribute_value": 214857,
       "attribute_units": "persons",

--- a/hiap-meed/data/mock/city_api_mock.json
+++ b/hiap-meed/data/mock/city_api_mock.json
@@ -1,68 +1,96 @@
 {
   "meta": {
-    "generated_at_utc": "2026-02-26T11:38:45.183100+00:00",
-    "backend_consumer": "hiap-meed",
-    "upstream_provider": "global-api",
+    "generated_at_utc": "2026-05-13T09:39:51.706285+00:00",
     "api_context": {
-      "endpoint": "GET /v1/cities/{locode}",
-      "locode": "CL IQQ"
+      "endpoint": "GET /api/v0/city_attributes/{locode}",
+      "locode": "CL IQQ",
+      "version_label": null
     },
-    "total_records": 1
+    "datasources": [
+      {
+        "datasource_name": "cl-ine-censo",
+        "publisher_name": "Instituto Nacional de Estadisticas (Chile)",
+        "publisher_url": "https://www.ine.gob.cl/",
+        "dataset_name": "Chile Population and Housing Census",
+        "dataset_url": "https://www.ine.gob.cl/estadisticas/sociales/censos-de-poblacion-y-vivienda/poblacion-y-vivienda",
+        "version_label": "2024",
+        "released_at": "2025-01-01",
+        "source_url": "https://censo2024.ine.gob.cl/resultados/",
+        "is_latest": true
+      }
+    ]
   },
   "city": {
-    "comuna_name": "Iquique",
     "locode": "CL IQQ",
-    "countryCode": "CL",
-    "region_name": "Tarapacá",
-    "comuna_code": "CL01101",
+    "city_name": "Iquique",
+    "country_code": "CL",
     "region_code": "CL01",
-    "populationSize": 214857,
-    "populationDensity": 953.69,
-    "area": 225,
+    "region_name": "Tarapaca",
+    "area_km2": 2646,
+    "population_size": 214857,
+    "population_density": 953.69,
     "unemployment_rate": {
       "attribute_value": 9.44,
       "attribute_units": "percent",
-      "attribute_category": "high"
+      "attribute_category": "high",
+      "datasource": "cl-ine-censo",
+      "version_label": "2024"
     },
     "renter_share": {
       "attribute_value": 43.48,
       "attribute_units": "percent",
-      "attribute_category": "high"
+      "attribute_category": "high",
+      "datasource": "cl-ine-censo",
+      "version_label": "2024"
     },
     "employment_in_transport_and_logistics": {
       "attribute_value": 7.35,
       "attribute_units": "percent",
-      "attribute_category": "low"
+      "attribute_category": "low",
+      "datasource": "cl-ine-censo",
+      "version_label": "2024"
     },
     "electricity_access_rate": {
       "attribute_value": 100.0,
       "attribute_units": "percent",
-      "attribute_category": "very low"
+      "attribute_category": "very low",
+      "datasource": "cl-ine-censo",
+      "version_label": "2024"
     },
     "industry_construction_employment": {
       "attribute_value": 22.79,
       "attribute_units": "percent",
-      "attribute_category": "high"
+      "attribute_category": "high",
+      "datasource": "cl-ine-censo",
+      "version_label": "2024"
     },
     "median_household_income": {
       "attribute_value": 1200000.0,
       "attribute_units": "CLP",
-      "attribute_category": "high"
+      "attribute_category": "high",
+      "datasource": "cl-ine-censo",
+      "version_label": "2024"
     },
     "public_transport_share": {
       "attribute_value": 31.84,
       "attribute_units": "percent",
-      "attribute_category": "medium"
+      "attribute_category": "medium",
+      "datasource": "cl-ine-censo",
+      "version_label": "2024"
     },
     "poverty_rate": {
       "attribute_value": 26.77,
       "attribute_units": "percent",
-      "attribute_category": "very high"
+      "attribute_category": "very high",
+      "datasource": "cl-ine-censo",
+      "version_label": "2024"
     },
     "home_ownership": {
       "attribute_value": 40.0,
       "attribute_units": "percent",
-      "attribute_category": "very low"
+      "attribute_category": "very low",
+      "datasource": "cl-ine-censo",
+      "version_label": "2024"
     }
   }
 }

--- a/hiap-meed/docs/pipeline-description.md
+++ b/hiap-meed/docs/pipeline-description.md
@@ -163,6 +163,11 @@ File:
 
 - `data/mock/city_api_mock.json`
 
+Shape note:
+
+- This mock now follows the upstream `GET /api/v0/city_attributes/{locode}` schema.
+- The city payload uses snake_case names such as `city_name`, `country_code`, `population_size`, `population_density`, and `area_km2`.
+
 Fields that affect the result:
 
 - `city.unemployment_rate.attribute_category`

--- a/hiap-meed/docs/pipeline-description.md
+++ b/hiap-meed/docs/pipeline-description.md
@@ -122,13 +122,13 @@ Fields that affect the result:
 - `requestData.cityDataList[].cityStrategicPreferenceSectors[]`
 - `requestData.cityDataList[].cityStrategicPreferenceTimeframes[]`
 - `requestData.cityDataList[].cityStrategicPreferenceCoBenefitKeys[]`
-- `requestData.cityDataList[].cityEmissionsData.gpcData.<reference>.activities[].activityType`
 - `requestData.cityDataList[].cityEmissionsData.gpcData.<reference>.activities[].totalEmissions`
 
 What these are used for:
 
 - `topN` controls how many ranked actions are returned.
 - `weightsOverride` changes how much Impact, Alignment, and Feasibility matter in the final score.
+- `weightsOverride` may be partial. Any missing keys are filled from the defaults before validation, and the resolved final `impact/alignment/feasibility` set must sum to `1.0`.
 - `excludedActionIds[]` removes user-confirmed exclusions before scoring.
 - `cityStrategicPreferenceSectors[]` influences the Alignment block.
 - `cityStrategicPreferenceSectors[]` must use only:
@@ -156,6 +156,7 @@ What these are used for:
 - `requestData.requestedLanguages` controls the explanation languages requested for post-ranking output.
 - The backend always generates canonical English explanations first, then translates from English into each requested non-English target language.
 - `totalEmissions` values are the main city emissions numbers used in the Impact block.
+- `activityType` rows are preserved for future activity-data-level matching and diagnostics, but they do not currently change ranking output.
 
 ### City context data
 
@@ -349,22 +350,23 @@ Input field:
 
 What the pipeline does:
 
-- For each emissions category in the request, it adds together all `totalEmissions` values found under that category.
+- For each outer GPC key in the request, the pipeline first normalizes that key to a `sector.subsector` key.
+- It then adds together all `totalEmissions` values found under that normalized subsector key.
 
 Plain-language formula:
 
 ```text
-City emissions for one emissions category
-= sum of all activity-level totalEmissions values inside that category
+ City emissions for one normalized subsector key
+= sum of all activity-level totalEmissions values inside request rows that normalize to that subsector key
 ```
 
 Output:
 
-- A table that says, for each emissions category, how much total city emissions it represents.
+- A table that says, for each normalized `sector.subsector` key, how much total city emissions it represents.
 
 Example:
 
-- If one emissions category contains three activity rows, the pipeline adds the three `totalEmissions` values together and stores one total for that category.
+- If multiple request rows normalize to the same `sector.subsector` key, the pipeline adds their activity-level `totalEmissions` values together and stores one total for that normalized subsector key.
 
 ## 4. Hard Filter
 
@@ -1073,6 +1075,7 @@ From the request or the defaults:
 - `requestData.cityDataList[].weightsOverride.impact`
 - `requestData.cityDataList[].weightsOverride.alignment`
 - `requestData.cityDataList[].weightsOverride.feasibility`
+- partial overrides are allowed; missing keys are filled from defaults before validating the resolved final weights
 
 From the request size:
 
@@ -1151,11 +1154,11 @@ For each ranked action, the output includes:
 - `alignment_score`
 - `feasibility_score`
 - `evidence_summary`
-- `explanation`
+- `explanations`
 
 Important current behavior:
 
-- `explanation` is `null` unless `requestData.createExplanations=true` and the explanation call succeeds
+- `explanations` is `{}` unless `requestData.createExplanations=true` and the explanation call succeeds
 - Explanations are generated only after ranking is finished; they do not change scores or ranks
 - The explanation stage uses the ranked actions plus curated evidence from the Impact, Alignment, and Feasibility blocks
 - The explanation stage returns explanation texts keyed by language code per action.
@@ -1164,7 +1167,7 @@ Important current behavior:
 - Response metadata records `generated_languages` as the languages actually present in the returned explanation payload.
 - Explanations receive `cityStrategicPreferenceCoBenefitKeys[]` directly from the request context
 - The backend logs a warning if the explanation prompt becomes unusually large
-- If explanation generation fails or times out, ranking still returns normally with `explanation=null`
+- If explanation generation fails or times out, ranking still returns normally with `explanations={}`
 - When explanation artifacts are enabled, the run folder stores:
   - `llm/explanations_prompt.txt`
   - `llm/explanations_io.json`
@@ -1225,16 +1228,18 @@ Current behavior:
 - validated against the allowed co-benefit taxonomy
 - contributes to the Alignment block through normalized selected co-benefit impact values
 
-### Placeholder 3: ranked action `explanation`
+### Placeholder 3: ranked action `explanations`
 
 Current behavior:
 
-- `null` unless `requestData.createExplanations=true` and explanation generation succeeds
+- `{}` unless `requestData.createExplanations=true` and explanation generation succeeds
+- when generated, the field is an object keyed by language code
+- canonical English explanations are generated first and requested non-English languages are returned through the current translation flow
+- `/v1/explanations/translate` is already available as the stateless translation endpoint for canonical explanation text
 
-Planned use:
+Planned improvements:
 
 - continue improving the generated explanation quality and prompt grounding
-- extend the response contract and explanation pipeline so one request can return fully multilingual explanation payloads instead of today's single-string, first-language-wins behavior
 
 ## 11. Practical Reading of the Current System
 

--- a/hiap-meed/docs/pipeline-description.md
+++ b/hiap-meed/docs/pipeline-description.md
@@ -167,6 +167,8 @@ Shape note:
 
 - This mock now follows the upstream `GET /api/v0/city_attributes/{locode}` schema.
 - The city payload uses snake_case names such as `city_name`, `country_code`, `population_size`, `population_density`, and `area_km2`.
+- The city payload also includes a `population` indicator object alongside the top-level `population_size` and `population_density` fields.
+- The city API contract is strict, so unexpected keys or wrong casing now fail validation instead of being ignored.
 
 Fields that affect the result:
 
@@ -190,6 +192,12 @@ What these are used for:
 File:
 
 - `data/mock/actions_api_mock.json`
+
+Future contract note:
+
+- This file still represents the current action mock/upstream shape used by this branch.
+- It may include fields such as `biome` that are not expected in the future `GET /api/v1/action-pathways` payload.
+- When that new action API is integrated, the strict action response DTOs and the mock action file should be updated together in one dedicated contract migration.
 
 Fields that affect the result:
 

--- a/hiap-meed/docs/pipeline-description.md
+++ b/hiap-meed/docs/pipeline-description.md
@@ -166,9 +166,9 @@ File:
 Shape note:
 
 - This mock now follows the upstream `GET /api/v0/city_attributes/{locode}` schema.
-- The city payload uses snake_case names such as `city_name`, `country_code`, `population_size`, `population_density`, and `area_km2`.
-- The city payload also includes a `population` indicator object alongside the top-level `population_size` and `population_density` fields.
-- The city API contract is strict, so unexpected keys or wrong casing now fail validation instead of being ignored.
+- The city payload uses fields such as `city_name`, `country_code`, `populationSize`, `populationDensity`, and `area_km2`.
+- The city payload also includes a `population` indicator object alongside the top-level population fields.
+- The current city response DTOs are intentionally lenient: they still accept the current camelCase population aliases and ignore unexpected extra keys.
 
 Fields that affect the result:
 
@@ -197,7 +197,7 @@ Future contract note:
 
 - This file still represents the current action mock/upstream shape used by this branch.
 - It may include fields such as `biome` that are not expected in the future `GET /api/v1/action-pathways` payload.
-- When that new action API is integrated, the strict action response DTOs and the mock action file should be updated together in one dedicated contract migration.
+- When that new action API is integrated, the action response DTOs and the mock action file should be updated together in one dedicated contract migration.
 
 Fields that affect the result:
 

--- a/hiap-meed/docs/service-architecture.md
+++ b/hiap-meed/docs/service-architecture.md
@@ -79,7 +79,7 @@ This is the right choice as long as the orchestrator and data clients are synchr
 
 | Client                    | Method                                | Status                                                                                  | Target upstream |
 | ------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------- | --------------- |
-| City data client          | `get_city(locode)`                    | Mock/API switch (`HIAP_MEED_CITY_DATA_SOURCE`); `mock` is file-backed, `api` performs synchronous HTTP GET `/api/v0/city_attributes/{locode}` | `ccglobal.openearth.dev` city attributes API |
+| City data client          | `get_city(locode)`                    | Mock/API switch (`HIAP_MEED_CITY_DATA_SOURCE`); `mock` is file-backed, `api` performs synchronous HTTP GET `/api/v0/city_attributes/{locode}` against the shared `CCGLOBAL_API_BASE_URL` (default `https://ccglobal.openearth.dev` locally; overridden in workflows per environment) | configurable city attributes API host |
 | Action data client        | `list_actions()`                      | Mock/API switch (`HIAP_MEED_ACTION_DATA_SOURCE`); `mock` is file-backed, `api` is placeholder and raises `NotImplementedError` | Global API (future) |
 | Legal data client         | `get_action_legal_requirements(locode)` | Mock/API switch (`HIAP_MEED_LEGAL_DATA_SOURCE`); `mock` is file-backed, `api` is placeholder and raises `NotImplementedError` | Global API (future) |
 | Policy signals data client | `get_action_policy_signals(locode)`    | Mock/API switch (`HIAP_MEED_POLICY_SIGNALS_DATA_SOURCE`); `mock` is file-backed, `api` is placeholder and raises `NotImplementedError` | Global API (future) |

--- a/hiap-meed/docs/service-architecture.md
+++ b/hiap-meed/docs/service-architecture.md
@@ -38,7 +38,7 @@ graph TD
     Orch -->|"getActionLegalRequirements(locode)"| LegalClient
     Orch -->|"getActionPolicySignals(locode)"| PolicyClient
 
-    CityClient -.->|"API mode (not implemented yet)"| GlobalAPI
+    CityClient -.->|"API mode: GET /api/v0/city_attributes/{locode}"| GlobalAPI
     ActionClient -.->|"API mode (not implemented yet)"| GlobalAPI
     LegalClient -.->|"API mode (not implemented yet)"| GlobalAPI
     PolicyClient -.->|"API mode (not implemented yet)"| GlobalAPI
@@ -79,12 +79,12 @@ This is the right choice as long as the orchestrator and data clients are synchr
 
 | Client                    | Method                                | Status                                                                                  | Target upstream |
 | ------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------- | --------------- |
-| City data client          | `get_city(locode)`                    | Mock/API switch (`HIAP_MEED_CITY_DATA_SOURCE`); `mock` is file-backed, `api` is placeholder and raises `NotImplementedError` | Global API (future) |
+| City data client          | `get_city(locode)`                    | Mock/API switch (`HIAP_MEED_CITY_DATA_SOURCE`); `mock` is file-backed, `api` performs synchronous HTTP GET `/api/v0/city_attributes/{locode}` | `ccglobal.openearth.dev` city attributes API |
 | Action data client        | `list_actions()`                      | Mock/API switch (`HIAP_MEED_ACTION_DATA_SOURCE`); `mock` is file-backed, `api` is placeholder and raises `NotImplementedError` | Global API (future) |
 | Legal data client         | `get_action_legal_requirements(locode)` | Mock/API switch (`HIAP_MEED_LEGAL_DATA_SOURCE`); `mock` is file-backed, `api` is placeholder and raises `NotImplementedError` | Global API (future) |
 | Policy signals data client | `get_action_policy_signals(locode)`    | Mock/API switch (`HIAP_MEED_POLICY_SIGNALS_DATA_SOURCE`); `mock` is file-backed, `api` is placeholder and raises `NotImplementedError` | Global API (future) |
 
-Clients are injected via FastAPI's `Depends()` pattern. Mock clients are active by default; API clients are scaffolds for future HTTP integration.
+Clients are injected via FastAPI's `Depends()` pattern. The city client defaults to the live city attributes API, while the action, legal, and policy clients still default to checked-in mock payloads.
 
 ---
 

--- a/hiap-meed/docs/service-architecture.md
+++ b/hiap-meed/docs/service-architecture.md
@@ -87,7 +87,7 @@ This is the right choice as long as the orchestrator and data clients are synchr
 Clients are injected via FastAPI's `Depends()` pattern. The city client defaults to the live city attributes API, while the action, legal, and policy clients still default to checked-in mock payloads.
 
 Future action API note:
-- the current strict action DTOs still match the checked-in `actions_api_mock.json`
+- the current action DTOs still match the checked-in `actions_api_mock.json`
 - that current mock contract still includes optional fields such as `biome`
 - when `GET /api/v1/action-pathways` is integrated, the action DTOs and mapping layer should be updated in one dedicated change to match the new payload shape, including dropping `biome` and aligning to the new action/co-benefit/emissions field names
 

--- a/hiap-meed/docs/service-architecture.md
+++ b/hiap-meed/docs/service-architecture.md
@@ -86,6 +86,11 @@ This is the right choice as long as the orchestrator and data clients are synchr
 
 Clients are injected via FastAPI's `Depends()` pattern. The city client defaults to the live city attributes API, while the action, legal, and policy clients still default to checked-in mock payloads.
 
+Future action API note:
+- the current strict action DTOs still match the checked-in `actions_api_mock.json`
+- that current mock contract still includes optional fields such as `biome`
+- when `GET /api/v1/action-pathways` is integrated, the action DTOs and mapping layer should be updated in one dedicated change to match the new payload shape, including dropping `biome` and aligning to the new action/co-benefit/emissions field names
+
 ---
 
 ## Request lifecycle

--- a/hiap-meed/pyproject.toml
+++ b/hiap-meed/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.128.0",
+    "httpx>=0.28.1",
     "openai>=2.32.0",
     "python-dotenv>=1.2.1",
     "uvicorn>=0.40.0",
@@ -13,6 +14,5 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "httpx>=0.28.1",
     "pytest>=9.0.2",
 ]

--- a/hiap-meed/tests/integration/test_city_attributes_live_api.py
+++ b/hiap-meed/tests/integration/test_city_attributes_live_api.py
@@ -1,0 +1,162 @@
+"""Live contract checks for the implemented upstream city attributes API path."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.modules.prioritizer.models import CityApiResponse
+from app.services.city_attributes_api import (
+    CITY_ATTRIBUTES_ENDPOINT_TEMPLATE,
+    CityAttributesApiService,
+)
+from app.services.http_client import get_json_with_retries
+
+
+BASE_CITY_KEYS = {
+    "area_km2",
+    "city_name",
+    "country_code",
+    "locode",
+    "populationDensity",
+    "populationSize",
+    "region_code",
+    "region_name",
+}
+INDICATOR_KEYS = {
+    "attribute_category",
+    "attribute_units",
+    "attribute_value",
+    "datasource",
+    "version_label",
+}
+EXPECTED_CITY_INDICATOR_FIELDS = {
+    "electricity_access_rate",
+    "employment_in_transport_and_logistics",
+    "home_ownership",
+    "industry_construction_employment",
+    "median_household_income",
+    "population",
+    "poverty_rate",
+    "public_transport_share",
+    "renter_share",
+    "unemployment_rate",
+}
+EXPECTED_DATASOURCE_KEYS = {
+    "dataset_name",
+    "dataset_url",
+    "datasource_name",
+    "is_latest",
+    "publisher_name",
+    "publisher_url",
+    "released_at",
+    "source_url",
+    "version_label",
+}
+
+
+def _assert_city_indicator_shape(indicator_payload: dict[str, object], field_name: str) -> None:
+    """Assert one city indicator object matches the expected contract shape."""
+    assert INDICATOR_KEYS.issubset(indicator_payload.keys()), field_name
+    assert isinstance(indicator_payload["attribute_value"], (int, float, str)) or (
+        indicator_payload["attribute_value"] is None
+    ), field_name
+    assert indicator_payload["attribute_units"] is None or isinstance(
+        indicator_payload["attribute_units"], str
+    ), field_name
+    assert indicator_payload["attribute_category"] is None or isinstance(
+        indicator_payload["attribute_category"], str
+    ), field_name
+    assert indicator_payload["datasource"] is None or isinstance(
+        indicator_payload["datasource"], str
+    ), field_name
+    assert indicator_payload["version_label"] is None or isinstance(
+        indicator_payload["version_label"], str
+    ), field_name
+
+
+@pytest.mark.integration
+@pytest.mark.external
+def test_city_attributes_live_payload_matches_expected_contract() -> None:
+    """The live upstream city payload keeps the contract our service currently implements."""
+    service = CityAttributesApiService()
+    url = service._build_city_url("CL IQQ")
+
+    payload, status_code = get_json_with_retries(
+        url=url,
+        operation_name="city attributes API call",
+        headers={"accept": "application/json"},
+    )
+
+    assert status_code == 200
+    assert {"meta", "city"}.issubset(payload.keys())
+
+    meta = payload["meta"]
+    assert {"api_context", "datasources", "generated_at_utc"}.issubset(meta.keys())
+    assert isinstance(meta["generated_at_utc"], str)
+    assert meta["generated_at_utc"]
+
+    api_context = meta["api_context"]
+    assert {"endpoint", "locode", "version_label"}.issubset(api_context.keys())
+    assert api_context["endpoint"] == CITY_ATTRIBUTES_ENDPOINT_TEMPLATE
+    assert api_context["locode"] == "CL IQQ"
+    assert api_context["version_label"] is None or isinstance(
+        api_context["version_label"], str
+    )
+
+    datasources = meta["datasources"]
+    assert isinstance(datasources, list)
+    assert datasources
+    for datasource in datasources:
+        assert EXPECTED_DATASOURCE_KEYS.issubset(datasource.keys())
+        assert isinstance(datasource["datasource_name"], str)
+        assert datasource["datasource_name"]
+        assert datasource["is_latest"] is None or isinstance(datasource["is_latest"], bool)
+
+    city = payload["city"]
+    assert (BASE_CITY_KEYS | EXPECTED_CITY_INDICATOR_FIELDS).issubset(city.keys())
+    assert city["locode"] == "CL IQQ"
+    assert isinstance(city["city_name"], str)
+    assert city["city_name"]
+    assert city["country_code"] is None or isinstance(city["country_code"], str)
+    assert isinstance(city["region_code"], str)
+    assert city["region_code"]
+    assert isinstance(city["region_name"], str)
+    assert city["region_name"]
+    assert city["area_km2"] is None or isinstance(city["area_km2"], (int, float))
+    assert isinstance(city["populationSize"], int)
+    assert isinstance(city["populationDensity"], (int, float))
+
+    for field_name in EXPECTED_CITY_INDICATOR_FIELDS:
+        indicator_payload = city[field_name]
+        assert isinstance(indicator_payload, dict), field_name
+        _assert_city_indicator_shape(indicator_payload, field_name)
+
+    # Keep service-model validation in the loop so missing or mistyped required fields fail.
+    validated = CityApiResponse.model_validate(payload)
+    assert validated.city.locode == "CL IQQ"
+    assert isinstance(validated.city.city_name, str)
+    assert validated.city.city_name
+    assert validated.city.population_size == city["populationSize"]
+    assert validated.city.population_density == pytest.approx(city["populationDensity"])
+
+
+@pytest.mark.integration
+@pytest.mark.external
+def test_city_attributes_live_service_maps_current_upstream_payload() -> None:
+    """The synchronous city service maps the live upstream payload into internal CityData."""
+    city = CityAttributesApiService().get_city("CL IQQ")
+
+    assert city.locode == "CL IQQ"
+    assert isinstance(city.city_name, str)
+    assert city.city_name
+    assert city.source == "city_attributes_api"
+    assert city.source_metadata["requested_locode"] == "CL IQQ"
+    assert city.source_metadata["upstream_endpoint"] == CITY_ATTRIBUTES_ENDPOINT_TEMPLATE
+    assert city.source_metadata["http_status_code"] == 200
+    assert isinstance(city.source_metadata["upstream_generated_at_utc"], str)
+    assert city.source_metadata["upstream_generated_at_utc"]
+    assert city.raw["locode"] == "CL IQQ"
+    assert isinstance(city.raw["city_name"], str)
+    assert city.raw["city_name"]
+    assert city.raw["population_size"] == city.population_size
+    assert city.raw["population_density"] == pytest.approx(city.population_density)

--- a/hiap-meed/tests/integration/test_prioritize_e2e_mock_api_data.py
+++ b/hiap-meed/tests/integration/test_prioritize_e2e_mock_api_data.py
@@ -142,6 +142,17 @@ def test_prioritize_e2e_with_mock_api_payloads(
         assert response_summary_payload["event_type"] == "response_summary.completed"
         assert response_summary_payload["step_name"] == "response_summary"
 
+        fetch_city_files = [
+            file_name for file_name in generated_files if file_name.endswith("_fetch_city.json")
+        ]
+        assert len(fetch_city_files) == 1
+        fetch_city_payload = json.loads(
+            (run_dir / fetch_city_files[0]).read_text("utf-8")
+        )["payload"]
+        assert fetch_city_payload["city_name"] == "Iquique"
+        assert fetch_city_payload["source"] == "mock_city_api"
+        assert fetch_city_payload["source_metadata"]["requested_locode"] == "CL IQQ"
+
         response_full_payload = json.loads(
             (run_dir / "response_full.json").read_text("utf-8")
         )

--- a/hiap-meed/tests/integration/test_prioritize_smoke.py
+++ b/hiap-meed/tests/integration/test_prioritize_smoke.py
@@ -440,7 +440,7 @@ def test_prioritize_returns_502_for_upstream_city_schema_drift(
         assert response.json()["detail"]["request_id"] == "req-city-schema-drift"
         assert response.json()["detail"]["upstream_status_code"] == 200
         assert response.json()["detail"]["upstream_url"] == (
-            f"{DEFAULT_CITY_ATTRIBUTES_BASE_URL.rstrip('/')}/api/v0/city_attributes/CL SCL"
+            f"{DEFAULT_CITY_ATTRIBUTES_BASE_URL.rstrip('/')}/api/v0/city_attributes/CL%20SCL"
         )
     finally:
         app.dependency_overrides.clear()

--- a/hiap-meed/tests/integration/test_prioritize_smoke.py
+++ b/hiap-meed/tests/integration/test_prioritize_smoke.py
@@ -23,6 +23,7 @@ from app.modules.prioritizer.internal_models import (
     CityData,
     LegalRequirementRecord,
 )
+from app.services.http_client import UpstreamApiError
 
 
 @dataclass
@@ -71,6 +72,18 @@ class MockPolicySignalsDataApiClient:
         """Return policy support signals for the requested city test case."""
         del locode
         return dict(self.policy_signals_by_action_id)
+
+
+@dataclass
+class FailingCityDataApiClient:
+    """City client double that raises a structured upstream API error."""
+
+    error: UpstreamApiError
+
+    def get_city(self, locode: str) -> CityData:
+        """Raise the configured upstream API error for the requested locode."""
+        del locode
+        raise self.error
 
 
 @dataclass
@@ -156,10 +169,11 @@ def test_prioritize_rejects_invalid_weights_override(
 ) -> None:
     """Invalid `weightsOverride` values are rejected with HTTP 422."""
     city = CityData(
-        comuna_name="Santiago",
+        city_name="Santiago",
         locode="CL-SCL",
         region_name="Metropolitana",
-        comuna_code="13101",
+
+
         region_code="13",
         city_context=[],
     )
@@ -217,13 +231,139 @@ def test_prioritize_rejects_invalid_weights_override(
 
 
 @pytest.mark.integration
+def test_prioritize_returns_404_when_upstream_city_is_missing() -> None:
+    """Prioritize returns HTTP 404 when the upstream city API has no city data."""
+    mock_city_client = FailingCityDataApiClient(
+        error=UpstreamApiError(
+            status_code=404,
+            message="city attributes API call failed with upstream status 404",
+            upstream_status_code=404,
+            url="https://example.test/api/v0/city_attributes/CL-SCL",
+        )
+    )
+    mock_action_client = MockActionDataApiClient(actions=[])
+    mock_legal_client = MockLegalDataApiClient(requirements_by_action_id={})
+    mock_policy_client = MockPolicySignalsDataApiClient(policy_signals_by_action_id={})
+
+    app.dependency_overrides[get_city_data_api_client] = lambda: mock_city_client
+    app.dependency_overrides[get_action_data_api_client] = lambda: mock_action_client
+    app.dependency_overrides[get_legal_data_api_client] = lambda: mock_legal_client
+    app.dependency_overrides[get_policy_signals_data_api_client] = (
+        lambda: mock_policy_client
+    )
+    try:
+        with TestClient(app) as test_client:
+            response = test_client.post(
+                "/v1/prioritize",
+                json={
+                    "meta": {
+                        "requestId": "req-city-404",
+                        "generatedAtUtc": "2026-02-26T11:43:40.011939+00:00",
+                        "backendConsumer": "hiap-meed",
+                        "upstreamProvider": "city_catalyst_frontend",
+                        "apiContext": {
+                            "endpoint": "POST /v1/prioritize",
+                            "locodes": ["CL-SCL"],
+                        },
+                        "totalRecords": 1,
+                    },
+                    "requestData": {
+                        "requestedLanguages": ["en"],
+                        "cityDataList": [
+                            {
+                                "locode": "CL-SCL",
+                                "countryCode": "CL",
+                                "populationSize": 1000,
+                                "cityStrategicPreferenceSectors": [],
+                                "cityStrategicPreferenceCoBenefitKeys": [],
+                                "cityEmissionsData": {
+                                    "inventoryYear": None,
+                                    "gpcData": {},
+                                },
+                            }
+                        ],
+                    },
+                },
+            )
+        assert response.status_code == 404
+        assert response.json()["detail"]["request_id"] == "req-city-404"
+        assert response.json()["detail"]["upstream_status_code"] == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.integration
+def test_prioritize_returns_503_for_retryable_upstream_city_failure() -> None:
+    """Prioritize returns HTTP 503 when the upstream city API is unavailable."""
+    mock_city_client = FailingCityDataApiClient(
+        error=UpstreamApiError(
+            status_code=503,
+            message="city attributes API call is temporarily unavailable",
+            url="https://example.test/api/v0/city_attributes/CL-SCL",
+        )
+    )
+    mock_action_client = MockActionDataApiClient(actions=[])
+    mock_legal_client = MockLegalDataApiClient(requirements_by_action_id={})
+    mock_policy_client = MockPolicySignalsDataApiClient(policy_signals_by_action_id={})
+
+    app.dependency_overrides[get_city_data_api_client] = lambda: mock_city_client
+    app.dependency_overrides[get_action_data_api_client] = lambda: mock_action_client
+    app.dependency_overrides[get_legal_data_api_client] = lambda: mock_legal_client
+    app.dependency_overrides[get_policy_signals_data_api_client] = (
+        lambda: mock_policy_client
+    )
+    try:
+        with TestClient(app) as test_client:
+            response = test_client.post(
+                "/v1/prioritize",
+                json={
+                    "meta": {
+                        "requestId": "req-city-503",
+                        "generatedAtUtc": "2026-02-26T11:43:40.011939+00:00",
+                        "backendConsumer": "hiap-meed",
+                        "upstreamProvider": "city_catalyst_frontend",
+                        "apiContext": {
+                            "endpoint": "POST /v1/prioritize",
+                            "locodes": ["CL-SCL"],
+                        },
+                        "totalRecords": 1,
+                    },
+                    "requestData": {
+                        "requestedLanguages": ["en"],
+                        "cityDataList": [
+                            {
+                                "locode": "CL-SCL",
+                                "countryCode": "CL",
+                                "populationSize": 1000,
+                                "cityStrategicPreferenceSectors": [],
+                                "cityStrategicPreferenceCoBenefitKeys": [],
+                                "cityEmissionsData": {
+                                    "inventoryYear": None,
+                                    "gpcData": {},
+                                },
+                            }
+                        ],
+                    },
+                },
+            )
+        assert response.status_code == 503
+        assert response.json()["detail"]["request_id"] == "req-city-503"
+        assert response.json()["detail"]["upstream_url"] == (
+            "https://example.test/api/v0/city_attributes/CL-SCL"
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.integration
 def test_prioritize_rejects_negative_non_afolu_total_emissions() -> None:
     """Endpoint rejects negative city emissions outside AFOLU at request validation."""
     city = CityData(
-        comuna_name="Santiago",
+        city_name="Santiago",
         locode="CL-SCL",
         region_name="Metropolitana",
-        comuna_code="13101",
+
+
         region_code="13",
         city_context=[],
     )
@@ -292,10 +432,11 @@ def test_prioritize_rejects_negative_non_afolu_total_emissions() -> None:
 def test_prioritize_smoke() -> None:
     """Frontend envelope request returns deterministic ranked action IDs."""
     city = CityData(
-        comuna_name="Santiago",
+        city_name="Santiago",
         locode="CL-SCL",
         region_name="Metropolitana",
-        comuna_code="13101",
+
+
         region_code="13",
         city_context=[
             {
@@ -565,10 +706,11 @@ def test_exclusion_preview_rejects_invalid_co_benefit_key() -> None:
 def test_prioritize_honors_confirmed_excluded_action_ids() -> None:
     """Ranking endpoint removes confirmed exclusions before scoring."""
     city = CityData(
-        comuna_name="Santiago",
+        city_name="Santiago",
         locode="CL-SCL",
         region_name="Metropolitana",
-        comuna_code="13101",
+
+
         region_code="13",
         city_context=[],
     )
@@ -639,10 +781,11 @@ def test_prioritize_honors_confirmed_excluded_action_ids() -> None:
 def test_prioritize_rejects_no_preference_with_other_timeframes() -> None:
     """`no_preference` cannot be combined with explicit timeframe choices."""
     city = CityData(
-        comuna_name="Santiago",
+        city_name="Santiago",
         locode="CL-SCL",
         region_name="Metropolitana",
-        comuna_code="13101",
+
+
         region_code="13",
         city_context=[],
     )
@@ -705,10 +848,11 @@ def test_prioritize_rejects_no_preference_with_other_timeframes() -> None:
 def test_prioritize_rejects_invalid_city_preference_sector_tag() -> None:
     """Prioritize endpoint should reject unsupported preferred sector tags."""
     city = CityData(
-        comuna_name="Santiago",
+        city_name="Santiago",
         locode="CL-SCL",
         region_name="Metropolitana",
-        comuna_code="13101",
+
+
         region_code="13",
         city_context=[],
     )
@@ -768,10 +912,11 @@ def test_prioritize_rejects_invalid_city_preference_sector_tag() -> None:
 def test_prioritize_rejects_invalid_city_preference_co_benefit_key() -> None:
     """Prioritize endpoint should reject unsupported preferred co-benefit keys."""
     city = CityData(
-        comuna_name="Santiago",
+        city_name="Santiago",
         locode="CL-SCL",
         region_name="Metropolitana",
-        comuna_code="13101",
+
+
         region_code="13",
         city_context=[],
     )
@@ -831,10 +976,11 @@ def test_prioritize_rejects_invalid_city_preference_co_benefit_key() -> None:
 def test_prioritize_alignment_timeframe_multi_select_uses_best_match() -> None:
     """Multi-select timeframes use the best score, including nearest selected bucket."""
     city = CityData(
-        comuna_name="Santiago",
+        city_name="Santiago",
         locode="CL-SCL",
         region_name="Metropolitana",
-        comuna_code="13101",
+
+
         region_code="13",
         city_context=[],
     )
@@ -922,10 +1068,11 @@ def test_prioritize_alignment_timeframe_multi_select_uses_best_match() -> None:
 def test_prioritize_discards_hard_legal_mismatch() -> None:
     """Actions failing hard legal requirements are removed before ranking."""
     city = CityData(
-        comuna_name="Santiago",
+        city_name="Santiago",
         locode="CL-SCL",
         region_name="Metropolitana",
-        comuna_code="13101",
+
+
         region_code="13",
         city_context=[],
     )
@@ -1007,10 +1154,11 @@ def test_prioritize_discards_hard_legal_mismatch() -> None:
 def test_prioritize_keeps_no_evidence_hard_legal_requirements() -> None:
     """No-evidence hard requirements keep actions but expose unknown requirement evidence."""
     city = CityData(
-        comuna_name="Santiago",
+        city_name="Santiago",
         locode="CL-SCL",
         region_name="Metropolitana",
-        comuna_code="13101",
+
+
         region_code="13",
         city_context=[],
     )
@@ -1098,10 +1246,11 @@ def test_prioritize_skips_explanations_when_flag_false(
 ) -> None:
     """Request flag=false must skip explanation service invocation."""
     city = CityData(
-        comuna_name="Santiago",
+        city_name="Santiago",
         locode="CL-SCL",
         region_name="Metropolitana",
-        comuna_code="13101",
+
+
         region_code="13",
         city_context=[],
     )
@@ -1169,10 +1318,11 @@ def test_prioritize_generates_explanations_for_returned_top_n_only(
 ) -> None:
     """Explanation service receives only top-N scored actions from orchestrator."""
     city = CityData(
-        comuna_name="Santiago",
+        city_name="Santiago",
         locode="CL-SCL",
         region_name="Metropolitana",
-        comuna_code="13101",
+
+
         region_code="13",
         city_context=[],
     )
@@ -1246,10 +1396,11 @@ def test_prioritize_fails_open_when_explanation_generation_errors(
 ) -> None:
     """LLM failures should not break ranking response semantics."""
     city = CityData(
-        comuna_name="Santiago",
+        city_name="Santiago",
         locode="CL-SCL",
         region_name="Metropolitana",
-        comuna_code="13101",
+
+
         region_code="13",
         city_context=[],
     )
@@ -1316,10 +1467,11 @@ def test_prioritize_logs_non_zero_explanation_elapsed_time(
 ) -> None:
     """Explanation completion logs should report measured elapsed time."""
     city = CityData(
-        comuna_name="Santiago",
+        city_name="Santiago",
         locode="CL-SCL",
         region_name="Metropolitana",
-        comuna_code="13101",
+
+
         region_code="13",
         city_context=[],
     )
@@ -1417,10 +1569,11 @@ def test_prioritize_returns_canonical_english_and_requested_translations(
 ) -> None:
     """Prioritization should always return English plus requested translated explanations."""
     city = CityData(
-        comuna_name="Santiago",
+        city_name="Santiago",
         locode="CL-SCL",
         region_name="Metropolitana",
-        comuna_code="13101",
+
+
         region_code="13",
         city_context=[],
     )
@@ -1506,10 +1659,11 @@ def test_prioritize_reports_only_successfully_generated_languages(
 ) -> None:
     """Metadata should reflect only explanation languages present in the response."""
     city = CityData(
-        comuna_name="Santiago",
+        city_name="Santiago",
         locode="CL-SCL",
         region_name="Metropolitana",
-        comuna_code="13101",
+
+
         region_code="13",
         city_context=[],
     )
@@ -1755,3 +1909,5 @@ def test_translate_endpoint_rejects_duplicate_action_ids() -> None:
         )
 
     assert response.status_code == 422
+
+

--- a/hiap-meed/tests/integration/test_prioritize_smoke.py
+++ b/hiap-meed/tests/integration/test_prioritize_smoke.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 import time
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -23,7 +24,9 @@ from app.modules.prioritizer.internal_models import (
     CityData,
     LegalRequirementRecord,
 )
+from app.services.city_attributes_api import DEFAULT_CITY_ATTRIBUTES_BASE_URL
 from app.services.http_client import UpstreamApiError
+from app.services.data_clients import ApiCityDataApiClient
 
 
 @dataclass
@@ -350,6 +353,94 @@ def test_prioritize_returns_503_for_retryable_upstream_city_failure() -> None:
         assert response.json()["detail"]["request_id"] == "req-city-503"
         assert response.json()["detail"]["upstream_url"] == (
             "https://example.test/api/v0/city_attributes/CL-SCL"
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.integration
+def test_prioritize_returns_502_for_upstream_city_schema_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prioritize returns HTTP 502 when the upstream city payload fails schema validation."""
+
+    def _mock_get(
+        self: httpx.Client, url: str, headers: dict[str, str] | None = None
+    ) -> httpx.Response:
+        request = httpx.Request("GET", url, headers=headers)
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "meta": {
+                    "generated_at_utc": "2026-05-13T09:39:51.706285+00:00",
+                    "api_context": {
+                        "endpoint": "GET /api/v0/city_attributes/{locode}",
+                        "locode": "CL SCL",
+                        "version_label": None,
+                    },
+                    "datasources": [],
+                },
+                "city": {
+                    "locode": "CL SCL",
+                    "country_code": "CL",
+                    "region_code": "13",
+                    "region_name": "Metropolitana",
+                },
+            },
+        )
+
+    monkeypatch.setattr(httpx.Client, "get", _mock_get)
+
+    mock_action_client = MockActionDataApiClient(actions=[])
+    mock_legal_client = MockLegalDataApiClient(requirements_by_action_id={})
+    mock_policy_client = MockPolicySignalsDataApiClient(policy_signals_by_action_id={})
+
+    app.dependency_overrides[get_city_data_api_client] = lambda: ApiCityDataApiClient()
+    app.dependency_overrides[get_action_data_api_client] = lambda: mock_action_client
+    app.dependency_overrides[get_legal_data_api_client] = lambda: mock_legal_client
+    app.dependency_overrides[get_policy_signals_data_api_client] = (
+        lambda: mock_policy_client
+    )
+    try:
+        with TestClient(app) as test_client:
+            response = test_client.post(
+                "/v1/prioritize",
+                json={
+                    "meta": {
+                        "requestId": "req-city-schema-drift",
+                        "generatedAtUtc": "2026-02-26T11:43:40.011939+00:00",
+                        "backendConsumer": "hiap-meed",
+                        "upstreamProvider": "city_catalyst_frontend",
+                        "apiContext": {
+                            "endpoint": "POST /v1/prioritize",
+                            "locodes": ["CL SCL"],
+                        },
+                        "totalRecords": 1,
+                    },
+                    "requestData": {
+                        "requestedLanguages": ["en"],
+                        "cityDataList": [
+                            {
+                                "locode": "CL SCL",
+                                "countryCode": "CL",
+                                "populationSize": 1000,
+                                "cityStrategicPreferenceSectors": [],
+                                "cityStrategicPreferenceCoBenefitKeys": [],
+                                "cityEmissionsData": {
+                                    "inventoryYear": None,
+                                    "gpcData": {},
+                                },
+                            }
+                        ],
+                    },
+                },
+            )
+        assert response.status_code == 502
+        assert response.json()["detail"]["request_id"] == "req-city-schema-drift"
+        assert response.json()["detail"]["upstream_status_code"] == 200
+        assert response.json()["detail"]["upstream_url"] == (
+            f"{DEFAULT_CITY_ATTRIBUTES_BASE_URL.rstrip('/')}/api/v0/city_attributes/CL SCL"
         )
     finally:
         app.dependency_overrides.clear()

--- a/hiap-meed/tests/unit/test_data_clients.py
+++ b/hiap-meed/tests/unit/test_data_clients.py
@@ -116,7 +116,7 @@ def test_city_attributes_service_uses_env_base_url_override(
     assert service.base_url == "https://city-attributes.example.test/root/"
     assert (
         service._build_city_url("CL IQQ")
-        == "https://city-attributes.example.test/root/api/v0/city_attributes/CL IQQ"
+        == "https://city-attributes.example.test/root/api/v0/city_attributes/CL%20IQQ"
     )
 
 
@@ -231,7 +231,7 @@ def test_api_city_client_rejects_incomplete_remote_payload(
     assert error_info.value.upstream_status_code == 200
     assert (
         error_info.value.url
-        == f"{DEFAULT_CITY_ATTRIBUTES_BASE_URL.rstrip('/')}/api/v0/city_attributes/CL IQQ"
+        == f"{DEFAULT_CITY_ATTRIBUTES_BASE_URL.rstrip('/')}/api/v0/city_attributes/CL%20IQQ"
     )
 
 
@@ -467,22 +467,24 @@ def test_action_api_item_rejects_scalar_subsector_number() -> None:
 
 
 @pytest.mark.unit
-def test_action_api_item_rejects_unexpected_upstream_field() -> None:
-    """Upstream action contract rejects unexpected extra fields instead of dropping them."""
-    with pytest.raises(ValidationError):
-        ActionApiItem.model_validate(
-            {
-                "actionId": "action_1",
-                "actionName": "Action 1",
-                "unexpectedField": "should-fail",
-                "emissions": {
-                    "sector_number": "I",
-                    "subsector_number": [1],
-                    "gpc_reference_number": ["I.1.1"],
-                    "impact_text": "high",
-                },
-            }
-        )
+def test_action_api_item_ignores_unexpected_upstream_field() -> None:
+    """Upstream action DTO ignores additive extra fields it does not use."""
+    action = ActionApiItem.model_validate(
+        {
+            "actionId": "action_1",
+            "actionName": "Action 1",
+            "unexpectedField": "ignored",
+            "emissions": {
+                "sector_number": "I",
+                "subsector_number": [1],
+                "gpc_reference_number": ["I.1.1"],
+                "impact_text": "high",
+            },
+        }
+    )
+
+    assert action.actionId == "action_1"
+    assert not hasattr(action, "unexpectedField")
 
 
 @pytest.mark.unit

--- a/hiap-meed/tests/unit/test_data_clients.py
+++ b/hiap-meed/tests/unit/test_data_clients.py
@@ -14,6 +14,10 @@ from app.modules.prioritizer.models import (
     PolicySignalByAction,
     PrioritizerApiRequest,
 )
+from app.services.city_attributes_api import (
+    DEFAULT_CITY_ATTRIBUTES_BASE_URL,
+    CityAttributesApiService,
+)
 from app.services.http_client import UpstreamApiError, get_json_with_retries
 from app.services.data_clients import (
     ApiCityDataApiClient,
@@ -83,6 +87,37 @@ def test_get_city_data_client_defaults_to_api(monkeypatch: pytest.MonkeyPatch) -
     client = get_city_data_api_client()
 
     assert isinstance(client, ApiCityDataApiClient)
+
+
+@pytest.mark.unit
+def test_city_attributes_service_uses_default_base_url_when_env_is_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """City attributes service falls back to the documented default host."""
+    monkeypatch.delenv("CCGLOBAL_API_BASE_URL", raising=False)
+
+    service = CityAttributesApiService()
+
+    assert service.base_url == DEFAULT_CITY_ATTRIBUTES_BASE_URL
+
+
+@pytest.mark.unit
+def test_city_attributes_service_uses_env_base_url_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """City attributes service honors the configured upstream host override."""
+    monkeypatch.setenv(
+        "CCGLOBAL_API_BASE_URL",
+        "https://city-attributes.example.test/root/ ",
+    )
+
+    service = CityAttributesApiService()
+
+    assert service.base_url == "https://city-attributes.example.test/root/"
+    assert (
+        service._build_city_url("CL IQQ")
+        == "https://city-attributes.example.test/root/api/v0/city_attributes/CL IQQ"
+    )
 
 
 @pytest.mark.unit
@@ -158,7 +193,7 @@ def test_api_city_client_maps_remote_payload_and_metadata(
 def test_api_city_client_rejects_incomplete_remote_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """API city client fails fast when required city fields are missing upstream."""
+    """API city client maps invalid upstream payloads to a structured 502 error."""
 
     def _mock_get(
         self: httpx.Client, url: str, headers: dict[str, str] | None = None
@@ -189,8 +224,15 @@ def test_api_city_client_rejects_incomplete_remote_payload(
     monkeypatch.setattr(httpx.Client, "get", _mock_get)
     client = ApiCityDataApiClient()
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(UpstreamApiError) as error_info:
         client.get_city("CL IQQ")
+
+    assert error_info.value.status_code == 502
+    assert error_info.value.upstream_status_code == 200
+    assert (
+        error_info.value.url
+        == f"{DEFAULT_CITY_ATTRIBUTES_BASE_URL.rstrip('/')}/api/v0/city_attributes/CL IQQ"
+    )
 
 
 @pytest.mark.unit

--- a/hiap-meed/tests/unit/test_data_clients.py
+++ b/hiap-meed/tests/unit/test_data_clients.py
@@ -115,8 +115,8 @@ def test_api_city_client_maps_remote_payload_and_metadata(
                     "region_code": "CL01",
                     "region_name": "Tarapaca",
                     "area_km2": 2646,
-                    "population_size": 214857,
-                    "population_density": 953.69,
+                    "populationSize": 214857,
+                    "populationDensity": 953.69,
                     "population": {
                         "attribute_value": 214857,
                         "attribute_units": "persons",
@@ -194,10 +194,10 @@ def test_api_city_client_rejects_incomplete_remote_payload(
 
 
 @pytest.mark.unit
-def test_api_city_client_rejects_camelcase_population_fields(
+def test_api_city_client_accepts_camelcase_population_fields(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """API city client rejects camelCase population fields from a drifted upstream schema."""
+    """API city client accepts the current upstream camelCase population fields."""
 
     def _mock_get(
         self: httpx.Client, url: str, headers: dict[str, str] | None = None
@@ -232,8 +232,12 @@ def test_api_city_client_rejects_camelcase_population_fields(
     monkeypatch.setattr(httpx.Client, "get", _mock_get)
     client = ApiCityDataApiClient()
 
-    with pytest.raises(ValidationError):
-        client.get_city("CL ARI")
+    city = client.get_city("CL ARI")
+
+    assert city.locode == "CL ARI"
+    assert city.city_name == "Arica"
+    assert city.population_size == 236109
+    assert city.population_density == pytest.approx(43.96)
 
 
 @pytest.mark.unit

--- a/hiap-meed/tests/unit/test_data_clients.py
+++ b/hiap-meed/tests/unit/test_data_clients.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import httpx
 import pytest
 from pydantic import ValidationError
 
@@ -13,7 +14,9 @@ from app.modules.prioritizer.models import (
     PolicySignalByAction,
     PrioritizerApiRequest,
 )
+from app.services.http_client import UpstreamApiError, get_json_with_retries
 from app.services.data_clients import (
+    ApiCityDataApiClient,
     MockActionDataApiClient,
     MockCityDataApiClient,
     MockPolicySignalsDataApiClient,
@@ -63,22 +66,216 @@ def test_mock_city_client_loads_city_from_file() -> None:
 
     city = client.get_city("CL IQQ")
 
-    assert city.comuna_name == "Iquique"
-    assert city.region_name == "Tarapacá"
+    assert city.city_name == "Iquique"
+    assert city.region_name == "Tarapaca"
     assert city.city_context
     assert any(
         row.get("attribute_name") == "unemployment_rate" for row in city.city_context
     )
+    assert city.source_metadata["mock_file_path"].endswith("city_api_mock.json")
 
 
 @pytest.mark.unit
-def test_get_city_data_client_defaults_to_mock(monkeypatch: pytest.MonkeyPatch) -> None:
-    """City dependency provider defaults to mock data source."""
+def test_get_city_data_client_defaults_to_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    """City dependency provider defaults to API data source."""
     monkeypatch.delenv("HIAP_MEED_CITY_DATA_SOURCE", raising=False)
 
     client = get_city_data_api_client()
 
-    assert isinstance(client, MockCityDataApiClient)
+    assert isinstance(client, ApiCityDataApiClient)
+
+
+@pytest.mark.unit
+def test_api_city_client_maps_remote_payload_and_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """API city client maps remote payload fields and exposes fetch metadata."""
+
+    def _mock_get(
+        self: httpx.Client, url: str, headers: dict[str, str] | None = None
+    ) -> httpx.Response:
+        request = httpx.Request("GET", url, headers=headers)
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "meta": {
+                    "generated_at_utc": "2026-05-13T09:39:51.706285+00:00",
+                    "api_context": {
+                        "endpoint": "GET /api/v0/city_attributes/{locode}",
+                        "locode": "CL IQQ",
+                        "version_label": None,
+                    },
+                    "datasources": [],
+                },
+                "city": {
+                    "locode": "CL IQQ",
+                    "city_name": "Iquique",
+                    "country_code": "CL",
+                    "region_code": "CL01",
+                    "region_name": "Tarapaca",
+                    "area_km2": 2646,
+                    "population_size": 214857,
+                    "population_density": 953.69,
+                    "unemployment_rate": {
+                        "attribute_value": 9.44,
+                        "attribute_units": "percent",
+                        "attribute_category": "high",
+                        "datasource": "cl-ine-censo",
+                        "version_label": "2024",
+                    },
+                },
+            },
+        )
+
+    monkeypatch.setattr(httpx.Client, "get", _mock_get)
+    client = ApiCityDataApiClient()
+
+    city = client.get_city("CL IQQ")
+
+    assert city.city_name == "Iquique"
+    assert city.population_size == 214857
+    assert city.population_density == pytest.approx(953.69)
+    assert city.area_km2 == pytest.approx(2646)
+    assert city.source_metadata["upstream_endpoint"] == (
+        "GET /api/v0/city_attributes/{locode}"
+    )
+    assert city.source_metadata["http_status_code"] == 200
+    assert city.source_metadata["requested_locode"] == "CL IQQ"
+    assert city.source_metadata["upstream_generated_at_utc"] == (
+        "2026-05-13T09:39:51.706285+00:00"
+    )
+
+
+@pytest.mark.unit
+def test_api_city_client_rejects_incomplete_remote_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """API city client fails fast when required city fields are missing upstream."""
+
+    def _mock_get(
+        self: httpx.Client, url: str, headers: dict[str, str] | None = None
+    ) -> httpx.Response:
+        request = httpx.Request("GET", url, headers=headers)
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "meta": {
+                    "generated_at_utc": "2026-05-13T09:39:51.706285+00:00",
+                    "api_context": {
+                        "endpoint": "GET /api/v0/city_attributes/{locode}",
+                        "locode": "CL IQQ",
+                        "version_label": None,
+                    },
+                    "datasources": [],
+                },
+                "city": {
+                    "locode": "CL IQQ",
+                    "country_code": "CL",
+                    "region_code": "CL01",
+                    "region_name": "Tarapaca",
+                },
+            },
+        )
+
+    monkeypatch.setattr(httpx.Client, "get", _mock_get)
+    client = ApiCityDataApiClient()
+
+    with pytest.raises(ValidationError):
+        client.get_city("CL IQQ")
+
+
+@pytest.mark.unit
+def test_get_json_with_retries_retries_retryable_http_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shared HTTP helper retries once for retryable upstream HTTP statuses."""
+    responses = iter(
+        [
+            httpx.Response(
+                503,
+                request=httpx.Request("GET", "https://example.test/city"),
+            ),
+            httpx.Response(
+                200,
+                request=httpx.Request("GET", "https://example.test/city"),
+                json={"ok": True},
+            ),
+        ]
+    )
+
+    def _mock_get(
+        self: httpx.Client, url: str, headers: dict[str, str] | None = None
+    ) -> httpx.Response:
+        del self, url, headers
+        return next(responses)
+
+    monkeypatch.setattr(httpx.Client, "get", _mock_get)
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    monkeypatch.setenv("UPSTREAM_HTTP_MAX_RETRIES", "1")
+
+    payload, status_code = get_json_with_retries(
+        url="https://example.test/city",
+        operation_name="test upstream call",
+    )
+
+    assert payload == {"ok": True}
+    assert status_code == 200
+
+
+@pytest.mark.unit
+def test_get_json_with_retries_maps_timeout_to_504(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shared HTTP helper maps exhausted timeouts to HTTP 504."""
+
+    def _mock_get(
+        self: httpx.Client, url: str, headers: dict[str, str] | None = None
+    ) -> httpx.Response:
+        del self, url, headers
+        raise httpx.ReadTimeout("timed out")
+
+    monkeypatch.setattr(httpx.Client, "get", _mock_get)
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    monkeypatch.setenv("UPSTREAM_HTTP_MAX_RETRIES", "0")
+
+    with pytest.raises(UpstreamApiError) as error_info:
+        get_json_with_retries(
+            url="https://example.test/city",
+            operation_name="test upstream call",
+        )
+
+    assert error_info.value.status_code == 504
+
+
+@pytest.mark.unit
+def test_get_json_with_retries_maps_invalid_json_to_502(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shared HTTP helper maps invalid JSON upstream payloads to HTTP 502."""
+
+    def _mock_get(
+        self: httpx.Client, url: str, headers: dict[str, str] | None = None
+    ) -> httpx.Response:
+        request = httpx.Request("GET", url, headers=headers)
+        return httpx.Response(
+            200,
+            request=request,
+            content=b"not-json",
+            headers={"content-type": "application/json"},
+        )
+
+    monkeypatch.setattr(httpx.Client, "get", _mock_get)
+    monkeypatch.setenv("UPSTREAM_HTTP_MAX_RETRIES", "0")
+
+    with pytest.raises(UpstreamApiError) as error_info:
+        get_json_with_retries(
+            url="https://example.test/city",
+            operation_name="test upstream call",
+        )
+
+    assert error_info.value.status_code == 502
 
 
 @pytest.mark.unit

--- a/hiap-meed/tests/unit/test_data_clients.py
+++ b/hiap-meed/tests/unit/test_data_clients.py
@@ -117,6 +117,13 @@ def test_api_city_client_maps_remote_payload_and_metadata(
                     "area_km2": 2646,
                     "population_size": 214857,
                     "population_density": 953.69,
+                    "population": {
+                        "attribute_value": 214857,
+                        "attribute_units": "persons",
+                        "attribute_category": "very high",
+                        "datasource": "cl-ine-censo",
+                        "version_label": "2024",
+                    },
                     "unemployment_rate": {
                         "attribute_value": 9.44,
                         "attribute_units": "percent",
@@ -184,6 +191,49 @@ def test_api_city_client_rejects_incomplete_remote_payload(
 
     with pytest.raises(ValidationError):
         client.get_city("CL IQQ")
+
+
+@pytest.mark.unit
+def test_api_city_client_rejects_camelcase_population_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """API city client rejects camelCase population fields from a drifted upstream schema."""
+
+    def _mock_get(
+        self: httpx.Client, url: str, headers: dict[str, str] | None = None
+    ) -> httpx.Response:
+        request = httpx.Request("GET", url, headers=headers)
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "meta": {
+                    "generated_at_utc": "2026-05-13T14:43:41.038750+00:00",
+                    "api_context": {
+                        "endpoint": "GET /api/v0/city_attributes/{locode}",
+                        "locode": "CL ARI",
+                        "version_label": None,
+                    },
+                    "datasources": [],
+                },
+                "city": {
+                    "locode": "CL ARI",
+                    "city_name": "Arica",
+                    "country_code": "CL",
+                    "region_code": "CL15",
+                    "region_name": "Arica y Parinacota",
+                    "area_km2": 5371,
+                    "populationSize": 236109,
+                    "populationDensity": 43.96,
+                },
+            },
+        )
+
+    monkeypatch.setattr(httpx.Client, "get", _mock_get)
+    client = ApiCityDataApiClient()
+
+    with pytest.raises(ValidationError):
+        client.get_city("CL ARI")
 
 
 @pytest.mark.unit
@@ -371,6 +421,25 @@ def test_action_api_item_rejects_scalar_subsector_number() -> None:
 
 
 @pytest.mark.unit
+def test_action_api_item_rejects_unexpected_upstream_field() -> None:
+    """Upstream action contract rejects unexpected extra fields instead of dropping them."""
+    with pytest.raises(ValidationError):
+        ActionApiItem.model_validate(
+            {
+                "actionId": "action_1",
+                "actionName": "Action 1",
+                "unexpectedField": "should-fail",
+                "emissions": {
+                    "sector_number": "I",
+                    "subsector_number": [1],
+                    "gpc_reference_number": ["I.1.1"],
+                    "impact_text": "high",
+                },
+            }
+        )
+
+
+@pytest.mark.unit
 def test_prioritizer_request_accepts_activity_type_field() -> None:
     """Frontend request contract accepts `activityType` in city activity rows."""
     request = PrioritizerApiRequest.model_validate(
@@ -420,6 +489,43 @@ def test_prioritizer_request_accepts_activity_type_field() -> None:
         .activities[0]
     )
     assert activity.activityType == "Natural gas"
+
+
+@pytest.mark.unit
+def test_prioritizer_request_rejects_unexpected_frontend_field() -> None:
+    """Frontend request contract rejects unexpected extra fields at the API boundary."""
+    with pytest.raises(ValidationError):
+        PrioritizerApiRequest.model_validate(
+            {
+                "meta": {
+                    "requestId": "req-1",
+                    "generatedAtUtc": "2026-05-12T00:00:00+00:00",
+                    "backendConsumer": "hiap-meed",
+                    "upstreamProvider": "city_catalyst_frontend",
+                    "apiContext": {
+                        "endpoint": "POST /v1/prioritize",
+                        "locodes": ["CL-SCL"],
+                    },
+                    "totalRecords": 1,
+                },
+                "requestData": {
+                    "requestedLanguages": ["en"],
+                    "cityDataList": [
+                        {
+                            "locode": "CL-SCL",
+                            "countryCode": "CL",
+                            "cityStrategicPreferenceSectors": [],
+                            "cityStrategicPreferenceCoBenefitKeys": [],
+                            "unexpectedField": "should-fail",
+                            "cityEmissionsData": {
+                                "inventoryYear": 2022,
+                                "gpcData": {},
+                            },
+                        }
+                    ],
+                },
+            }
+        )
 
 
 @pytest.mark.unit

--- a/hiap-meed/tests/unit/test_prioritizer_blocks.py
+++ b/hiap-meed/tests/unit/test_prioritizer_blocks.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 
 import pytest
-from pydantic import ValidationError
 
 from app.modules.prioritizer.api import _extract_city_emissions_context
 from app.modules.prioritizer.blocks import (
@@ -117,28 +116,30 @@ def test_mock_city_loader_keeps_renamed_indicator_keys() -> None:
 
 
 @pytest.mark.unit
-def test_city_api_item_rejects_unknown_indicator_names() -> None:
-    """Strict city contract rejects unknown upstream keys instead of dropping them silently."""
-    with pytest.raises(ValidationError):
-        CityApiItem.model_validate(
-            {
-                "city_name": "Iquique",
-                "locode": "CL IQQ",
-                "country_code": "CL",
-                "region_name": "Tarapaca",
-                "region_code": "CL01",
-                "transport_logistics_employment": {
-                    "attribute_value": 7.35,
-                    "attribute_units": "percent",
-                    "attribute_category": "low",
-                },
-                "electricity_access": {
-                    "attribute_value": 100.0,
-                    "attribute_units": "percent",
-                    "attribute_category": "very low",
-                },
-            }
-        )
+def test_city_api_item_ignores_unknown_indicator_names() -> None:
+    """City API parsing tolerates additive upstream keys we do not consume yet."""
+    city = CityApiItem.model_validate(
+        {
+            "city_name": "Iquique",
+            "locode": "CL IQQ",
+            "country_code": "CL",
+            "region_name": "Tarapaca",
+            "region_code": "CL01",
+            "transport_logistics_employment": {
+                "attribute_value": 7.35,
+                "attribute_units": "percent",
+                "attribute_category": "low",
+            },
+            "electricity_access": {
+                "attribute_value": 100.0,
+                "attribute_units": "percent",
+                "attribute_category": "very low",
+            },
+        }
+    )
+
+    assert city.locode == "CL IQQ"
+    assert city.city_name == "Iquique"
 
 
 @pytest.mark.unit

--- a/hiap-meed/tests/unit/test_prioritizer_blocks.py
+++ b/hiap-meed/tests/unit/test_prioritizer_blocks.py
@@ -119,11 +119,10 @@ def test_city_api_item_ignores_legacy_indicator_names() -> None:
     """Legacy city indicator names are ignored so mismatches remain visible."""
     city = CityApiItem.model_validate(
         {
-            "comuna_name": "Iquique",
+            "city_name": "Iquique",
             "locode": "CL IQQ",
-            "countryCode": "CL",
+            "country_code": "CL",
             "region_name": "Tarapaca",
-            "comuna_code": "CL01101",
             "region_code": "CL01",
             "transport_logistics_employment": {
                 "attribute_value": 7.35,

--- a/hiap-meed/tests/unit/test_prioritizer_blocks.py
+++ b/hiap-meed/tests/unit/test_prioritizer_blocks.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from app.modules.prioritizer.api import _extract_city_emissions_context
 from app.modules.prioritizer.blocks import (
@@ -107,6 +108,7 @@ def test_mock_city_loader_keeps_renamed_indicator_keys() -> None:
 
     assert "employment_in_transport_and_logistics" in city.raw
     assert "electricity_access_rate" in city.raw
+    assert "population" in city.raw
     city_context_names = {
         row["attribute_name"] for row in city.city_context if "attribute_name" in row
     }
@@ -115,30 +117,28 @@ def test_mock_city_loader_keeps_renamed_indicator_keys() -> None:
 
 
 @pytest.mark.unit
-def test_city_api_item_ignores_legacy_indicator_names() -> None:
-    """Legacy city indicator names are ignored so mismatches remain visible."""
-    city = CityApiItem.model_validate(
-        {
-            "city_name": "Iquique",
-            "locode": "CL IQQ",
-            "country_code": "CL",
-            "region_name": "Tarapaca",
-            "region_code": "CL01",
-            "transport_logistics_employment": {
-                "attribute_value": 7.35,
-                "attribute_units": "percent",
-                "attribute_category": "low",
-            },
-            "electricity_access": {
-                "attribute_value": 100.0,
-                "attribute_units": "percent",
-                "attribute_category": "very low",
-            },
-        }
-    )
-
-    assert city.employment_in_transport_and_logistics is None
-    assert city.electricity_access_rate is None
+def test_city_api_item_rejects_unknown_indicator_names() -> None:
+    """Strict city contract rejects unknown upstream keys instead of dropping them silently."""
+    with pytest.raises(ValidationError):
+        CityApiItem.model_validate(
+            {
+                "city_name": "Iquique",
+                "locode": "CL IQQ",
+                "country_code": "CL",
+                "region_name": "Tarapaca",
+                "region_code": "CL01",
+                "transport_logistics_employment": {
+                    "attribute_value": 7.35,
+                    "attribute_units": "percent",
+                    "attribute_category": "low",
+                },
+                "electricity_access": {
+                    "attribute_value": 100.0,
+                    "attribute_units": "percent",
+                    "attribute_category": "very low",
+                },
+            }
+        )
 
 
 @pytest.mark.unit

--- a/hiap-meed/uv.lock
+++ b/hiap-meed/uv.lock
@@ -102,6 +102,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "openai" },
     { name = "python-dotenv" },
     { name = "uvicorn" },
@@ -109,23 +110,20 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "httpx" },
     { name = "pytest" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.128.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "openai", specifier = ">=2.32.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "uvicorn", specifier = ">=0.40.0" },
 ]
 
 [package.metadata.requires-dev]
-dev = [
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "pytest", specifier = ">=9.0.2" },
-]
+dev = [{ name = "pytest", specifier = ">=9.0.2" }]
 
 [[package]]
 name = "httpcore"


### PR DESCRIPTION
## Summary

Extends HIAP-MEED prioritization with city context via the city attributes API, stricter upstream contract validation for clearer failures, and broader integration/unit coverage (including optional live city-attributes API tests when configured).

## Changes

- Add reusable HTTP client wrapper, city attributes client, and orchestration changes to fetch and pass city context through prioritization.
- Tighten prioritizer/API models and validation; refresh mock city payloads and docs to match contracts and field names.
- Add `hiap-meed/tests/integration/test_city_attributes_live_api.py` and expand smoke, E2E mock, and unit tests around data clients and prioritizer blocks.

## Commits (3)

- chore: added city context API and http wrapper
- chore: made API contracts strict for fail fast and better validation
- chore: added API tests, fixed field names
