### PR TITLE
Adds a consistent upload existing inventory path for GHGI and city onboarding.

### DIFF
--- a/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/setup/page.tsx
+++ b/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/setup/page.tsx
@@ -56,6 +56,7 @@ export default function OnboardingSetup(props: {
   const params = useSearchParams();
 
   const projectId = params.get("project");
+  const isUploadMode = params.get("mode") === "upload";
 
   const EnterpriseMode = hasFeatureFlag(FeatureFlags.ENTERPRISE_MODE);
 
@@ -92,12 +93,20 @@ export default function OnboardingSetup(props: {
     }
   }, [cityData]);
 
-  const steps = [
-    { title: t("set-inventory-details-step") },
-    { title: t("set-population-step") },
-    { title: t("set-third-party-data-step") },
-    { title: t("confirm-step") },
-  ];
+  const steps = isUploadMode
+    ? [
+        { title: t("set-inventory-details-step") },
+        { title: t("set-population-step") },
+        { title: t("confirm-step") },
+      ]
+    : [
+        { title: t("set-inventory-details-step") },
+        { title: t("set-population-step") },
+        { title: t("set-third-party-data-step") },
+        { title: t("confirm-step") },
+      ];
+
+  const confirmStepIndex = isUploadMode ? 2 : 3;
 
   const {
     value: activeStep,
@@ -273,10 +282,10 @@ export default function OnboardingSetup(props: {
 
   // Reset third-party choice each time the user enters that step
   useEffect(() => {
-    if (activeStep === 2) {
+    if (!isUploadMode && activeStep === 2) {
       setThirdPartyDataChoice(null);
     }
-  }, [activeStep]);
+  }, [activeStep, isUploadMode]);
 
   const [selectedProject, setSelectedProject] = useState<string[]>([]);
   useEffect(() => {
@@ -349,7 +358,7 @@ export default function OnboardingSetup(props: {
               numberFormat={userInfo?.numberFormat}
             />
           )}
-          {activeStep === 2 && (
+          {!isUploadMode && activeStep === 2 && (
             <ThirdPartyInventoryDataStep
               t={t}
               cityId={cityId}
@@ -363,7 +372,7 @@ export default function OnboardingSetup(props: {
               onValueChange={setThirdPartyDataChoice}
             />
           )}
-          {activeStep === 3 && (
+          {activeStep === confirmStepIndex && (
             <ConfirmStep
               cityName={data.name}
               t={t}
@@ -437,7 +446,7 @@ export default function OnboardingSetup(props: {
                   <MdArrowForward height="24px" width="24px" />
                 </Button>
               )}
-              {activeStep == 2 && (
+              {!isUploadMode && activeStep == 2 && (
                 <Button
                   w="auto"
                   gap="8px"
@@ -457,7 +466,7 @@ export default function OnboardingSetup(props: {
                   <MdArrowForward height="24px" width="24px" />
                 </Button>
               )}
-              {activeStep == 3 && (
+              {activeStep == confirmStepIndex && (
                 <Button
                   h={16}
                   w="auto"

--- a/app/src/app/[lng]/cities/onboarding/page.tsx
+++ b/app/src/app/[lng]/cities/onboarding/page.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "@/i18n/client";
 import { Box, Button, Heading, HStack, Text } from "@chakra-ui/react";
 import Image from "next/image";
 import NextLink from "next/link";
-import { MdArrowForward } from "react-icons/md";
+import { MdArrowForward, MdUpload } from "react-icons/md";
 import { useOrganizationContext } from "@/hooks/organization-context-provider/use-organizational-context";
 import { useRouter, useSearchParams } from "next/navigation";
 import { api } from "@/services/api";
@@ -35,6 +35,11 @@ export default function Onboarding(props: {
   }, [searchParams, acceptOrgInvite]);
 
   const steps = [1, 2, 3, 4];
+  const projectId = searchParams.get("project");
+  const setupHref = projectId ? `setup?project=${projectId}` : "setup";
+  const uploadSetupHref = projectId
+    ? `setup?project=${projectId}&mode=upload`
+    : "setup?mode=upload";
 
   return (
     <>
@@ -105,6 +110,7 @@ export default function Onboarding(props: {
           justifyContent="end"
           py="32px"
           px="175px"
+          gap="16px"
         >
           <Button
             w="auto"
@@ -112,7 +118,23 @@ export default function Onboarding(props: {
             py="16px"
             px="24px"
             h="64px"
-            onClick={() => router.push("setup")}
+            variant="outline"
+            onClick={() => router.push(uploadSetupHref)}
+            data-testid="upload-inventory-button"
+          >
+            <MdUpload height="24px" width="24px" />
+            <Text fontFamily="button.md" fontWeight="600" letterSpacing="wider">
+              {t("upload-existing-inventory")}
+            </Text>
+          </Button>
+          <Button
+            w="auto"
+            gap="8px"
+            py="16px"
+            px="24px"
+            h="64px"
+            onClick={() => router.push(setupHref)}
+            data-testid="start-inventory-button"
           >
             <Text fontFamily="button.md" fontWeight="600" letterSpacing="wider">
               {t("welcome-CTA")}

--- a/app/src/app/[lng]/cities/onboarding/setup/page.tsx
+++ b/app/src/app/[lng]/cities/onboarding/setup/page.tsx
@@ -60,6 +60,7 @@ export default function OnboardingSetup(props: {
 
   const params = useSearchParams();
   const projectId = params.get("project");
+  const isUploadMode = params.get("mode") === "upload";
 
   const EnterpriseMode = hasFeatureFlag(FeatureFlags.ENTERPRISE_MODE);
 
@@ -76,12 +77,21 @@ export default function OnboardingSetup(props: {
     }
   }, [projectsList]);
 
-  const steps = [
-    { title: t("setup-step") },
-    { title: t("set-inventory-details-step") },
-    { title: t("set-population-step") },
-    { title: t("set-third-party-data-step") },
-  ];
+  const steps = isUploadMode
+    ? [
+        { title: t("setup-step") },
+        { title: t("set-inventory-details-step") },
+        { title: t("set-population-step") },
+      ]
+    : [
+        { title: t("setup-step") },
+        { title: t("set-inventory-details-step") },
+        { title: t("set-population-step") },
+        { title: t("set-third-party-data-step") },
+      ];
+
+  const thirdPartyStepIndex = 3;
+  const inventoryConfirmStepIndex = isUploadMode ? 2 : thirdPartyStepIndex;
 
   const {
     value: activeStep,
@@ -229,9 +239,15 @@ export default function OnboardingSetup(props: {
       }
 
       setConfirming(false);
-      router.push(
-        `/${lng}/cities/${createdCityId}/GHGI/${inventory.inventoryId}`,
-      );
+      if (isUploadMode) {
+        router.push(
+          `/${lng}/cities/${createdCityId}/GHGI/onboarding/import?inventory=${inventory.inventoryId}`,
+        );
+      } else {
+        router.push(
+          `/${lng}/cities/${createdCityId}/GHGI/${inventory.inventoryId}`,
+        );
+      }
     } catch (err: any) {
       logger.error({ err }, "Onboarding - Failed to create inventory");
       makeErrorToast("failed-to-create-inventory", err.data?.error?.message);
@@ -313,10 +329,10 @@ export default function OnboardingSetup(props: {
 
   // Reset third-party choice when user enters that step
   useEffect(() => {
-    if (activeStep === 3) {
+    if (!isUploadMode && activeStep === thirdPartyStepIndex) {
       setThirdPartyDataChoice(null);
     }
-  }, [activeStep]);
+  }, [activeStep, isUploadMode]);
 
   const [selectedProject, setSelectedProject] = useState<string[]>([]);
   useEffect(() => {
@@ -405,7 +421,7 @@ export default function OnboardingSetup(props: {
               numberFormat={userInfo?.numberFormat}
             />
           )}
-          {activeStep === 3 && (
+          {!isUploadMode && activeStep === thirdPartyStepIndex && (
             <ThirdPartyInventoryDataStep
               t={t}
               cityId={createdCityId!}
@@ -436,40 +452,45 @@ export default function OnboardingSetup(props: {
               <ProgressSteps steps={steps} currentStep={activeStep} />
             </Box>
             <Box w="full" display="flex" justifyContent="end" px="135px">
-              {(activeStep === 0 || activeStep === 1 || activeStep === 2) && (
-                <Button
-                  w="auto"
-                  gap="8px"
-                  py="16px"
-                  px="24px"
-                  onClick={handleSubmit(onSubmit)}
-                  h="64px"
-                  type="submit"
-                  loading={isCreatingCity}
-                  disabled={
-                    isCreatingCity ||
-                    (activeStep === 0 && !ocCityData) ||
-                    (activeStep === 1 && !isInventoryDetailsValid) ||
-                    (activeStep === 2 && !isPopulationValid)
-                  }
-                >
-                  <Text
-                    fontFamily="button.md"
-                    fontWeight="600"
-                    letterSpacing="wider"
+              {(activeStep === 0 || activeStep === 1 || activeStep === 2) &&
+                activeStep !== inventoryConfirmStepIndex && (
+                  <Button
+                    w="auto"
+                    gap="8px"
+                    py="16px"
+                    px="24px"
+                    onClick={handleSubmit(onSubmit)}
+                    h="64px"
+                    type="submit"
+                    loading={isCreatingCity}
+                    disabled={
+                      isCreatingCity ||
+                      (activeStep === 0 && !ocCityData) ||
+                      (activeStep === 1 && !isInventoryDetailsValid) ||
+                      (activeStep === 2 && !isPopulationValid)
+                    }
                   >
-                    {t("continue")}
-                  </Text>
-                  <MdArrowForward height="24px" width="24px" />
-                </Button>
-              )}
-              {activeStep === 3 && (
+                    <Text
+                      fontFamily="button.md"
+                      fontWeight="600"
+                      letterSpacing="wider"
+                    >
+                      {t("continue")}
+                    </Text>
+                    <MdArrowForward height="24px" width="24px" />
+                  </Button>
+                )}
+              {activeStep === inventoryConfirmStepIndex && (
                 <Button
                   h={16}
                   w="auto"
                   px="24px"
                   loading={isConfirming}
-                  disabled={!thirdPartyDataChoice || isConfirming}
+                  disabled={
+                    isConfirming ||
+                    (!isUploadMode && !thirdPartyDataChoice) ||
+                    (isUploadMode && !isPopulationValid)
+                  }
                   onClick={onInventoryConfirm}
                 >
                   <Text

--- a/app/src/components/HomePage/JNDrawer.tsx
+++ b/app/src/components/HomePage/JNDrawer.tsx
@@ -488,7 +488,7 @@ const ProjectFilterSection = ({
                 variant="ghost"
                 onClick={() => {
                   router.push(
-                    `/cities/onboarding/setup?project=${selectedProject}`,
+                    `/${lng}/cities/onboarding?project=${selectedProject}`,
                   );
                 }}
                 rounded={0}


### PR DESCRIPTION
Summary
Adds a consistent upload existing inventory path for GHGI and city onboarding. Upload mode (?mode=upload) skips the third-party data step and sends users to the import wizard after inventory creation.

Changes
- GHGI setup: hide third-party step when mode=upload
- City onboarding landing: add Upload existing inventory button; preserve project param to setup
- City onboarding setup: upload mode skips third-party and redirects to import
- JN Drawer: “Add new city” goes to /cities/onboarding?project={id} instead of setup