### PR TITLE
fix: improve inventory mapping screen display values

### DIFF
--- a/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/import/page.tsx
+++ b/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/import/page.tsx
@@ -590,6 +590,16 @@ export default function ImportPage(props: {
     setPendingNavigation(null);
   };
 
+  useEffect(() => {
+    if (!inventoryId) {
+      router.replace(`/${lng}/cities/${cityId}/GHGI/onboarding`);
+    }
+  }, [inventoryId, router, lng, cityId]);
+
+  if (!inventoryId) {
+    return null;
+  }
+
   return (
     <>
       <Box pt={16} pb={16} maxW="full" mx="auto" w="1090px">

--- a/app/src/backend/InventoryFileStorageService.ts
+++ b/app/src/backend/InventoryFileStorageService.ts
@@ -14,7 +14,7 @@ const BUCKET = process.env.AWS_FILE_UPLOAD_S3_BUCKET_ID;
 const REGION = process.env.AWS_FILE_UPLOAD_REGION ?? "us-east-1";
 
 function getS3Client(): S3Client {
-  return new S3Client({ region: REGION });
+  return new S3Client({ region: REGION, followRegionRedirects: true });
 }
 
 /** Returns true when the S3 bucket is configured (production). Falls back to BYTEA in dev when false. */

--- a/app/src/components/steps/GHGI/import/mapping-columns-step.tsx
+++ b/app/src/components/steps/GHGI/import/mapping-columns-step.tsx
@@ -44,14 +44,39 @@ export default function MappingColumnsStep({
     },
   );
 
-  const columns: ColumnInfo[] = data?.columnMappings?.columns || [];
+  const columns: ColumnInfo[] = [...(data?.columnMappings?.columns || [])].sort(
+    (a, b) => (b.interpretedAs ? 1 : 0) - (a.interpretedAs ? 1 : 0),
+  );
   const requiredMappings: RequiredMappingOption[] =
     data?.columnMappings?.requiredMappings || [];
+
+  const EMISSION_FACTOR_KEYS = new Set([
+    "emissionFactorCO2",
+    "emissionFactorCH4",
+    "emissionFactorN2O",
+    "emissionFactorTotalCO2e",
+  ]);
 
   const getKeyForLabel = (label: string | null): string => {
     if (!label) return "";
     const m = requiredMappings.find((r) => r.label === label);
     return m?.key ?? "";
+  };
+
+  const formatExampleValue = (column: ColumnInfo): string | null => {
+    if (!column.exampleValue) return null;
+    if (EMISSION_FACTOR_KEYS.has(getKeyForLabel(column.interpretedAs))) {
+      const num = parseFloat(column.exampleValue);
+      if (!isNaN(num)) {
+        const tonnes = num / 1000;
+        const formatted =
+          tonnes < 0.0001
+            ? tonnes.toExponential(2)
+            : parseFloat(tonnes.toFixed(4)).toString();
+        return `${formatted} t CO2e`;
+      }
+    }
+    return column.exampleValue;
   };
 
   const handleMappingChange = (columnName: string, value: string) => {
@@ -133,9 +158,20 @@ export default function MappingColumnsStep({
                     <Text fontWeight="medium">{column.columnName}</Text>
                   </Table.Cell>
                   <Table.Cell>
-                    <Text color="content.secondary">
-                      {column.exampleValue || "-"}
-                    </Text>
+                    {(() => {
+                      const displayValue = formatExampleValue(column);
+                      return (
+                        <Text
+                          color={
+                            displayValue
+                              ? "content.secondary"
+                              : "content.tertiary"
+                          }
+                        >
+                          {displayValue || t("not-specified")}
+                        </Text>
+                      );
+                    })()}
                   </Table.Cell>
                   <Table.Cell>
                     <NativeSelect.Root>

--- a/app/src/components/steps/GHGI/import/review-confirm-step.tsx
+++ b/app/src/components/steps/GHGI/import/review-confirm-step.tsx
@@ -80,8 +80,8 @@ export default function ReviewConfirmStep({
 
   // Fallback to fileInfo and validationResults if reviewData is not available
   const importSummary = reviewData?.importSummary || {
-    sourceFile: fileInfo?.originalFileName || "-",
-    formatDetected: fileInfo?.fileType?.toUpperCase() || "-",
+    sourceFile: fileInfo?.originalFileName || null,
+    formatDetected: fileInfo?.fileType?.toUpperCase() || null,
     rowsFound: data?.rowCount || 0,
     fieldsMapped:
       reviewData?.fieldMappings?.length ||
@@ -129,13 +129,29 @@ export default function ReviewConfirmStep({
               <Text fontSize="body.sm" color="content.tertiary" mb={1}>
                 {t("source-file")}
               </Text>
-              <Text fontWeight="medium">{importSummary.sourceFile}</Text>
+              <Text
+                fontWeight={importSummary.sourceFile ? "medium" : undefined}
+                color={
+                  importSummary.sourceFile ? undefined : "content.tertiary"
+                }
+              >
+                {importSummary.sourceFile || t("not-specified")}
+              </Text>
             </Box>
             <Box w="full">
               <Text fontSize="body.sm" color="content.tertiary" mb={1}>
                 {t("format-detected")}
               </Text>
-              <Text fontWeight="medium">{importSummary.formatDetected}</Text>
+              <Text
+                fontWeight={
+                  importSummary.formatDetected ? "medium" : undefined
+                }
+                color={
+                  importSummary.formatDetected ? undefined : "content.tertiary"
+                }
+              >
+                {importSummary.formatDetected || t("not-specified")}
+              </Text>
             </Box>
             <Box w="full">
               <Text fontSize="body.sm" color="content.tertiary" mb={1}>

--- a/app/src/components/steps/GHGI/import/validation-results-step.tsx
+++ b/app/src/components/steps/GHGI/import/validation-results-step.tsx
@@ -46,6 +46,32 @@ export default function ValidationResultsStep({
     (col) => col.status === "detected",
   ).length;
 
+  const EMISSION_FACTOR_LABELS = new Set([
+    "Emission Factor - CO2",
+    "Emission Factor - CH4",
+    "Emission Factor - N2O",
+    "Emission Factor - Total CO2e",
+  ]);
+
+  const formatExampleValue = (column: ColumnInfo): string | null => {
+    if (!column.exampleValue) return null;
+    if (
+      column.interpretedAs &&
+      EMISSION_FACTOR_LABELS.has(column.interpretedAs)
+    ) {
+      const num = parseFloat(column.exampleValue);
+      if (!isNaN(num)) {
+        const tonnes = num / 1000;
+        const formatted =
+          tonnes < 0.0001
+            ? tonnes.toExponential(2)
+            : parseFloat(tonnes.toFixed(4)).toString();
+        return `${formatted} t CO2e`;
+      }
+    }
+    return column.exampleValue;
+  };
+
   return (
     <Box w="full">
       <Box display="flex" flexDir="column" gap="24px" mb={6}>
@@ -121,12 +147,29 @@ export default function ValidationResultsStep({
                       <Text fontWeight="medium">{column.columnName}</Text>
                     </Table.Cell>
                     <Table.Cell>
-                      <Text color="content.secondary">
-                        {column.exampleValue || "-"}
-                      </Text>
+                      {(() => {
+                        const displayValue = formatExampleValue(column);
+                        return (
+                          <Text
+                            color={
+                              displayValue
+                                ? "content.secondary"
+                                : "content.tertiary"
+                            }
+                          >
+                            {displayValue || t("not-specified")}
+                          </Text>
+                        );
+                      })()}
                     </Table.Cell>
                     <Table.Cell>
-                      <Text>{column.interpretedAs || "-"}</Text>
+                      <Text
+                        color={
+                          column.interpretedAs ? undefined : "content.tertiary"
+                        }
+                      >
+                        {column.interpretedAs || t("not-specified")}
+                      </Text>
                     </Table.Cell>
                     <Table.Cell>
                       {column.status === "detected" && (

--- a/app/src/i18n/locales/de/onboarding.json
+++ b/app/src/i18n/locales/de/onboarding.json
@@ -174,6 +174,7 @@
   "upload-started-description": "Hochladen von {{fileName}}...",
   "loading-validation-results": "Lade Validierungsergebnisse...",
   "no-field-mappings": "Keine Feldzuordnungen verfügbar",
+  "not-specified": "Nicht angegeben",
   "extract-with-ai": "Extrahieren mit KI",
   "pdf-ready-for-extraction": "PDF bereit für Extraktion",
   "validation-results-description-pdf": "{{count}} Reihen wurden aus der PDF extrahiert. Überprüfen Sie die untenstehenden Daten.",

--- a/app/src/i18n/locales/en/onboarding.json
+++ b/app/src/i18n/locales/en/onboarding.json
@@ -184,6 +184,7 @@
   "upload-started-description": "Uploading {{fileName}}...",
   "loading-validation-results": "Loading validation results...",
   "no-field-mappings": "No field mappings available",
+  "not-specified": "Not specified",
   "upload-failed": "Upload failed",
   "failed-to-upload-file": "Failed to upload file",
   "edit": "Edit",

--- a/app/src/i18n/locales/es/onboarding.json
+++ b/app/src/i18n/locales/es/onboarding.json
@@ -175,6 +175,7 @@
   "upload-started-description": "Subiendo {{fileName}}...",
   "loading-validation-results": "Cargando resultados de validación...",
   "no-field-mappings": "No hay mapeos de campos disponibles",
+  "not-specified": "No especificado",
   "extract-with-ai": "Extraer con IA",
   "pdf-ready-for-extraction": "PDF listo para extracción",
   "validation-results-description-pdf": "Se extrajeron {{count}} filas del PDF. Revisa los datos a continuación.",

--- a/app/src/i18n/locales/fr/onboarding.json
+++ b/app/src/i18n/locales/fr/onboarding.json
@@ -172,6 +172,7 @@
   "upload-started-description": "Téléchargement de {{fileName}} en cours...",
   "loading-validation-results": "Chargement des résultats de validation...",
   "no-field-mappings": "Aucun mappage de champ disponible",
+  "not-specified": "Non spécifié",
   "extract-with-ai": "Extraire avec IA",
   "pdf-ready-for-extraction": "PDF prêt pour l'extraction",
   "validation-results-description-pdf": "{{count}} lignes ont été extraites du PDF. Vérifiez les données ci-dessous.",

--- a/app/src/i18n/locales/pt/onboarding.json
+++ b/app/src/i18n/locales/pt/onboarding.json
@@ -174,6 +174,7 @@
   "upload-started-description": "Fazendo upload de {{fileName}}...",
   "loading-validation-results": "Carregando resultados de validação...",
   "no-field-mappings": "Sem mapeamentos de campo disponíveis",
+  "not-specified": "Não especificado",
   "extract-with-ai": "Extrair com IA",
   "pdf-ready-for-extraction": "PDF pronto para extração",
   "validation-results-description-pdf": "{{count}} linhas foram extraídas do PDF. Revise os dados abaixo.",


### PR DESCRIPTION

## Summary

Improves the inventory mapping screen (upload flow) to display empty/undefined field values as "Not specified" in tertiary color instead of a bare dash, making it clear when a field is intentionally unspecified rather than an error. Also groups detected fields visually at the top of the mapping table, converts emission factor example values to metric tonnes (t CO₂e) for readability, and fixes an S3 PermanentRedirect error that prevented file uploads when the bucket's AWS region did not match the client's default.

## Changes

- Replace "-" placeholder with "Not specified" styled in content.tertiary color across the validation results, mapping columns, and review/confirm steps
- Sort mapping columns so auto-detected fields (interpretedAs !== null) appear first, grouping required fields together visually
- Convert emission factor example values (CO₂, CH₄, N₂O, Total CO₂e) from raw kg units to metric tonnes (t CO₂e) in both the validation results and mapping columns steps
- Add followRegionRedirects: true to the S3 client in InventoryFileStorageService to handle buckets hosted in a region that differs from AWS_FILE_UPLOAD_REGION — previously the SDK threw a PermanentRedirect error instead of following the redirect automatically
- Add "not-specified" i18n key across all 5 supported locales (en, es, fr, de, pt)

## How to test

1. Navigate to /{lng}/cities/{cityId}/GHGI/onboarding/import?inventory={inventoryId}
2. Upload a CSV or Excel inventory file (e.g. a CRF-format file)
3. Validation Results step: columns where no example value or interpretation was detected should show "Not specified" in light grey instead of "-"; emission factor columns (CO₂, CH₄, N₂O, Total CO₂e) should display values in t CO₂e (e.g. 63.1 gCO₂e/MJ → 0.0631 t CO₂e)
4. Mapping Columns step: same "Not specified" and t CO₂e behaviour; detected fields should appear above undetected ones
5. Review & Confirm step: if source file or format cannot be determined, those fields show "Not specified" in tertiary color rather than "-"
6. If AWS_FILE_UPLOAD_S3_BUCKET_ID is set and the bucket lives in a different region than AWS_FILE_UPLOAD_REGION, uploads should succeed rather than failing with a PermanentRedirect error



## Preview

<img width="1303" height="831" alt="Screenshot 2026-07-01 at 10 08 51 PM" src="https://github.com/user-attachments/assets/cfa47544-c139-46b5-9f75-f68c8752f406" />

## Ticket

[ON-5985](https://openearth.atlassian.net/browse/ON-5985?atlOrigin=eyJpIjoiNjJjNWY3OWM4Y2U3NDI3NTliNDlhY2YyNDFjNDliMWUiLCJwIjoiaiJ9)

## Notes

S3 redirect fix detail: the AWS SDK v3 S3 client by default treats a 301 PermanentRedirect response (returned when the bucket's region doesn't match the request endpoint) as a fatal error. Adding followRegionRedirects: true to the client config instructs the SDK to re-issue the request against the correct regional endpoint automatically. This means uploads work correctly even if AWS_FILE_UPLOAD_REGION is unset (defaults to us-east-1) or misconfigured — no change to environment variable setup is required for existing deployments.


[ON-5985]: https://openearth.atlassian.net/browse/ON-5985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ