### PR TITLE
ON-5782: Fix CA token proxy host handling

### DIFF
--- a/app/src/app/api/v1/chat/threads/route.ts
+++ b/app/src/app/api/v1/chat/threads/route.ts
@@ -68,7 +68,6 @@ export const POST = apiHandler(async (req, { session }) => {
   );
 
   const caData = await createClimateAdvisorThread({
-    origin: req.nextUrl.origin,
     userId: session.user.id,
     inventoryId: inventory_id,
   });

--- a/app/src/app/api/v1/stationary-energy-drafts/[draftRunId]/review/route.ts
+++ b/app/src/app/api/v1/stationary-energy-drafts/[draftRunId]/review/route.ts
@@ -37,7 +37,6 @@ export const POST = apiHandler(async (req, { session, params }) => {
   const body = requestSchema.parse(await req.json());
   const draftRunId = params.draftRunId;
   const response = await callClimateAdvisor({
-    origin: req.nextUrl.origin,
     path: `/v1/stationary-energy-drafts/${draftRunId}/review`,
     method: "POST",
     tokenUserID: session.user.id,

--- a/app/src/app/api/v1/stationary-energy-drafts/[draftRunId]/route.ts
+++ b/app/src/app/api/v1/stationary-energy-drafts/[draftRunId]/route.ts
@@ -23,7 +23,6 @@ export const GET = apiHandler(async (req, { session, params }) => {
   const query = querySchema.parse(Object.fromEntries(searchParams.entries()));
   const draftRunId = params.draftRunId;
   const response = await callClimateAdvisor({
-    origin: req.nextUrl.origin,
     path: `/v1/stationary-energy-drafts/${draftRunId}?user_id=${encodeURIComponent(session.user.id)}`,
     method: "GET",
     tokenUserID: session.user.id,

--- a/app/src/app/api/v1/stationary-energy-drafts/[draftRunId]/save/route.ts
+++ b/app/src/app/api/v1/stationary-energy-drafts/[draftRunId]/save/route.ts
@@ -22,7 +22,6 @@ export const POST = apiHandler(async (req, { session, params }) => {
   const body = requestSchema.parse(await req.json());
   const draftRunId = params.draftRunId;
   const response = await callClimateAdvisor({
-    origin: req.nextUrl.origin,
     path: `/v1/stationary-energy-drafts/${draftRunId}/save`,
     method: "POST",
     tokenUserID: session.user.id,

--- a/app/src/app/api/v1/stationary-energy-drafts/resume/route.ts
+++ b/app/src/app/api/v1/stationary-energy-drafts/resume/route.ts
@@ -44,7 +44,6 @@ export const GET = apiHandler(async (req, { session, searchParams }) => {
     sector_code: "stationary_energy",
   });
   const response = await callClimateAdvisor({
-    origin: req.nextUrl.origin,
     path: `/v1/stationary-energy-drafts/resume?${params.toString()}`,
     method: "GET",
     tokenUserID: session.user.id,

--- a/app/src/app/api/v1/stationary-energy-drafts/route.ts
+++ b/app/src/app/api/v1/stationary-energy-drafts/route.ts
@@ -44,7 +44,6 @@ export const GET = apiHandler(async (req, { session, searchParams }) => {
     sector_code: "stationary_energy",
   });
   const response = await callClimateAdvisor({
-    origin: req.nextUrl.origin,
     path: `/v1/stationary-energy-drafts?${params.toString()}`,
     method: "GET",
     tokenUserID: session.user.id,

--- a/app/src/app/api/v1/stationary-energy-drafts/start/route.ts
+++ b/app/src/app/api/v1/stationary-energy-drafts/start/route.ts
@@ -24,7 +24,6 @@ export const POST = apiHandler(async (req, { session }) => {
 
   const body = requestSchema.parse(await req.json());
   const response = await callClimateAdvisor({
-    origin: req.nextUrl.origin,
     path: "/v1/stationary-energy-drafts/start",
     method: "POST",
     tokenUserID: session.user.id,

--- a/app/src/backend/agentic/ghgi/stationary-energy/ca.ts
+++ b/app/src/backend/agentic/ghgi/stationary-energy/ca.ts
@@ -84,14 +84,14 @@ async function throwClimateAdvisorProxyError(
 }
 
 export async function issueCaUserToken(params: {
-  origin: string;
   tokenUserID: string;
   inventoryId?: string;
 }): Promise<TokenResponse> {
   const serviceKey = requireEnv("CC_SERVICE_API_KEY");
+  const host = requireEnv("HOST");
   let response: Response;
   try {
-    response = await fetch(`${params.origin}/api/v1/internal/ca/user-token`, {
+    response = await fetch(`${host}/api/v1/internal/ca/user-token/`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -118,7 +118,6 @@ export async function issueCaUserToken(params: {
 }
 
 export async function callClimateAdvisor(params: {
-  origin: string;
   path: string;
   tokenUserID: string;
   inventoryId?: string;
@@ -126,7 +125,6 @@ export async function callClimateAdvisor(params: {
   body?: Record<string, unknown>;
 }): Promise<Response> {
   const token = await issueCaUserToken({
-    origin: params.origin,
     tokenUserID: params.tokenUserID,
     inventoryId: params.inventoryId,
   });

--- a/app/src/backend/chat/climate-advisor.ts
+++ b/app/src/backend/chat/climate-advisor.ts
@@ -98,14 +98,14 @@ function buildClimateAdvisorUrl(
  * Issue a short-lived CA user token through the internal service endpoint.
  */
 export async function issueClimateAdvisorUserToken(params: {
-  origin: string;
   userId: string;
   inventoryId?: string;
 }): Promise<TokenResponse> {
   const serviceKey = requireEnv("CC_SERVICE_API_KEY");
+  const host = requireEnv("HOST");
   let response: Response;
   try {
-    response = await fetch(`${params.origin}/api/v1/internal/ca/user-token`, {
+    response = await fetch(`${host}/api/v1/internal/ca/user-token/`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -180,12 +180,10 @@ export async function readClimateAdvisorResponsePayload(
  * Create a CA thread after issuing a user-scoped access token.
  */
 export async function createClimateAdvisorThread(params: {
-  origin: string;
   userId: string;
   inventoryId?: string;
 }): Promise<ThreadCreateResponse> {
   const token = await issueClimateAdvisorUserToken({
-    origin: params.origin,
     userId: params.userId,
     inventoryId: params.inventoryId,
   });

--- a/app/tests/api/chat-routes.jest.ts
+++ b/app/tests/api/chat-routes.jest.ts
@@ -47,6 +47,7 @@ describe("Chat routes", () => {
   const originalFetch = global.fetch;
   const originalCaBaseUrl = process.env.CA_BASE_URL;
   const originalServiceKey = process.env.CC_SERVICE_API_KEY;
+  const originalHost = process.env.HOST;
   const originalDbInitialized = db.initialized;
   let sessionSpy: ReturnType<typeof jest.spyOn>;
 
@@ -67,6 +68,7 @@ describe("Chat routes", () => {
   });
 
   beforeEach(() => {
+    process.env.HOST = "http://localhost:3000";
     process.env.CA_BASE_URL = "http://ca.example";
     process.env.CC_SERVICE_API_KEY = "cc-service-key";
     db.initialized = true;
@@ -80,6 +82,7 @@ describe("Chat routes", () => {
 
   afterAll(() => {
     db.initialized = originalDbInitialized;
+    process.env.HOST = originalHost;
     process.env.CA_BASE_URL = originalCaBaseUrl;
     process.env.CC_SERVICE_API_KEY = originalServiceKey;
     sessionSpy.mockRestore();
@@ -117,7 +120,7 @@ describe("Chat routes", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
-      "http://localhost:3000/api/v1/internal/ca/user-token",
+      "http://localhost:3000/api/v1/internal/ca/user-token/",
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({

--- a/app/tests/api/chat-routes.jest.ts
+++ b/app/tests/api/chat-routes.jest.ts
@@ -148,6 +148,39 @@ describe("Chat routes", () => {
     expect(createThreadHeaders.get("Content-Type")).toBe("application/json");
   });
 
+  it("uses configured HOST instead of request origin for CA token issuance", async () => {
+    process.env.HOST = "https://configured.example";
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>;
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          access_token: "token-123",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            thread_id: "thread-1",
+          },
+          { status: 201 },
+        ),
+      );
+
+    const response = await postChatThread(
+      makeRequest("https://request-origin.example/api/v1/chat/threads", "POST", {
+        inventory_id: testInventoryId,
+      }),
+      { params: Promise.resolve({}) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://configured.example/api/v1/internal/ca/user-token/",
+    );
+  });
+
   it("preserves JSON token-issuance errors when creating a CA thread", async () => {
     const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>;
     fetchMock.mockResolvedValueOnce(

--- a/app/tests/api/stationary-energy-draft-routes.jest.ts
+++ b/app/tests/api/stationary-energy-draft-routes.jest.ts
@@ -54,6 +54,7 @@ describe("Stationary Energy draft routes", () => {
   const originalFeatureFlags = process.env.NEXT_PUBLIC_FEATURE_FLAGS;
   const originalCaBaseUrl = process.env.CA_BASE_URL;
   const originalServiceKey = process.env.CC_SERVICE_API_KEY;
+  const originalHost = process.env.HOST;
   const originalDbInitialized = db.initialized;
   let sessionSpy: ReturnType<typeof jest.spyOn>;
 
@@ -76,6 +77,7 @@ describe("Stationary Energy draft routes", () => {
   beforeEach(() => {
     process.env.NEXT_PUBLIC_FEATURE_FLAGS =
       "CA_SERVICE_INTEGRATION,STATIONARY_ENERGY_AGENTIC";
+    process.env.HOST = "http://localhost:3000";
     process.env.CA_BASE_URL = "http://ca.example";
     process.env.CC_SERVICE_API_KEY = "cc-service-key";
     db.initialized = true;
@@ -90,6 +92,7 @@ describe("Stationary Energy draft routes", () => {
   afterAll(() => {
     db.initialized = originalDbInitialized;
     process.env.NEXT_PUBLIC_FEATURE_FLAGS = originalFeatureFlags;
+    process.env.HOST = originalHost;
     process.env.CA_BASE_URL = originalCaBaseUrl;
     process.env.CC_SERVICE_API_KEY = originalServiceKey;
     sessionSpy.mockRestore();

--- a/app/tests/api/stationary-energy-draft-routes.jest.ts
+++ b/app/tests/api/stationary-energy-draft-routes.jest.ts
@@ -181,6 +181,41 @@ describe("Stationary Energy draft routes", () => {
     });
   });
 
+  it("uses configured HOST instead of request origin for CA token issuance", async () => {
+    process.env.HOST = "https://configured.example";
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>;
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          access_token: "token-123",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          draft_run_id: TEST_DRAFT_RUN_ID,
+        }),
+      );
+
+    const response = await startDraft(
+      makeRequest(
+        "https://request-origin.example/api/v1/stationary-energy-drafts/start",
+        "POST",
+        {
+          city_id: TEST_CITY_ID,
+          inventory_id: TEST_INVENTORY_ID,
+        },
+      ),
+      { params: Promise.resolve({}) },
+    );
+
+    expect(response.status).toBe(201);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://configured.example/api/v1/internal/ca/user-token/",
+    );
+  });
+
   it("preserves JSON token-issuance errors from the shared CA helper", async () => {
     const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>;
     fetchMock.mockResolvedValueOnce(


### PR DESCRIPTION
## Summary

Fixes the Climate Advisor token proxy path used before creating CA chat threads and stationary-energy agentic calls. The ON-5782 changes moved token issuance into shared helpers and changed the internal auth proxy call from configured `HOST` to the request-derived origin, which made dev depend on ingress/request-origin behavior instead of the proven deployment host.

The auth proxy call also now uses the explicit trailing slash on `/api/v1/internal/ca/user-token/` to avoid the no-slash redirect on the token issuance path. In dev this surfaced as `500 Internal Server Error` with `fetch failed` while trying to authenticate before creating the CA thread.

## Changes

- Restore CA user-token issuance to call `${process.env.HOST}/api/v1/internal/ca/user-token/`.
- Remove request-origin forwarding from chat and stationary-energy CA callers.
- Add regression tests for both chat thread creation and stationary-energy draft calls to ensure token issuance uses configured `HOST`, not `req.nextUrl.origin`.

## Tests

- `npm run jest:windows -- tests/api/chat-routes.jest.ts tests/api/stationary-energy-draft-routes.jest.ts --runInBand --coverage=false`

## Commits (2)

- `Fix CA token proxy host`
- `Add CA token host regression tests`