### PR TITLE
docs: add PR template and non-tech-contribute skill

### DIFF
--- a/.cursor/skills/non-tech-contribute/SKILL.md
+++ b/.cursor/skills/non-tech-contribute/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: non-tech-contribute
+description: Guide non-technical contributors through making safe code changes to CityCatalyst. Use when someone without coding experience wants to update text, translations, colors, copy, or small UI details, and needs the agent to handle git, verification, and PR creation for them.
+---
+
+# Non-Tech Contribute
+
+Help non-technical team members (product, design, business, data) ship real changes to CityCatalyst. You handle git, verification, and PR creation for them — they only describe the change in plain language.
+
+## When to use
+
+- The user is not an engineer and asks to change something visible: text, translation, color, copy, tooltip, spacing, image, link.
+- The user says "I want to change/fix/update…" and does not mention git, branches, or commits.
+- The change is small in scope (typically ≤ 5 files). If it grows beyond that or requires architecture decisions, flag it for engineering review.
+
+## Golden rules
+
+- The user never types git commands. You run them.
+- Never commit to `develop` or `main` directly — always a new branch.
+- One PR per logical change.
+- Always run the TypeScript check before committing.
+- If the change requires new dependencies, migrations, or architecture decisions, stop and flag it.
+
+## Workflow
+
+### Phase 1 — Understand the change
+
+Ask, in plain language:
+
+1. **What** do you want to change? (text, color, behavior, layout)
+2. **Where** in the app is it? (which page, section, button — a screenshot or Jam link helps a lot)
+3. **What should it look like after?** (new text, new color hex, new behavior)
+
+Confirm your understanding in one sentence before touching anything.
+
+### Phase 2 — Git setup (automatic)
+
+1. Run `git status` and `git branch --show-current`.
+2. If not on a clean branch off `develop`, run:
+
+```bash
+git checkout develop && git pull
+git checkout -b <username>/<type>-<short-description>
+```
+
+**Branch naming:** `<username>/<type>-<short-description>`
+
+- `<username>`: run `git config user.name` and slugify (lowercase, no spaces). If empty, ask the user's first name.
+- `<type>`: `fix` (bug/typo), `feat` (new feature/content), `style` (visual), `i18n` (translation), `docs` (documentation), `hotfix` (urgent prod fix).
+
+Examples:
+
+- `brian/fix-spanish-translation-help-button`
+- `amanda/feat-add-tooltip-emissions-chart`
+- `greta/style-update-sidebar-color`
+
+### Phase 3 — Find and modify
+
+1. Locate the right file(s):
+   - **Text / translations:** `app/src/i18n/locales/<lang>/*.json`
+   - **Pages / components:** `app/src/app/` (routes) or `app/src/components/`
+   - **Colors / theme:** Chakra UI theme in `app/src/lib/theme.ts` (or component-level styles)
+   - **API / data:** `app/src/services/` or `app/src/app/api/`
+2. Make a minimal, focused edit.
+3. Explain the diff in plain language, e.g. *"I changed the button text from 'Need Help' to '¿Necesitas Ayuda?' in the Spanish translation file."*
+
+### Phase 4 — Verify
+
+Quick sanity checks:
+
+```bash
+cd app && npx tsc --noEmit 2>&1 | tail -20
+git diff --stat
+```
+
+For visible changes (translations, colors, copy), also run a lint pass if it is fast:
+
+```bash
+cd app && npm run lint -- --quiet 2>&1 | tail -20
+```
+
+Fix any errors before proceeding. If you cannot fix them, stop and explain what is blocking.
+
+### Phase 5 — Commit, push, and open the PR (automatic)
+
+Do not ask the user to type git commands.
+
+1. Commit with a Conventional-Commit style subject:
+
+   ```bash
+   git add -A
+   git commit -m "<type>: <short imperative description>"
+   ```
+
+   Types: `fix:`, `feat:`, `style:`, `i18n:`, `docs:`.
+
+2. Push the branch:
+
+   ```bash
+   git push -u origin <branch-name>
+   ```
+
+3. Open the PR by **delegating to the [pull-request-standards skill](../pull-request-standards/SKILL.md)**. Do not hand-roll a title or body here — that skill owns the format, uses `.github/PULL_REQUEST_TEMPLATE.md`, and picks the right GitHub tool. Give it the plain-language description you got from the user so it can fill:
+
+   - **Summary** — the outcome in the user's own words (1–3 sentences).
+   - **Changes** — the minimal bullet list of what was touched.
+   - **How to test** — the exact click-path a reviewer can follow (e.g. *"Open `/onboarding` in Spanish and check the header button says 'EDITAR'."*).
+   - **Ticket** — only if the user gave you a ticket ID (e.g. `ON-1234`); otherwise omit the section.
+   - **Notes** — only for screenshots or callouts the reviewer needs.
+
+### Phase 6 — Hand off
+
+Once the PR is open, tell the user:
+
+- The PR URL.
+- Who or which team is expected to review (usually within 24h).
+- Where to watch status (GitHub PR page, CI checks).
+- Where to ask for help if CI fails (Slack channel).
+
+## Escalate to engineering when
+
+- The change touches more than ~5 files or crosses backend + frontend.
+- The change requires a new dependency, migration, environment variable, or feature flag.
+- Verification (`tsc`, lint) fails and the fix is not obvious.
+- The change is user-facing on a critical path (auth, payments, data export) — even if small.
+
+## Examples
+
+**Input:** "I want the onboarding 'EDIT' button to show 'EDITAR' in Spanish."
+**Action:** Find the key in `app/src/i18n/locales/es/*.json`, update the value, `tsc`, commit `i18n: translate onboarding edit button to Spanish`, push, delegate PR creation with a How-to-test that names the page and button.
+
+---
+
+**Input:** "The sidebar color should be darker, like #1a1a2e instead of the current blue."
+**Action:** Find the sidebar component or theme token, update the color, `tsc` + lint, commit `style: darken sidebar background`, push, delegate PR creation with a screenshot request in Notes if the user has one.
+
+---
+
+**Input:** "I want to add a tooltip that says 'Values shown in tCO2e' next to the emissions chart."
+**Action:** Locate the chart component, wrap the label with a Chakra `Tooltip`, add an i18n key if the copy is user-facing, `tsc`, commit `feat: add tCO2e tooltip on emissions chart`, push, delegate PR creation with a How-to-test pointing to the chart page.

--- a/.cursor/skills/pull-request-standards/SKILL.md
+++ b/.cursor/skills/pull-request-standards/SKILL.md
@@ -57,13 +57,18 @@ Examples:
 
 ### Body
 
-Keep the body short and concise. Prefer this structure:
+Keep the body short and concise.
+
+**If the repo has `.github/PULL_REQUEST_TEMPLATE.md`, use it as the scaffold.** Fill each section, delete any that do not apply, and remove the HTML comment hints. Do not invent extra sections.
+
+If no template exists, prefer this structure:
 
 1. **Summary** (1-3 sentences): What this PR does and why.
 2. **Changes** (optional): Bullet list of main changes, only if it adds clarity.
-3. **Commits** (optional): Short commit subject list when drafting from history.
+3. **How to test** (optional): Concrete steps a reviewer can follow. Include when the change is user-facing or non-obvious to verify.
+4. **Commits** (optional): Short commit subject list when drafting from history.
 
-Example:
+Example (matches the repo template):
 
 ```markdown
 ## Summary
@@ -75,11 +80,14 @@ Briefly states the user-visible outcome and motivation.
 - Touched area A
 - Touched area B
 
-## Commits (3)
+## How to test
 
-- fix: handle null path in inventory API
-- test: add regression coverage
-- docs: clarify export limits
+1. Run `npm run dev` and open `/inventory`.
+2. Confirm the null case renders the empty state instead of a 500.
+
+## Ticket
+
+ON-1234
 ```
 
 ## Create Or Update Workflow
@@ -87,9 +95,10 @@ Briefly states the user-visible outcome and motivation.
 1. Derive `owner`, `repo`, `head`, and `base` from git state.
 2. Check whether a PR already exists for the branch.
 3. Inspect commits between `origin/<base>` and `HEAD`, and **scope file/area lists** with `git diff origin/<base>...HEAD` (three-dot), not two-dot tip diff—see **PR change scope** above.
-4. Draft a concise title and body using the standards above.
-5. Create a PR when none exists, or update the existing PR when one exists or when the user asks to update.
-6. Return the PR URL and summarize only the metadata changed.
+4. Check whether `.github/PULL_REQUEST_TEMPLATE.md` exists. If it does, use it as the body scaffold.
+5. Draft a concise title and body using the standards above.
+6. Create a PR when none exists, or update the existing PR when one exists or when the user asks to update.
+7. Return the PR URL and summarize only the metadata changed.
 
 ## GitHub Tool Guidance
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+Keep this PR short and reviewer-friendly. Delete any section you do not need.
+For the full authoring guide, see `.cursor/skills/pull-request-standards/SKILL.md`.
+Prefer prefixing the PR title with a ticket ID when applicable, e.g. `ON-1234: Short feature name`.
+-->
+
+## Summary
+
+<!-- 1–3 sentences: what this PR does and why. Focus on the user-visible outcome. -->
+
+## Changes
+
+<!-- Optional bullet list of the main changes. Remove this section if the summary is enough. -->
+
+-
+
+## How to test
+
+<!-- Steps a reviewer can follow to verify the change. Include URLs, sample inputs, or screenshots when useful. -->
+
+1.
+
+## Ticket
+
+<!-- Optional: link to the Linear/Jira ticket (e.g. ON-1234). -->
+
+## Notes
+
+<!-- Optional: screenshots, follow-ups, risks, migration steps, or anything reviewers should know. -->


### PR DESCRIPTION
## Summary

Introduce a repo-level PR template so pull requests opened through the GitHub web UI (and by non-engineering contributors via the new skill) share the same short, reviewer-friendly format defined in the `pull-request-standards` skill. Also add a `non-tech-contribute` skill that walks non-technical teammates through git and PR creation, and cross-link the two skills so the PR-authoring format has a single source of truth.

## Changes

- Add `.github/PULL_REQUEST_TEMPLATE.md` with `Summary` / `Changes` / `How to test` / `Ticket` / `Notes` sections and HTML-comment hints.
- Add `.cursor/skills/non-tech-contribute/SKILL.md` — an end-to-end guide for non-engineering contributors that handles git for them and delegates PR creation to `pull-request-standards` (no duplicated authoring logic).
- Update `.cursor/skills/pull-request-standards/SKILL.md` to consume `.github/PULL_REQUEST_TEMPLATE.md` as the body scaffold and add a `How to test` section to the body standard.

## How to test

1. Open a new PR in the GitHub UI from any branch against `develop` — the description field should be pre-filled with the new template.
2. In Cursor, ask *"help me change a small piece of copy in CityCatalyst"* — the `non-tech-contribute` skill should trigger, drive the git flow end-to-end, and delegate PR creation to `pull-request-standards`.
3. In Cursor, ask *"open a PR for the current branch"* on any branch — `pull-request-standards` should now populate the template sections in the PR body.

## Notes

Documentation-only change: no runtime code is affected and no dependencies are added.

## Commits (2)

- docs: add PULL_REQUEST_TEMPLATE.md and link it from pull-request-standards skill
- docs: add non-tech-contribute skill for non-engineering contributors

Made with [Cursor](https://cursor.com)