### PR TITLE
Improve third-party dataset cards styling and icons

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -130,7 +130,7 @@ npm run dev
 
 The standard port is 3000 and the application can be opend at http://localhost:3000. Please check the log outputs, if a different port has been used.
 
-Use `johndeo@example.com` and `password` to login.
+Use `johndoe@example.com` and `password` to login.
 
 #### HIAP
 To connect to the HIAP prioritizer/plan creator, run

--- a/app/src/components/GHGI/inventory-pages/add-data-steps-page.tsx
+++ b/app/src/components/GHGI/inventory-pages/add-data-steps-page.tsx
@@ -66,7 +66,6 @@ import {
   MdOutlineHomeWork,
   MdOutlineDelete,
   MdOutlineFactory,
-  MdOutlineAgriculture,
   MdOutlineLocalShipping,
   MdRefresh,
   MdSearch,
@@ -92,6 +91,7 @@ import {
 } from "@/components/ui/breadcrumb";
 import { Tag } from "@/components/ui/tag";
 import { TbWorldSearch } from "react-icons/tb";
+import { LuWheat } from "react-icons/lu";
 import AddFileDataDialog from "@/components/Modals/add-file-data-dialog";
 import { UseErrorToast, UseSuccessToast } from "@/hooks/Toasts";
 import { useOrganizationContext } from "@/hooks/organization-context-provider/use-organizational-context";
@@ -991,7 +991,7 @@ export default function AddDataSteps() {
                                 II: MdOutlineLocalShipping,
                                 III: MdOutlineDelete,
                                 IV: MdOutlineFactory,
-                                V: MdOutlineAgriculture,
+                                V: LuWheat,
                               }[currentStep.referenceNumber] ??
                               MdOutlineHomeWork
                             }

--- a/app/src/components/GHGI/inventory-pages/add-data-steps-page.tsx
+++ b/app/src/components/GHGI/inventory-pages/add-data-steps-page.tsx
@@ -958,7 +958,7 @@ export default function AddDataSteps() {
                 year={year}
               />
             ) : (
-              <SimpleGrid templateColumns="repeat(3, 1fr)" gap="16px">
+              <SimpleGrid templateColumns={{ base: "1fr", md: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" }} gap="16px">
                 {dataSources
                   .slice(0, isDataSectionExpanded ? dataSources.length : 6)
                   .map(({ source, data }) => {
@@ -978,8 +978,7 @@ export default function AddDataSteps() {
                         shadow="none"
                         _hover={{ shadow: "xl" }}
                         transition="all 300ms"
-                        height="540px"
-                        w="337px"
+                        w="full"
                         p="24px"
                         gap="4px"
                       >
@@ -997,7 +996,7 @@ export default function AddDataSteps() {
                             }
                             boxSize={9}
                             color="content.tertiary-light"
-                            mb="18px"
+                            mb="10px"
                           />
                           <Flex direction="row" align="center" gap="8px">
                             <Badge
@@ -1035,10 +1034,10 @@ export default function AddDataSteps() {
                               </Text>
                             </Tooltip>
                           </Flex>
-                          <Heading fontSize="title.md" lineClamp={2} minHeight={10} mt="9px" lineHeight={24}>
+                          <Heading fontSize="title.md" lineClamp={2} minHeight={10} mt="6px" lineHeight={24}>
                             {getTranslationFromDict(source.datasetName)}
                           </Heading>
-                          <Text fontSize="label.md" mt="7px">
+                          <Text fontSize="label.md" mt="4px">
                             {t("by-data-source")} {" "}
                             <Link
                               href={source.publisher?.url}
@@ -1070,10 +1069,11 @@ export default function AddDataSteps() {
                                   )}
                                 </Text>
                               )}
-                            <Flex direction="column" gap="4px">
+                            <Flex direction="row" gap="4px" flexWrap="nowrap">
                               <Badge
                                 fontSize={12}
                                 borderColor="border.overlay"
+                                w="fit-content"
                               >
                                 <Icon
                                   as={DataCheckIcon}
@@ -1087,6 +1087,7 @@ export default function AddDataSteps() {
                                 <Badge
                                   fontSize={12}
                                   borderColor="border.overlay"
+                                  w="fit-content"
                                 >
                                   <Icon
                                     as={FiTarget}
@@ -1120,7 +1121,7 @@ export default function AddDataSteps() {
                             fontSize="body.md"
                             lineHeight="20px"
                             fontWeight="regular"
-                            marginTop="11px"
+                            marginTop="8px"
                           >
                             {getTranslationFromDict(
                               source.datasetDescription,
@@ -1129,10 +1130,10 @@ export default function AddDataSteps() {
                                 source.methodologyDescription,
                               )}
                           </Text>
-                          <VStack w="full" mb="24px">
+                          <VStack w="full" mb="16px">
                             <Link
                               textDecoration="underline"
-                              mt={6}
+                              mt={4}
                               mb={2}
                               onClick={() => onSourceClick(source, data)}
                               alignSelf="flex-start"

--- a/app/src/components/GHGI/inventory-pages/add-data-steps-page.tsx
+++ b/app/src/components/GHGI/inventory-pages/add-data-steps-page.tsx
@@ -64,6 +64,10 @@ import {
   MdOutlineCheckCircle,
   MdOutlineEdit,
   MdOutlineHomeWork,
+  MdOutlineDelete,
+  MdOutlineFactory,
+  MdOutlineAgriculture,
+  MdOutlineLocalShipping,
   MdRefresh,
   MdSearch,
   MdWarning,
@@ -974,23 +978,68 @@ export default function AddDataSteps() {
                         shadow="none"
                         _hover={{ shadow: "xl" }}
                         transition="all 300ms"
-                        height="488px"
+                        height="540px"
                         w="337px"
                         p="24px"
-                        spaceY="16px"
+                        gap="4px"
                       >
-                        <Card.Header p="0" spaceY="8px">
-                          {/* TODO add icon to DataSource */}
+                        <Card.Header p="0" display="flex" flexDirection="column" gap="0">
                           <Icon
-                            as={MdOutlineHomeWork}
+                            as={
+                              {
+                                I: MdOutlineHomeWork,
+                                II: MdOutlineLocalShipping,
+                                III: MdOutlineDelete,
+                                IV: MdOutlineFactory,
+                                V: MdOutlineAgriculture,
+                              }[currentStep.referenceNumber] ??
+                              MdOutlineHomeWork
+                            }
                             boxSize={9}
                             color="content.tertiary-light"
+                            mb="18px"
                           />
-                          <Heading size="sm" lineClamp={2} minHeight={10}>
+                          <Flex direction="row" align="center" gap="8px">
+                            <Badge
+                              variant="plain"
+                              fontSize="label.sm"
+                              fontWeight="medium"
+                              fontFamily="heading"
+                              letterSpacing="widest"
+                              bg="background.graySubtle"
+                              color="content.secondary"
+                              px="8px"
+                              py="1px"
+                              borderRadius="md"
+                              lineHeight="1.2"
+                              borderWidth="0"
+                            >
+                              {source.subCategory?.referenceNumber ||
+                                source.subSector?.referenceNumber}
+                            </Badge>
+                            <Tooltip
+                              showArrow
+                              content={source.subSector?.subsectorName}
+                            >
+                              <Text
+                                fontSize="overline"
+                                fontWeight="bold"
+                                color="content.primary"
+                                textTransform="uppercase"
+                                letterSpacing="widest"
+                                lineHeight="24"
+                                fontFamily="heading"
+                                lineClamp={1}
+                              >
+                                {source.subSector?.subsectorName}
+                              </Text>
+                            </Tooltip>
+                          </Flex>
+                          <Heading fontSize="title.md" lineClamp={2} minHeight={10} mt="9px" lineHeight={24}>
                             {getTranslationFromDict(source.datasetName)}
                           </Heading>
-                          <Text fontSize="label.md" fontWeight="semibold">
-                            {t("by-data-source")}:{" "}
+                          <Text fontSize="label.md" mt="7px">
+                            {t("by-data-source")} {" "}
                             <Link
                               href={source.publisher?.url}
                               target="_blank"
@@ -1002,15 +1051,16 @@ export default function AddDataSteps() {
                             </Link>
                           </Text>
                         </Card.Header>
-                        <Card.Body justifyContent="space-between" p="0">
-                          <Flex direction="row" mb={4} wrap="wrap" gap={2}>
+                        <Card.Body justifyContent="space-between" p="0" >
+                          <Flex direction="row" mb={0} wrap="wrap" gap={2}>
                             {/* show converted to CO2eq total emissions for the data source */}
                             {/* Only show emissions if data is connected */}
                             {!isSourceConnected(source) &&
                               !source.inventoryValues?.length && (
                                 <Text
-                                  fontSize="headline.md"
+                                  fontSize="display.sm"
                                   fontWeight="semibold"
+                                  
                                 >
                                   {convertKgToTonnes(
                                     bigIntToDecimal(
@@ -1020,10 +1070,9 @@ export default function AddDataSteps() {
                                   )}
                                 </Text>
                               )}
-                            <Box>
+                            <Flex direction="column" gap="4px">
                               <Badge
-                                fontSize={11}
-                                fontWeight="semibold"
+                                fontSize={12}
                                 borderColor="border.overlay"
                               >
                                 <Icon
@@ -1036,8 +1085,7 @@ export default function AddDataSteps() {
                               </Badge>
                               {source.subCategory?.scope && (
                                 <Badge
-                                  fontSize={11}
-                                  fontWeight="semibold"
+                                  fontSize={12}
                                   borderColor="border.overlay"
                                 >
                                   <Icon
@@ -1049,7 +1097,7 @@ export default function AddDataSteps() {
                                   {source.subCategory.scope.scopeName}
                                 </Badge>
                               )}
-                            </Box>
+                            </Flex>
                           </Flex>
                           <Text
                             textOverflow="ellipsis"
@@ -1072,6 +1120,7 @@ export default function AddDataSteps() {
                             fontSize="body.md"
                             lineHeight="20px"
                             fontWeight="regular"
+                            marginTop="11px"
                           >
                             {getTranslationFromDict(
                               source.datasetDescription,
@@ -1080,25 +1129,31 @@ export default function AddDataSteps() {
                                 source.methodologyDescription,
                               )}
                           </Text>
-                          <VStack w="full">
+                          <VStack w="full" mb="24px">
                             <Link
                               textDecoration="underline"
-                              mt={4}
-                              mb={6}
+                              mt={6}
+                              mb={2}
                               onClick={() => onSourceClick(source, data)}
                               alignSelf="flex-start"
                               fontSize="label.lg"
-                              fontWeight="semibold"
+                              fontWeight="medium"
+                              letterSpacing="wide"
                             >
                               {t("see-more-details")}
                             </Link>
                             {isSourceConnected(source) &&
                             source.inventoryValues?.length ? (
                               <Button
-                                variant="solid"
+                                variant="outline"
                                 w="full"
-                                bg="content.alternative"
-                                fontWeight="normal"
+                                h="50px"
+                                bg={isHovered ? "semantic.dangerOverlay" : "semantic.successOverlay"}
+                                borderColor={isHovered ? "semantic.danger" : "semantic.success"}
+                                borderWidth="1px"
+                                color={isHovered ? "semantic.danger" : "semantic.success"}
+                                fontWeight="semibold"
+                                fontSize="14px"
                                 onClick={() =>
                                   isFrozenCheck()
                                     ? null
@@ -1125,12 +1180,12 @@ export default function AddDataSteps() {
                                 <Button
                                   variant="outline"
                                   w="full"
-                                  borderWidth="1px"
-                                  py="16px"
-                                  bgColor="background.backgroundDisabled"
-                                  border="none"
+                                  h="50px"
+                                  borderWidth="0"
+                                  bgColor="background.graySubtle"
                                   disabled
                                   color="interactive.control"
+                                  fontWeight="semibold"
                                   fontSize="14px"
                                 >
                                   {t("connect-data")}
@@ -1141,15 +1196,18 @@ export default function AddDataSteps() {
                               <Button
                                 variant="outline"
                                 w="full"
+                                h="50px"
                                 borderWidth="1px"
-                                py="16px"
+                                borderColor="border.overlay"
                                 bgColor="background.neutral"
+                                color="interactive.secondary"
+                                fontWeight="semibold"
+                                fontSize="14px"
                                 onClick={() => onConnectClick(source)}
                                 loading={
                                   isConnectDataSourceLoading &&
                                   source.datasourceId === connectingDataSourceId
                                 }
-                                fontSize="14px"
                               >
                                 {t("connect-data")}
                               </Button>

--- a/app/src/lib/theme/recipes/app-theme.ts
+++ b/app/src/lib/theme/recipes/app-theme.ts
@@ -189,6 +189,20 @@ export const appTheme = createSystem(defaultConfig, {
           radioUnselected: {
             value: "#E4E4E7",
           },
+          graySubtle: {
+            value: {
+              base: "{colors.blue_theme.background.graySubtle}",
+              _blue_theme: "{colors.blue_theme.background.graySubtle}",
+              _light_brown_theme:
+                "{colors.light_brown_theme.background.graySubtle}",
+              _dark_orange_theme:
+                "{colors.dark_orange_theme.background.graySubtle}",
+              _green_theme: "{colors.green_theme.background.graySubtle}",
+              _light_blue_theme:
+                "{colors.light_blue_theme.background.graySubtle}",
+              _violet_theme: "{colors.violet_theme.background.graySubtle}",
+            },
+          },
           /** Disabled controls and non-interactive surfaces. */
           backgroundDisabled: {
             value: "#D9D9D9",
@@ -266,6 +280,7 @@ export const appTheme = createSystem(defaultConfig, {
             alternative: { value: "#EFFDE5" }, // #C5CBF5
             alternativeLight: { value: "#F9FAFE" },
             overlay: { value: "#C5CBF5" },
+            graySubtle: { value: "#F4F4F5" },
           },
           border: {
             neutral: { value: "#D7D8FA" },
@@ -300,6 +315,7 @@ export const appTheme = createSystem(defaultConfig, {
               value: "#FAEBB8",
             },
             neutral: { value: "#F4E8BE" },
+            graySubtle: { value: "#F4F4F5" },
           },
           border: {
             neutral: { value: "#F4E4A9" },
@@ -345,6 +361,7 @@ export const appTheme = createSystem(defaultConfig, {
               value: "#FAD9B8",
             },
             neutral: { value: "#F4D9BE" },
+            graySubtle: { value: "#F4F4F5" },
           },
         },
         green_theme: {
@@ -376,6 +393,7 @@ export const appTheme = createSystem(defaultConfig, {
               value: "#E4FAB8",
             },
             neutral: { value: "#E2F4BE" },
+            graySubtle: { value: "#F4F4F5" },
           },
           interactive: {
             secondary: { value: "#739F19" },
@@ -410,6 +428,7 @@ export const appTheme = createSystem(defaultConfig, {
               value: "#B8F8FA",
             },
             neutral: { value: "#BEF3F4" },
+            graySubtle: { value: "#F4F4F5" },
           },
           interactive: {
             secondary: { value: "#0D9EA0" },
@@ -444,6 +463,7 @@ export const appTheme = createSystem(defaultConfig, {
               value: "#E4B8FA",
             },
             neutral: { value: "#E2BEF4" },
+            graySubtle: { value: "#F4F4F5" },
           },
           interactive: {
             secondary: { value: "#A200B5" },

--- a/app/src/util/constants.ts
+++ b/app/src/util/constants.ts
@@ -1,6 +1,7 @@
 import { BsTruck } from "react-icons/bs";
-import { PiPlant, PiTrashLight } from "react-icons/pi";
+import { PiTrashLight } from "react-icons/pi";
 import { TbBuildingCommunity } from "react-icons/tb";
+import { LuWheat } from "react-icons/lu";
 import { IconBaseProps } from "react-icons";
 import { LiaIndustrySolid } from "react-icons/lia";
 import { SectorColors, SubSectorColors } from "@/lib/theme/custom-colors";
@@ -132,7 +133,7 @@ export const SECTORS: ISector[] = [
     number: 5,
     name: "afolu",
     description: "afolu-description",
-    icon: PiPlant,
+    icon: LuWheat,
     color: SectorColors.V,
     testId: "afolu-sector-card",
     inventoryTypes: {


### PR DESCRIPTION
[Ticket](https://openearth.atlassian.net/browse/ON-5907?actionerId=621e185b8a4bb60068f162c3&sourceType=assign)

<img width="1184" height="545" alt="image" src="https://github.com/user-attachments/assets/a5199ae8-ff11-4e6a-8cc5-c83d953fb994" />


**Summary**

- Redesign data source cards with updated layout, spacing, and button styles to match the new design
- Add sector-specific icons (home, shipping, trash, factory, wheat) to cards based on GPC sector
- Add subsector reference number badge with tooltip for truncated subsector names
- Add graySubtle for subsector reference number badge background
- Restyle connect/disconnect/disabled states with semantic colors (green for connected, red on hover for disconnect, gray for disabled)
- Replace AFOLU sector leaf icon (PiPlant) with wheat icon (LuWheat) globally
- Fix typo in README login email

Test plan

- [ ]  Verify data source cards display correct sector icons per sector (I-V)
- [ ]  Verify subsector reference number badge appears with correct styling
- [ ]  Hover over truncated subsector name to confirm tooltip shows full name
- [ ]  Verify button states: connected (green), hover disconnect (red), disabled (gray), default connect (blue outline)
- [ ]  Check AFOLU sector shows wheat icon in sector cards and breadcrumbs
- [ ]  Verify background.graySubtle renders correctly across all themes