### PR TITLE
fix: make PDB apply non-blocking (CI permission fix)

### DIFF
--- a/.github/workflows/web-develop.yml
+++ b/.github/workflows/web-develop.yml
@@ -447,7 +447,7 @@ jobs:
         run: |
           kubectl create -f k8s/cc-seed.yml -n default
           kubectl apply -f k8s/cc-web-deploy.yml -n default
-          kubectl apply -f k8s/cc-web-pdb.yml -n default
+          kubectl apply -f k8s/cc-web-pdb.yml -n default || echo "PDB apply skipped (requires policy API permissions)"
           kubectl set env deployment/cc-web-deploy \
             SMTP_USER=${{secrets.SMTP_USER}} \
             SMTP_PASSWORD=${{secrets.SMTP_PASSWORD}} \

--- a/.github/workflows/web-tag.yml
+++ b/.github/workflows/web-tag.yml
@@ -193,7 +193,7 @@ jobs:
           kubectl create -f k8s/prod/cc-prod-seed.yml -n default
           kubectl apply -f k8s/prod/cc-prod-sync-catalogue.yml -n default
           kubectl apply -f k8s/cc-web-deploy.yml -n default
-          kubectl apply -f k8s/cc-web-pdb.yml -n default
+          kubectl apply -f k8s/cc-web-pdb.yml -n default || echo "PDB apply skipped (requires policy API permissions)"
           kubectl set image deployment/cc-web-deploy \
             cc-web=$WEBIMAGE:$VERSION \
             -n default

--- a/.github/workflows/web-test.yml
+++ b/.github/workflows/web-test.yml
@@ -222,7 +222,7 @@ jobs:
           kubectl create -f k8s/test/cc-test-seed.yml -n default
           kubectl apply -f k8s/test/cc-test-sync-catalogue.yml -n default
           kubectl apply -f k8s/test/cc-test-web-deploy.yml -n default
-          kubectl apply -f k8s/cc-web-pdb.yml -n default
+          kubectl apply -f k8s/cc-web-pdb.yml -n default || echo "PDB apply skipped (requires policy API permissions)"
           kubectl set env deployment/cc-test-web-deploy \
             SMTP_USER=${{secrets.SMTP_USER}} \
             SMTP_PASSWORD=${{secrets.SMTP_PASSWORD}} \


### PR DESCRIPTION
Follow-up to #2709. The PDB apply fails because the CI user lacks `policy` API permissions. This makes it non-blocking so the core deploy (2 replicas + memory) succeeds. PDB will be applied manually or after RBAC is updated.

Made with [Cursor](https://cursor.com)