### PR TITLE
fix: add missing 'edit' translation for onboarding EDIT button (CC-378)

### DIFF
--- a/app/src/i18n/locales/de/onboarding.json
+++ b/app/src/i18n/locales/de/onboarding.json
@@ -186,6 +186,7 @@
   "map-rows-description-pdf": "Extrahierte Zeilen sind bereits auf Bestandsfelder abgebildet. Überprüfen Sie die untenstehenden Daten und fahren Sie mit dem letzten Schritt fort.",
   "upload-failed": "Upload fehlgeschlagen",
   "failed-to-upload-file": "Datei konnte nicht hochgeladen werden",
+  "edit": "Bearbeiten",
   "citycatalyst-demo": "CityCatalyst Demo",
   "inventory-goal-description-ghgi": "The GPC provides a robust framework for accounting and reporting city-wide greenhouse gas emissions.",
   "gwp-description-ghgi": "Global warming potential (GWP) is a measure of how much heat a greenhouse gas traps in the atmosphere over a specific time period, relative to carbon dioxide.",

--- a/app/src/i18n/locales/es/onboarding.json
+++ b/app/src/i18n/locales/es/onboarding.json
@@ -187,6 +187,7 @@
   "map-rows-description-pdf": "Las filas extraídas ya están asignadas a los campos del inventario. Revisa los datos a continuación y continúa hasta el último paso.",
   "upload-failed": "Error al subir",
   "failed-to-upload-file": "No se pudo subir el archivo",
+  "edit": "Editar",
   "citycatalyst-demo": "CityCatalyst Demo",
   "inventory-goal-description-ghgi": "El GPC proporciona un marco sólido para contabilizar e informar las emisiones de gases de efecto invernadero a escala municipal.",
   "gwp-description-ghgi": "El potencial de calentamiento global (GWP) mide cuánto calor atrapa un gas de efecto invernadero en la atmósfera durante un período específico, en relación con el dióxido de carbono.",

--- a/app/src/i18n/locales/fr/onboarding.json
+++ b/app/src/i18n/locales/fr/onboarding.json
@@ -184,6 +184,7 @@
   "map-rows-description-pdf": "Les rangées extraites sont déjà mappées aux champs d'inventaire. Examinez les données ci-dessous et passez à l'étape finale.",
   "upload-failed": "Échec du téléchargement",
   "failed-to-upload-file": "Échec de l'envoi du fichier",
+  "edit": "Modifier",
   "citycatalyst-demo": "CityCatalyst Demo",
   "inventory-goal-description-ghgi": "Le GPC fournit un cadre solide pour la comptabilisation et la déclaration des émissions de gaz à effet de serre à l'échelle de la ville.",
   "gwp-description-ghgi": "Le potentiel de réchauffement global (GWP) mesure la quantité de chaleur qu'un gaz à effet de serre piège dans l'atmosphère sur une période donnée, par rapport au dioxyde de carbone.",

--- a/app/src/i18n/locales/pt/onboarding.json
+++ b/app/src/i18n/locales/pt/onboarding.json
@@ -186,6 +186,7 @@
   "map-rows-description-pdf": "As linhas extraídas já estão mapeadas para os campos do inventário. Reveja os dados abaixo e continue para a etapa final.",
   "upload-failed": "Falha no upload",
   "failed-to-upload-file": "Falha ao enviar o arquivo",
+  "edit": "Editar",
   "citycatalyst-demo": "CityCatalyst Demo",
   "inventory-goal-description-ghgi": "O GPC fornece um quadro robusto para contabilizar e reportar as emissões de gases de efeito estufa em toda a cidade.",
   "gwp-description-ghgi": "O potencial de aquecimento global (GWP) mede a quantidade de calor que um gás de efeito estufa retém na atmosfera durante um período específico, em relação ao dióxido de carbono.",


### PR DESCRIPTION
## Summary
- Fixed untranslated EDIT button in the onboarding confirmation step
- Added missing 'edit' translation key to Spanish, German, French, and Portuguese translation files

## Changes
The EDIT button in the GHGI onboarding confirmation step (displayed at the end of the onboarding flow) was hardcoded to display in English even when the application language was set to Spanish or other languages.

The component `app/src/components/steps/GHGI/confirm-inventory-data-step.tsx` was already using the translation function `t("edit")`, but the translation key was only present in the English translation file.

### Files Changed:
- `app/src/i18n/locales/es/onboarding.json` - Added Spanish translation: "Editar"
- `app/src/i18n/locales/de/onboarding.json` - Added German translation: "Bearbeiten"
- `app/src/i18n/locales/fr/onboarding.json` - Added French translation: "Modifier"
- `app/src/i18n/locales/pt/onboarding.json` - Added Portuguese translation: "Editar"

## Test plan
- [x] Verified JSON syntax is valid for all modified translation files
- [x] Confirmed translation keys are present in all language files
- [ ] Manual testing: Navigate to onboarding flow in Spanish and verify the EDIT button displays "Editar"
- [ ] Manual testing: Navigate to onboarding flow in German and verify the EDIT button displays "Bearbeiten"
- [ ] Manual testing: Navigate to onboarding flow in French and verify the EDIT button displays "Modifier"
- [ ] Manual testing: Navigate to onboarding flow in Portuguese and verify the EDIT button displays "Editar"

## Tests added
N/A - This is a translation fix. The existing code structure and tests remain unchanged. Only translation data was added.

Fixes CC-378