### PR TITLE
fix(ui): ON-5806 help sidebar cut off on JN onboarding flow

### DIFF
--- a/app/src/app/[lng]/cities/onboarding/setup/page.tsx
+++ b/app/src/app/[lng]/cities/onboarding/setup/page.tsx
@@ -428,7 +428,6 @@ export default function OnboardingSetup(props: {
           left={0}
           pb={8}
           px={1}
-          zIndex={9999}
           transition="all"
           data-onboarding-bottom-bar
         >


### PR DESCRIPTION
Removes zIndex property on bottom bar of JN onboarding flow to match GHGI onboaring flow