### PR TITLE
ON-5833: Align inventory fallback redirects to city GHGI routes

### DIFF
--- a/app/src/app/[lng]/cities/[cityId]/GHGI/[inventory]/page.tsx
+++ b/app/src/app/[lng]/cities/[cityId]/GHGI/[inventory]/page.tsx
@@ -29,15 +29,20 @@ export default function CityInventoryPage() {
 
     // If inventory doesn't exist or user doesn't have access, redirect appropriately
     if (inventoryError || !inventoryData) {
-      if (userInfo?.defaultInventoryId) {
-        // Redirect to default inventory
+      if (userInfo?.defaultInventoryId && userInfo?.defaultCityId) {
+        // Redirect to default inventory in city-scoped GHGI route
+        router.replace(
+          `/${lngValue}/cities/${userInfo.defaultCityId}/GHGI/${userInfo.defaultInventoryId}`,
+        );
+      } else if (userInfo?.defaultInventoryId) {
+        // Keep a safe fallback for users missing defaultCityId
         router.replace(`/${lngValue}/${userInfo.defaultInventoryId}`);
       } else if (userInfo?.defaultCityId) {
         // Redirect to default city
         router.replace(`/${lngValue}/cities/${userInfo.defaultCityId}`);
       } else {
         // Redirect to onboarding
-        router.replace(`/${lngValue}/onboarding`);
+        router.replace(`/${lngValue}/cities/onboarding`);
       }
     }
   }, [

--- a/app/src/components/GHGIHomePage/ProjectDrawer.tsx
+++ b/app/src/components/GHGIHomePage/ProjectDrawer.tsx
@@ -141,7 +141,7 @@ const SingleProjectView = ({
       return;
     }
 
-    router.push(`/${lng}/${inventoryId}`);
+    router.push(`/${lng}/cities/${city.cityId}/GHGI/${inventoryId}`);
   };
 
   const [searchTerm, setSearchTerm] = React.useState("");

--- a/app/src/components/missing-inventory.tsx
+++ b/app/src/components/missing-inventory.tsx
@@ -28,8 +28,15 @@ const MissingInventory = ({
       return;
     }
 
-    if (userInfo?.defaultInventoryId) {
+    if (userInfo?.defaultInventoryId && userInfo?.defaultCityId) {
       // TODO send to JNHome [ON-4452]
+      router.push(
+        `/${lng}/cities/${userInfo.defaultCityId}/GHGI/${userInfo.defaultInventoryId}`,
+      );
+      return;
+    }
+
+    if (userInfo?.defaultInventoryId) {
       router.push(`/${lng}/${userInfo.defaultInventoryId}`);
       return;
     }
@@ -100,7 +107,11 @@ const MissingInventory = ({
           </Text>
           <Button
             onClick={() => {
-              if (userInfo?.defaultInventoryId) {
+              if (userInfo?.defaultInventoryId && userInfo?.defaultCityId) {
+                router.push(
+                  `/${lng}/cities/${userInfo.defaultCityId}/GHGI/${userInfo.defaultInventoryId}`,
+                );
+              } else if (userInfo?.defaultInventoryId) {
                 router.push(`/${lng}/${userInfo?.defaultInventoryId}`);
               } else if (cityId) {
                 router.push(`/${lng}/cities/${cityId}/GHGI/onboarding`);

--- a/app/src/hooks/useResourceValidation.ts
+++ b/app/src/hooks/useResourceValidation.ts
@@ -43,15 +43,20 @@ export function useResourceValidation({
     // If resource doesn't exist or user doesn't have access, redirect appropriately
     if (resourceError || !resourceData) {
       if (resourceType === 'inventory') {
-        if (userInfo?.defaultInventoryId) {
-          // Redirect to default inventory
+        if (userInfo?.defaultInventoryId && userInfo?.defaultCityId) {
+          // Redirect to default inventory in city-scoped GHGI route
+          router.replace(
+            `/${lng}/cities/${userInfo.defaultCityId}/GHGI/${userInfo.defaultInventoryId}`,
+          );
+        } else if (userInfo?.defaultInventoryId) {
+          // Keep a safe fallback for users missing defaultCityId
           router.replace(`/${lng}/${userInfo.defaultInventoryId}`);
         } else if (userInfo?.defaultCityId) {
           // Redirect to default city
           router.replace(`/${lng}/cities/${userInfo.defaultCityId}`);
         } else {
           // Redirect to onboarding
-          router.replace(`/${lng}/onboarding`);
+          router.replace(`/${lng}/cities/onboarding`);
         }
       } else if (resourceType === 'city') {
         if (userInfo?.defaultCityId) {


### PR DESCRIPTION
## Summary

Align inventory fallback navigation with city-scoped GHGI routes to reduce reliance on legacy `/${lng}/${inventoryId}` URLs.

## Changes

- Updated inventory validation redirects to prefer `/${lng}/cities/${cityId}/GHGI/${inventoryId}`
- Updated GHGI project drawer city navigation to use city-scoped inventory URLs
- Updated missing-inventory flows and CTA redirects to use city-scoped defaults when available
- Kept legacy inventory URL fallback only when `defaultCityId` is missing

## Test plan

- Open GHGI project drawer and navigate to a city inventory
- Trigger missing-inventory route and verify redirect behavior
- Verify fallback still works when only `defaultInventoryId` exists