### PR TITLE
fix: ON-5961 button to manage missing subsectors should not appear in inventory results

### DIFF
--- a/app/src/components/GHGI/ReportResults.tsx
+++ b/app/src/components/GHGI/ReportResults.tsx
@@ -508,7 +508,6 @@ export default function ReportResults({
   }
 
   // Determine what to show based on context
-  const showManageMissingSectors = context === "inventory" && !isPublic;
   const showOpenCCInventories = context === "dashboard" && !isPublic;
 
   const { data: userInfo } = api.useGetUserInfoQuery(undefined, {
@@ -523,7 +522,7 @@ export default function ReportResults({
           inventory={inventory}
           title={"tab-emission-inventory-results-title"}
           isPublic={isPublic}
-          showActionButtons={showManageMissingSectors}
+          showActionButtons={false}
         />
       )}
 


### PR DESCRIPTION

[Ticket ON-5961 ](https://openearth.atlassian.net/browse/ON-5961)
## Description:

The "Manage missing sub-sectors" button was incorrectly showing on the Inventory Results tab. It should only be available on the Calculation tab, where users actually add/manage missing sector data — not on the Results tab, which is for reviewing completed inventory data.

## Changes
ReportResults.tsx: removed the showManageMissingSectors logic (previously context === "inventory" && !isPublic) and hard-coded showActionButtons={false} on the TabHeader used by the Results tab.
The Calculation tab (InventoryCalculationTab.tsx) is unaffected — it still renders the button by default.

## Test plan

- [ ]  Open an inventory → Calculation tab → confirm "Manage missing sub-sectors" button still appears.
- [ ]  Open the same inventory → Results tab → confirm the button no longer appears.
- [ ]  Check public inventory view and dashboard GHGI widget → confirm no regression (button was already hidden there).
