### PR TITLE
Trigger CA redeploy and validate OpenRouter key

### DIFF
--- a/.github/workflows/climate-advisor-develop.yml
+++ b/.github/workflows/climate-advisor-develop.yml
@@ -69,6 +69,15 @@ jobs:
         run: |
           uv sync --locked --group dev
 
+      - name: Validate OpenRouter API key
+        working-directory: climate-advisor
+        env:
+          OPENROUTER_SMOKE_TEST: "1"
+        run: |
+          uv run --directory service pytest tests/test_openrouter_key_smoke.py \
+                 --junit-xml=test-results-openrouter-smoke.xml \
+                 -v --tb=short --color=yes
+
       - name: Run unit tests
         working-directory: climate-advisor
         run: |

--- a/climate-advisor/service/app/routes/health.py
+++ b/climate-advisor/service/app/routes/health.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 router = APIRouter()
 
 
-@router.get('/health')
-async def health() -> dict:
-    return {'status': 'ok'}
+@router.get("/health")
+async def health() -> dict[str, str]:
+    """Return the minimal health payload used by probes and deploy checks."""
+    return {"status": "ok"}

--- a/climate-advisor/service/tests/test_openrouter_key_smoke.py
+++ b/climate-advisor/service/tests/test_openrouter_key_smoke.py
@@ -1,0 +1,38 @@
+"""Smoke test for the OpenRouter credential used by Climate Advisor deploys."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import requests
+
+OPENROUTER_AUTH_URL = "https://openrouter.ai/api/v1/auth/key"
+
+
+def test_openrouter_api_key_is_present_and_valid() -> None:
+    """Validate the deployed OpenRouter key without issuing a chat completion."""
+    if os.getenv("OPENROUTER_SMOKE_TEST") != "1":
+        pytest.skip("OpenRouter credential smoke test is enabled only in CI/CD")
+
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    assert api_key, "OPENROUTER_API_KEY must be configured for Climate Advisor deploys"
+
+    try:
+        response = requests.get(
+            OPENROUTER_AUTH_URL,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Accept": "application/json",
+            },
+            timeout=10,
+        )
+    except requests.RequestException as error:
+        pytest.fail(
+            "OpenRouter credential smoke test could not reach auth endpoint: "
+            f"{type(error).__name__}"
+        )
+
+    assert (
+        response.status_code == 200
+    ), f"OpenRouter rejected OPENROUTER_API_KEY with status {response.status_code}"


### PR DESCRIPTION
## Summary

Adds a Climate Advisor CI smoke test that validates the configured `OPENROUTER_API_KEY` against OpenRouter before the CA build/deploy path can continue. This branch also touches CA service code in `climate-advisor/service/**` so merging it to `develop` triggers the CA image build and EKS deploy workflow.

## Changes

- Add an opt-in OpenRouter credential smoke test using `/api/v1/auth/key` rather than a chat completion.
- Run that smoke test in the CA develop workflow after dependency sync.
- Make a no-behavior health route cleanup so the CA service path filter is definitely triggered.

## Tests

- `uv run --directory service pytest tests/test_openrouter_key_smoke.py -v --tb=short --color=yes`
- `uv run --directory service pytest tests/test_api_routes.py::HealthRouteTests -v --tb=short --color=yes`

## Notes

This PR does not include any secret value. The workflow will validate whatever `OPENROUTER_API_KEY` is configured in GitHub Actions secrets.