### PR TITLE
feat: ON-5816 don't add notation keys during onboarding

### DIFF
--- a/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/setup/page.tsx
+++ b/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/setup/page.tsx
@@ -243,10 +243,6 @@ export default function OnboardingSetup(props: {
             { errors, inventoryId: inventory.inventoryId },
             "Some third-party sources failed to connect during onboarding",
           );
-          makeErrorToast(
-            t("connect-data-sources-partial-failure-title"),
-            t("connect-data-sources-partial-failure-description"),
-          );
         }
       }
 

--- a/app/src/app/[lng]/cities/onboarding/setup/page.tsx
+++ b/app/src/app/[lng]/cities/onboarding/setup/page.tsx
@@ -231,10 +231,6 @@ export default function OnboardingSetup(props: {
             { errors, inventoryId: inventory.inventoryId },
             "Some third-party sources failed to connect during onboarding",
           );
-          makeWarningToast(
-            t("connect-data-sources-partial-failure-title"),
-            t("connect-data-sources-partial-failure-description"),
-          );
         }
       }
 

--- a/app/src/app/api/v1/datasource/[inventoryId]/connect-all/route.ts
+++ b/app/src/app/api/v1/datasource/[inventoryId]/connect-all/route.ts
@@ -42,6 +42,7 @@ export const POST = apiHandler(async (_req, { params, session }) => {
     params.inventoryId,
     inventory.city.locode,
     session?.user.id,
+    false, // don't autofill empty GPC refnos with notation key entries (not estimated)
   );
 
   return NextResponse.json({ errors });

--- a/app/src/backend/DataSourceConnectService.ts
+++ b/app/src/backend/DataSourceConnectService.ts
@@ -138,6 +138,7 @@ export default class DataSourceConnectService {
     inventoryId: string,
     cityLocode: string,
     userId: string | undefined,
+    addNotationKeysForEmptyRefnos: boolean = true,
   ): Promise<ConnectAllDataSourcesError[]> {
     const errors: ConnectAllDataSourcesError[] = [];
     logger.info(
@@ -259,7 +260,7 @@ export default class DataSourceConnectService {
           }
         }
 
-        if (!isSuccessful) {
+        if (!isSuccessful && addNotationKeysForEmptyRefnos) {
           await DataSourceConnectService.createUnavailableInventoryValue(
             inventoryId,
             gpcReferenceNumber,
@@ -269,7 +270,7 @@ export default class DataSourceConnectService {
             "reason-NE",
           );
         }
-      } else {
+      } else if (addNotationKeysForEmptyRefnos) {
         await DataSourceConnectService.createUnavailableInventoryValue(
           inventoryId,
           gpcReferenceNumber,

--- a/app/src/i18n/locales/de/onboarding.json
+++ b/app/src/i18n/locales/de/onboarding.json
@@ -75,8 +75,6 @@
   "sources-drawer-incomplete-setup": "Schließen Sie Inventarjahr und Ziel in den vorherigen Schritten ab, um Quellen anzuzeigen.",
   "sources-drawer-load-error": "Quellen konnten nicht geladen werden. Bitte versuchen Sie es später erneut.",
   "sources-drawer-no-sources": "Für diese Stadt und dieses Inventarjahr sind keine Datenquellen Dritter verfügbar.",
-  "connect-data-sources-partial-failure-title": "Einige Datenquellen konnten nicht verbunden werden",
-  "connect-data-sources-partial-failure-description": "Ihr Inventar wurde erstellt. Verbleibende Quellen können Sie manuell in den Datenschritten verbinden.",
   "sources-drawer-title": "Quellen",
   "sources-drawer-description": "In diesem Abschnitt finden Sie Informationen zu den Quellen für Ihr Inventarziel.",
   "sources-category-empty-placeholder": "Quellendetails für diese Kategorie werden in Kürze verfügbar sein.",

--- a/app/src/i18n/locales/en/onboarding.json
+++ b/app/src/i18n/locales/en/onboarding.json
@@ -43,8 +43,6 @@
   "sources-drawer-incomplete-setup": "Complete inventory year and goal on the previous steps to preview sources.",
   "sources-drawer-load-error": "Could not load sources. Please try again later.",
   "sources-drawer-no-sources": "No third-party sources are available for this city and inventory year.",
-  "connect-data-sources-partial-failure-title": "Some data sources could not be connected",
-  "connect-data-sources-partial-failure-description": "Your inventory was created. You can connect remaining sources manually from the data entry steps.",
   "sources-drawer-title": "Sources",
   "sources-drawer-description": "In this section you'll find information related to the sources for your inventory goal.",
   "sources-category-empty-placeholder": "Source details for this category will be available soon.",

--- a/app/src/i18n/locales/es/onboarding.json
+++ b/app/src/i18n/locales/es/onboarding.json
@@ -75,8 +75,6 @@
   "sources-drawer-incomplete-setup": "Complete el año y el objetivo del inventario en los pasos anteriores para ver las fuentes.",
   "sources-drawer-load-error": "No se pudieron cargar las fuentes. Inténtelo de nuevo más tarde.",
   "sources-drawer-no-sources": "No hay fuentes de terceros disponibles para esta ciudad y año de inventario.",
-  "connect-data-sources-partial-failure-title": "Algunas fuentes de datos no se pudieron conectar",
-  "connect-data-sources-partial-failure-description": "Su inventario se creó correctamente. Puede conectar las fuentes restantes manualmente en los pasos de datos.",
   "sources-drawer-title": "Fuentes",
   "sources-drawer-description": "En esta sección encontrará información relacionada con las fuentes de su objetivo de inventario.",
   "sources-category-empty-placeholder": "Los detalles de las fuentes para esta categoría estarán disponibles pronto.",

--- a/app/src/i18n/locales/fr/onboarding.json
+++ b/app/src/i18n/locales/fr/onboarding.json
@@ -40,8 +40,6 @@
   "sources-drawer-incomplete-setup": "Complétez l'année et l'objectif de l'inventaire aux étapes précédentes pour prévisualiser les sources.",
   "sources-drawer-load-error": "Impossible de charger les sources. Veuillez réessayer plus tard.",
   "sources-drawer-no-sources": "Aucune source tierce n'est disponible pour cette ville et cette année d'inventaire.",
-  "connect-data-sources-partial-failure-title": "Certaines sources de données n'ont pas pu être connectées",
-  "connect-data-sources-partial-failure-description": "Votre inventaire a été créé. Vous pouvez connecter les sources restantes manuellement depuis les étapes de saisie.",
   "sources-drawer-title": "Sources",
   "sources-drawer-description": "Dans cette section, vous trouverez des informations relatives aux sources de votre objectif d'inventaire.",
   "sources-category-empty-placeholder": "Les détails des sources pour cette catégorie seront bientôt disponibles.",

--- a/app/src/i18n/locales/pt/onboarding.json
+++ b/app/src/i18n/locales/pt/onboarding.json
@@ -74,8 +74,6 @@
   "sources-drawer-incomplete-setup": "Conclua o ano e o objetivo do inventário nas etapas anteriores para visualizar as fontes.",
   "sources-drawer-load-error": "Não foi possível carregar as fontes. Tente novamente mais tarde.",
   "sources-drawer-no-sources": "Não há fontes de terceiros disponíveis para esta cidade e ano de inventário.",
-  "connect-data-sources-partial-failure-title": "Algumas fontes de dados não puderam ser conectadas",
-  "connect-data-sources-partial-failure-description": "Seu inventário foi criado. Você pode conectar as fontes restantes manualmente nas etapas de dados.",
   "sources-drawer-title": "Fontes",
   "sources-drawer-description": "Nesta seção você encontrará informações relacionadas às fontes do seu objetivo de inventário.",
   "sources-category-empty-placeholder": "Os detalhes das fontes para esta categoria estarão disponíveis em breve.",


### PR DESCRIPTION
- Don't add notation key entries for missing GPC reference numbers during onboarding connect-all route
- Remove error and warning messages during onboarding when data sources fail to connect
- Remove translation keys for these messages