### PR TITLE
Fix language selector updates without page reload

### DIFF
--- a/app/src/app/providers.tsx
+++ b/app/src/app/providers.tsx
@@ -9,6 +9,7 @@ import { Provider } from "react-redux";
 import { appTheme } from "@/lib/theme/recipes/app-theme";
 import { ThemeProvider } from "next-themes";
 import { OrganizationContextProvider } from "@/hooks/organization-context-provider/use-organizational-context";
+import I18nLanguageSync from "@/components/I18nLanguageSync";
 
 const openSans = localFont({
   src: [
@@ -82,7 +83,10 @@ export function Providers({ children }: { children: React.ReactNode }) {
         <ChakraProvider value={appTheme}>
           <OrganizationContextProvider>
             <SessionProvider>
-              <Provider store={store}>{children}</Provider>
+              <Provider store={store}>
+                <I18nLanguageSync />
+                {children}
+              </Provider>
             </SessionProvider>
           </OrganizationContextProvider>
         </ChakraProvider>

--- a/app/src/components/I18nLanguageSync.tsx
+++ b/app/src/components/I18nLanguageSync.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+import { useParams } from "next/navigation";
+import i18next from "i18next";
+import Cookies from "js-cookie";
+import { languages } from "@/i18n/settings";
+
+/**
+ * Keeps the client-side i18next instance aligned with the `[lng]` URL segment.
+ * Without this, translations only update after a full page reload.
+ */
+export default function I18nLanguageSync() {
+  const params = useParams();
+  const lngParam = params.lng;
+  const lng = Array.isArray(lngParam) ? lngParam[0] : lngParam;
+
+  useEffect(() => {
+    if (!lng || !languages.includes(lng)) return;
+    if (i18next.resolvedLanguage === lng) return;
+
+    Cookies.set("i18next", lng, { path: "/", sameSite: "strict" });
+    void i18next.changeLanguage(lng);
+  }, [lng]);
+
+  return null;
+}

--- a/app/src/components/navigation-bar.tsx
+++ b/app/src/components/navigation-bar.tsx
@@ -29,7 +29,7 @@ import {
   MdOutlineMenu,
 } from "react-icons/md";
 import Cookies from "js-cookie";
-import { useRouter } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { api, useGetUserAccessStatusQuery } from "@/services/api";
 import {
   MenuContent,
@@ -50,6 +50,7 @@ import { Trans } from "react-i18next";
 import JNDrawer from "./HomePage/JNDrawer";
 import { getDashboardPath, getHomePath } from "@/util/routes";
 import { useRouteParams } from "@/hooks/useRouteParams";
+import { getParamValue } from "@/util/helpers";
 
 function countryFromLanguage(language: string) {
   return language == "en" ? "us" : language;
@@ -73,7 +74,9 @@ export function NavigationBar({
   restrictAccess?: boolean;
   isOrgOwner?: boolean;
 }) {
-  const { t } = useTranslation(lng, "navigation");
+  const params = useParams();
+  const activeLng = getParamValue(params.lng) ?? lng;
+  const { t } = useTranslation(activeLng, "navigation");
   const { organization, clearOrganization } = useOrganizationContext();
   const logoUrl = organization?.logoUrl;
   const isFrozen = organization != null && !organization.active;
@@ -93,24 +96,20 @@ export function NavigationBar({
     },
   );
 
-  const onChangeLanguage = (language: string) => {
-    Cookies.set("i18next", language, { path: "/", sameSite: "strict" });
-    const cookieLanguage = Cookies.get("i18next");
-
-    if (cookieLanguage) {
-      i18next.changeLanguage(cookieLanguage);
-    }
-
-    // Use Next.js router to properly handle language change with middleware
-    const currentPath = pathname || location.pathname;
-    const newPath = currentPath.replace(/^\/[a-z]{2}/, `/${language}`);
-    router.replace(newPath);
-  };
-
   const { data: session, status } = useSession();
   const { data: userInfo, isLoading: isUserInfoLoading } =
     api.useGetUserInfoQuery();
   const router = useRouter();
+
+  const onChangeLanguage = async (language: string) => {
+    Cookies.set("i18next", language, { path: "/", sameSite: "strict" });
+    await i18next.changeLanguage(language);
+
+    const currentPath = pathname || location.pathname;
+    const newPath = currentPath.replace(/^\/[a-z]{2}(?=\/|$)/, `/${language}`);
+    router.replace(newPath);
+    router.refresh();
+  };
 
   // Derive the active module name from the current pathname
   const moduleName = useMemo(() => {
@@ -133,12 +132,13 @@ export function NavigationBar({
 
   // Memoize paths to recompute when pathname or IDs change
   const dashboardPath = useMemo(
-    () => getDashboardPath(lng, currentCityId ?? "", currentInventoryId ?? ""),
-    [lng, currentCityId, currentInventoryId],
+    () =>
+      getDashboardPath(activeLng, currentCityId ?? "", currentInventoryId ?? ""),
+    [activeLng, currentCityId, currentInventoryId],
   );
   const homePath = useMemo(
-    () => getHomePath(lng, currentCityId ?? "", currentInventoryId ?? ""),
-    [lng, currentCityId, currentInventoryId],
+    () => getHomePath(activeLng, currentCityId ?? "", currentInventoryId ?? ""),
+    [activeLng, currentCityId, currentInventoryId],
   );
   const { setTheme } = useTheme();
 
@@ -283,18 +283,18 @@ export function NavigationBar({
                   whiteSpace="nowrap"
                 >
                   <Box display="flex" alignItems="center" gap="3">
-                    <CircleFlag
-                      countryCode={
-                        countryFromLanguage(i18next.language) === "pt"
-                          ? "br"
-                          : countryFromLanguage(i18next.language)
-                      }
-                      width="24"
-                    />
+                      <CircleFlag
+                        countryCode={
+                          countryFromLanguage(activeLng) === "pt"
+                            ? "br"
+                            : countryFromLanguage(activeLng)
+                        }
+                        width="24"
+                      />
 
-                    <Text fontSize="title.md" fontWeight="bold">
-                      {i18next.language.toUpperCase()}
-                    </Text>
+                      <Text fontSize="title.md" fontWeight="bold">
+                        {activeLng.toUpperCase()}
+                      </Text>
 
                     <Icon
                       as={isLanguageMenuOpen ? MdArrowDropUp : MdArrowDropDown}
@@ -523,7 +523,7 @@ export function NavigationBar({
         {/* Should be shown if JN is enabled */}
         {hasFeatureFlag(FeatureFlags.JN_ENABLED) && (
           <JNDrawer
-            lng={lng}
+            lng={activeLng}
             currentCityId={currentCityId}
             organizationId={
               (organization?.organizationId ??
@@ -538,7 +538,7 @@ export function NavigationBar({
         {/* Project Drawer */}
         {!hasFeatureFlag(FeatureFlags.JN_ENABLED) && (
           <ProjectDrawer
-            lng={lng}
+            lng={activeLng}
             currentInventoryId={currentInventoryId as string}
             isOpen={isDrawerOpen}
             onClose={() => setIsDrawerOpen(false)}

--- a/app/src/i18n/client.ts
+++ b/app/src/i18n/client.ts
@@ -31,9 +31,9 @@ i18next
   });
 
 export function useTranslation(
-  _lng: string,
+  lng: string,
   ns: string,
   options: UseTranslationOptions<undefined> = {},
 ) {
-  return useTranslationOrg(ns, options);
+  return useTranslationOrg(ns, { ...options, lng });
 }


### PR DESCRIPTION
## Summary
- Pass the URL locale into react-i18next so client components re-render on language change
- Add I18nLanguageSync to keep i18next aligned with the [lng] route segment
- Update the nav language selector to await changeLanguage and call router.refresh()
