### PR TITLE
Fix Ask Clima bubble alignment and hide suggestions scrollbar

### DIFF
--- a/app/src/components/ChatBot/ChatMessageList.tsx
+++ b/app/src/components/ChatBot/ChatMessageList.tsx
@@ -232,7 +232,9 @@ export function ChatMessageList({
                     <Icon as={BsStars} boxSize={5} color="base.light" />
                   </Box>
                 )}
-                <Spacer />
+                {/* Push the bubble right only for user messages; assistant
+                    bubbles stay left next to the avatar. */}
+                {isUser && <Spacer />}
                 {!shouldShowPulsing && (
                   <Box
                     borderTopLeftRadius={isUser ? "2xl" : "0"}
@@ -289,6 +291,8 @@ export function ChatMessageList({
                     </>
                   </Box>
                 )}
+                {/* Fill remaining space to the right of an assistant bubble. */}
+                {!isUser && !shouldShowPulsing && <Spacer />}
               </Box>
             </HStack>
           </Box>

--- a/app/src/components/ChatBot/ChatSuggestions.tsx
+++ b/app/src/components/ChatBot/ChatSuggestions.tsx
@@ -18,7 +18,21 @@ export function ChatSuggestions({
   disabled = false,
 }: ChatSuggestionsProps) {
   return (
-    <Box display="flex" flexDir="row" gap={2} whiteSpace="nowrap" pb="3" overflowX="auto" flexShrink={0}>
+    <Box
+      display="flex"
+      flexDir="row"
+      gap={2}
+      whiteSpace="nowrap"
+      pb="3"
+      overflowX="auto"
+      flexShrink={0}
+      // Keep horizontal scrolling but hide the scrollbar across browsers.
+      css={{
+        scrollbarWidth: "none",
+        msOverflowStyle: "none",
+        "&::-webkit-scrollbar": { display: "none" },
+      }}
+    >
       {suggestions.map((suggestion, i) => (
         <Button
           key={i}


### PR DESCRIPTION
## Summary

Two small UI fixes for the Ask Clima chat panel.

## Changes

- **Bubble alignment**: assistant replies were pushed to the right because a `Spacer` was rendered before every bubble regardless of role. Now the `Spacer` sits before the bubble only for user messages and after it for assistant messages, so assistant bubbles align left next to the avatar (user bubbles stay right).
- **Suggestions scrollbar**: hide the horizontal scrollbar on the suggested-prompt row (`ChatSuggestions`) while keeping it scrollable.

## Verification

- ESLint + Prettier clean · `tsc --noEmit` clean.
- Visual: the assistant greeting and streamed replies render left-aligned; the suggestion chip row scrolls with no visible scrollbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)