### PR TITLE
Fix: Ask Clima AI button padding collapses on long translations

### DIFF
--- a/app/src/components/ChatBot/chat-popover.tsx
+++ b/app/src/components/ChatBot/chat-popover.tsx
@@ -148,8 +148,11 @@ export default function ChatPopover({
             fontWeight="600"
             letterSpacing="wider"
             py="26px"
+            px="24px"
             bg="interactive.tertiary"
-            maxW="220px"
+            w="fit-content"
+            maxW="280px"
+            whiteSpace="nowrap"
             fontFamily="heading"
             aria-label={t("ai-expert")}
             variant="solid"


### PR DESCRIPTION
[Ticket: ON-5965](https://openearth.atlassian.net/browse/ON-5965)

## Summary
- The floating "Ask Clima AI" button had a fixed `maxW="220px"` and no explicit horizontal padding, so longer translated labels (e.g. Portuguese "Pergunte ao Clima AI", Spanish "Preguntale a Clima AI") got squeezed against the pill's edges with no breathing room.
- Updated the button to size to its content (`w="fit-content"`, `maxW="280px"`) with explicit `px="24px"` padding and `whiteSpace="nowrap"` so the label always has consistent spacing regardless of locale.

## Test plan
- [ ] Switch the app language to Portuguese and confirm the "Ask Clima AI" button has proper padding around the text
- [ ] Repeat for Spanish, French, German, and English
- [ ] Confirm the button still renders correctly (position, icon alignment) across breakpoints
- [ ] Confirm clicking the button still opens the Clima AI popover as expected
