### PR TITLE
Feat/on 5969 add browse and connect third party data to subsector scope tabs

### DIFF
--- a/app/src/components/Tabs/Activity/activity-tab.tsx
+++ b/app/src/components/Tabs/Activity/activity-tab.tsx
@@ -1,4 +1,21 @@
-import { Box, Icon, IconButton, Spinner, Tabs, Text } from "@chakra-ui/react";
+import {
+  Box,
+  Icon,
+  IconButton,
+  Spinner,
+  Tabs,
+  Text,
+  Badge,
+  Card,
+  Center,
+  Flex,
+  Heading,
+  HStack,
+  Link,
+  SimpleGrid,
+  VStack,
+  useDisclosure,
+} from "@chakra-ui/react";
 import React, { FC, useMemo, useState } from "react";
 import HeadingText from "../../heading-text";
 import { TFunction } from "i18next";
@@ -21,9 +38,32 @@ import EmissionDataSection from "@/components/Tabs/Activity/emission-data-sectio
 import SelectMethodology from "@/components/Tabs/Activity/select-methodology";
 import ExternalDataSection from "@/components/Tabs/Activity/external-data-section";
 import { api } from "@/services/api";
-import { MdModeEditOutline } from "react-icons/md";
+import {
+  MdModeEditOutline,
+  MdCheckCircleOutline,
+  MdInfoOutline,
+  MdClose,
+  MdOutlineHomeWork,
+  MdOutlineLocalShipping,
+  MdOutlineDelete,
+  MdOutlineFactory,
+} from "react-icons/md";
+import { LuWheat } from "react-icons/lu";
+import { FiTarget } from "react-icons/fi";
 import { Switch } from "@/components/ui/switch";
 import { useOrganizationContext } from "@/hooks/organization-context-provider/use-organizational-context";
+import { Tooltip } from "@/components/ui/tooltip";
+import { Button } from "@/components/ui/button";
+import { SourceDrawer } from "@/components/GHGI/data-step/SourceDrawer";
+import { convertKgToTonnes } from "@/util/helpers";
+import { bigIntToDecimal } from "@/util/big_int";
+import { getTranslationFromDict } from "@/i18n";
+import { DataCheckIcon } from "@/components/icons";
+import { logger } from "@/services/logger";
+import type { DataSourceWithRelations } from "@/components/GHGI/data-step/types";
+import { SECTORS } from "@/util/constants";
+import { UseErrorToast } from "@/hooks/Toasts";
+import { toaster } from "@/components/ui/toaster";
 
 interface ActivityTabProps {
   t: TFunction;
@@ -41,14 +81,192 @@ interface ActivityTabProps {
   inventoryValues: InventoryValueAttributes[];
 }
 
+const ensureProtocol = (url?: string) => {
+  if (!url) return "";
+  if (!/^https?:\/\//i.test(url)) {
+    return "https://" + url;
+  }
+  return url;
+};
+
 const ActivityTab: FC<ActivityTabProps> = ({
   t,
   referenceNumber,
   inventoryId,
+  step,
   activityData,
   subsectorId,
   inventoryValues,
 }) => {
+  const { data: inventoryProgress } = api.useGetInventoryProgressQuery(inventoryId);
+
+  const {
+    data: allDataSources,
+    isLoading: isDataSourcesLoading,
+    refetch: refetchDataSources,
+  } = api.useGetAllDataSourcesQuery({ inventoryId });
+
+  const [connectDataSource, { isLoading: isConnectDataSourceLoading }] =
+    api.useConnectDataSourceMutation();
+
+  const [disconnectThirdPartyData, { isLoading: isDisconnectLoading }] =
+    api.useDisconnectThirdPartyDataMutation();
+
+  const [connectingDataSourceId, setConnectingDataSourceId] = useState<string | null>(null);
+  const [disconnectingDataSourceId, setDisconnectingDataSourceId] = useState<string | null>(null);
+  const [newlyConnectedDataSourceIds, setNewlyConnectedDataSourceIds] = useState<string[]>([]);
+  const [hoverStates, setHoverStates] = useState<Record<string, boolean>>({});
+
+  const {
+    open: isSourceDrawerOpen,
+    onClose: onSourceDrawerClose,
+    onOpen: onSourceDrawerOpen,
+  } = useDisclosure();
+  const [selectedSource, setSelectedSource] = useState<DataSourceWithRelations>();
+  const [selectedSourceData, setSelectedSourceData] = useState<any>();
+
+  const onSourceClick = (source: DataSourceWithRelations, data: any) => {
+    setSelectedSource(source);
+    setSelectedSourceData(data);
+    onSourceDrawerOpen();
+  };
+
+  const onButtonHover = (source: DataSourceWithRelations) => {
+    setHoverStates((prev) => ({ ...prev, [source.datasourceId]: true }));
+  };
+
+  const onMouseLeave = (source: DataSourceWithRelations) => {
+    setHoverStates((prev) => ({ ...prev, [source.datasourceId]: false }));
+  };
+
+
+
+  const showError = (title: string, description: string, duration?: number) => {
+    const { showErrorToast } = UseErrorToast({
+      title: t(title),
+      description: t(description),
+      duration,
+    });
+    showErrorToast();
+  };
+
+  const onConnectClick = async (source: DataSourceWithRelations) => {
+    if (isSourceGpcBlocked(source)) {
+      return;
+    }
+    if (!inventoryProgress) {
+      logger.error(
+        "Tried to assign data source while inventory progress was not yet loaded!",
+      );
+      return;
+    }
+    logger.debug({ source }, "Connect source");
+    setConnectingDataSourceId(source.datasourceId);
+    try {
+      const response = await connectDataSource({
+        inventoryId: inventoryProgress?.inventory.inventoryId,
+        dataSourceIds: [source.datasourceId],
+      }).unwrap();
+
+      if (response.failed.length > 0) {
+        showError(
+          "data-source-connect-failed",
+          "data-source-connect-load-error",
+        );
+        return;
+      } else if (response.invalid.length > 0) {
+        showError(
+          "data-source-connect-failed",
+          "data-source-connect-invalid-error",
+        );
+        return;
+      }
+
+      if (response.successful.length > 0) {
+        setNewlyConnectedDataSourceIds(
+          newlyConnectedDataSourceIds.concat(response.successful),
+        );
+        onSourceDrawerClose();
+      }
+    } catch (error: any) {
+      logger.error(
+        { err: error, source: source },
+        "Failed to connect data source",
+      );
+      showError("data-source-connect-failed", error.data?.error?.message);
+    } finally {
+      setConnectingDataSourceId(null);
+      refetchDataSources();
+    }
+  };
+
+  const onDisconnectThirdPartyData = async (source: DataSourceWithRelations) => {
+    setDisconnectingDataSourceId(source.datasourceId);
+    try {
+      await disconnectThirdPartyData({
+        inventoryId: inventoryId,
+        datasourceId: source.datasourceId,
+      }).unwrap();
+      toaster.create({
+        title: t("disconnected-data-source"),
+        type: "info",
+        duration: 5000,
+      });
+      setNewlyConnectedDataSourceIds(
+        newlyConnectedDataSourceIds.filter((id) => id !== source.datasourceId),
+      );
+    } catch (error: any) {
+      logger.error(
+        { err: error, source: source },
+        "Failed to disconnect data source",
+      );
+    } finally {
+      setDisconnectingDataSourceId(null);
+      refetchDataSources();
+    }
+  };
+
+  function isSourceConnected(source?: DataSourceWithRelations): boolean {
+    if (!source) {
+      return false;
+    }
+    return (
+      (source.inventoryValues && source.inventoryValues.length > 0) ||
+      newlyConnectedDataSourceIds.indexOf(source.datasourceId) > -1
+    );
+  }
+
+  function getSourceGpcReferenceNumber(
+    source: DataSourceWithRelations,
+  ): string | undefined {
+    return (
+      source.subCategory?.referenceNumber ?? source.subSector?.referenceNumber
+    );
+  }
+
+  function isSourceGpcBlocked(source: DataSourceWithRelations): boolean {
+    if (isSourceConnected(source)) {
+      return false;
+    }
+    const gpcReferenceNumber = getSourceGpcReferenceNumber(source);
+    if (!gpcReferenceNumber) {
+      return false;
+    }
+    return (
+      inventoryProgress?.inventory.inventoryValues?.some(
+        (value) => value.gpcReferenceNumber === gpcReferenceNumber,
+      ) ?? false
+    );
+  }
+
+  const matchingSources = useMemo(() => {
+    if (!allDataSources?.data) return [];
+    return allDataSources.data.filter(({ source, data }) => {
+      const sourceRef = source.subCategory?.referenceNumber || source.subSector?.referenceNumber;
+      return sourceRef === referenceNumber && data;
+    });
+  }, [allDataSources, referenceNumber]);
+
   let totalEmissions = 0;
 
   activityData?.forEach((activity: any) => {
@@ -377,6 +595,286 @@ const ActivityTab: FC<ActivityTabProps> = ({
             />
           )}
         </>
+      )}
+
+      {matchingSources.length > 0 && (
+        <Box mt={12} borderTop="1px solid" borderColor="border.neutral" pt={8}>
+          <Heading fontSize="title.lg" mb={2}>
+            {t("browse-and-connect-external-datasets-heading")}
+          </Heading>
+          <Text color="content.tertiary" mb={8}>
+            {t("browse-and-connect-external-datasets-description")}
+          </Text>
+          <SimpleGrid
+            columns={{
+              base: 1,
+              md: 2,
+              lg: 3,
+            }}
+            gap="16px"
+          >
+            {matchingSources.map(({ source, data }) => {
+              const isHovered = hoverStates[source.datasourceId];
+              const isConnected = isSourceConnected(source);
+              const isBlocked = isSourceGpcBlocked(source);
+
+              const romanSector = {
+                "1": "I",
+                "2": "II",
+                "3": "III",
+                "4": "IV",
+                "5": "V",
+              }[step] ?? "I";
+
+              const sectorIcon = {
+                I: MdOutlineHomeWork,
+                II: MdOutlineLocalShipping,
+                III: MdOutlineDelete,
+                IV: MdOutlineFactory,
+                V: LuWheat,
+              }[romanSector] ?? MdOutlineHomeWork;
+
+              return (
+                <Card.Root
+                  key={source.datasourceId}
+                  data-testid="source-card"
+                  variant="outline"
+                  borderWidth="1px"
+                  borderColor={
+                    isConnected
+                      ? "interactive.tertiary"
+                      : "border.overlay"
+                  }
+                  shadow="none"
+                  _hover={{ shadow: "xl" }}
+                  transition="all 300ms"
+                  w="full"
+                  p="24px"
+                  gap="4px"
+                >
+                  <Card.Header p="0" display="flex" flexDirection="column" gap="0">
+                    <Icon
+                      as={sectorIcon}
+                      boxSize={9}
+                      color="content.tertiary-light"
+                      mb="10px"
+                    />
+                    <Flex direction="row" align="center" gap="8px">
+                      <Badge
+                        variant="plain"
+                        fontSize="label.sm"
+                        fontWeight="medium"
+                        fontFamily="heading"
+                        letterSpacing="widest"
+                        bg="background.graySubtle"
+                        color="content.secondary"
+                        px="8px"
+                        py="1px"
+                        borderRadius="md"
+                        lineHeight="1.2"
+                        borderWidth="0"
+                      >
+                        {source.subCategory?.referenceNumber ||
+                          source.subSector?.referenceNumber}
+                      </Badge>
+                      <Tooltip showArrow content={source.subSector?.subsectorName}>
+                        <Text
+                          fontSize="overline"
+                          fontWeight="bold"
+                          color="content.primary"
+                          textTransform="uppercase"
+                          letterSpacing="widest"
+                          lineHeight="24"
+                          fontFamily="heading"
+                          lineClamp={1}
+                        >
+                          {source.subSector?.subsectorName}
+                        </Text>
+                      </Tooltip>
+                    </Flex>
+                    <Heading
+                      fontSize="title.md"
+                      lineClamp={2}
+                      minHeight={10}
+                      mt="6px"
+                      lineHeight={24}
+                    >
+                      {getTranslationFromDict(source.datasetName)}
+                    </Heading>
+                    <Text fontSize="label.md" mt="4px">
+                      {t("by-data-source")}{" "}
+                      <Link
+                        href={ensureProtocol(source.publisher?.url)}
+                        target="_blank"
+                        textDecoration="underline"
+                        color="content.link"
+                        rel="noreferrer noopener"
+                      >
+                        {source.publisher?.name}
+                      </Link>
+                    </Text>
+                  </Card.Header>
+                  <Card.Body justifyContent="space-between" p="0" mt="12px">
+                    <Flex direction="row" mb={0} wrap="wrap" gap={2}>
+                      {!isConnected && (
+                        <Text fontSize="display.sm" fontWeight="semibold">
+                          {convertKgToTonnes(
+                            bigIntToDecimal(
+                              data?.totals?.emissions?.co2eq_100yr ?? 0n,
+                            ).toNumber(),
+                          )}
+                        </Text>
+                      )}
+                      <Flex direction="row" gap="4px" flexWrap="nowrap">
+                        <Badge fontSize={12} borderColor="border.overlay" w="fit-content">
+                          <Icon as={DataCheckIcon} boxSize={5} color="content.tertiary" />
+                          {t("data-quality")}: {t("quality-" + source.dataQuality)}
+                        </Badge>
+                        {source.subCategory?.scope && (
+                          <Badge fontSize={12} borderColor="border.overlay" w="fit-content">
+                            <Icon as={FiTarget} boxSize={4} color="content.tertiary" />
+                            {t("scope")}: {source.subCategory.scope.scopeName}
+                          </Badge>
+                        )}
+                      </Flex>
+                    </Flex>
+                    <Text
+                      textOverflow="ellipsis"
+                      whiteSpace="nowrap"
+                      overflow="hidden"
+                      color="content.tertiary"
+                      lineClamp={isConnected ? 0 : 4}
+                      maxHeight={isConnected ? "100px" : "184px"}
+                      fontFamily="body"
+                      fontSize="body.md"
+                      lineHeight="20px"
+                      fontWeight="regular"
+                      marginTop="8px"
+                    >
+                      {getTranslationFromDict(source.datasetDescription) ||
+                        getTranslationFromDict(source.methodologyDescription)}
+                    </Text>
+                    <VStack w="full" mb="16px" mt="12px">
+                      <Link
+                        textDecoration="underline"
+                        mt={4}
+                        mb={2}
+                        onClick={() => onSourceClick(source, data)}
+                        alignSelf="flex-start"
+                        fontSize="label.lg"
+                        fontWeight="medium"
+                        letterSpacing="wide"
+                      >
+                        {t("see-more-details")}
+                      </Link>
+                      {isConnected ? (
+                        <Button
+                          variant="outline"
+                          w="full"
+                          h="50px"
+                          bg={
+                            isHovered
+                              ? "semantic.dangerOverlay"
+                              : "semantic.successOverlay"
+                          }
+                          borderColor={
+                            isHovered
+                              ? "semantic.danger"
+                              : "semantic.success"
+                          }
+                          borderWidth="1px"
+                          color={
+                            isHovered
+                              ? "semantic.danger"
+                              : "semantic.success"
+                          }
+                          fontWeight="semibold"
+                          fontSize="14px"
+                          onClick={() =>
+                            isFrozenCheck()
+                              ? null
+                              : onDisconnectThirdPartyData(source)
+                          }
+                          loading={
+                            isDisconnectLoading &&
+                            source.datasourceId === disconnectingDataSourceId
+                          }
+                          onMouseEnter={() => onButtonHover(source)}
+                          onMouseLeave={() => onMouseLeave(source)}
+                        >
+                          <Icon as={MdCheckCircleOutline} />
+                          {isHovered
+                            ? t("disconnect-data")
+                            : t("data-connected")}
+                        </Button>
+                      ) : isBlocked ? (
+                        <Tooltip
+                          showArrow
+                          content={t("data-already-added-connected")}
+                        >
+                          <Button
+                            variant="outline"
+                            w="full"
+                            h="50px"
+                            borderWidth="0"
+                            bgColor="background.graySubtle"
+                            disabled
+                            color="interactive.control"
+                            fontWeight="semibold"
+                            fontSize="14px"
+                          >
+                            {t("connect-data")}
+                            <Icon as={MdInfoOutline} boxSize={4} />
+                          </Button>
+                        </Tooltip>
+                      ) : (
+                        <Button
+                          variant="outline"
+                          w="full"
+                          h="50px"
+                          borderWidth="1px"
+                          borderColor="border.overlay"
+                          bgColor="background.neutral"
+                          color="interactive.secondary"
+                          fontWeight="semibold"
+                          fontSize="14px"
+                          onClick={() => onConnectClick(source)}
+                          loading={
+                            isConnectDataSourceLoading &&
+                            source.datasourceId === connectingDataSourceId
+                          }
+                        >
+                          {t("connect-data")}
+                        </Button>
+                      )}
+                    </VStack>
+                  </Card.Body>
+                </Card.Root>
+              );
+            })}
+          </SimpleGrid>
+        </Box>
+      )}
+
+      {selectedSource && (
+        <SourceDrawer
+          inventoryId={inventoryId}
+          source={selectedSource}
+          hideActions={true}
+          totalEmissionsData={selectedSourceData?.totals?.emissions?.co2eq_100yr?.toString()}
+          sourceData={selectedSourceData}
+          sector={{ sectorName: SECTORS[parseInt(step) - 1].name }}
+          isOpen={isSourceDrawerOpen}
+          onClose={onSourceDrawerClose}
+          onConnectClick={() => onConnectClick(selectedSource)}
+          isConnectLoading={
+            isConnectDataSourceLoading &&
+            selectedSource?.datasourceId === connectingDataSourceId
+          }
+          t={t}
+          numberFormat={userInfo?.numberFormat}
+          isConnected={isSourceConnected(selectedSource)}
+        />
       )}
     </>
   );

--- a/app/src/components/Tabs/Activity/activity-tab.tsx
+++ b/app/src/components/Tabs/Activity/activity-tab.tsx
@@ -558,6 +558,12 @@ const ActivityTab: FC<ActivityTabProps> = ({
             t={t}
             inventoryValue={externalInventoryValue as unknown as InventoryValue}
             numberFormat={userInfo?.numberFormat}
+            onDisconnect={(datasourceId) => {
+              setNewlyConnectedDataSourceIds((prev) =>
+                prev.filter((id) => id !== datasourceId),
+              );
+              refetchDataSources();
+            }}
           />
         </Box>
       )}
@@ -597,7 +603,7 @@ const ActivityTab: FC<ActivityTabProps> = ({
         </>
       )}
 
-      {matchingSources.length > 0 && (
+      {(isDataSourcesLoading || matchingSources.length > 0) && (
         <Box mt={12} borderTop="1px solid" borderColor="border.neutral" pt={8}>
           <Heading fontSize="title.lg" mb={2}>
             {t("browse-and-connect-external-datasets-heading")}
@@ -605,6 +611,11 @@ const ActivityTab: FC<ActivityTabProps> = ({
           <Text color="content.tertiary" mb={8}>
             {t("browse-and-connect-external-datasets-description")}
           </Text>
+          {isDataSourcesLoading ? (
+            <Center py="48px">
+              <Spinner size="xl" color="interactive.secondary" />
+            </Center>
+          ) : (
           <SimpleGrid
             columns={{
               base: 1,
@@ -853,6 +864,7 @@ const ActivityTab: FC<ActivityTabProps> = ({
               );
             })}
           </SimpleGrid>
+          )}
         </Box>
       )}
 

--- a/app/src/components/Tabs/Activity/external-data-section.tsx
+++ b/app/src/components/Tabs/Activity/external-data-section.tsx
@@ -1,7 +1,6 @@
 import {
   Badge,
   Box,
-  Button,
   Card,
   Center,
   Flex,
@@ -9,24 +8,40 @@ import {
   Icon,
   Link,
   SimpleGrid,
-  Tag,
-  TagLabel,
   Text,
   useDisclosure,
+  VStack,
 } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { TFunction } from "i18next";
 import { InventoryValue } from "@/models/InventoryValue";
 import HeadingText from "@/components/heading-text";
-import { MdHomeWork } from "react-icons/md";
+import {
+  MdCheckCircleOutline,
+  MdOutlineHomeWork,
+  MdOutlineLocalShipping,
+  MdOutlineDelete,
+  MdOutlineFactory,
+} from "react-icons/md";
+import { LuWheat } from "react-icons/lu";
 import { getTranslationFromDict } from "@/i18n";
 import { DataCheckIcon } from "@/components/icons";
-import { FiCheckCircle, FiTarget } from "react-icons/fi";
+import { FiTarget } from "react-icons/fi";
 import { SourceDrawer } from "@/components/GHGI/data-step/SourceDrawer";
 import type { DataSourceWithRelations } from "@/components/GHGI/data-step/types";
 import { api } from "@/services/api";
 import { convertKgToTonnes } from "@/util/helpers";
-import { UseErrorToast } from "@/hooks/Toasts";
+import { Tooltip } from "@/components/ui/tooltip";
+import { Button } from "@/components/ui/button";
+import { toaster } from "@/components/ui/toaster";
+
+const ensureProtocol = (url?: string) => {
+  if (!url) return "";
+  if (!/^https?:\/\//i.test(url)) {
+    return "https://" + url;
+  }
+  return url;
+};
 
 const ExternalDataSection = ({
   t,
@@ -47,21 +62,12 @@ const ExternalDataSection = ({
     onOpen: onSourceDrawerOpen,
   } = useDisclosure();
   const onSourceClick = (_source: DataSourceWithRelations, _data: any) => {
-    // setSelectedSource(source);
-    // setSelectedSourceData(data);
     onSourceDrawerOpen();
   };
   const [hovered, setHovered] = useState(false);
 
   const handleMouseEnter = () => setHovered(true);
   const handleMouseLeave = () => setHovered(false);
-
-  const buttonContent = hovered ? t("disconnect-data") : t("data-connected");
-  const buttonIcon = !hovered ? <Icon as={FiCheckCircle} /> : null;
-  const buttonColorScheme = hovered ? "danger" : "primary"; // TODO create these color palletes
-  const { showErrorToast } = UseErrorToast({
-    title: "disconnected-data-source",
-  });
 
   const onDisconnectThirdPartyData = async (
     _source: DataSourceWithRelations,
@@ -70,7 +76,11 @@ const ExternalDataSection = ({
       inventoryId: inventoryValue.inventoryId,
       datasourceId: inventoryValue.datasourceId,
     });
-    showErrorToast();
+    toaster.create({
+      title: t("disconnected-data-source"),
+      type: "info",
+      duration: 5000,
+    });
   };
 
   if (!source) {
@@ -89,6 +99,17 @@ const ExternalDataSection = ({
       </Center>
     );
   }
+
+  const refNum = inventoryValue.sector?.referenceNumber;
+  const romanSector = refNum ?? "I";
+
+  const sectorIcon = {
+    I: MdOutlineHomeWork,
+    II: MdOutlineLocalShipping,
+    III: MdOutlineDelete,
+    IV: MdOutlineFactory,
+    V: LuWheat,
+  }[romanSector] ?? MdOutlineHomeWork;
 
   return (
     <Box>
@@ -115,63 +136,164 @@ const ExternalDataSection = ({
           </Text>
         </Box>
       </Box>
-      <SimpleGrid columns={3} spaceX={4} spaceY={4}>
+      <SimpleGrid
+        columns={{
+          base: 1,
+          md: 2,
+          lg: 3,
+        }}
+        gap="16px"
+      >
         <Card.Root
           key={source.datasourceId}
+          data-testid="source-card"
           variant="outline"
+          borderWidth="1px"
           borderColor={hovered ? "semantic.danger" : "interactive.tertiary"}
-          borderWidth={2}
-          boxShadow="none"
-          _hover={{ filter: "drop-shadow(0 10px 15px rgba(0,0,0,0.1))" }}
-          transition="box-shadow 0.2s"
+          shadow="none"
+          _hover={{ shadow: "xl" }}
+          transition="all 300ms"
+          w="full"
+          p="24px"
+          gap="4px"
         >
-          <Card.Body>
-            {/* TODO add icon to DataSource */}
-            <Icon as={MdHomeWork} boxSize={9} mb={6} />
-            <Heading size="sm" lineClamp={2} minHeight={10}>
+          <Card.Header p="0" display="flex" flexDirection="column" gap="0">
+            <Icon
+              as={sectorIcon}
+              boxSize={9}
+              color="content.tertiary-light"
+              mb="10px"
+            />
+            <Flex direction="row" align="center" gap="8px">
+              <Badge
+                variant="plain"
+                fontSize="label.sm"
+                fontWeight="medium"
+                fontFamily="heading"
+                letterSpacing="widest"
+                bg="background.graySubtle"
+                color="content.secondary"
+                px="8px"
+                py="1px"
+                borderRadius="md"
+                lineHeight="1.2"
+                borderWidth="0"
+              >
+                {source.subCategory?.referenceNumber ||
+                  source.subSector?.referenceNumber}
+              </Badge>
+              <Tooltip showArrow content={source.subSector?.subsectorName}>
+                <Text
+                  fontSize="overline"
+                  fontWeight="bold"
+                  color="content.primary"
+                  textTransform="uppercase"
+                  letterSpacing="widest"
+                  lineHeight="24"
+                  fontFamily="heading"
+                  lineClamp={1}
+                >
+                  {source.subSector?.subsectorName}
+                </Text>
+              </Tooltip>
+            </Flex>
+            <Heading
+              fontSize="title.md"
+              lineClamp={2}
+              minHeight={10}
+              mt="6px"
+              lineHeight={24}
+            >
               {getTranslationFromDict(source.datasetName)}
             </Heading>
-            <Flex direction="row" my={4} wrap="wrap" gap={2}>
-              <Badge>
-                <Icon as={DataCheckIcon} boxSize={5} color="content.tertiary" />
-                {t("data-quality")}: {t("quality-" + source.dataQuality)}
-              </Badge>
-              {source.subCategory?.scope && (
-                <Tag.Root>
-                  <Tag.StartElement>
+            <Text fontSize="label.md" mt="4px">
+              {t("by-data-source")}{" "}
+              <Link
+                href={ensureProtocol(source.publisher?.url)}
+                target="_blank"
+                textDecoration="underline"
+                color="content.link"
+                rel="noreferrer noopener"
+              >
+                {source.publisher?.name}
+              </Link>
+            </Text>
+          </Card.Header>
+          <Card.Body justifyContent="space-between" p="0" mt="12px">
+            <Flex direction="row" mb={0} wrap="wrap" gap={2}>
+              <Flex direction="row" gap="4px" flexWrap="nowrap">
+                <Badge fontSize={12} borderColor="border.overlay" w="fit-content">
+                  <Icon as={DataCheckIcon} boxSize={5} color="content.tertiary" />
+                  {t("data-quality")}: {t("quality-" + source.dataQuality)}
+                </Badge>
+                {source.subCategory?.scope && (
+                  <Badge fontSize={12} borderColor="border.overlay" w="fit-content">
                     <Icon as={FiTarget} boxSize={4} color="content.tertiary" />
-                  </Tag.StartElement>
-                  <TagLabel fontSize={11}>
                     {t("scope")}: {source.subCategory.scope.scopeName}
-                  </TagLabel>
-                </Tag.Root>
-              )}
+                  </Badge>
+                )}
+              </Flex>
             </Flex>
-            <Text color="content.tertiary" lineClamp={5} minHeight={120}>
+            <Text
+              textOverflow="ellipsis"
+              whiteSpace="nowrap"
+              overflow="hidden"
+              color="content.tertiary"
+              lineClamp={0}
+              maxHeight="100px"
+              fontFamily="body"
+              fontSize="body.md"
+              lineHeight="20px"
+              fontWeight="regular"
+              marginTop="8px"
+            >
               {getTranslationFromDict(source.datasetDescription) ||
                 getTranslationFromDict(source.methodologyDescription)}
             </Text>
-            <Link
-              textDecoration="underline"
-              mt={4}
-              mb={6}
-              onClick={() => onSourceClick(source, null)}
-            >
-              {t("see-more-details")}
-            </Link>
-            <Button
-              variant="solid"
-              colorScheme={buttonColorScheme}
-              px={6}
-              py={4}
-              onClick={() => onDisconnectThirdPartyData(source)}
-              loading={isDisconnectLoading}
-              onMouseEnter={handleMouseEnter}
-              onMouseLeave={handleMouseLeave}
-            >
-              {buttonIcon}
-              {buttonContent}
-            </Button>
+            <VStack w="full" mb="16px" mt="12px">
+              <Link
+                textDecoration="underline"
+                mt={4}
+                mb={2}
+                onClick={() => onSourceClick(source, null)}
+                alignSelf="flex-start"
+                fontSize="label.lg"
+                fontWeight="medium"
+                letterSpacing="wide"
+              >
+                {t("see-more-details")}
+              </Link>
+              <Button
+                variant="outline"
+                w="full"
+                h="50px"
+                bg={
+                  hovered
+                    ? "semantic.dangerOverlay"
+                    : "semantic.successOverlay"
+                }
+                borderColor={
+                  hovered
+                    ? "semantic.danger"
+                    : "semantic.success"
+                }
+                borderWidth="1px"
+                color={
+                  hovered
+                    ? "semantic.danger"
+                    : "semantic.success"
+                }
+                fontWeight="semibold"
+                fontSize="14px"
+                onClick={() => onDisconnectThirdPartyData(source)}
+                loading={isDisconnectLoading}
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+              >
+                <Icon as={MdCheckCircleOutline} />
+                {hovered ? t("disconnect-data") : t("data-connected")}
+              </Button>
+            </VStack>
           </Card.Body>
         </Card.Root>
       </SimpleGrid>
@@ -202,7 +324,7 @@ const ExternalDataSection = ({
       </Box>
       <SourceDrawer
         inventoryId={inventoryValue.inventoryId!}
-        source={{ ...inventoryValue, ...source }}
+        source={{ ...inventoryValue, ...source } as any}
         hideActions={true}
         totalEmissionsData={inventoryValue.co2eq as unknown as string}
         sourceData={null}
@@ -213,6 +335,7 @@ const ExternalDataSection = ({
         isConnectLoading={false}
         t={t}
         numberFormat={numberFormat}
+        isConnected={true}
       />
     </Box>
   );

--- a/app/src/components/Tabs/Activity/external-data-section.tsx
+++ b/app/src/components/Tabs/Activity/external-data-section.tsx
@@ -47,10 +47,12 @@ const ExternalDataSection = ({
   t,
   inventoryValue,
   numberFormat,
+  onDisconnect,
 }: {
   t: TFunction;
   inventoryValue: InventoryValue;
   numberFormat?: string;
+  onDisconnect?: (datasourceId: string) => void;
 }) => {
   const source = inventoryValue.dataSource;
   const [disconnectThirdPartyData, { isLoading: isDisconnectLoading }] =
@@ -81,6 +83,7 @@ const ExternalDataSection = ({
       type: "info",
       duration: 5000,
     });
+    onDisconnect?.(inventoryValue.datasourceId!);
   };
 
   if (!source) {
@@ -331,7 +334,7 @@ const ExternalDataSection = ({
         sector={inventoryValue.sector}
         isOpen={isSourceDrawerOpen}
         onClose={onSourceDrawerClose}
-        onConnectClick={() => {}}
+        onConnectClick={() => { }}
         isConnectLoading={false}
         t={t}
         numberFormat={numberFormat}

--- a/app/src/i18n/locales/en/data.json
+++ b/app/src/i18n/locales/en/data.json
@@ -103,6 +103,8 @@
   "manually-added": "Manually added data",
   "check-data-heading": "Explore Relevant Datasets to Connect Into Your Inventory",
   "check-data-details": "Review and integrate automatically sourced data relevant to your city's GHG inventory.",
+  "browse-and-connect-external-datasets-heading": "Browse and connect external datasets to your GHG emissions inventory",
+  "browse-and-connect-external-datasets-description": "You can review and integrate emissions data from external providers directly into your GHG emissions inventory.",
   "no-data-sources": "No External Data Sources Available",
   "no-data-sources-description": "It seems like there are no external sources available at this moment.<1></1>If you know any, <3>please report this</3> and we’ll prioritize your request.",
   "data-quality": "Data Quality",

--- a/app/src/i18n/locales/es/data.json
+++ b/app/src/i18n/locales/es/data.json
@@ -97,6 +97,8 @@
   "manually-added": "Datos añadidos manualmente",
   "check-data-heading": "Explora Conjuntos de Datos Relevantes para Conectar a tu Inventario",
   "check-data-details": "Revisa e integra datos automáticamente obtenidos relevantes para el inventario de GEI de tu ciudad.",
+  "browse-and-connect-external-datasets-heading": "Examinar y conectar conjuntos de datos externos a su inventario de emisiones de GEI",
+  "browse-and-connect-external-datasets-description": "Puede revisar e integrar datos de emisiones de proveedores externos directamente en su inventario de emisiones de GEI.",
   "no-data-sources": "No hay Fuentes de Datos Externas Disponibles",
   "no-data-sources-description": "Parece que no hay fuentes externas disponibles en este momento.<1></1>Si conoces alguna, <3>por favor repórtalo</3> y priorizaremos tu solicitud.",
   "data-quality": "Calidad de los Datos",

--- a/app/src/i18n/locales/fr/data.json
+++ b/app/src/i18n/locales/fr/data.json
@@ -100,6 +100,8 @@
   "manually-added": "Données ajoutées manuellement",
   "check-data-heading": "Explorez les ensembles de données pertinents à intégrer dans votre inventaire",
   "check-data-details": "Examinez et intégrez automatiquement les données pertinentes pour l'inventaire des GES de votre ville.",
+  "browse-and-connect-external-datasets-heading": "Parcourir et connecter des ensembles de données externes à votre inventaire d'émissions de GES",
+  "browse-and-connect-external-datasets-description": "Vous pouvez examiner et intégrer les données d'émissions de fournisseurs externes directement dans votre inventaire d'émissions de GES.",
   "no-data-sources": "Aucune source de données externe disponible",
   "no-data-sources-description": "Il semble qu'il n'y ait aucune source externe disponible pour le moment.<1></1>Si vous en connaissez, <3>veuillez le signaler</3> et nous donnerons la priorité à votre demande.",
   "data-quality": "Qualité des Données",

--- a/app/src/i18n/locales/pt/data.json
+++ b/app/src/i18n/locales/pt/data.json
@@ -98,6 +98,8 @@
   "manually-added": "Dados adicionados manualmente",
   "check-data-heading": "Explore Conjuntos de Dados Relevantes para Conectar ao Seu Inventário",
   "check-data-details": "Revise e integre automaticamente dados relevantes para o inventário de GEE da sua cidade.",
+  "browse-and-connect-external-datasets-heading": "Navegar e conectar conjuntos de dados externos ao seu inventário de emissões de GEE",
+  "browse-and-connect-external-datasets-description": "Você pode revisar e integrar dados de emissões de provedores externos diretamente em seu inventário de emissões de GEE.",
   "no-data-sources": "Sem Fontes de Dados Externas Disponíveis",
   "no-data-sources-description": "Parece que não há fontes externas disponíveis no momento.<1></1>Se você conhece alguma, <3>por favor, relate isso</3> e priorizaremos sua solicitação.",
   "data-quality": "Qualidade dos Dados",

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -351,6 +351,7 @@ export const api = createApi({
       >({
         query: ({ inventoryId }) => `datasource/${inventoryId}`,
         transformResponse: (response: GetDataSourcesResult) => response,
+        providesTags: ["InventoryValue"],
       }),
       getDataSourcePreview: builder.query<
         DataSourcePreviewResult,
@@ -465,6 +466,8 @@ export const api = createApi({
           "InventoryValue",
           "ReportResults",
           "YearlyReportResults",
+          "UserInventories",
+          "Inventories",
         ],
       }),
       updateOrCreateInventoryValue: builder.mutation<
@@ -749,9 +752,10 @@ export const api = createApi({
           "ReportResults",
           "SubSectorValue",
           "YearlyReportResults",
-          "InventoryValue",
           "SectorBreakdown",
           "Inventory",
+          "UserInventories",
+          "Inventories",
         ],
         transformResponse: (response: { data: EmissionsFactorResponse }) =>
           response.data,


### PR DESCRIPTION
## Summary

Adds a "Browse and connect external datasets" section to the manual-input subsector scope tabs (`ActivityTab`), allowing users to discover, connect, and disconnect third-party data sources directly from within each scope tab. Also restyled the existing "External Dataset Integrated" card to match the new browse card design.

## Changes

### `activity-tab.tsx` (+514 lines)
- Added RTK Query hooks (`useGetAllDataSourcesQuery`, `useConnectDataSourceMutation`, `useDisconnectThirdPartyDataMutation`) and local state for connection tracking, hover states, and source drawer.
- Implemented `isSourceConnected`, `isSourceGpcBlocked`, and `getSourceGpcReferenceNumber` helpers to determine card button state.
- Filtered data sources via `matchingSources` memo to only show sources matching the active tab's GPC reference number.
- Rendered a responsive card grid with sector icons, GPC badges, publisher links, quality/scope badges, and connect/disconnect buttons with hover transitions.
- Integrated `<SourceDrawer>` for detailed source view on "See more details" click.
- Added `ensureProtocol` helper for safe publisher URL linking.
- Added a loading spinner while data sources are being fetched.
- Passed `onDisconnect` callback to `ExternalDataSection` that clears `newlyConnectedDataSourceIds` and refetches data sources.
- Replaced error toast on disconnect with a translated info toast (`toaster.create`).

### `external-data-section.tsx` (+250/−65 lines)
- Restyled the integrated external data card to match the browse card mockup (sector icon, GPC badge, publisher link, quality/scope badges, outline button).
- Added `onDisconnect` callback prop that passes `datasourceId` to the parent after disconnect, ensuring browse cards update immediately.
- Replaced red error toast with translated info toast on disconnect.
- Added `ensureProtocol` for publisher URL validation.

### `api.ts` (+6/−1 lines)
- Added `providesTags: ["InventoryValue"]` to `getAllDataSources` query for automatic cache invalidation.
- Added `"UserInventories"` and `"Inventories"` invalidation tags to `connectDataSource` and `disconnectThirdPartyData` mutations.
- Removed duplicate `"InventoryValue"` entry from `disconnectThirdPartyData` invalidation tags.

### Locale files (`en`, `es`, `fr`, `pt` — `data.json`)
- Added translation keys: `browse-and-connect-external-datasets-heading` and `browse-and-connect-external-datasets-description`.


