### PR TITLE
Title: fix: ON-5968 city dashboard shows N/A for total emissions on prefilled inventory

### DIFF
--- a/app/src/app/api/v1/city/[city]/dashboard/route.ts
+++ b/app/src/app/api/v1/city/[city]/dashboard/route.ts
@@ -15,6 +15,7 @@ import type {
 import { Inventory } from "@/models/Inventory";
 import type { AppSession } from "@/lib/auth";
 import { logger } from "@/services/logger";
+import { QueryTypes } from "sequelize";
 
 /**
  * @swagger
@@ -159,6 +160,28 @@ export const GET = apiHandler(async (req, { params, session }) => {
   const [ghgiData, hiapData, ccraData, organization] =
     await Promise.all(widgetPromises);
 
+  // Compute totalEmissions for all inventories from InventoryValue.co2eq sums
+  let totalEmissionsByInventory: Record<string, number | null> = {};
+  if (inventories.length > 0) {
+    const inventoryIds = inventories.map((inv) => inv.inventoryId);
+    const emissionRows = (await db.sequelize!.query(
+      `SELECT inventory_id,
+        CASE WHEN COUNT(*) > 0 THEN COALESCE(SUM(co2eq), 0) ELSE NULL END AS sum
+       FROM "InventoryValue"
+       WHERE inventory_id IN (:inventoryIds)
+       GROUP BY inventory_id`,
+      {
+        replacements: { inventoryIds },
+        type: QueryTypes.SELECT,
+        raw: true,
+      },
+    )) as { inventory_id: string; sum: number | null }[];
+
+    for (const row of emissionRows) {
+      totalEmissionsByInventory[row.inventory_id] = row.sum;
+    }
+  }
+
   // Fetch city with project/organization data
   const cityWithRelations = await db.models.City.findByPk(cityId, {
     include: [
@@ -186,7 +209,10 @@ export const GET = apiHandler(async (req, { params, session }) => {
 
   const response: CityDashboardResponse = {
     city: cityWithRelations as CityDashboardResponse["city"],
-    inventories: inventories.map((inv) => inv.toJSON()),
+    inventories: inventories.map((inv) => ({
+      ...inv.toJSON(),
+      totalEmissions: totalEmissionsByInventory[inv.inventoryId] ?? inv.totalEmissions ?? null,
+    })),
     population:
       populationData &&
       populationData.year !== null &&

--- a/app/src/app/api/v1/city/[city]/dashboard/route.ts
+++ b/app/src/app/api/v1/city/[city]/dashboard/route.ts
@@ -211,7 +211,7 @@ export const GET = apiHandler(async (req, { params, session }) => {
     city: cityWithRelations as CityDashboardResponse["city"],
     inventories: inventories.map((inv) => ({
       ...inv.toJSON(),
-      totalEmissions: totalEmissionsByInventory[inv.inventoryId] ?? inv.totalEmissions ?? null,
+      totalEmissions: totalEmissionsByInventory[inv.inventoryId] ?? inv.totalEmissions ?? undefined,
     })),
     population:
       populationData &&

--- a/app/src/backend/InventoryService.ts
+++ b/app/src/backend/InventoryService.ts
@@ -60,8 +60,11 @@ export class InventoryService {
     }
 
     // TODO [ON-2429]: Save total emissions for inventory every time activity data is modified
+    // Returns 0 when inventory values exist but all co2eq are null (e.g. notation-key-only prefill),
+    // and NULL only when no inventory values exist at all.
     const rawQuery = `
-    SELECT SUM(co2eq)
+    SELECT
+      CASE WHEN COUNT(*) > 0 THEN COALESCE(SUM(co2eq), 0) ELSE NULL END AS sum
     FROM "InventoryValue"
     WHERE inventory_id = :inventoryId
   `;
@@ -70,9 +73,9 @@ export class InventoryService {
       replacements: { inventoryId },
       type: QueryTypes.SELECT,
       raw: true,
-    })) as unknown as { sum: number }[];
+    })) as unknown as { sum: number | null }[];
 
-    inventory.totalEmissions = sum;
+    inventory.totalEmissions = sum as unknown as number;
     return inventory;
   }
 }

--- a/app/src/components/GHGIHomePage/HomePage.tsx
+++ b/app/src/components/GHGIHomePage/HomePage.tsx
@@ -197,9 +197,10 @@ export default function HomePage({
     { skip: !inventory?.cityId || !inventory?.year },
   );
 
-  const formattedEmissions = inventory?.totalEmissions
-    ? formatEmissions(inventory.totalEmissions, userInfo?.numberFormat)
-    : { value: t("N/A"), unit: "" };
+  const formattedEmissions =
+    inventory?.totalEmissions != null
+      ? formatEmissions(inventory.totalEmissions, userInfo?.numberFormat)
+      : { value: t("N/A"), unit: "" };
 
   const inventoriesForCurrentCity = useMemo(() => {
     if (!cityYears) return [];

--- a/app/src/components/HomePageJN/Hero.tsx
+++ b/app/src/components/HomePageJN/Hero.tsx
@@ -45,9 +45,10 @@ export function Hero({
     skip: !city?.locode,
   });
 
-  const formattedEmissions = ghgiCityData?.totalEmissions
-    ? formatEmissions(ghgiCityData.totalEmissions, numberFormat)
-    : { value: t("n-a"), unit: "" };
+  const formattedEmissions =
+    ghgiCityData?.totalEmissions != null
+      ? formatEmissions(ghgiCityData.totalEmissions, numberFormat)
+      : { value: t("n-a"), unit: "" };
 
   const popWithDS = useMemo(
     () =>


### PR DESCRIPTION

[Ticket: ON-5968](https://openearth.atlassian.net/browse/ON-5968)

## Problem
The city dashboard and GHGI homepage showed "N/A" for Total Emissions even when a prefilled inventory had data sources connected. Two root causes:

1. `SUM(co2eq)` on all-null `InventoryValue` rows (e.g. notation-key-only prefill) returns SQL NULL — the frontend truthy check treated this as "no data"
2. The `/dashboard/` route returned raw DB inventories via `inv.toJSON()`, reading the `total_emissions` column which is never written to — so `totalEmissions` was always null regardless of connected data


## Solution
- **`InventoryService.ts`** — changed the SQL to return `0` when `InventoryValue` rows exist but all `co2eq` are null, and `NULL` only for truly empty inventories (no rows at all)
- **`dashboard/route.ts`** — added a bulk `SUM(co2eq)` query per inventory before building the response, replacing the never-populated DB column value
- **`HomePageJN/Hero.tsx` + `GHGIHomePage/HomePage.tsx`** — changed truthy check (`totalEmissions ?`) to `!= null` so `0` renders as "0 kg CO2e" instead of falling through to N/A

## Testing
- [ ] City with a prefilled inventory (notation keys only) — dashboard shows "0 kg CO2e" instead of N/A
- [ ] City with a prefilled inventory with actual data — dashboard shows correct emissions value
- [ ] Brand new city with no inventory data — dashboard still shows N/A
- [ ] `/cities/[cityId]/dashboard/` route
- [ ] `/cities/[cityId]/GHGI/[inventoryId]` route

## Notes
The underlying architectural issue [(ON-2429)](https://openearth.atlassian.net/browse/ON-2429?search_id=9f928bc2-2c79-49d0-9d05-140e41eeeba3&referrer=quick-find) — `Inventory.total_emissions` is never kept in sync — is out of scope for this fix but should be addressed to prevent the same class of bug recurring in future routes.
