### PR TITLE
fix: ON-5960 legend in emissions forecast needs bottom padding or has max height

### DIFF
--- a/app/src/components/GHGI/inventory-result/EmissionsForecast/EmissionsForecastCard.tsx
+++ b/app/src/components/GHGI/inventory-result/EmissionsForecast/EmissionsForecastCard.tsx
@@ -37,7 +37,7 @@ export const EmissionsForecastCard = ({
         lng={lng}
       />
 
-      <Card.Root paddingY="0px" paddingX="0px" height="650px" width="100%">
+      <Card.Root paddingY="0px" paddingX="0px" minHeight="650px" width="100%">
         <CardHeader>
           <HStack>
             <TitleMedium>
@@ -63,10 +63,11 @@ export const EmissionsForecastCard = ({
           </HStack>
         </CardHeader>
         <CardBody
-          paddingY="0px"
+          paddingTop="0px"
+          paddingBottom={6}
           paddingLeft={4}
           paddingRight={0}
-          height="600px"
+          minHeight="600px"
           width="100%"
         >
           <EmissionsForecastChart


### PR DESCRIPTION
[Ticket: ON-5960](https://openearth.atlassian.net/browse/ON-5960)
## Summary
- The "Sector Emissions Forecast" card and its body used fixed pixel heights (650px / 600px). When a city has enough sectors/sub-sectors to wrap the legend onto more than two lines, there was no room left in the fixed-height container, so the legend got clipped/cramped.
- Switched `Card.Root` and `CardBody` from `height` to `minHeight`, and added bottom padding to `CardBody`, so the card grows to fit the legend instead of clipping it.

## Test plan
- [ ] Use a real inventory with enough sectors to cover more than one line or reproduced the issue locally by temporarily injecting extra mock sectors into the legend to force a 3-line wrap, confirmed the card clipped the legend before the fix
- [ ] Re-verified with the fix applied: card grows and legend has breathing room with 3+ lines
- [ ] Confirm card still looks correct on narrow/mobile viewports
