### PR TITLE
feat: adding new skills for product and engineering

### DIFF
--- a/.cursor/skills/create-ticket/SKILL.md
+++ b/.cursor/skills/create-ticket/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: create-ticket
+description: Generate structured Linear tickets (stories, tasks, bugs, spikes) with AI-enriched code references and acceptance criteria from a brief description. Use when the product team asks to create a ticket, write a story, draft a task, report a bug, or plan a spike for CityCatalyst.
+---
+
+# Create Ticket
+
+Generate a sprint-ready Linear ticket from a short description. The agent classifies the work, asks targeted questions, searches the codebase for relevant references, and outputs formatted markdown.
+
+For ticket type definitions, estimation policy, and Linear conventions, see [reference.md](reference.md).
+
+## Workflow
+
+### Phase 1: Classify
+
+Determine the ticket type from the user's description. If ambiguous, ask:
+
+```
+AskQuestion:
+  id: ticket_type
+  prompt: "What type of work is this?"
+  options:
+    - Story (user-facing feature or enhancement)
+    - Task (technical work not directly visible to users)
+    - Bug (defect in existing functionality)
+    - Spike (time-boxed research to reduce uncertainty)
+    - Incident (production issue requiring immediate response)
+```
+
+Then determine the area:
+
+```
+AskQuestion:
+  id: ticket_area
+  prompt: "Which area does this primarily affect?"
+  options:
+    - Core Product (app/ — frontend + API + DB)
+    - Data (global-api/)
+    - AI/ML (hiap/, hiap-meed/, climate-advisor/)
+    - Infrastructure (k8s/, CI/CD, DevOps)
+    - Multiple (cross-cutting)
+  allow_multiple: true
+```
+
+### Phase 2: Gather Context
+
+Ask follow-up questions conditional on the ticket type.
+
+**For Story:**
+
+```
+AskQuestion:
+  id: story_context
+  prompt: "Who is the primary user persona?"
+  options:
+    - City official / inventory manager
+    - Platform admin
+    - Data analyst / researcher
+    - External API consumer
+    - Internal team member
+```
+
+Then ask in free-form (normal message): "What should the user be able to do, and what value does it provide?"
+
+**For Bug:**
+
+```
+AskQuestion:
+  id: bug_severity
+  prompt: "How severe is this bug?"
+  options:
+    - Critical (data loss, security, or complete feature broken)
+    - Major (feature partially broken, workaround exists)
+    - Minor (cosmetic, edge case, or low-impact)
+```
+
+Then ask: "What are the steps to reproduce, and what is the expected vs actual behavior?"
+
+**For Task:**
+
+Ask: "What triggers this work? Are there dependencies or deadlines?"
+
+**For Spike:**
+
+```
+AskQuestion:
+  id: spike_timebox
+  prompt: "What timebox for this investigation?"
+  options:
+    - 1 day
+    - 2 days
+    - 3 days
+```
+
+Then ask: "What decision or work does this spike unblock?"
+
+### Phase 3: AI Enrichment
+
+After gathering context, perform codebase analysis:
+
+1. **Find relevant code** — Use `Grep` and `Glob` to locate:
+   - Files in the affected service(s) related to the described functionality
+   - Similar patterns or existing implementations that serve as reference
+   - Related models, API routes, components, or services
+
+2. **Identify technical implications** — Based on code analysis, determine:
+   - Is a database migration needed?
+   - Is a new API endpoint required?
+   - Are new i18n keys needed?
+   - Should a feature flag wrap this?
+   - Which existing services/hooks/components can be reused?
+
+3. **Draft acceptance criteria** — Generate 3-6 testable AC items from the description and code context.
+
+### Phase 4: Generate Output
+
+Produce the ticket in this exact markdown format:
+
+```markdown
+## [TYPE] Title
+
+### Summary
+2-3 sentence description of the work and its purpose.
+
+### User Story
+<!-- Include only for type: Story -->
+As a [persona], I want [capability] so that [benefit].
+
+### Context & Code References
+- **Relevant files:**
+  - `path/to/file.ts` — brief reason this file is relevant
+  - `path/to/other.ts` — brief reason
+- **Similar implementations:** describe existing patterns to follow
+- **Affected services:** list services (app / global-api / hiap / etc.)
+
+### Acceptance Criteria
+- [ ] Specific, testable criterion 1
+- [ ] Specific, testable criterion 2
+- [ ] Specific, testable criterion 3
+- [ ] <!-- PM: add additional criteria here -->
+
+### Definition of Ready
+- [ ] Design/Figma link attached (if UI work)
+- [ ] API contract defined (if backend)
+- [ ] Dependencies identified
+- [ ] AC reviewed by engineer
+- [ ] Estimate assigned
+
+### Technical Notes
+- **Suggested approach:** brief description based on codebase patterns
+- **Migration needed:** Yes/No
+- **New API endpoint:** Yes/No
+- **i18n keys needed:** Yes/No
+- **Feature flag:** Yes/No (recommend for: new pages, major behavior changes)
+- **Reusable existing code:** list hooks/components/services to leverage
+
+### Open Questions
+- <!-- PM: list unknowns or decisions pending -->
+
+### Metadata
+| Field | Value |
+|-------|-------|
+| Type | Story / Task / Bug / Spike |
+| Priority | <!-- to fill --> |
+| Estimate | <!-- Fibonacci: 1,2,3,5,8,13 --> |
+| Impact | <!-- High / Medium / Low --> |
+| Team | <!-- Core Product / Data / AI / Infra --> |
+| Labels | <!-- suggested labels from reference.md --> |
+| Sprint | <!-- to assign --> |
+```
+
+### Phase 5: Review & Refine
+
+After presenting the output:
+
+1. Highlight which fields still need human input (Priority, Estimate, Sprint, Figma link).
+2. Ask if the PM wants to adjust anything before copying to Linear.
+3. If the PM provides additional context, regenerate the affected sections.
+
+## Conventions
+
+- Always search the codebase before generating technical notes — never guess file paths.
+- Keep code references to 3-8 files maximum; prefer the most relevant ones.
+- Acceptance criteria must be testable (avoid vague "should work well" language).
+- For Spikes, replace "Acceptance Criteria" with "Questions to Answer" (a list of what the spike must clarify).
+- For Incidents, add a "Timeline" section and skip estimation.
+- Use the team's Linear label conventions from [reference.md](reference.md).
+
+## Quick Examples
+
+**Input:** "Users need to export their inventory data as PDF"
+
+**Output type:** Story
+
+**Key sections generated:**
+- User story: "As a city official, I want to export my inventory as PDF so that I can share it with stakeholders offline."
+- Code refs: `app/src/services/pdf.ts`, `app/src/app/api/v1/inventory/[inventory]/route.ts`, existing PDF generation patterns
+- Technical notes: No migration, new API endpoint (GET /api/v1/inventory/:id/export/pdf), i18n keys for export UI, feature flag recommended
+
+---
+
+**Input:** "The emissions chart crashes when a sector has zero values"
+
+**Output type:** Bug
+
+**Key sections generated:**
+- Steps to reproduce with code path
+- Code refs: chart component, data transformation logic
+- Technical notes: No migration, no new endpoint, fix in existing component

--- a/.cursor/skills/create-ticket/reference.md
+++ b/.cursor/skills/create-ticket/reference.md
@@ -1,0 +1,113 @@
+# Ticket Taxonomy & Conventions
+
+Reference material for the `create-ticket` skill. The agent reads this file when it needs taxonomy details, Linear conventions, or estimation guidance.
+
+## Issue Types
+
+| Type | Purpose | Pointed? | Who Creates |
+|------|---------|----------|-------------|
+| **Epic** | Large initiative spanning multiple sprints (e.g., "HIAP v2 Integration") | No (derived from children) | PM / PO |
+| **Story** | User-facing value delivery with clear acceptance criteria | Yes (Fibonacci) | PM / PO |
+| **Task** | Technical work not directly user-visible (refactor, infra, CI/CD, migrations) | Yes (Fibonacci) | Engineer / Tech Lead |
+| **Spike** | Time-boxed research/investigation to reduce uncertainty | No (time-boxed: 1-3 days) | Engineer or PM |
+| **Bug** | Defect in existing functionality | Yes (Fibonacci) | Anyone |
+| **Incident** | Production issue requiring immediate response | No (tracked by MTTR/severity) | On-call / SRE |
+| **Sub-task** | Breakdown of a Story/Task for sprint tracking | No (parent carries points) | Engineer |
+
+## Story Point Policy
+
+- **Scale:** Fibonacci — 1, 2, 3, 5, 8, 13
+- **Rule:** Anything estimated above 13 must be split into smaller items.
+- **What it measures:** Effort + complexity + uncertainty (never calendar time).
+- **Time tracking:** Every ticket records actual time spent so the team can compare effort vs elapsed time across same-point items, feed velocity charts, and compute DORA/ROI metrics.
+
+### ROI & Metrics Guidance
+
+Each Story or Task carries an **Impact** field:
+
+| Impact | Definition |
+|--------|-----------|
+| High | Affects >50% of users or directly tied to revenue/funding milestone |
+| Medium | Improves experience for a significant segment or unblocks other high-impact work |
+| Low | Quality-of-life improvement, internal tooling, or minor polish |
+
+This enables: `points-delivered / impact-weighted` analysis per sprint, ROI dashboards, and investment allocation reviews.
+
+### DORA Metrics Tracked
+
+| Metric | Source |
+|--------|--------|
+| Lead Time for Changes | Ticket created -> PR merged |
+| Deployment Frequency | Releases per sprint |
+| Change Failure Rate | Incidents / total deployments |
+| Mean Time to Recovery | Incident created -> resolved |
+
+## Linear Mapping
+
+| Taxonomy Type | Linear Concept | Notes |
+|---------------|---------------|-------|
+| Epic | **Project** (or parent Issue with sub-issues) | Use Projects for multi-sprint initiatives |
+| Story | Issue with label `story` | Estimate field = Fibonacci points |
+| Task | Issue with label `task` | Estimate field = Fibonacci points |
+| Bug | Issue with label `bug` | Estimate field = Fibonacci points |
+| Spike | Issue with label `spike` | No estimate; set due date as timebox |
+| Incident | Issue with label `incident`, priority: Urgent | Link to monitoring alert if available |
+| Sub-task | Sub-issue (child of a Story or Task) | No separate estimate |
+
+### Linear Labels (recommended)
+
+| Label | Color hint | Applied to |
+|-------|-----------|-----------|
+| `story` | Blue | User-facing features |
+| `task` | Gray | Technical work |
+| `bug` | Red | Defects |
+| `spike` | Purple | Research/investigation |
+| `incident` | Orange | Production issues |
+| `frontend` | Teal | Touches app/ UI |
+| `backend` | Green | Touches app/ API or services |
+| `ai` | Violet | Touches hiap, hiap-meed, climate-advisor |
+| `data` | Yellow | Touches global-api or data pipelines |
+| `infra` | Dark gray | k8s, CI/CD, DevOps |
+
+### Linear Priorities
+
+| Priority | When to use |
+|----------|-------------|
+| Urgent | Incidents, security vulnerabilities, data loss |
+| High | Sprint commitment, blocking other work |
+| Medium | Important but not blocking |
+| Low | Nice-to-have, backlog grooming candidates |
+
+## Team Areas
+
+| Area | Services | Typical owners |
+|------|----------|----------------|
+| Core Product | `app/` (frontend + API + DB) | Product + Engineering |
+| Data | `global-api/` | Data team |
+| AI/ML | `hiap/`, `hiap-meed/`, `climate-advisor/` | AI team |
+| Infrastructure | `k8s/`, `.github/workflows/`, DevOps | Engineering |
+
+## Definition of Ready (DoR) Checklist
+
+A ticket is ready for sprint when:
+
+- [ ] Summary and acceptance criteria are clear and unambiguous
+- [ ] Design/Figma link attached (if UI work)
+- [ ] API contract or schema defined (if backend/data work)
+- [ ] Dependencies identified and unblocked
+- [ ] Acceptance criteria reviewed by at least one engineer
+- [ ] Estimate assigned (for pointed types)
+- [ ] Impact field set (High/Medium/Low)
+
+## Definition of Done (DoD) Checklist
+
+A ticket is done when:
+
+- [ ] Code merged to develop branch
+- [ ] All acceptance criteria verified
+- [ ] Unit/integration tests passing
+- [ ] No new lint errors introduced
+- [ ] i18n keys added (if user-facing text)
+- [ ] Documentation updated (if API or architecture change)
+- [ ] Deployed to staging and smoke-tested
+- [ ] Time tracked (actual hours logged)

--- a/.cursor/skills/refine-ticket/SKILL.md
+++ b/.cursor/skills/refine-ticket/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: refine-ticket
+description: Enrich an existing ticket with detailed technical breakdown, sub-tasks, code references, and estimation guidance. Use when an engineer asks to refine a ticket, break down a story, add technical details, estimate a task, or decompose work into sub-tasks.
+---
+
+# Refine Ticket
+
+Take an existing ticket (pasted markdown or description) and enrich it with engineering-specific details: sub-task breakdown, precise code references, implementation approach, and estimation rationale.
+
+For ticket taxonomy and estimation conventions, see [../create-ticket/reference.md](../create-ticket/reference.md).
+
+## Workflow
+
+### Step 1: Parse the Ticket
+
+Read the provided ticket content and extract:
+- Type (Story / Task / Bug / Spike)
+- Summary and acceptance criteria
+- Any existing code references or technical notes
+
+If the ticket is just a title or brief description, treat it as needing full technical enrichment.
+
+### Step 2: Codebase Analysis
+
+Search the repository to build a technical picture:
+
+1. **Identify affected layers** — For each acceptance criterion, determine which layers are touched:
+   - Database (models, migrations)
+   - Backend API (routes, services, validation)
+   - Frontend data (RTK Query endpoints, Redux slices)
+   - Frontend UI (components, pages, hooks)
+   - External services (global-api, hiap, climate-advisor)
+
+2. **Find implementation anchor points** — Locate the specific files where changes will be made:
+   - Use `Glob` to find relevant models: `app/src/models/<Entity>.ts`
+   - Use `Grep` to find related API routes: pattern in `app/src/app/api/v1/`
+   - Use `Grep` to find related components: pattern in `app/src/components/`
+   - Use `Grep` for RTK Query endpoints: pattern in `app/src/services/api.ts`
+
+3. **Identify reusable patterns** — Find existing code that solves similar problems:
+   - Similar API handlers with the same auth/validation pattern
+   - Components with comparable UI requirements
+   - Existing hooks or utilities that can be extended
+
+### Step 3: Break into Sub-tasks
+
+Decompose the ticket into implementation sub-tasks. Follow this layer order to avoid dependency issues:
+
+```
+1. [DB]       Migration / model changes
+2. [API]      Validation schemas + route handlers
+3. [Service]  Backend business logic (if complex)
+4. [RTK]      RTK Query endpoints (query + mutation)
+5. [UI]       Components + pages
+6. [i18n]     Translation keys
+7. [Test]     Unit/integration/E2E tests
+8. [Docs]     API docs, README updates
+```
+
+Each sub-task should be:
+- Independently reviewable (could be its own PR)
+- Estimated separately if useful
+- Linked to specific files
+
+### Step 4: Estimate
+
+Provide estimation rationale using the team's Fibonacci scale:
+
+| Points | Guideline |
+|--------|-----------|
+| 1 | Single file change, trivial logic, <1h work |
+| 2 | 2-3 files, straightforward pattern, <half day |
+| 3 | Multiple files, some decisions required, ~1 day |
+| 5 | Cross-layer work, new patterns needed, 2-3 days |
+| 8 | Significant feature, multiple PRs likely, ~1 week |
+| 13 | Large scope, architectural decisions, should consider splitting |
+
+Factors to weigh:
+- Number of layers touched
+- Novelty (new pattern vs following existing convention)
+- Uncertainty (clear requirements vs ambiguous)
+- Testing complexity
+- Review/iteration cycles expected
+
+### Step 5: Generate Enriched Output
+
+Append or replace the technical sections of the ticket:
+
+```markdown
+### Technical Breakdown
+
+**Implementation approach:**
+Brief description of the recommended approach, referencing existing patterns.
+
+**Affected files (by layer):**
+
+| Layer | File | Change |
+|-------|------|--------|
+| DB | `app/migrations/YYYYMMDD-<name>.cjs` | New migration |
+| Model | `app/src/models/<Entity>.ts` | New/modified model |
+| Validation | `app/src/util/validation.ts` | New Zod schema |
+| API | `app/src/app/api/v1/<route>/route.ts` | New handler |
+| RTK | `app/src/services/api.ts` | New query/mutation |
+| Component | `app/src/components/<Feature>/<name>.tsx` | New component |
+| Page | `app/src/app/[lng]/<route>/page.tsx` | Wire component |
+| i18n | `app/src/i18n/locales/en/<ns>.json` | New keys |
+| Test | `app/tests/api/<feature>.jest.ts` | API tests |
+
+**Reusable code:**
+- `app/src/backend/SomeService.ts` — similar pattern for X
+- `app/src/components/Existing/thing.tsx` — reuse for Y
+- `app/src/hooks/useSomething.ts` — extend for Z
+
+### Sub-tasks
+
+- [ ] **[DB]** Create migration for <entity> table — *1 pt*
+- [ ] **[API]** Add validation schema and route handler — *2 pts*
+- [ ] **[RTK]** Add query and mutation endpoints — *1 pt*
+- [ ] **[UI]** Build <component> with form/list — *3 pts*
+- [ ] **[i18n]** Add translation keys — *1 pt*
+- [ ] **[Test]** Write API and component tests — *2 pts*
+
+### Estimation
+
+| Item | Points | Rationale |
+|------|--------|-----------|
+| Total | X | Summary of complexity factors |
+
+### Risks & Dependencies
+
+- Risk: <describe any uncertainty>
+- Dependency: <blocked by ticket X or external decision>
+- Note: <anything the PM should know>
+```
+
+## Conventions
+
+- Always verify file paths by searching the codebase — never invent paths.
+- Reference the [full-feature skill](../full-feature/SKILL.md) layer order for consistency.
+- Sub-tasks should map to potential PRs (reviewable independently).
+- If total estimate exceeds 13 points, recommend splitting into multiple tickets.
+- For Spikes: instead of sub-tasks, output a list of investigation steps and expected deliverables (decision doc, PoC, etc.).
+- For Bugs: include a "Root Cause" section describing where the defect likely lives based on code analysis.


### PR DESCRIPTION
## Summary

Adds two new Cursor agent skills to streamline ticket creation for the Product team and technical breakdown for Engineers. The `create-ticket` skill interactively guides PMs through generating Linear-ready tickets with AI-enriched code references, while `refine-ticket` helps engineers decompose existing tickets into sub-tasks with precise file paths and estimation rationale.

## Changes

- `create-ticket` skill — interactive workflow that classifies work type, asks targeted questions, searches the codebase for relevant code, and outputs a structured ticket template compatible with Linear
- `create-ticket/reference.md` — taxonomy reference defining issue types (Epic, Story, Task, Spike, Bug, Incident), Fibonacci story point policy, Linear label conventions, DORA metrics tracking, and DoR/DoD checklists
- `refine-ticket` skill — engineer companion that takes an existing ticket and adds layer-by-layer sub-task breakdown, affected file mapping, reusable code identification, and estimation guidance