### PR TITLE
fix: gracefully handle missing subcategories in GHGI version history

### DIFF
--- a/app/src/app/api/v1/inventory/[inventory]/version-history/route.ts
+++ b/app/src/app/api/v1/inventory/[inventory]/version-history/route.ts
@@ -14,7 +14,7 @@ import { VersionHistoryEntry } from "@/util/types";
 
 const validModules = ["ghgi", "hiap"];
 
-function findSubCategory(subCategoryId: string): SubCategory {
+function findSubCategory(subCategoryId: string): SubCategory | undefined {
   const subCategories = Inventory_Sector_Hierarchy.flatMap((sector) =>
     sector.subSectors.flatMap((subSector) => subSector.subCategories),
   );
@@ -23,11 +23,11 @@ function findSubCategory(subCategoryId: string): SubCategory {
   );
 
   if (!subCategory) {
-    logger.error(
+    logger.warn(
       { subCategoryId },
-      "Sub-category not found for version history!",
+      "Sub-category not found for version history, skipping.",
     );
-    throw new createHttpError.NotFound("sub-category-not-found");
+    return undefined;
   }
 
   return subCategory;

--- a/app/src/components/GHGI/inventory-versions/VersionEntry.tsx
+++ b/app/src/components/GHGI/inventory-versions/VersionEntry.tsx
@@ -162,10 +162,11 @@ export default function VersionEntry({
       isDeleted: entry.version.isDeleted,
       // module specific fields
       referenceNumber: entry.subCategory?.referenceNumber,
-      subCategory:
-        entry.subCategory?.referenceNumber +
-        " " +
-        tData(entry.subCategory?.subcategoryName ?? ""),
+      subCategory: entry.subCategory
+        ? entry.subCategory.referenceNumber +
+          " " +
+          tData(entry.subCategory.subcategoryName ?? "")
+        : "-",
       totalEmissions: entry.version.data?.co2eq
         ? toEmissionsString(entry.version.data.co2eq, numberFormat)
         : "-",


### PR DESCRIPTION

## Summary

Fix undefined subcategory display in the GHGI history tab. When a version record references a subCategoryId that no longer exists in the current GPC hierarchy, the API was throwing a 404 and crashing the entire history response. Even on the path where subCategoryId was null, the frontend concatenated undefined + " " + undefined, showing "undefined undefined" in the sub-category column.

## Changes

- app/src/app/api/v1/inventory/[inventory]/version-history/route.ts — findSubCategory() now returns undefined instead of throwing a 404 when a subCategoryId is not found in Inventory_Sector_Hierarchy; logs a warning instead of an error so history still loads for all other entries.

- app/src/components/GHGI/inventory-versions/VersionEntry.tsx — guard the subcategory display string so rows with an unresolvable subcategory show "-" instead of "undefined undefined".

## How to test

1. Navigate to a city → inventory → GHGI → History tab.
2. Confirm the tab loads without error even when version records contain stale subCategoryId values.
3. Rows whose subcategory can't be resolved should display "-" in the SUB-CATEGORY column instead of "undefined".

## Ticket
[ON-5974](https://openearth.atlassian.net/browse/ON-5974)

## Notes

The createHttpError import in route.ts is still used for the BadRequest on invalid module names — it was intentionally left in place.

## UI before and after 

<img width="969" height="455" alt="Screenshot 2026-07-01 at 2 11 13 PM" src="https://github.com/user-attachments/assets/4e683299-df30-4095-abce-c661a3371b88" />

<img width="969" height="455" alt="Screenshot 2026-07-01 at 2 14 47 PM" src="https://github.com/user-attachments/assets/bdcba8fa-989d-4f6d-a943-4e98d2ce53ca" />


[ON-5974]: https://openearth.atlassian.net/browse/ON-5974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ