### PR TITLE
fix: ON-5954 Add country flag to invite screen

### DIFF
--- a/app/src/components/InviteAcceptance/InviteSuccessModal.tsx
+++ b/app/src/components/InviteAcceptance/InviteSuccessModal.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { Box, VStack, HStack, Text, Icon } from "@chakra-ui/react";
+import { CircleFlag } from "react-circle-flags";
 import { DisplaySmall } from "@/components/package/Texts/Display";
 import { BodyLarge } from "@/components/package/Texts/Body";
 import { useTranslation } from "@/i18n/client";
@@ -16,7 +17,7 @@ interface InviteData {
   cities?: Array<{
     cityId: string;
     cityName: string;
-    flag: string;
+    countryCode?: string;
   }>;
 }
 
@@ -86,10 +87,12 @@ const InviteSuccessModal: React.FC<InviteSuccessModalProps> = ({
                   w="100%"
                   justify="flex-start"
                 >
-                  {city.flag && (
-                    <Text fontSize="20px" mr="8px">
-                      {city.flag}
-                    </Text>
+                  {city.countryCode && (
+                    <CircleFlag
+                      countryCode={city.countryCode}
+                      width={20}
+                      style={{ marginRight: "8px" }}
+                    />
                   )}
                   <Text
                     fontSize="body.md"

--- a/app/src/components/InviteAcceptance/InviteSuccessModal.tsx
+++ b/app/src/components/InviteAcceptance/InviteSuccessModal.tsx
@@ -116,8 +116,8 @@ const InviteSuccessModal: React.FC<InviteSuccessModalProps> = ({
           my="24px"
           fontSize="body.md"
         >
-          <Icon as={MdArrowForward} />
           {t("continue")}
+          <Icon as={MdArrowForward} />
         </Button>
       </VStack>
     </Box>

--- a/app/src/components/InviteAcceptance/UnifiedInviteAcceptancePage.tsx
+++ b/app/src/components/InviteAcceptance/UnifiedInviteAcceptancePage.tsx
@@ -43,7 +43,7 @@ const UnifiedInviteAcceptancePage = ({ params, inviteType }: UnifiedInviteAccept
     cities?: Array<{
       cityId: string;
       cityName: string;
-      flag: string;
+      countryCode?: string;
     }>;
   } | null>(null);
 
@@ -100,17 +100,6 @@ const UnifiedInviteAcceptancePage = ({ params, inviteType }: UnifiedInviteAccept
       };
       return charMap[char] || char;
     });
-  };
-
-  const getCountryFlag = (countryCode: string | undefined): string => {
-    if (!countryCode || countryCode.length !== 2) return "🏙️";
-
-    const codePoints = countryCode
-      .toUpperCase()
-      .split("")
-      .map(char => 127397 + char.charCodeAt(0));
-
-    return String.fromCodePoint(...codePoints);
   };
 
   const acceptInvite = async () => {
@@ -197,7 +186,7 @@ const UnifiedInviteAcceptancePage = ({ params, inviteType }: UnifiedInviteAccept
           cities?: Array<{
             cityId: string;
             cityName: string;
-            flag: string;
+            countryCode?: string;
           }>} = {
             type: currentInviteType,
             email: sanitizedEmail,
@@ -217,7 +206,9 @@ const UnifiedInviteAcceptancePage = ({ params, inviteType }: UnifiedInviteAccept
                 return {
                   cityId,
                   cityName: city?.name || "Unknown City",
-                  flag: getCountryFlag(city?.countryLocode)
+                  countryCode: city?.countryLocode
+                    ?.substring(0, 2)
+                    .toLowerCase(),
                 };
               });
 


### PR DESCRIPTION
[Ticket ON-5954](https://openearth.atlassian.net/browse/ON-5954)
[Ticket ON-5951](https://openearth.atlassian.net/browse/ON-5951)

## Summary
- Replace emoji-based country flags with the `CircleFlag` component on the invite acceptance success screen
- Emoji flags depend on OS font support and render as raw letter pairs (e.g. "BR") on platforms without flag-emoji fonts, such as Windows
- `CircleFlag` is already used elsewhere in the app (city selection, project header) for consistent, platform-independent flag rendering
- Move arrow icon after text on invite success Continue button (ON-5951)

## Test plan
- [ ] Verify on the invite-acceptance flow (accept a city invite end-to-end) in staging
- [ ] Verify the arrow is placed after the word 'Continue' on the modal button and not before
