### PR TITLE
fix(ui): ON-5963 allow inviting users as admin from dashboards

### DIFF
--- a/app/src/components/GHGIHomePage/ActionCards.tsx
+++ b/app/src/components/GHGIHomePage/ActionCards.tsx
@@ -13,6 +13,7 @@ export function ActionCards({
   city,
   inventory,
   inventoryId,
+  organizationId,
   lng,
   t,
 }: {
@@ -21,6 +22,7 @@ export function ActionCards({
   city?: CityAttributes;
   lng: string;
   inventory?: InventoryAttributes;
+  organizationId?: string;
 }) {
   const pathname = usePathname();
 
@@ -82,7 +84,7 @@ export function ActionCards({
         </Card.Root>
       </NextLink>
       <Box display="flex" flexDirection="column" gap="8px">
-        <AddCollaboratorButton lng={lng} />
+        <AddCollaboratorButton lng={lng} organizationId={organizationId} />
         <DownloadButton
           lng={lng}
           inventoryId={inventoryId!}

--- a/app/src/components/GHGIHomePage/AddCollaboratorButton.tsx
+++ b/app/src/components/GHGIHomePage/AddCollaboratorButton.tsx
@@ -5,7 +5,13 @@ import { useDisclosure } from "@chakra-ui/react";
 import { useTranslation } from "@/i18n/client";
 import ActionCardSmall from "./ActionCardSmall";
 
-export function AddCollaboratorButton({ lng }: { lng: string }) {
+export function AddCollaboratorButton({
+  lng,
+  organizationId,
+}: {
+  lng: string;
+  organizationId?: string;
+}) {
   const {
     open: isModalOpen,
     setOpen: setIsModalOpen,
@@ -20,6 +26,7 @@ export function AddCollaboratorButton({ lng }: { lng: string }) {
         isOpen={isModalOpen}
         onClose={onModalClose}
         onOpen={onModalOpen}
+        organizationId={organizationId}
       />
       <ActionCardSmall
         onClick={onModalOpen}

--- a/app/src/components/GHGIHomePage/AddCollaboratorModal/AddCollaboratorsModal.tsx
+++ b/app/src/components/GHGIHomePage/AddCollaboratorModal/AddCollaboratorsModal.tsx
@@ -39,14 +39,12 @@ import { Checkbox } from "@/components/ui/checkbox";
 import {
   SelectContent,
   SelectItem,
-  SelectItemGroup,
   SelectLabel,
   SelectRoot,
   SelectTrigger,
   SelectValueText,
 } from "@/components/ui/select";
 import Callout from "@/components/ui/callout";
-import { toaster } from "@/components/ui/toaster";
 import { OrganizationRole } from "@/util/types";
 import { trackEvent } from "@/lib/analytics";
 
@@ -92,7 +90,6 @@ const AddCollaboratorsDialog = ({
 
   const { data: projectsData, isLoading } = useGetUserProjectsQuery({});
 
-
   const projectCollection = useMemo(() => {
     return createListCollection({
       items:
@@ -102,7 +99,6 @@ const AddCollaboratorsDialog = ({
         })) ?? [],
     });
   }, [projectsData, organizationProjectsData]);
-
 
   const [inviteUsers, { isLoading: isInviteUsersLoading }] =
     useInviteUsersMutation();
@@ -178,10 +174,10 @@ const AddCollaboratorsDialog = ({
       if (inviteResponse.data.inviteUrls) {
         const inviteUrls = Object.values(inviteResponse.data.inviteUrls);
         if (inviteUrls.length > 0) {
-          const urlsText = inviteUrls.join('\n');
+          const urlsText = inviteUrls.join("\n");
           navigator.clipboard.writeText(urlsText).catch(() => {
             // Fallback if clipboard API fails
-            console.warn('Failed to copy to clipboard');
+            console.warn("Failed to copy to clipboard");
           });
         }
       }

--- a/app/src/components/GHGIHomePage/HomePage.tsx
+++ b/app/src/components/GHGIHomePage/HomePage.tsx
@@ -217,7 +217,7 @@ export default function HomePage({
     inventoryIdFromParam!,
   );
 
-  const { isFrozenCheck } = useOrganizationContext();
+  const { isFrozenCheck, organization } = useOrganizationContext();
 
   if (isUserInfoLoading) {
     return <ProgressLoader />;
@@ -266,6 +266,7 @@ export default function HomePage({
                   lng={language}
                   city={city}
                   inventory={inventory}
+                  organizationId={organization.organizationId}
                 />
               )}
             </VStack>

--- a/app/src/components/GHGIHomePage/HomePage.tsx
+++ b/app/src/components/GHGIHomePage/HomePage.tsx
@@ -266,7 +266,7 @@ export default function HomePage({
                   lng={language}
                   city={city}
                   inventory={inventory}
-                  organizationId={organization.organizationId}
+                  organizationId={organization?.organizationId}
                 />
               )}
             </VStack>

--- a/app/src/components/HomePageJN/ActionCards.tsx
+++ b/app/src/components/HomePageJN/ActionCards.tsx
@@ -103,7 +103,10 @@ export function ActionCards({
 
           {/* Invite colleagues card */}
           <GridItem display="flex" alignItems="center" gap={4} minH={0} p={0}>
-            <AddCollaboratorButton lng={lng} />
+            <AddCollaboratorButton
+              lng={lng}
+              organizationId={organization.organizationId}
+            />
           </GridItem>
 
           {/* All projects card */}

--- a/app/src/components/HomePageJN/AddCollaboratorButton.tsx
+++ b/app/src/components/HomePageJN/AddCollaboratorButton.tsx
@@ -5,7 +5,13 @@ import { useTranslation } from "@/i18n/client";
 import ActionCardSmall from "./ActionCardSmall";
 import { AddCollaboratorIcon } from "../icons";
 
-export function AddCollaboratorButton({ lng }: { lng: string }) {
+export function AddCollaboratorButton({
+  lng,
+  organizationId,
+}: {
+  lng: string;
+  organizationId?: string;
+}) {
   const {
     open: isModalOpen,
     setOpen: setIsModalOpen,
@@ -20,6 +26,7 @@ export function AddCollaboratorButton({ lng }: { lng: string }) {
         isOpen={isModalOpen}
         onClose={onModalClose}
         onOpen={onModalOpen}
+        organizationId={organizationId}
       />
       <ActionCardSmall
         onClick={onModalOpen}


### PR DESCRIPTION
## Summary
Allows inviting users as admins from journey navigator and GHGI dashboard pages (previously only worked on admin panel and account settings).

## Changes

- Supply organizationId in usages of `AddCollaboratorsModal` component (included via redundant `AddCollaboratorsButton` components defined separately for GHGI and JN, should be refactored into one component in the future)

## How to test

1. Try to invite a user with the admin role from both the journey navigator dashboard "add collaborators" button as well as the same button on the GHGI module dashboard

## Ticket

https://openearth.atlassian.net/browse/ON-5963