### PR TITLE
feat(test): use expectStatusCode helper consistenly in all tests

### DIFF
--- a/app/tests/api/activity_value.jest.ts
+++ b/app/tests/api/activity_value.jest.ts
@@ -11,7 +11,12 @@ import {
 
 import { db } from "@/models";
 import { randomUUID } from "node:crypto";
-import { mockRequest, setupTests, testUserID } from "../helpers";
+import {
+  expectStatusCode,
+  mockRequest,
+  setupTests,
+  testUserID,
+} from "../helpers";
 import { City } from "@/models/City";
 import { Inventory } from "@/models/Inventory";
 import { SubCategory } from "@/models/SubCategory";
@@ -154,7 +159,7 @@ describe.skip("Activity Value API", () => {
     const res = await createActivityValue(req, {
       params: Promise.resolve({ inventory: inventory.inventoryId }),
     });
-    expect(res.status).toBe(400);
+    await expectStatusCode(res, 400);
   });
 
   it("should not create an activity value with with formulas with invalid data", async () => {
@@ -171,7 +176,7 @@ describe.skip("Activity Value API", () => {
       params: Promise.resolve({ inventory: inventory.inventoryId }),
     });
 
-    expect(res.status).toBe(400);
+    await expectStatusCode(res, 400);
   });
 
   it("should create an activity value with activity times emissions factor", async () => {
@@ -188,7 +193,7 @@ describe.skip("Activity Value API", () => {
       params: Promise.resolve({ inventory: inventory.inventoryId }),
     });
 
-    expect(res.status).toBe(200);
+    await expectStatusCode(res, 200);
     const { data } = await res.json();
 
     createdActivityValue2 = data;
@@ -215,7 +220,7 @@ describe.skip("Activity Value API", () => {
 
     const { data } = await res.json();
 
-    expect(res.status).toBe(200);
+    await expectStatusCode(res, 200);
     expect(data.activityData.co2_amount).toBe(
       updatedActivityValueWithFormula.activityData.co2_amount,
     );
@@ -234,7 +239,7 @@ describe.skip("Activity Value API", () => {
       }),
     });
 
-    expect(res.status).toBe(400);
+    await expectStatusCode(res, 400);
   });
 
   it("should create an activity, creating an inventory value with inventoryValue params", async () => {
@@ -248,7 +253,7 @@ describe.skip("Activity Value API", () => {
       params: Promise.resolve({ inventory: inventory.inventoryId }),
     });
 
-    expect(res.status).toBe(200);
+    await expectStatusCode(res, 200);
     const { data } = await res.json();
     createdActivityValue2 = data;
     expect(data.activityData.co2_amount).toBe(
@@ -272,7 +277,7 @@ describe.skip("Activity Value API", () => {
       params: Promise.resolve({ inventory: inventory.inventoryId }),
     });
 
-    expect(res.status).toBe(200);
+    await expectStatusCode(res, 200);
     const { data } = await res.json();
     createdActivityValue = data;
     expect(data.activityData.co2_amount).toBe(
@@ -291,7 +296,7 @@ describe.skip("Activity Value API", () => {
     });
 
     const { data } = await res.json();
-    expect(res.status).toBe(200);
+    await expectStatusCode(res, 200);
     expect(data.co2eq).toBe(createdActivityValue.co2eq);
     expect(data.co2eqYears).toBe(createdActivityValue.co2eqYears);
     expect(data.inventoryValueId).toBe(inventoryValue.id);
@@ -325,7 +330,7 @@ describe.skip("Activity Value API", () => {
     });
 
     const { data } = await res.json();
-    expect(res.status).toBe(200);
+    await expectStatusCode(res, 200);
     expect(data.activityData.co2_amount).toBe(
       updatedActivityValue.activityData.co2_amount,
     );
@@ -341,7 +346,7 @@ describe.skip("Activity Value API", () => {
     });
 
     const { data } = await res.json();
-    expect(res.status).toBe(200);
+    await expectStatusCode(res, 200);
     expect(data).toBe(true);
   });
 

--- a/app/tests/api/admin.jest.ts
+++ b/app/tests/api/admin.jest.ts
@@ -11,7 +11,13 @@ import {
   expect,
   jest,
 } from "@jest/globals";
-import { mockRequest, setupTests, testUserData, testUserID } from "../helpers";
+import {
+  expectStatusCode,
+  mockRequest,
+  setupTests,
+  testUserData,
+  testUserID,
+} from "../helpers";
 import { AppSession, Auth } from "@/lib/auth";
 import { Roles } from "@/util/types";
 import {
@@ -79,7 +85,7 @@ describe("Admin API", () => {
     const req = mockRequest(mockBulkInventoriesRequest);
     Auth.getServerSession = jest.fn(() => Promise.resolve(mockAdminSession));
     const res = await createBulkInventories(req, emptyParams);
-    expect(res.status).toBe(200);
+    await expectStatusCode(res, 200);
     const body = await res.json();
     expect(body.errors.length).toBe(0);
     expect(body.results.length).toBe(
@@ -147,7 +153,7 @@ describe("Admin API", () => {
     const req = mockRequest(mockConnectSourcesRequest);
     Auth.getServerSession = jest.fn(() => Promise.resolve(mockAdminSession));
     const res = await bulkConnectDataSources(req, emptyParams);
-    expect(res.status).toBe(200);
+    await expectStatusCode(res, 200);
     const body = await res.json();
     // expect(body.errors.length).toBe(0);
     console.error(body.errors.slice(0, 10));
@@ -160,7 +166,7 @@ describe("Admin API", () => {
     });
     Auth.getServerSession = jest.fn(() => Promise.resolve(mockAdminSession));
     const res = await changeRole(req, emptyParams);
-    expect(res.status).toBe(200);
+    await expectStatusCode(res, 200);
     const body = await res.json();
     expect(body.success).toBe(true);
 
@@ -176,7 +182,7 @@ describe("Admin API", () => {
       role: Roles.Admin,
     });
     const res = await changeRole(req, emptyParams);
-    expect(res.status).toBe(403);
+    await expectStatusCode(res, 403);
 
     const user = await db.models.User.findOne({
       where: { email: testUserData.email },
@@ -191,7 +197,7 @@ describe("Admin API", () => {
     });
     Auth.getServerSession = jest.fn(() => Promise.resolve(mockAdminSession));
     const res = await changeRole(req, emptyParams);
-    expect(res.status).toBe(404);
+    await expectStatusCode(res, 404);
   });
 
   it("should validate the request", async () => {
@@ -199,7 +205,7 @@ describe("Admin API", () => {
 
     const req = mockRequest({ email: testUserData.email, role: "invalid" });
     const res = await changeRole(req, emptyParams);
-    expect(res.status).toBe(400);
+    await expectStatusCode(res, 400);
 
     const req2 = mockRequest({ email: "not-an-email", role: "admin" });
     const res2 = await changeRole(req2, emptyParams);

--- a/app/tests/api/bulk-hiap-prioritization.jest.ts
+++ b/app/tests/api/bulk-hiap-prioritization.jest.ts
@@ -37,7 +37,7 @@ import {
   cleanupTestData,
   TestData,
 } from "../helpers/testDataCreationHelper";
-import { setupTests, mockRequest } from "../helpers";
+import { setupTests, mockRequest, expectStatusCode } from "../helpers";
 
 const MOCK_CRON_API_KEY = "MOCK_CRON_API_KEY";
 
@@ -339,7 +339,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       const res = await POST(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toBe(401);
+      await expectStatusCode(res, 401);
       const body = await res.json();
       expect(body.error.message).toContain("Unauthorized");
     });
@@ -356,7 +356,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       const res = await POST(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toBe(403);
+      await expectStatusCode(res, 403);
       const body = await res.json();
       expect(body.error.message).toContain("Forbidden");
     });
@@ -369,7 +369,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       const res = await POST(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toBe(400);
+      await expectStatusCode(res, 400);
       const body = await res.json();
       expect(body.error).toBeTruthy();
     });
@@ -384,7 +384,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       const res = await POST(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toBe(400);
+      await expectStatusCode(res, 400);
       const body = await res.json();
       expect(body.error.issues).toBeDefined();
       expect(body.error.issues[0].path).toContain("actionType");
@@ -400,7 +400,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       const res = await POST(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toBe(400);
+      await expectStatusCode(res, 400);
       const body = await res.json();
       expect(body.error.issues).toBeDefined();
       expect(body.error.issues[0].path).toContain("languages");
@@ -416,7 +416,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       const res = await POST(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const body = await res.json();
 
       // Should return immediately with summary
@@ -467,7 +467,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       const res = await POST(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const body = await res.json();
       expect(body.data.totalCities).toBe(0);
       expect(body.data.firstBatchSize).toBe(0);
@@ -483,7 +483,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       const res = await POST(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const body = await res.json();
       expect(body.data.totalCities).toBeGreaterThan(0);
 
@@ -1526,7 +1526,7 @@ describe("Bulk HIAP Prioritization API", () => {
       const res = await POST(req, { params: Promise.resolve({}) });
 
       // API should still return 200 since it responds immediately
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const body = await res.json();
       expect(body.data.totalCities).toBeGreaterThan(0);
 
@@ -1663,7 +1663,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       // Call cron endpoint (simulating cron job run)
       const response = await callHiapCronJobRoute();
-      expect(response.status).toBe(200);
+      await expectStatusCode(response, 200);
 
       // Parse response body
       const responseBody = await response.json();
@@ -1737,7 +1737,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       // Call cron endpoint
       const response = await callHiapCronJobRoute();
-      expect(response.status).toBe(200);
+      await expectStatusCode(response, 200);
 
       // Parse response body
       const responseBody = await response.json();
@@ -1969,7 +1969,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       const res = await PATCH(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const body = await res.json();
 
       // Should exclude 1 and retry 2
@@ -2030,7 +2030,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       const res = await PATCH(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const body = await res.json();
 
       expect(body.data.excludedCount).toBe(2);
@@ -2066,7 +2066,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       const res = await PATCH(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const body = await res.json();
 
       expect(body.data.excludedCount).toBe(0);
@@ -2124,7 +2124,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       const res = await PATCH(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const body = await res.json();
 
       // Should only affect batch-1
@@ -2175,7 +2175,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       const res = await PUT(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const body = await res.json();
 
       expect(body.data.unexcludedCount).toBe(2);
@@ -2220,7 +2220,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       const res = await PUT(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const body = await res.json();
 
       expect(body.data.unexcludedCount).toBe(1);
@@ -2256,7 +2256,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       const res = await PUT(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toBe(400);
+      await expectStatusCode(res, 400);
       const body = await res.json();
       expect(body.error).toBeTruthy();
     });
@@ -2270,7 +2270,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       const res = await PUT(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const body = await res.json();
       expect(body.data.unexcludedCount).toBe(0);
     });
@@ -2286,7 +2286,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       const res = await PUT(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toBe(403);
+      await expectStatusCode(res, 403);
       const body = await res.json();
       expect(body.error.message).toContain("Forbidden");
     });
@@ -2320,7 +2320,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       // Call cron endpoint
       const response = await callHiapCronJobRoute();
-      expect(response.status).toBe(200);
+      await expectStatusCode(response, 200);
 
       // Parse response body
       const responseBody = await response.json();
@@ -2440,7 +2440,7 @@ describe("Bulk HIAP Prioritization API", () => {
 
       // Call cron endpoint
       const response = await callHiapCronJobRoute();
-      expect(response.status).toBe(200);
+      await expectStatusCode(response, 200);
 
       const responseBody = await response.json();
 

--- a/app/tests/api/city-hiap-action_plan.jest.ts
+++ b/app/tests/api/city-hiap-action_plan.jest.ts
@@ -7,14 +7,23 @@ import {
   it,
   jest,
 } from "@jest/globals";
-import { mockRequest, setupTests } from "../helpers";
+import {
+  expectStatusCode,
+  expectStatusCodes,
+  mockRequest,
+  setupTests,
+} from "../helpers";
 import {
   createTestData,
   cleanupTestData,
   TestData,
 } from "../helpers/testDataCreationHelper";
 import { AppSession, Auth } from "@/lib/auth";
-import { Roles, ACTION_TYPES, HighImpactActionRankingStatus } from "@/util/types";
+import {
+  Roles,
+  ACTION_TYPES,
+  HighImpactActionRankingStatus,
+} from "@/util/types";
 import { db } from "@/models";
 import { randomUUID } from "node:crypto";
 import {
@@ -26,9 +35,7 @@ import {
   PATCH as updateActionPlan,
   DELETE as deleteActionPlan,
 } from "@/app/api/v1/city/[city]/hiap/action-plan/[id]/route";
-import {
-  POST as generateActionPlan,
-} from "@/app/api/v1/city/[city]/hiap/action-plan/generate/[rankingId]/route";
+import { POST as generateActionPlan } from "@/app/api/v1/city/[city]/hiap/action-plan/generate/[rankingId]/route";
 
 import * as HiapApiService from "@/backend/hiap/HiapApiService";
 
@@ -117,7 +124,7 @@ describe("City HIAP Prioritization API", () => {
         params: Promise.resolve({ city: testData.cityId }),
       });
 
-      expect(res.status).toBe(400);
+      await expectStatusCode(res, 400);
       const body = await res.json();
       expect(body?.error?.message).toMatch(/Invalid query parameters/i);
     });
@@ -131,7 +138,7 @@ describe("City HIAP Prioritization API", () => {
         params: Promise.resolve({ city: testData.cityId }),
       });
 
-      expect(res.status).toBe(400);
+      await expectStatusCode(res, 400);
       const body = await res.json();
       expect(body?.error?.message).toMatch(/Invalid query parameters/i);
     });
@@ -180,7 +187,7 @@ describe("City HIAP Prioritization API", () => {
         params: Promise.resolve({ city: testData.cityId }),
       });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const body = await res.json();
       expect(body.data).toBeTruthy();
       // fetchOrTranslateActionPlan returns an array
@@ -191,10 +198,13 @@ describe("City HIAP Prioritization API", () => {
 
       // Cleanup
       await db.models.ActionPlan.destroy({ where: { id: actionPlan.id } });
-      await db.models.HighImpactActionRanked.destroy({ where: { id: rankedAction.id } });
-      await db.models.HighImpactActionRanking.destroy({ where: { id: ranking.id } });
+      await db.models.HighImpactActionRanked.destroy({
+        where: { id: rankedAction.id },
+      });
+      await db.models.HighImpactActionRanking.destroy({
+        where: { id: ranking.id },
+      });
     });
-
   });
 
   describe("POST /api/v0/city/[city]/hiap/action-plan", () => {
@@ -208,7 +218,7 @@ describe("City HIAP Prioritization API", () => {
         session: mockSession,
       } as any);
 
-      expect(res.status).toBe(400);
+      await expectStatusCode(res, 400);
       const body = await res.json();
       expect(body?.error).toBeTruthy();
     });
@@ -255,7 +265,7 @@ describe("City HIAP Prioritization API", () => {
         session: mockSession,
       } as any);
 
-      expect(res.status).toBe(201);
+      await expectStatusCode(res, 201);
       const body = await res.json();
       expect(body.data).toBeTruthy();
       expect(body.data.actionId).toBe(rankedAction.actionId);
@@ -263,7 +273,7 @@ describe("City HIAP Prioritization API", () => {
 
       // Verify it was saved to database
       const savedPlan = await db.models.ActionPlan.findOne({
-        where: { 
+        where: {
           actionId: rankedAction.actionId,
           language: "en",
         },
@@ -275,8 +285,12 @@ describe("City HIAP Prioritization API", () => {
       if (savedPlan) {
         await db.models.ActionPlan.destroy({ where: { id: savedPlan.id } });
       }
-      await db.models.HighImpactActionRanked.destroy({ where: { id: rankedAction.id } });
-      await db.models.HighImpactActionRanking.destroy({ where: { id: ranking.id } });
+      await db.models.HighImpactActionRanked.destroy({
+        where: { id: rankedAction.id },
+      });
+      await db.models.HighImpactActionRanking.destroy({
+        where: { id: ranking.id },
+      });
     });
 
     it("validates UUID format for inventoryId and hiActionRankingId", async () => {
@@ -294,7 +308,7 @@ describe("City HIAP Prioritization API", () => {
         session: mockSession,
       } as any);
 
-      expect(res.status).toBe(400);
+      await expectStatusCode(res, 400);
       const body = await res.json();
       expect(body?.error).toBeTruthy();
     });
@@ -308,7 +322,7 @@ describe("City HIAP Prioritization API", () => {
         params: Promise.resolve({ city: testData.cityId, id: nonExistentId }),
       });
 
-      expect(res.status).toBe(404);
+      await expectStatusCode(res, 404);
       const body = await res.json();
       expect(body?.error?.message).toMatch(/not found/i);
     });
@@ -353,15 +367,19 @@ describe("City HIAP Prioritization API", () => {
         params: Promise.resolve({ city: testData.cityId, id: actionPlan.id }),
       });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const body = await res.json();
       expect(body.data).toBeTruthy();
       expect(body.data.id).toBe(actionPlan.id);
 
       // Cleanup
       await db.models.ActionPlan.destroy({ where: { id: actionPlan.id } });
-      await db.models.HighImpactActionRanked.destroy({ where: { id: rankedAction.id } });
-      await db.models.HighImpactActionRanking.destroy({ where: { id: ranking.id } });
+      await db.models.HighImpactActionRanked.destroy({
+        where: { id: rankedAction.id },
+      });
+      await db.models.HighImpactActionRanking.destroy({
+        where: { id: ranking.id },
+      });
     });
   });
 
@@ -411,7 +429,7 @@ describe("City HIAP Prioritization API", () => {
         params: Promise.resolve({ city: testData.cityId, id: actionPlan.id }),
       });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const body = await res.json();
       expect(body.data).toBeTruthy();
       expect(body.data.actionName).toBe("Updated Action Name");
@@ -422,8 +440,12 @@ describe("City HIAP Prioritization API", () => {
 
       // Cleanup
       await db.models.ActionPlan.destroy({ where: { id: actionPlan.id } });
-      await db.models.HighImpactActionRanked.destroy({ where: { id: rankedAction.id } });
-      await db.models.HighImpactActionRanking.destroy({ where: { id: ranking.id } });
+      await db.models.HighImpactActionRanked.destroy({
+        where: { id: rankedAction.id },
+      });
+      await db.models.HighImpactActionRanking.destroy({
+        where: { id: ranking.id },
+      });
     });
 
     it("returns 404 when action plan does not exist", async () => {
@@ -433,7 +455,7 @@ describe("City HIAP Prioritization API", () => {
       });
 
       // Service returns 200 with null data when not found
-      expect([200, 404]).toContain(res.status);
+      await expectStatusCodes(res, [200, 404]);
     });
   });
 
@@ -478,7 +500,7 @@ describe("City HIAP Prioritization API", () => {
         params: Promise.resolve({ city: testData.cityId, id: actionPlan.id }),
       });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const body = await res.json();
       expect(body.success).toBe(true);
 
@@ -487,8 +509,12 @@ describe("City HIAP Prioritization API", () => {
       expect(deleted).toBeNull();
 
       // Cleanup
-      await db.models.HighImpactActionRanked.destroy({ where: { id: rankedAction.id } });
-      await db.models.HighImpactActionRanking.destroy({ where: { id: ranking.id } });
+      await db.models.HighImpactActionRanked.destroy({
+        where: { id: rankedAction.id },
+      });
+      await db.models.HighImpactActionRanking.destroy({
+        where: { id: ranking.id },
+      });
     });
 
     it("returns 404 when action plan does not exist", async () => {
@@ -498,7 +524,7 @@ describe("City HIAP Prioritization API", () => {
       });
 
       // Service may return 200 or 404 depending on implementation
-      expect([200, 404]).toContain(res.status);
+      await expectStatusCodes(res, [200, 404]);
     });
   });
 
@@ -540,24 +566,33 @@ describe("City HIAP Prioritization API", () => {
 
       const req = mockRequest(requestBody);
       const res = await generateActionPlan(req, {
-        params: Promise.resolve({ city: testData.cityId, rankingId: ranking.id }),
+        params: Promise.resolve({
+          city: testData.cityId,
+          rankingId: ranking.id,
+        }),
         session: mockSession,
       } as any);
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const body = await res.json();
       expect(body.data).toBeTruthy();
       expect(body.data.actionName).toBe("Mock Action");
 
       // Verify the mock was called
-      expect(HiapApiService.hiapApiWrapper.startActionPlanJob).toHaveBeenCalled();
+      expect(
+        HiapApiService.hiapApiWrapper.startActionPlanJob,
+      ).toHaveBeenCalled();
 
       // Cleanup action plans created by the service
       await db.models.ActionPlan.destroy({
         where: { actionId: rankedAction.actionId },
       });
-      await db.models.HighImpactActionRanked.destroy({ where: { id: rankedAction.id } });
-      await db.models.HighImpactActionRanking.destroy({ where: { id: ranking.id } });
+      await db.models.HighImpactActionRanked.destroy({
+        where: { id: rankedAction.id },
+      });
+      await db.models.HighImpactActionRanking.destroy({
+        where: { id: ranking.id },
+      });
     });
 
     it("returns 400 when required fields are missing", async () => {
@@ -566,12 +601,14 @@ describe("City HIAP Prioritization API", () => {
         // missing inventoryId and cityLocode
       });
       const res = await generateActionPlan(req, {
-        params: Promise.resolve({ city: testData.cityId, rankingId: randomUUID() }),
+        params: Promise.resolve({
+          city: testData.cityId,
+          rankingId: randomUUID(),
+        }),
         session: mockSession,
       } as any);
 
-      expect(res.status).toBe(400);
+      await expectStatusCode(res, 400);
     });
   });
 });
-

--- a/app/tests/api/city-hiap.jest.ts
+++ b/app/tests/api/city-hiap.jest.ts
@@ -7,7 +7,7 @@ import {
   it,
   jest,
 } from "@jest/globals";
-import { mockRequest, setupTests } from "../helpers";
+import { expectStatusCode, mockRequest, setupTests } from "../helpers";
 import {
   createTestData,
   cleanupTestData,
@@ -128,7 +128,7 @@ describe("Inventory HIAP API", () => {
         params: Promise.resolve({ inventory: inventoryId }),
       });
 
-      expect(res.status).toBe(500);
+      await expectStatusCode(res, 500);
       const body = await res.json();
       expect(body?.error).toBeTruthy();
     });
@@ -143,7 +143,7 @@ describe("Inventory HIAP API", () => {
         params: Promise.resolve({ inventory: inventoryId }),
       });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const body = await res.json();
       expect(body.data).toBeTruthy();
 
@@ -209,7 +209,7 @@ describe("Inventory HIAP API", () => {
         params: Promise.resolve({ inventory: inventoryId }),
       });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const body = await res.json();
       expect(body.data).toBeTruthy();
       // The response contains the ranking data directly
@@ -269,7 +269,7 @@ describe("Inventory HIAP API", () => {
         params: Promise.resolve({ inventory: inventoryId }),
       });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const json = await res.json();
       expect(json.success).toBe(true);
       expect(typeof json.updated).toBe("number");
@@ -300,7 +300,7 @@ describe("Inventory HIAP API", () => {
         params: Promise.resolve({ inventory: inventoryId }),
       });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const json = await res.json();
       expect(json.success).toBe(true);
       expect(json.updated).toBe(0);

--- a/app/tests/api/city.jest.ts
+++ b/app/tests/api/city.jest.ts
@@ -16,7 +16,12 @@ import { POST as createCity } from "@/app/api/v1/city/route";
 import { db } from "@/models";
 import { CreateCityRequest } from "@/util/validation";
 import assert from "node:assert";
-import { mockRequest, setupTests, testUserID } from "../helpers";
+import {
+  expectStatusCode,
+  mockRequest,
+  setupTests,
+  testUserID,
+} from "../helpers";
 import { City } from "@/models/City";
 import { randomUUID } from "node:crypto";
 import { AppSession, Auth } from "@/lib/auth";
@@ -102,11 +107,13 @@ describe("City API", () => {
 
     // Get the organization ID from the project
     const projectWithOrg = await db.models.Project.findByPk(project.projectId, {
-      include: [{
-        model: db.models.Organization,
-        as: 'organization',
-        attributes: ['organizationId']
-      }]
+      include: [
+        {
+          model: db.models.Organization,
+          as: "organization",
+          attributes: ["organizationId"],
+        },
+      ],
     });
     organizationId = projectWithOrg?.organization?.organizationId as string;
 
@@ -118,7 +125,7 @@ describe("City API", () => {
     await db.models.OrganizationAdmin.create({
       organizationAdminId: randomUUID(),
       userId: orgAdminUserId,
-      organizationId: organizationId
+      organizationId: organizationId,
     });
   });
 
@@ -155,7 +162,7 @@ describe("City API", () => {
 
     const req = mockRequest({ ...cityData, projectId: project?.projectId });
     const res = await createCity(req, emptyParams);
-    assert.equal(res.status, 200);
+    await expectStatusCode(res, 200);
     const { data } = await res.json();
     assert.equal(data.locode, cityData.locode);
     assert.equal(data.name, cityData.name);
@@ -169,7 +176,7 @@ describe("City API", () => {
 
     const req = mockRequest({ ...cityData, projectId: project?.projectId });
     const res = await createCity(req, emptyParams);
-    assert.equal(res.status, 403);
+    await expectStatusCode(res, 403);
     const { error } = await res.json();
     assert.equal(error.message, "You do not have access to this project");
   });
@@ -179,7 +186,7 @@ describe("City API", () => {
 
     const req = mockRequest(invalidCity);
     const res = await createCity(req, emptyParams);
-    assert.equal(res.status, 400);
+    await expectStatusCode(res, 400);
     const {
       error: { issues },
     } = await res.json();
@@ -193,7 +200,7 @@ describe("City API", () => {
     const res = await findCity(req, {
       params: Promise.resolve({ city: city.cityId }),
     });
-    assert.equal(res.status, 200);
+    await expectStatusCode(res, 200);
     const { data } = await res.json();
     assert.equal(data.locode, cityData.locode);
     assert.equal(data.name, cityData.name);
@@ -209,7 +216,7 @@ describe("City API", () => {
     const res = await findCity(req, {
       params: Promise.resolve({ city: city.cityId }),
     });
-    assert.equal(res.status, 200);
+    await expectStatusCode(res, 200);
     const { data } = await res.json();
     assert.equal(data.locode, cityData.locode);
     assert.equal(data.name, cityData.name);
@@ -222,14 +229,14 @@ describe("City API", () => {
     Auth.getServerSession = jest.fn(() => Promise.resolve(collaboratorSession));
     const req = mockRequest();
     const res = await getAllCities(req, emptyParams);
-    assert.equal(res.status, 403);
+    await expectStatusCode(res, 403);
   });
 
   it("should get all cities for system admin", async () => {
     Auth.getServerSession = jest.fn(() => Promise.resolve(systemAdminSession));
     const req = mockRequest();
     const res = await getAllCities(req, emptyParams);
-    assert.equal(res.status, 200);
+    await expectStatusCode(res, 200);
     const { data } = await res.json();
     assert.notEqual(data.length, 0);
   });
@@ -241,7 +248,7 @@ describe("City API", () => {
     const res = await findCity(req, {
       params: Promise.resolve({ city: randomUUID() }),
     });
-    assert.equal(res.status, 404);
+    await expectStatusCode(res, 404);
   });
 
   it("should return 404 for non-existing city as collaborator", async () => {
@@ -251,7 +258,7 @@ describe("City API", () => {
     const res = await findCity(req, {
       params: Promise.resolve({ city: randomUUID() }),
     });
-    assert.equal(res.status, 404);
+    await expectStatusCode(res, 404);
   });
 
   it("should update a city", async () => {
@@ -259,7 +266,7 @@ describe("City API", () => {
     const res = await updateCity(req, {
       params: Promise.resolve({ city: city.cityId }),
     });
-    assert.equal(res.status, 200);
+    await expectStatusCode(res, 200);
     const { data } = await res.json();
     assert.equal(data.locode, city2.locode);
     assert.equal(data.name, city2.name);
@@ -273,7 +280,7 @@ describe("City API", () => {
     const res = await updateCity(req, {
       params: Promise.resolve({ city: city.cityId }),
     });
-    assert.equal(res.status, 400);
+    await expectStatusCode(res, 400);
     const {
       error: { issues },
     } = await res.json();
@@ -285,7 +292,7 @@ describe("City API", () => {
     const res = await deleteCity(req, {
       params: Promise.resolve({ city: city.cityId }),
     });
-    assert.equal(res.status, 200);
+    await expectStatusCode(res, 200);
     const { data, deleted } = await res.json();
     assert.equal(deleted, true);
     assert.equal(data.locode, cityData.locode);
@@ -300,6 +307,6 @@ describe("City API", () => {
     const res = await deleteCity(req, {
       params: Promise.resolve({ city: randomUUID() }),
     });
-    assert.equal(res.status, 404);
+    await expectStatusCode(res, 404);
   });
 });

--- a/app/tests/api/city_transfer.jest.ts
+++ b/app/tests/api/city_transfer.jest.ts
@@ -1,7 +1,12 @@
 import { AppSession, Auth } from "@/lib/auth";
 import { Roles } from "@/util/types";
 import { afterAll, beforeAll, describe, expect, it, jest } from "@jest/globals";
-import { mockRequest, setupTests, testUserID } from "../helpers";
+import {
+  expectStatusCode,
+  mockRequest,
+  setupTests,
+  testUserID,
+} from "../helpers";
 import { db } from "@/models";
 import {
   CreateOrganizationRequest,
@@ -98,7 +103,7 @@ describe("City Transfer API", () => {
     });
 
     const res = await transferCity(req, emptyParams);
-    expect(res.status).toBe(200);
+    await expectStatusCode(res, 200);
     const data = await res.json();
     expect(data).toEqual({ success: true });
 
@@ -123,10 +128,10 @@ describe("City Transfer API", () => {
       projectId: project2.projectId,
     });
 
-    const resJSON = await transferCity(req, emptyParams);
-    const res = await resJSON.json();
-    expect(resJSON.status).toBe(404);
-    expect(res.error).toEqual({
+    const res = await transferCity(req, emptyParams);
+    await expectStatusCode(res, 404);
+    const data = await res.json();
+    expect(data.error).toEqual({
       message: "Cities not found for IDs: " + invalidCityId,
     });
   });
@@ -150,7 +155,7 @@ describe("City Transfer API", () => {
     });
 
     const res = await transferCity(req, emptyParams);
-    expect(res.status).toBe(403);
+    await expectStatusCode(res, 403);
     const data = await res.json();
     expect(data.error).toEqual({ message: "Forbidden" });
   });

--- a/app/tests/api/datasource.jest.ts
+++ b/app/tests/api/datasource.jest.ts
@@ -189,7 +189,7 @@ describe("DataSource API", () => {
         sectorId: sector.sectorId,
       }),
     });
-    expect(res.status).toBe(200);
+    await expectStatusCode(res, 200);
     const { data } = await res.json();
     expect(data.length).toBe(1);
     const { source } = data[0];
@@ -206,7 +206,7 @@ describe("DataSource API", () => {
     const res = await getAllDataSources(req, {
       params: Promise.resolve({ inventoryId: inventory.inventoryId }),
     });
-    expect(res.status).toBe(200);
+    await expectStatusCode(res, 200);
     const { data } = await res.json();
     expect(data.length).toBe(2);
   });
@@ -272,7 +272,7 @@ describe("DataSource API", () => {
         datasourceId: datasource.datasourceId,
       }),
     });
-    expect(res.status).toBe(200);
+    await expectStatusCode(res, 200);
     const data = await res.json();
     expect(data.source.datasourceId).toBe(datasource.datasourceId);
     expect(data.data).toBeDefined();
@@ -287,7 +287,7 @@ describe("DataSource API", () => {
         datasourceId: randomUUID(),
       }),
     });
-    expect(res.status).toBe(404);
+    await expectStatusCode(res, 404);
   });
 
   it("should return 404 if inventory not found", async () => {
@@ -302,6 +302,6 @@ describe("DataSource API", () => {
         datasourceId: datasource.datasourceId,
       }),
     });
-    expect(res.status).toBe(404);
+    await expectStatusCode(res, 404);
   });
 });

--- a/app/tests/api/import-routes.jest.ts
+++ b/app/tests/api/import-routes.jest.ts
@@ -29,7 +29,7 @@ import { SubSector } from "@/models/SubSector";
 import { SubCategory } from "@/models/SubCategory";
 import { Op } from "sequelize";
 import Excel from "exceljs";
-import { expectStatusCode, expectStatusCodes } from "helpers";
+import { expectStatusCode, expectStatusCodes } from "../helpers";
 
 // Test helpers (avoiding helpers.ts due to import.meta.url ESM issue)
 const mockUrl = "http://localhost:3000/api/v1";

--- a/app/tests/api/import-routes.jest.ts
+++ b/app/tests/api/import-routes.jest.ts
@@ -3,14 +3,13 @@ import {
   beforeAll,
   beforeEach,
   describe,
+  expect,
   it,
   jest,
 } from "@jest/globals";
 import { POST as uploadImportFile } from "@/app/api/v1/city/[city]/inventory/[inventory]/import/route";
 import { GET as getImportStatus } from "@/app/api/v1/city/[city]/inventory/[inventory]/import/[importedFileId]/route";
-import {
-  POST as approveImport,
-} from "@/app/api/v1/city/[city]/inventory/[inventory]/import/approve/route";
+import { POST as approveImport } from "@/app/api/v1/city/[city]/inventory/[inventory]/import/approve/route";
 import { db } from "@/models";
 import assert from "node:assert";
 import { NextRequest } from "next/server";
@@ -21,12 +20,16 @@ import { City } from "@/models/City";
 import { Inventory } from "@/models/Inventory";
 import { randomUUID } from "node:crypto";
 import { ImportStatusEnum } from "@/util/enums";
-import { InventoryTypeEnum, GlobalWarmingPotentialTypeEnum } from "@/util/enums";
+import {
+  InventoryTypeEnum,
+  GlobalWarmingPotentialTypeEnum,
+} from "@/util/enums";
 import { Sector } from "@/models/Sector";
 import { SubSector } from "@/models/SubSector";
 import { SubCategory } from "@/models/SubCategory";
 import { Op } from "sequelize";
 import Excel from "exceljs";
+import { expectStatusCode, expectStatusCodes } from "helpers";
 
 // Test helpers (avoiding helpers.ts due to import.meta.url ESM issue)
 const mockUrl = "http://localhost:3000/api/v1";
@@ -112,20 +115,22 @@ export function setupTests() {
   }
 
   // mock getServerSession from NextAuth
-  jest.spyOn(Auth, "getServerSession").mockResolvedValue((() => {
-    const expires = new Date();
-    expires.setDate(expires.getDate() + 1);
-    return {
-      user: {
-        id: testUserID,
-        name: "Test User",
-        email: "test@example.com",
-        image: null,
-        role: Roles.User,
-      },
-      expires: expires.toISOString(),
-    } as AppSession;
-  })());
+  jest.spyOn(Auth, "getServerSession").mockResolvedValue(
+    (() => {
+      const expires = new Date();
+      expires.setDate(expires.getDate() + 1);
+      return {
+        user: {
+          id: testUserID,
+          name: "Test User",
+          email: "test@example.com",
+          image: null,
+          role: Roles.User,
+        },
+        expires: expires.toISOString(),
+      } as AppSession;
+    })(),
+  );
 }
 
 const testCityLocode = "XX_IMPORT_TEST";
@@ -263,10 +268,14 @@ describe("Import Routes API", () => {
       await db.models.City.destroy({ where: { cityId: city.cityId } });
     }
     if (subcategoryScope?.scopeId) {
-      await db.models.Scope.destroy({ where: { scopeId: subcategoryScope.scopeId } });
+      await db.models.Scope.destroy({
+        where: { scopeId: subcategoryScope.scopeId },
+      });
     }
     if (subsectorScope?.scopeId) {
-      await db.models.Scope.destroy({ where: { scopeId: subsectorScope.scopeId } });
+      await db.models.Scope.destroy({
+        where: { scopeId: subsectorScope.scopeId },
+      });
     }
     // Close database connection to prevent hanging async operations in CI
     if (db.sequelize) {
@@ -291,7 +300,7 @@ describe("Import Routes API", () => {
         }),
       });
 
-      assert.equal(res.status, 400);
+      await expectStatusCode(res, 400);
     });
 
     it("should reject request with invalid city ID", async () => {
@@ -377,7 +386,7 @@ describe("Import Routes API", () => {
         }),
       });
 
-      assert.equal(res.status, 200);
+      await expectStatusCode(res, 200);
       const json = await res.json();
       assert.ok(json.data);
       assert.equal(json.data.currentStep, 1);
@@ -418,7 +427,7 @@ describe("Import Routes API", () => {
         }),
       });
 
-      assert.equal(res.status, 200);
+      await expectStatusCode(res, 200);
       const json = await res.json();
       assert.ok(json.data);
       assert.equal(json.data.currentStep, 2);
@@ -462,7 +471,7 @@ describe("Import Routes API", () => {
         }),
       });
 
-      assert.equal(res.status, 200);
+      await expectStatusCode(res, 200);
       const json = await res.json();
       assert.ok(json.data);
       assert.equal(json.data.currentStep, 3);
@@ -514,7 +523,7 @@ describe("Import Routes API", () => {
         }),
       });
 
-      assert.equal(res.status, 200);
+      await expectStatusCode(res, 200);
       const json = await res.json();
       assert.ok(json.data);
       assert.equal(json.data.currentStep, 4);
@@ -535,7 +544,7 @@ describe("Import Routes API", () => {
         }),
       });
 
-      assert.equal(res.status, 404);
+      await expectStatusCode(res, 404);
     });
 
     it("should return 404 for imported file from different user", async () => {
@@ -568,7 +577,7 @@ describe("Import Routes API", () => {
         }),
       });
 
-      assert.equal(res.status, 404);
+      await expectStatusCode(res, 404);
     });
 
     it("should return inferredYearFromFile in data when present on validationResults", async () => {
@@ -607,7 +616,7 @@ describe("Import Routes API", () => {
         }),
       });
 
-      assert.equal(res.status, 200);
+      await expectStatusCode(res, 200);
       const json = await res.json();
       assert.strictEqual(json.data.inferredYearFromFile, 2021);
     });
@@ -659,17 +668,22 @@ describe("Import Routes API", () => {
 
       // Approve returns 202 Accepted when import is started in background; client polls for completion.
       // The import process may fail in tests due to incomplete file data, but we verify the approval step.
-      assert.ok([200, 202, 500].includes(res.status));
+      await expectStatusCodes(res, [200, 202, 500]);
 
       // Reload to check status - should have moved from WAITING_FOR_APPROVAL
       await importedFile.reload();
-      assert.ok([
-        ImportStatusEnum.APPROVED,
-        ImportStatusEnum.IMPORTING,
-        ImportStatusEnum.COMPLETED,
-        ImportStatusEnum.FAILED,
-      ].includes(importedFile.importStatus));
-      assert.notEqual(importedFile.importStatus, ImportStatusEnum.WAITING_FOR_APPROVAL);
+      assert.ok(
+        [
+          ImportStatusEnum.APPROVED,
+          ImportStatusEnum.IMPORTING,
+          ImportStatusEnum.COMPLETED,
+          ImportStatusEnum.FAILED,
+        ].includes(importedFile.importStatus),
+      );
+      assert.notEqual(
+        importedFile.importStatus,
+        ImportStatusEnum.WAITING_FOR_APPROVAL,
+      );
     });
 
     it("should reject approval for file not in waiting_for_approval status", async () => {
@@ -698,7 +712,7 @@ describe("Import Routes API", () => {
         }),
       });
 
-      assert.equal(res.status, 400);
+      await expectStatusCode(res, 400);
     });
 
     it("should reject approval with invalid importedFileId", async () => {
@@ -731,7 +745,7 @@ describe("Import Routes API", () => {
         }),
       });
 
-      assert.equal(res.status, 404);
+      await expectStatusCode(res, 404);
     });
 
     it("should accept mappingOverrides in request body", async () => {
@@ -781,7 +795,7 @@ describe("Import Routes API", () => {
       // Verify mapping overrides were stored
       await importedFile.reload();
       const config = importedFile.mappingConfiguration as any;
-      assert.ok(config?.overrides);
+      expect(config?.overrides).toBeTruthy();
     });
   });
 });

--- a/app/tests/api/inventory.jest.ts
+++ b/app/tests/api/inventory.jest.ts
@@ -19,7 +19,11 @@ import {
   setupTests,
   testUserID,
 } from "../helpers";
-import { createTestData, cleanupTestData, TestData } from "../helpers/testDataCreationHelper";
+import {
+  createTestData,
+  cleanupTestData,
+  TestData,
+} from "../helpers/testDataCreationHelper";
 import { SubSector, SubSectorAttributes } from "@/models/SubSector";
 import { City } from "@/models/City";
 import { Inventory } from "@/models/Inventory";
@@ -101,8 +105,14 @@ describe("Inventory API", () => {
   let testData: TestData;
 
   // Mock sessions for different user types
-  const collaboratorSession: AppSession = { user: { id: collaboratorUserId, role: Roles.User }, expires: "1h" };
-  const orgAdminSession: AppSession = { user: { id: orgAdminUserId, role: Roles.User }, expires: "1h" };
+  const collaboratorSession: AppSession = {
+    user: { id: collaboratorUserId, role: Roles.User },
+    expires: "1h",
+  };
+  const orgAdminSession: AppSession = {
+    user: { id: orgAdminUserId, role: Roles.User },
+    expires: "1h",
+  };
 
   let prevGetServerSession = Auth.getServerSession;
 
@@ -139,10 +149,10 @@ describe("Inventory API", () => {
     // Create proper test data hierarchy
     testData = await createTestData({
       cityName: cityName,
-      countryLocode: "XX"
+      countryLocode: "XX",
     });
 
-    city = await db.models.City.findByPk(testData.cityId) as City;
+    city = (await db.models.City.findByPk(testData.cityId)) as City;
     if (!city) {
       throw new Error(`Failed to find city with ID ${testData.cityId}`);
     }
@@ -151,12 +161,18 @@ describe("Inventory API", () => {
     await city.update({
       name: cityName,
       country: cityCountry,
-      locode
+      locode,
     });
 
     // Create test users
-    await db.models.User.upsert({ userId: collaboratorUserId, name: "COLLABORATOR_USER" });
-    await db.models.User.upsert({ userId: orgAdminUserId, name: "ORG_ADMIN_USER" });
+    await db.models.User.upsert({
+      userId: collaboratorUserId,
+      name: "COLLABORATOR_USER",
+    });
+    await db.models.User.upsert({
+      userId: orgAdminUserId,
+      name: "ORG_ADMIN_USER",
+    });
 
     // Set up permissions:
     // 1. Collaborator - can only access/edit inventories, not create/delete
@@ -166,7 +182,7 @@ describe("Inventory API", () => {
     await db.models.OrganizationAdmin.create({
       organizationAdminId: randomUUID(),
       userId: orgAdminUserId,
-      organizationId: testData.organizationId
+      organizationId: testData.organizationId,
     });
     sector = await db.models.Sector.create({
       sectorId: randomUUID(),
@@ -266,9 +282,11 @@ describe("Inventory API", () => {
     const res = await createInventory(req, {
       params: Promise.resolve({ city: city.cityId }),
     });
-    expect(res.status).toEqual(403);
+    await expectStatusCode(res, 403);
     const { error } = await res.json();
-    expect(error.message).toEqual("You do not have permission to create inventories in this city");
+    expect(error.message).toEqual(
+      "You do not have permission to create inventories in this city",
+    );
   });
 
   it("should not create an inventory with invalid data", async () => {
@@ -276,7 +294,7 @@ describe("Inventory API", () => {
     const res = await createInventory(req, {
       params: Promise.resolve({ city: locode }),
     });
-    expect(res.status).toEqual(400);
+    await expectStatusCode(res, 400);
     const {
       error: { issues },
     } = await res.json();
@@ -290,7 +308,7 @@ describe("Inventory API", () => {
     const res = await findInventory(req, {
       params: Promise.resolve({ inventory: inventory.inventoryId }),
     });
-    expect(res.status).toEqual(200);
+    await expectStatusCode(res, 200);
     const { data } = await res.json();
     expect(data.inventoryName).toEqual(inventory.inventoryName);
     expect(data.year).toEqual(inventory.year);
@@ -305,7 +323,7 @@ describe("Inventory API", () => {
     const res = await findInventory(req, {
       params: Promise.resolve({ inventory: inventory.inventoryId }),
     });
-    expect(res.status).toEqual(200);
+    await expectStatusCode(res, 200);
     const { data } = await res.json();
     expect(data.inventoryName).toEqual(inventory.inventoryName);
     expect(data.year).toEqual(inventory.year);
@@ -319,7 +337,7 @@ describe("Inventory API", () => {
     const res = await findInventory(req, {
       params: Promise.resolve({ inventory: inventory.inventoryId }),
     });
-    expect(res.status).toEqual(200);
+    await expectStatusCode(res, 200);
     expect(res.headers.get("content-type")).toEqual("text/csv");
     expect(
       res.headers.get("content-disposition")?.startsWith("attachment"),
@@ -352,7 +370,7 @@ describe("Inventory API", () => {
     const res = await findInventory(req, {
       params: Promise.resolve({ inventory: inventory.inventoryId }),
     });
-    expect(res.status).toEqual(200);
+    await expectStatusCode(res, 200);
     expect(res.headers.get("content-type")).toEqual("application/vnd.ms-excel");
     expect(
       res.headers.get("content-disposition")?.startsWith("attachment"),
@@ -367,7 +385,7 @@ describe("Inventory API", () => {
     const res = await findInventory(req, {
       params: Promise.resolve({ inventory: randomUUID() }),
     });
-    expect(res.status).toEqual(404);
+    await expectStatusCode(res, 404);
   });
 
   it("should return 404 for non-existing inventories as collaborator", async () => {
@@ -377,7 +395,7 @@ describe("Inventory API", () => {
     const res = await findInventory(req, {
       params: Promise.resolve({ inventory: randomUUID() }),
     });
-    expect(res.status).toEqual(404);
+    await expectStatusCode(res, 404);
   });
 
   it("should update an inventory", async () => {
@@ -385,7 +403,7 @@ describe("Inventory API", () => {
     const res = await updateInventory(req, {
       params: Promise.resolve({ inventory: inventory.inventoryId }),
     });
-    expect(res.status).toEqual(200);
+    await expectStatusCode(res, 200);
     const { data } = await res.json();
     expect(data.inventoryName).toEqual(inventoryData2.inventoryName);
     expect(data.year).toEqual(inventoryData2.year);
@@ -397,7 +415,7 @@ describe("Inventory API", () => {
     const res = await updateInventory(req, {
       params: Promise.resolve({ inventory: inventory.inventoryId }),
     });
-    expect(res.status).toEqual(400);
+    await expectStatusCode(res, 400);
     const {
       error: { issues },
     } = await res.json();
@@ -411,7 +429,7 @@ describe("Inventory API", () => {
     const res = await deleteInventory(req, {
       params: Promise.resolve({ inventory: inventory.inventoryId }),
     });
-    expect(res.status).toEqual(200);
+    await expectStatusCode(res, 200);
     const { data, deleted } = await res.json();
     expect(deleted).toEqual(true);
     expect(data.inventoryName).toEqual(inventory.inventoryName);
@@ -425,9 +443,11 @@ describe("Inventory API", () => {
     const res = await deleteInventory(req, {
       params: Promise.resolve({ inventory: inventory.inventoryId }),
     });
-    expect(res.status).toEqual(403);
+    await expectStatusCode(res, 403);
     const { error } = await res.json();
-    expect(error.message).toEqual("You do not have permission to delete this inventory");
+    expect(error.message).toEqual(
+      "You do not have permission to delete this inventory",
+    );
   });
 
   it("should not delete a non-existing inventory as org admin", async () => {
@@ -437,7 +457,7 @@ describe("Inventory API", () => {
     const res = await deleteInventory(req, {
       params: Promise.resolve({ inventory: randomUUID() }),
     });
-    expect(res.status).toEqual(404);
+    await expectStatusCode(res, 404);
   });
 
   // TODO these tests need to be redone.
@@ -501,7 +521,7 @@ describe("Inventory API", () => {
       params: Promise.resolve({ inventory: inventory.inventoryId }),
     });
 
-    expect(res.status).toEqual(200);
+    await expectStatusCode(res, 200);
     const { totalProgress, sectorProgress } = (await res.json()).data;
     const cleanedSectorProgress = sectorProgress
       .filter(({ sector: checkSector }: { sector: { sectorName: string } }) => {
@@ -554,7 +574,7 @@ describe("Inventory API", () => {
     const res = await findInventory(req, {
       params: Promise.resolve({ inventory: "null" }),
     });
-    expect(res.status).toEqual(400);
+    await expectStatusCode(res, 400);
   });
 
   // TODO: set up a default inventory for the test user
@@ -564,7 +584,7 @@ describe("Inventory API", () => {
     const res = await findInventory(req, {
       params: Promise.resolve({ inventory: "default" }),
     });
-    expect(res.status).toEqual(200);
+    await expectStatusCode(res, 200);
   });
 
   it("should return 400 for a non-UUID string in inventory ID", async () => {
@@ -572,7 +592,7 @@ describe("Inventory API", () => {
     const res = await findInventory(req, {
       params: Promise.resolve({ inventory: "not-an-inventory-id" }),
     });
-    expect(res.status).toEqual(400);
+    await expectStatusCode(res, 400);
   });
 
   it("should return 404 for a uuid string in that doesn't exist as org admin", async () => {
@@ -584,6 +604,6 @@ describe("Inventory API", () => {
         inventory: "D8802AA9-F9DA-460F-86FE-F45F7D8D23F9",
       }),
     });
-    expect(res.status).toEqual(404);
+    await expectStatusCode(res, 404);
   });
 });

--- a/app/tests/api/inventory.test.ts
+++ b/app/tests/api/inventory.test.ts
@@ -9,6 +9,7 @@ import { literal, Op } from "sequelize";
 import {
   cascadeDeleteDataSource,
   createRequest,
+  expectStatusCode,
   mockRequest,
   setupTests,
   testUserID,
@@ -167,7 +168,7 @@ describe("Inventory API", () => {
     const res = await findInventory(req, {
       params: Promise.resolve({ inventory: inventory.inventoryId }),
     });
-    assert.equal(res.status, 200);
+    await expectStatusCode(res, 200);
     assert.equal(res.headers.get("content-type"), "text/csv");
     assert.ok(res.headers.get("content-disposition")?.startsWith("attachment"));
     const csv = await res.text();
@@ -196,7 +197,7 @@ describe("Inventory API", () => {
     const res = await findInventory(req, {
       params: Promise.resolve({ inventory: inventory.inventoryId }),
     });
-    assert.equal(res.status, 200);
+    await expectStatusCode(res, 200);
     assert.equal(res.headers.get("content-type"), "application/vnd.ms-excel");
     assert.ok(res.headers.get("content-disposition")?.startsWith("attachment"));
     const body = await res.blob();
@@ -210,7 +211,7 @@ describe("Inventory API", () => {
       const res = await submitInventory(req, {
         params: Promise.resolve({ inventory: inventory.inventoryId }),
       });
-      assert.equal(res.status, 200);
+      await expectStatusCode(res, 200);
       const json = await res.json();
       assert.equal(json.success, true);
     },

--- a/app/tests/api/module-access-route.jest.ts
+++ b/app/tests/api/module-access-route.jest.ts
@@ -9,7 +9,7 @@ import {
   expect,
   jest,
 } from "@jest/globals";
-import { setupTests, mockRequest } from "../helpers";
+import { setupTests, mockRequest, expectStatusCode } from "../helpers";
 import {
   createTestData,
   cleanupTestData,
@@ -75,7 +75,7 @@ describe("City Module Access Route", () => {
     };
     const response = await GET(req, ctx);
     const data = await response.json();
-    expect(response.status).toBe(200);
+    await expectStatusCode(response, 200);
     expect(data).toEqual({ data: { hasAccess: true } });
     expect(mockHasModuleAccess).toHaveBeenCalledWith(
       testData.projectId,
@@ -105,7 +105,7 @@ describe("City Module Access Route", () => {
     };
     const response = await GET(req, ctx);
     const data = await response.json();
-    expect(response.status).toBe(200);
+    await expectStatusCode(response, 200);
     expect(data).toEqual({ data: { hasAccess: true } });
     expect(mockHasModuleAccess).toHaveBeenCalledWith(
       testData.projectId,
@@ -130,7 +130,7 @@ describe("City Module Access Route", () => {
       }),
     };
     const response = await GET(req, ctx);
-    expect(response.status).toBe(401);
+    await expectStatusCode(response, 401);
     const data = await response.json();
     expect(data.error.message).toMatch(/User is not part of this city/);
   });
@@ -147,7 +147,7 @@ describe("City Module Access Route", () => {
       }),
     };
     const response = await GET(req, ctx);
-    expect(response.status).toBe(401);
+    await expectStatusCode(response, 401);
     const data = await response.json();
     expect(data.error.message).toMatch(/Not signed in/);
   });
@@ -167,7 +167,7 @@ describe("City Module Access Route", () => {
     };
     const response = await GET(req, ctx);
     const data = await response.json();
-    expect(response.status).toBe(200);
+    await expectStatusCode(response, 200);
     expect(data).toEqual({ data: { hasAccess: false } });
     expect(mockHasModuleAccess).toHaveBeenCalledWith(
       testData.projectId,
@@ -188,7 +188,7 @@ describe("City Module Access Route", () => {
       }),
     };
     const response = await GET(req, ctx);
-    expect(response.status).toBe(404);
+    await expectStatusCode(response, 404);
     const data = await response.json();
     expect(data.error.message).toMatch(/City not found/);
   });
@@ -206,7 +206,7 @@ describe("City Module Access Route", () => {
       }),
     };
     const response = await GET(req, ctx);
-    expect(response.status).toBe(500);
+    await expectStatusCode(response, 500);
     const data = await response.json();
     expect(data.error.message).toMatch(/Internal server error/);
 
@@ -222,7 +222,7 @@ describe("City Module Access Route", () => {
       params: Promise.resolve({ city: testData.cityId, module: "" }),
     };
     const response = await GET(req, ctx);
-    expect(response.status).toBe(400);
+    await expectStatusCode(response, 400);
     const data = await response.json();
     expect(data.error.message).toMatch(/Invalid request/);
   });
@@ -241,7 +241,7 @@ describe("City Module Access Route", () => {
       }),
     };
     const response = await GET(req, ctx);
-    expect(response.status).toBe(500);
+    await expectStatusCode(response, 500);
     const data = await response.json();
     expect(data.error.message).toMatch(/Internal server error/);
   });

--- a/app/tests/api/oauth_client.jest.ts
+++ b/app/tests/api/oauth_client.jest.ts
@@ -138,7 +138,7 @@ describe("OAuth Client API", () => {
     it("should return an array of OAuth2.0 client objects with name and description in different languages", async () => {
       const req = mockRequest();
       const res = await listClients(req, { params: Promise.resolve({}) });
-      expect(res.status).toEqual(200);
+      await expectStatusCode(res, 200);
       const { data } = await res.json();
       expect(Array.isArray(data)).toBe(true);
       expect(data.length).toBeGreaterThanOrEqual(3);
@@ -179,7 +179,7 @@ describe("OAuth Client API", () => {
     it("should create a new OAuth2.0 client object", async () => {
       const req = mockRequest(clientCreationArgs);
       const res = await addClient(req, { params: Promise.resolve({}) });
-      expect(res.status).toEqual(201);
+      await expectStatusCode(res, 201);
       expect(res.headers.get("location")).toBeDefined();
       const { data } = await res.json();
       expect(data.clientId).toBeDefined();
@@ -198,7 +198,7 @@ describe("OAuth Client API", () => {
     it("should be in the list of all clients", async () => {
       const req = mockRequest();
       const res = await listClients(req, { params: Promise.resolve({}) });
-      expect(res.status).toEqual(200);
+      await expectStatusCode(res, 200);
       const { data } = await res.json();
       expect(Array.isArray(data)).toBe(true);
       const found = data.find((cl: any) => cl.clientId === createdClientId);
@@ -227,7 +227,7 @@ describe("OAuth Client API", () => {
       const res = await getClient(req, {
         params: Promise.resolve({ client: client.clientId }),
       });
-      expect(res.status).toEqual(200);
+      await expectStatusCode(res, 200);
       const { data } = await res.json();
       expect(data.clientId).toEqual(client.clientId);
       expect(data.redirectUri).toEqual(client.redirectURI);
@@ -254,7 +254,7 @@ describe("OAuth Client API", () => {
       const res = await getClient(req, {
         params: Promise.resolve({ client: testClientDNE }),
       });
-      expect(res.status).toEqual(404);
+      await expectStatusCode(res, 404);
     });
   });
 
@@ -303,13 +303,13 @@ describe("OAuth Client API", () => {
       const res = await removeClient(req, {
         params: Promise.resolve({ client: toDelete.clientId }),
       });
-      expect(res.status).toEqual(204);
+      await expectStatusCode(res, 204);
     });
 
     it("should not be in the list of all clients", async () => {
       const req = mockRequest();
       const res = await listClients(req, { params: Promise.resolve({}) });
-      expect(res.status).toEqual(200);
+      await expectStatusCode(res, 200);
       const { data } = await res.json();
       expect(Array.isArray(data)).toBe(true);
       const found = data.find((cl: any) => cl.clientId === toDelete.clientId);
@@ -321,7 +321,7 @@ describe("OAuth Client API", () => {
       const res = await removeClient(req, {
         params: Promise.resolve({ client: testClientDNE }),
       });
-      expect(res.status).toEqual(404);
+      await expectStatusCode(res, 404);
     });
   });
 });

--- a/app/tests/api/oauth_client_authz.jest.ts
+++ b/app/tests/api/oauth_client_authz.jest.ts
@@ -89,7 +89,7 @@ describe("OAuth Client Authz API", () => {
     it("should return an array of client authorization objects", async () => {
       const req = mockRequest();
       const res = await listClientAuthz(req, { params: Promise.resolve({}) });
-      expect(res.status).toEqual(200);
+      await expectStatusCode(res, 200);
       const { data } = await res.json();
       expect(Array.isArray(data)).toBe(true);
       expect(data.length).toEqual(testOAuthClientAuthzs.length);
@@ -120,7 +120,7 @@ describe("OAuth Client Authz API", () => {
       const res = await getClientAuthz(req, {
         params: Promise.resolve({ client: clientAuthz.clientId }),
       });
-      expect(res.status).toEqual(200);
+      await expectStatusCode(res, 200);
       const { data } = await res.json();
       expect(data.lastUsed).toBeDefined();
       expect(data.created).toBeDefined();
@@ -137,7 +137,7 @@ describe("OAuth Client Authz API", () => {
       const res = await getClientAuthz(req, {
         params: Promise.resolve({ client: testClientDNE }),
       });
-      expect(res.status).toEqual(404);
+      await expectStatusCode(res, 404);
     });
 
     it("should fail for an unauthorized client", async () => {
@@ -145,7 +145,7 @@ describe("OAuth Client Authz API", () => {
       const res = await getClientAuthz(req, {
         params: Promise.resolve({ client: "test-client-4" }),
       });
-      expect(res.status).toEqual(404);
+      await expectStatusCode(res, 404);
     });
   });
 
@@ -155,13 +155,13 @@ describe("OAuth Client Authz API", () => {
       const res = await deleteClientAuthz(req, {
         params: Promise.resolve({ client: "test-client-3" }),
       });
-      expect(res.status).toEqual(204);
+      await expectStatusCode(res, 204);
     });
 
     it("should not be in the list of all clients", async () => {
       const req = mockRequest();
       const res = await listClientAuthz(req, { params: Promise.resolve({}) });
-      expect(res.status).toEqual(200);
+      await expectStatusCode(res, 200);
       const { data } = await res.json();
       expect(Array.isArray(data)).toBe(true);
       const found = data.find(
@@ -175,7 +175,7 @@ describe("OAuth Client Authz API", () => {
       const res = await deleteClientAuthz(req, {
         params: Promise.resolve({ client: testClientDNE }),
       });
-      expect(res.status).toEqual(404);
+      await expectStatusCode(res, 404);
     });
 
     it("should fail for an unauthorized client", async () => {
@@ -183,7 +183,7 @@ describe("OAuth Client Authz API", () => {
       const res = await deleteClientAuthz(req, {
         params: Promise.resolve({ client: "test-client-4" }),
       });
-      expect(res.status).toEqual(404);
+      await expectStatusCode(res, 404);
     });
   });
 });

--- a/app/tests/api/oauth_discovery.jest.ts
+++ b/app/tests/api/oauth_discovery.jest.ts
@@ -4,7 +4,7 @@ import { db } from "@/models";
 
 import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
 
-import { mockRequest, setupTests } from "../helpers";
+import { expectStatusCode, mockRequest, setupTests } from "../helpers";
 
 import { setFeatureFlag, FeatureFlags } from "@/util/feature-flags";
 
@@ -30,7 +30,7 @@ describe("OAuth 2.0 Authorization Server Metadata", () => {
     it("should return a JSON object", async () => {
       const req = mockRequest();
       const res = await getMetadata(req, { params: Promise.resolve({}) });
-      expect(res.status).toEqual(200);
+      await expectStatusCode(res, 200);
       expect(res.headers.get("Content-Type")).toEqual("application/json");
       metadata = await res.json();
       expect(typeof metadata).toBe("object");

--- a/app/tests/api/openapi.jest.ts
+++ b/app/tests/api/openapi.jest.ts
@@ -1,7 +1,7 @@
 import { GET as getOpenAPISpec } from "@/app/api/openapi/json/route";
 import { db } from "@/models";
 import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
-import { mockRequest, setupTests } from "../helpers";
+import { expectStatusCode, mockRequest, setupTests } from "../helpers";
 import packageJson from "@/../package.json";
 
 describe("OpenAPI Specification Endpoint", () => {
@@ -21,7 +21,7 @@ describe("OpenAPI Specification Endpoint", () => {
       const req = mockRequest();
       const res = await getOpenAPISpec(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toEqual(200);
+      await expectStatusCode(res, 200);
       expect(res.headers.get("Content-Type")).toEqual("application/json");
 
       openApiSpec = await res.json();
@@ -45,7 +45,9 @@ describe("OpenAPI Specification Endpoint", () => {
     it("should have security schemes defined", () => {
       expect(openApiSpec).toHaveProperty("components");
       expect(openApiSpec.components).toHaveProperty("securitySchemes");
-      expect(openApiSpec.components.securitySchemes).toHaveProperty("BearerAuth");
+      expect(openApiSpec.components.securitySchemes).toHaveProperty(
+        "BearerAuth",
+      );
 
       const bearerAuth = openApiSpec.components.securitySchemes.BearerAuth;
       expect(bearerAuth.type).toBe("http");
@@ -82,7 +84,7 @@ describe("OpenAPI Specification Endpoint", () => {
       expect(methods.length).toBeGreaterThan(0);
 
       // Each method should have proper structure
-      methods.forEach(method => {
+      methods.forEach((method) => {
         const methodDef = pathDefinition[method];
         expect(methodDef).toHaveProperty("tags");
         expect(methodDef).toHaveProperty("summary");
@@ -94,7 +96,7 @@ describe("OpenAPI Specification Endpoint", () => {
       const paths = Object.keys(openApiSpec.paths);
 
       // Most paths should be under /api/v1/
-      const v1Paths = paths.filter(path => path.startsWith("/api/v1/"));
+      const v1Paths = paths.filter((path) => path.startsWith("/api/v1/"));
       expect(v1Paths.length).toBeGreaterThan(0);
 
       // Should represent majority of documented endpoints
@@ -111,3 +113,4 @@ describe("OpenAPI Specification Endpoint", () => {
     });
   });
 });
+

--- a/app/tests/api/organization.jest.ts
+++ b/app/tests/api/organization.jest.ts
@@ -14,7 +14,12 @@ import {
 } from "@/app/api/v1/organizations/[organization]/route";
 import { db } from "@/models";
 import { CreateOrganizationRequest } from "@/util/validation";
-import { mockRequest, setupTests, testUserID } from "../helpers";
+import {
+  expectStatusCode,
+  mockRequest,
+  setupTests,
+  testUserID,
+} from "../helpers";
 import { Organization } from "@/models/Organization";
 import { randomUUID } from "node:crypto";
 import { AppSession, Auth } from "@/lib/auth";
@@ -76,7 +81,7 @@ describe("Organization API", () => {
     const res = await getOrganization(req, {
       params: Promise.resolve({ organization: organization.organizationId }),
     });
-    expect(res.status).toEqual(200);
+    await expectStatusCode(res, 200);
     const data = await res.json();
     expect(data.name).toEqual(organizationData.name);
     expect(data.contactEmail).toEqual(organizationData.contactEmail);
@@ -87,7 +92,7 @@ describe("Organization API", () => {
     const res = await getOrganization(req, {
       params: Promise.resolve({ organization: randomUUID() }),
     });
-    expect(res.status).toEqual(404);
+    await expectStatusCode(res, 404);
   });
 
   it("should update an organization", async () => {
@@ -95,7 +100,7 @@ describe("Organization API", () => {
     const res = await updateOrganization(req, {
       params: Promise.resolve({ organization: organization.organizationId }),
     });
-    expect(res.status).toEqual(200);
+    await expectStatusCode(res, 200);
     const data = await res.json();
     expect(data.name).toEqual(organization2.name);
     expect(data.contactEmail).toEqual(organization2.contactEmail);
@@ -106,7 +111,7 @@ describe("Organization API", () => {
     const res = await updateOrganization(req, {
       params: Promise.resolve({ organization: organization.organizationId }),
     });
-    expect(res.status).toEqual(400);
+    await expectStatusCode(res, 400);
     const {
       error: { issues },
     } = await res.json();
@@ -126,7 +131,7 @@ describe("Organization API", () => {
     const res = await deleteOrganization(req, {
       params: Promise.resolve({ organization: organization.organizationId }),
     });
-    expect(res.status).toEqual(200);
+    await expectStatusCode(res, 200);
     const { deleted } = await res.json();
     expect(deleted).toBe(true);
   });
@@ -136,7 +141,7 @@ describe("Organization API", () => {
     const res = await deleteOrganization(req, {
       params: Promise.resolve({ organization: randomUUID() }),
     });
-    expect(res.status).toEqual(404);
+    await expectStatusCode(res, 404);
   });
 
   it("should not allow non-admins to update an organization", async () => {
@@ -145,7 +150,7 @@ describe("Organization API", () => {
     const res = await updateOrganization(req, {
       params: Promise.resolve({ organization: organization.organizationId }),
     });
-    expect(res.status).toEqual(403);
+    await expectStatusCode(res, 403);
   });
 
   it("should not allow non-admins to delete an organization", async () => {
@@ -154,6 +159,6 @@ describe("Organization API", () => {
     const res = await deleteOrganization(req, {
       params: Promise.resolve({ organization: organization.organizationId }),
     });
-    expect(res.status).toEqual(403);
+    await expectStatusCode(res, 403);
   });
 });

--- a/app/tests/api/organization_invite.jest.ts
+++ b/app/tests/api/organization_invite.jest.ts
@@ -12,7 +12,12 @@ import {
   POST as createOrganizationInvite,
 } from "@/app/api/v1/organizations/[organization]/invitations/route";
 import { db } from "@/models";
-import { mockRequest, setupTests, testUserID } from "../helpers";
+import {
+  expectStatusCode,
+  mockRequest,
+  setupTests,
+  testUserID,
+} from "../helpers";
 import { Organization } from "@/models/Organization";
 import { OrganizationInvite } from "@/models/OrganizationInvite";
 import { randomUUID } from "node:crypto";
@@ -85,7 +90,7 @@ describe("Organization Invitations API", () => {
 
     console.log(res, "the response from the invite API");
 
-    expect(res.status).toEqual(200);
+    await expectStatusCode(res, 200);
     const data = await res.json();
     expect(data.success).toEqual(true);
     expect(data.inviteUrls).toBeDefined();
@@ -98,7 +103,7 @@ describe("Organization Invitations API", () => {
     const res = await createOrganizationInvite(req, {
       params: Promise.resolve({ organization: inviteData.organizationId }),
     });
-    expect(res.status).toEqual(403);
+    await expectStatusCode(res, 403);
   });
 
   it("should allow admin to fetch all invitations", async () => {
@@ -114,7 +119,7 @@ describe("Organization Invitations API", () => {
     const res = await getOrganizationInvites(req, {
       params: Promise.resolve({ organization: inviteData.organizationId }),
     });
-    expect(res.status).toEqual(200);
+    await expectStatusCode(res, 200);
     const data = await res.json();
     expect(data).toHaveLength(1);
     expect(data[0].email).toEqual(inviteData.inviteeEmails[0]);
@@ -128,6 +133,6 @@ describe("Organization Invitations API", () => {
     const res = await getOrganizationInvites(req, {
       params: Promise.resolve({ organization: inviteData.organizationId }),
     });
-    expect(res.status).toEqual(403);
+    await expectStatusCode(res, 403);
   });
 });

--- a/app/tests/api/organizations.jest.ts
+++ b/app/tests/api/organizations.jest.ts
@@ -13,7 +13,12 @@ import {
 } from "@/app/api/v1/organizations/route";
 import { db } from "@/models";
 import { CreateOrganizationRequest } from "@/util/validation";
-import { mockRequest, setupTests, testUserID } from "../helpers";
+import {
+  expectStatusCode,
+  mockRequest,
+  setupTests,
+  testUserID,
+} from "../helpers";
 import { Organization } from "@/models/Organization";
 import { randomUUID } from "node:crypto";
 import { AppSession, Auth } from "@/lib/auth";
@@ -73,7 +78,7 @@ describe("Organization API", () => {
 
     const req = mockRequest(uniqueOrgData);
     const res = await createOrganization(req, emptyParams);
-    expect(res.status).toEqual(201);
+    await expectStatusCode(res, 201);
     const data = await res.json();
     expect(data.name).toEqual(uniqueOrgData.name);
     expect(data.contactEmail).toEqual(uniqueOrgData.contactEmail);
@@ -82,7 +87,7 @@ describe("Organization API", () => {
   it("should not create an organization with invalid data", async () => {
     const req = mockRequest(invalidOrganization);
     const res = await createOrganization(req, emptyParams);
-    expect(res.status).toEqual(400);
+    await expectStatusCode(res, 400);
     const {
       error: { issues },
     } = await res.json();
@@ -101,7 +106,7 @@ describe("Organization API", () => {
     const uniqueOrgData = getUniqueOrganizationData();
     const req = mockRequest(uniqueOrgData);
     const res = await createOrganization(req, emptyParams);
-    expect(res.status).toEqual(403);
+    await expectStatusCode(res, 403);
   });
 
   it("should allow admin to query organizations", async () => {
@@ -109,7 +114,7 @@ describe("Organization API", () => {
     const res = await getOrganizations(req, {
       params: Promise.resolve({ organizationId: organization.organizationId }),
     });
-    expect(res.status).toEqual(200);
+    await expectStatusCode(res, 200);
     const data = await res.json();
     expect(data.length).toBeGreaterThan(0);
   });
@@ -120,6 +125,6 @@ describe("Organization API", () => {
     const res = await getOrganizations(req, {
       params: Promise.resolve({ organizationId: organization.organizationId }),
     });
-    expect(res.status).toEqual(403);
+    await expectStatusCode(res, 403);
   });
 });

--- a/app/tests/api/population.jest.ts
+++ b/app/tests/api/population.jest.ts
@@ -1,6 +1,7 @@
 import { POST as savePopulations } from "@/app/api/v1/city/[city]/population/route";
 import { db } from "@/models";
 import {
+  expectStatusCode,
   expectToBeLooselyEqual,
   mockRequest,
   setupTests,
@@ -66,7 +67,7 @@ describe("Population API", () => {
     const res = await savePopulations(req, {
       params: Promise.resolve({ city: cityId }),
     });
-    expect(res.status).toEqual(200);
+    await expectStatusCode(res, 200);
     const data = await res.json();
     expectToBeLooselyEqual(
       data.data.cityPopulation.population,
@@ -108,7 +109,7 @@ describe("Population API", () => {
     const res = await savePopulations(req, {
       params: Promise.resolve({ city: cityId }),
     });
-    expect(res.status).toEqual(200);
+    await expectStatusCode(res, 200);
     const data = await res.json();
 
     expectToBeLooselyEqual(
@@ -150,7 +151,7 @@ describe("Population API", () => {
     const res = await savePopulations(req, {
       params: Promise.resolve({ city: cityId }),
     });
-    expect(res.status).toEqual(400);
+    await expectStatusCode(res, 400);
     const populations = await db.models.Population.findAll({
       where: { cityId, year: -1340 },
     });

--- a/app/tests/api/project.jest.ts
+++ b/app/tests/api/project.jest.ts
@@ -17,7 +17,12 @@ import {
   GET as getProject,
   PATCH as updateProject,
 } from "@/app/api/v1/projects/[project]/route";
-import { mockRequest, setupTests, testUserID } from "../helpers";
+import {
+  expectStatusCode,
+  mockRequest,
+  setupTests,
+  testUserID,
+} from "../helpers";
 
 import {
   CreateOrganizationRequest,
@@ -98,7 +103,7 @@ describe("Project API", () => {
           organization: organization.organizationId,
         }),
       });
-      expect(response.status).toBe(200);
+      await expectStatusCode(response, 200);
       const data = await response.json();
       expect(data.name).toBe(projectData.name);
 
@@ -118,7 +123,7 @@ describe("Project API", () => {
           organization: organization.organizationId,
         }),
       });
-      expect(response.status).toBe(400);
+      await expectStatusCode(response, 400);
     });
   });
 
@@ -138,7 +143,7 @@ describe("Project API", () => {
           organization: organization.organizationId,
         }),
       });
-      expect(response.status).toBe(200);
+      await expectStatusCode(response, 200);
       const data = await response.json();
       expect(data.length).toBe(1);
 
@@ -163,7 +168,7 @@ describe("Project API", () => {
       const response = await getProject(req, {
         params: Promise.resolve({ project: project.projectId }),
       });
-      expect(response.status).toBe(200);
+      await expectStatusCode(response, 200);
       const data = await response.json();
       expect(data.name).toBe(projectData.name);
 
@@ -179,7 +184,7 @@ describe("Project API", () => {
         params: Promise.resolve({ project: randomUUID() }),
       });
       const data = await response.json();
-      expect(response.status).toBe(404);
+      await expectStatusCode(response, 404);
     });
   });
 
@@ -200,7 +205,7 @@ describe("Project API", () => {
       const response = await updateProject(req, {
         params: Promise.resolve({ project: project.projectId }),
       });
-      expect(response.status).toBe(200);
+      await expectStatusCode(response, 200);
       const data = await response.json();
       expect(data.name).toBe(updatedProject.name);
 
@@ -224,7 +229,7 @@ describe("Project API", () => {
       const response = await deleteProject(req, {
         params: Promise.resolve({ project: project.projectId }),
       });
-      expect(response.status).toBe(200);
+      await expectStatusCode(response, 200);
     });
   });
 });

--- a/app/tests/api/root.jest.ts
+++ b/app/tests/api/root.jest.ts
@@ -1,7 +1,7 @@
 import { GET as getRootMessage } from "@/app/api/v1/route";
 import { db } from "@/models";
 import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
-import { mockRequest, setupTests } from "../helpers";
+import { expectStatusCode, mockRequest, setupTests } from "../helpers";
 
 describe("Root API", () => {
   beforeAll(async () => {
@@ -18,9 +18,10 @@ describe("Root API", () => {
       const req = mockRequest();
       const res = await getRootMessage(req, { params: Promise.resolve({}) });
 
-      expect(res.status).toBe(200);
+      await expectStatusCode(res, 200);
       const data = await res.json();
       expect(data.message).toBe("Welcome to the CityCatalyst backend API!");
     });
   });
 });
+

--- a/app/tests/api/user.jest.ts
+++ b/app/tests/api/user.jest.ts
@@ -97,7 +97,7 @@ describe("User API", () => {
   it("should not update a user with invalid data", async () => {
     const req = mockRequest(invalidUserUpdate);
     const res = await updateUser(req, emptyParams);
-    await expectStatusCode(res, 200);
+    await expectStatusCode(res, 400);
     const user = await db.models.User.findOne({
       where: { userId: userData.userId },
     });

--- a/app/tests/api/user.jest.ts
+++ b/app/tests/api/user.jest.ts
@@ -2,7 +2,12 @@ import { PATCH as updateUser } from "@/app/api/v1/user/route";
 import { db } from "@/models";
 import { UserAttributes } from "@/models/User";
 import { beforeAll, afterAll, describe, it, expect } from "@jest/globals";
-import { mockRequest, setupTests, testUserID } from "../helpers";
+import {
+  expectStatusCode,
+  mockRequest,
+  setupTests,
+  testUserID,
+} from "../helpers";
 import {
   GlobalWarmingPotentialTypeEnum,
   InventoryTypeEnum,
@@ -78,7 +83,7 @@ describe("User API", () => {
   it("should update a user", async () => {
     const req = mockRequest(userUpdate);
     const res = await updateUser(req, emptyParams);
-    expect(res.status).toBe(200);
+    await expectStatusCode(res, 200);
     const data = await res.json();
     expect(data.success).toBeTruthy();
     const user = await db.models.User.findOne({
@@ -92,7 +97,7 @@ describe("User API", () => {
   it("should not update a user with invalid data", async () => {
     const req = mockRequest(invalidUserUpdate);
     const res = await updateUser(req, emptyParams);
-    expect(res.status).toBe(400);
+    await expectStatusCode(res, 200);
     const user = await db.models.User.findOne({
       where: { userId: userData.userId },
     });

--- a/app/tests/api/user_file.jest.ts
+++ b/app/tests/api/user_file.jest.ts
@@ -162,7 +162,7 @@ describe.skip("UserFile API", () => {
     const res = await createUserFile(req, {
       params: Promise.resolve({ city: testCityID }),
     });
-    expect(res.status).toBe(400);
+    await expectStatusCode(res, 400);
   });
 
   it("should find all user files", async () => {
@@ -216,7 +216,7 @@ describe.skip("UserFile API", () => {
       }),
     });
 
-    expect(res.status).toBe(404);
+    await expectStatusCode(res, 404);
   });
 
   it("should delete user file", async () => {
@@ -238,7 +238,7 @@ describe.skip("UserFile API", () => {
     const res = await createUserFile(req, {
       params: Promise.resolve({ user: testUserID, city: testCityID }),
     });
-    expect(res.status).toBe(200);
+    await expectStatusCode(res, 200);
     const { data } = await res.json();
     const deletRequest = mockRequest();
     const deleteResponse = await deleteUserfile(deletRequest, {
@@ -251,7 +251,7 @@ describe.skip("UserFile API", () => {
 
     const { deleted } = await deleteResponse.json();
     expect(deleted).toBe(true);
-    expect(deleteResponse.status).toBe(200);
+    await expectStatusCode(deleteResponse, 200);
   });
 
   it("should not delete a non-existent user file", async () => {
@@ -264,6 +264,6 @@ describe.skip("UserFile API", () => {
       }),
     });
 
-    expect(deleteResponse.status).toBe(404);
+    await expectStatusCode(deleteResponse, 404);
   });
 });

--- a/app/tests/helpers.ts
+++ b/app/tests/helpers.ts
@@ -1,6 +1,6 @@
 import { AppSession, Auth } from "@/lib/auth";
 import env from "@next/env";
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { jest } from "@jest/globals";
 import stream from "stream";
 import { Blob } from "fetch-blob";
@@ -117,14 +117,16 @@ export function setupTests() {
   sessionSpy?.mockRestore();
 
   // mock getServerSession from NextAuth, since NextJS headers() isn't available outside of the server context (needs async storage)
-  sessionSpy = jest.spyOn(Auth, "getServerSession").mockResolvedValue((() => {
-    const expires = new Date();
-    expires.setDate(expires.getDate() + 1);
-    return {
-      user: testUserData,
-      expires: expires.toISOString(),
-    } as AppSession;
-  })());
+  sessionSpy = jest.spyOn(Auth, "getServerSession").mockResolvedValue(
+    (() => {
+      const expires = new Date();
+      expires.setDate(expires.getDate() + 1);
+      return {
+        user: testUserData,
+        expires: expires.toISOString(),
+      } as AppSession;
+    })(),
+  );
 }
 
 export function teardownTests() {
@@ -142,6 +144,20 @@ export async function expectStatusCode(
     const apiError = await response.text();
     (err as Error).message =
       `Expected status code ${statusCode}, got ${response.status}.\nAPI error: ${apiError}`;
+    throw err;
+  }
+}
+
+export async function expectStatusCodes(
+  response: ApiResponse,
+  statusCodes: number[],
+) {
+  try {
+    expect(statusCodes).toContain(response.status);
+  } catch (err: unknown) {
+    const apiError = await response.text();
+    (err as Error).message =
+      `Expected status code ${statusCodes.join(" or ")}, got ${response.status}.\nAPI error: ${apiError}`;
     throw err;
   }
 }


### PR DESCRIPTION
Makes debugging tests a lot easier by actually adding the request body to the error message, so you don't just get the status code but the actual error from the request.