### PR TITLE
Transportation tab gets cut off when selected

### DIFF
--- a/app/src/components/GHGI/ReportResults.tsx
+++ b/app/src/components/GHGI/ReportResults.tsx
@@ -131,7 +131,7 @@ function SectorTabs({
             <Tabs.Trigger
               key={index}
               value={name}
-              minWidth="170px"
+              minWidth="200px"
               height="64px"
             >
               <Icon
@@ -145,6 +145,7 @@ function SectorTabs({
               <Text
                 fontSize="16"
                 lineClamp={2}
+                wordBreak="keep-all"
                 textAlign="left"
                 fontWeight={selectedTab === name ? 600 : 400}
                 fontStyle="normal"


### PR DESCRIPTION
[Ticket: ON-5966](https://openearth.atlassian.net/browse/ON-5966)
## Summary
- The "Transportation" sector tab on the inventory results page (Sector Emissions section) wrapped mid-word ("Transportatio"/"n") because the tab's `minWidth` (170px) was too narrow to fit the icon + label on one line.
- Increased `minWidth` to 200px and added `wordBreak="keep-all"` so labels wrap only at word boundaries instead of breaking mid-character, which also guards against the same issue for longer translated sector names in other locales.

## Test plan
- [ ] Open a city's GHGI inventory results page (`/cities/{cityId}/GHGI/{inventoryId}`)
- [ ] Scroll to "Sector Emissions in {year}" and confirm the "Transportation" tab renders on a single line
- [ ] Click on Transportation tab 
- [ ] Confirm word doesn't cut off 
- [ ] Confirm multi-word tabs (e.g. "Industrial processes and product use (IPPU)") still wrap correctly across two lines
- [ ] Check at narrow viewport widths that tabs don't overlap or clip
