### PR TITLE
Fix/upload inventory improvements

### DIFF
--- a/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/import/page.tsx
+++ b/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/import/page.tsx
@@ -19,6 +19,7 @@ import { logger } from "@/services/logger";
 import type { ImportStatusResponse } from "@/util/types";
 import { usePollUntil } from "@/hooks/usePollUntil";
 import { TFunction } from "i18next";
+import { useAppDispatch } from "@/lib/hooks";
 
 /** If errorLog starts with "i18n:", return t(key); else return errorLog or fallback. */
 function resolveErrorMessage(
@@ -46,9 +47,23 @@ function ImportButton({
   onImport: () => void;
   t: TFunction;
 }) {
+  const dispatch = useAppDispatch();
   const [approveImport, { isLoading: isImporting }] =
     api.useApproveImportMutation();
   const [getImportStatus] = api.useLazyGetImportStatusQuery();
+
+  /** Invalidate inventory-related caches so the GHGI page shows fresh totalEmissions. */
+  const invalidateInventoryCache = () => {
+    dispatch(
+      api.util.invalidateTags([
+        "Inventory",
+        "InventoryProgress",
+        "InventoryValue",
+        "ReportResults",
+        "YearlyReportResults",
+      ]),
+    );
+  };
 
   const makeErrorToast = (title: string, description?: string) => {
     const { showErrorToast } = UseErrorToast({ description, title });
@@ -72,6 +87,7 @@ function ImportButton({
         return { done: false };
       },
       onSuccess: () => {
+        invalidateInventoryCache();
         makeSuccessToast(t("import-completed"), t("import-completed-description"));
         onImport();
       },
@@ -109,6 +125,7 @@ function ImportButton({
       }
 
       if ((result as { importStatus?: string }).importStatus === "completed") {
+        invalidateInventoryCache();
         makeSuccessToast(t("import-completed"), t("import-completed-description"));
         onImport();
         return;

--- a/app/src/app/api/v1/city/[city]/inventory/[inventory]/import/approve/route.ts
+++ b/app/src/app/api/v1/city/[city]/inventory/[inventory]/import/approve/route.ts
@@ -306,23 +306,31 @@ async function runApproveImportInBackground(args: {
           row.activityType?.trim() ||
           row.category?.trim() ||
           undefined;
-        const gpcRefNo =
+        let gpcRefNo =
           row.gpcRefNo?.trim() ||
           resolveGpcRefNo(sector, subsector, activityHint) ||
-          // Fallback: if subsector was split on " > " and the right part
-          // (e.g. "Other/uncategorized") didn't resolve, retry with the
-          // parent (left) subsector name (e.g. "On-road").
-          (() => {
-            const rawSub = row.subsector?.trim() ?? "";
-            if (rawSub.includes(" > ")) {
-              const parentSub = rawSub.split(" > ")[0].trim();
-              if (parentSub && parentSub !== subsector) {
-                return resolveGpcRefNo(sector, parentSub, activityHint);
+          null;
+        // Fallback: if the right side of " > " didn't resolve, try the left side
+        // e.g. "On-road > Other/uncategorized" → split gives subsector="Other/uncategorized" (fails)
+        //       → retry with left part "On-road" (resolves to on-road-transportation)
+        if (!gpcRefNo) {
+          const rawSub = row.subsector?.trim() ?? "";
+          if (rawSub.includes(" > ")) {
+            const leftPart = rawSub.split(" > ")[0].trim();
+            if (leftPart && leftPart !== subsector) {
+              gpcRefNo = resolveGpcRefNo(sector, leftPart, activityHint);
+            }
+          }
+          if (!gpcRefNo) {
+            const rawSec = row.sector?.trim() ?? "";
+            if (rawSec.includes(" > ")) {
+              const leftPart = rawSec.split(" > ")[0].trim();
+              if (leftPart && leftPart !== sector) {
+                gpcRefNo = resolveGpcRefNo(leftPart, subsector, activityHint);
               }
             }
-            return null;
-          })() ||
-          null;
+          }
+        }
 
         if (!gpcRefNo) {
           errors.push(

--- a/app/src/app/api/v1/city/[city]/inventory/[inventory]/import/approve/route.ts
+++ b/app/src/app/api/v1/city/[city]/inventory/[inventory]/import/approve/route.ts
@@ -309,6 +309,19 @@ async function runApproveImportInBackground(args: {
         const gpcRefNo =
           row.gpcRefNo?.trim() ||
           resolveGpcRefNo(sector, subsector, activityHint) ||
+          // Fallback: if subsector was split on " > " and the right part
+          // (e.g. "Other/uncategorized") didn't resolve, retry with the
+          // parent (left) subsector name (e.g. "On-road").
+          (() => {
+            const rawSub = row.subsector?.trim() ?? "";
+            if (rawSub.includes(" > ")) {
+              const parentSub = rawSub.split(" > ")[0].trim();
+              if (parentSub && parentSub !== subsector) {
+                return resolveGpcRefNo(sector, parentSub, activityHint);
+              }
+            }
+            return null;
+          })() ||
           null;
 
         if (!gpcRefNo) {

--- a/app/src/backend/ECRFImportService.ts
+++ b/app/src/backend/ECRFImportService.ts
@@ -137,11 +137,31 @@ export default class ECRFImportService {
           const activityType = activityHeader
             ? row[activityHeader]?.toString().trim()
             : undefined;
-          const resolved = resolveGpcRefNo(
+          let resolved = resolveGpcRefNo(
             rawSector,
             rawSubsector,
             activityType,
           );
+          // Fallback: if the subsector was split on " > " and the right part
+          // (e.g. "Other/uncategorized") didn't resolve, retry with the left
+          // part (e.g. "On-road") which is typically the parent subsector name.
+          if (!resolved) {
+            const originalSubsector = hasSubsectorColumn
+              ? row[headers[detectedColumns.subsector!]]?.toString().trim()
+              : "";
+            if (originalSubsector && originalSubsector.includes(" > ")) {
+              const parentSubsector = originalSubsector
+                .split(" > ")[0]
+                .trim();
+              if (parentSubsector && parentSubsector !== rawSubsector) {
+                resolved = resolveGpcRefNo(
+                  rawSector,
+                  parentSubsector,
+                  activityType,
+                );
+              }
+            }
+          }
           if (resolved) {
             gpcRefNo = resolved;
           } else {

--- a/app/src/backend/ECRFImportService.ts
+++ b/app/src/backend/ECRFImportService.ts
@@ -109,11 +109,16 @@ export default class ECRFImportService {
         let rawSubsector = hasSubsectorColumn
           ? row[headers[detectedColumns.subsector!]]?.toString().trim()
           : "";
+        // Preserve the left parts of " > " splits for fallback resolution
+        // e.g. "On-road > Other/uncategorized" → right = "Other/uncategorized", leftFallback = "On-road"
+        let sectorLeftFallback: string | undefined;
+        let subsectorLeftFallback: string | undefined;
         if (rawSector && rawSector.includes(" > ")) {
           const [left, right] = rawSector
             .split(" > ")
             .map((s: string) => s.trim());
           if (left && right) {
+            sectorLeftFallback = left;
             rawSector = left;
             if (!rawSubsector) rawSubsector = right;
           }
@@ -123,6 +128,7 @@ export default class ECRFImportService {
             .split(" > ")
             .map((s: string) => s.trim());
           if (left && right) {
+            subsectorLeftFallback = left;
             if (!rawSector) rawSector = left;
             rawSubsector = right;
           }
@@ -142,25 +148,21 @@ export default class ECRFImportService {
             rawSubsector,
             activityType,
           );
-          // Fallback: if the subsector was split on " > " and the right part
-          // (e.g. "Other/uncategorized") didn't resolve, retry with the left
-          // part (e.g. "On-road") which is typically the parent subsector name.
-          if (!resolved) {
-            const originalSubsector = hasSubsectorColumn
-              ? row[headers[detectedColumns.subsector!]]?.toString().trim()
-              : "";
-            if (originalSubsector && originalSubsector.includes(" > ")) {
-              const parentSubsector = originalSubsector
-                .split(" > ")[0]
-                .trim();
-              if (parentSubsector && parentSubsector !== rawSubsector) {
-                resolved = resolveGpcRefNo(
-                  rawSector,
-                  parentSubsector,
-                  activityType,
-                );
-              }
-            }
+          // Fallback: if the right side of " > " didn't resolve, try the left side
+          // e.g. "On-road > Other/uncategorized" → "Other/uncategorized" fails → try "On-road"
+          if (!resolved && subsectorLeftFallback) {
+            resolved = resolveGpcRefNo(
+              rawSector,
+              subsectorLeftFallback,
+              activityType,
+            );
+          }
+          if (!resolved && sectorLeftFallback) {
+            resolved = resolveGpcRefNo(
+              sectorLeftFallback,
+              rawSubsector,
+              activityType,
+            );
           }
           if (resolved) {
             gpcRefNo = resolved;

--- a/app/src/backend/FormatAdapterService.ts
+++ b/app/src/backend/FormatAdapterService.ts
@@ -235,13 +235,32 @@ export default class FormatAdapterService {
 
       let gpcRefNo = this.strVal(get(gpcRefIdx));
       const activityType = this.strVal(get(actTypeIdx));
+      const rawSectorVal = this.strVal(get(sectorIdx)) ?? "";
+      const rawSubsectorVal = this.strVal(get(subsectorIdx)) ?? "";
       const { sector, subsector } = splitSectorSubsectorLabels(
-        this.strVal(get(sectorIdx)) ?? "",
-        this.strVal(get(subsectorIdx)) ?? "",
+        rawSectorVal,
+        rawSubsectorVal,
       );
+      // Track which subsector name was actually used for resolution
+      let resolvedSubsector = subsector;
 
       if (!gpcRefNo && sector && subsector) {
         gpcRefNo = resolveGpcRefNo(sector, subsector, activityType ?? undefined);
+        // Fallback: if right side of " > " didn't resolve, try the left side
+        // e.g. "On-road > Other/uncategorized" → "Other/uncategorized" fails → try "On-road"
+        if (!gpcRefNo && rawSubsectorVal.includes(" > ")) {
+          const leftPart = rawSubsectorVal.split(" > ")[0].trim();
+          if (leftPart && leftPart !== subsector) {
+            gpcRefNo = resolveGpcRefNo(sector, leftPart, activityType ?? undefined);
+            if (gpcRefNo) resolvedSubsector = leftPart;
+          }
+        }
+        if (!gpcRefNo && rawSectorVal.includes(" > ")) {
+          const leftPart = rawSectorVal.split(" > ")[0].trim();
+          if (leftPart && leftPart !== sector) {
+            gpcRefNo = resolveGpcRefNo(leftPart, subsector, activityType ?? undefined);
+          }
+        }
       }
 
       const resolvedSector =
@@ -250,9 +269,9 @@ export default class FormatAdapterService {
       rows.push({
         year: targetYear ?? null,
         sector: resolvedSector,
-        subsector: subsector || null,
+        subsector: resolvedSubsector || null,
         scope: this.strVal(get(scopeIdx)),
-        category: subsector || null,
+        category: resolvedSubsector || null,
         totalCO2e,
         co2: this.numVal(get(co2Idx)),
         ch4: this.numVal(get(ch4Idx)),


### PR DESCRIPTION
### Summary
Fixes two issues with the inventory upload flow: (1) total emissions not appearing on the GHGI page until a manual reload after importing, and (2) transport sector rows failing to resolve GPC references when the subsector column contains compound values like "On-road > Other/uncategorized".

### Changes
- Cache invalidation timing: Invalidate RTK Query cache tags (Inventory, InventoryProgress, etc.) when the import polling detects completed status, not just when approveImport fires (before data is written). This ensures useGetInventoryQuery fetches fresh totalEmissions on navigation.
- GPC reference fallback for compound subsectors: When a subsector value like "On-road > Other/uncategorized" is split on " > ", the right side ("Other/uncategorized") may not map to any known GPC reference. The fix preserves the left side and retries resolution with it as a fallback. Applied across all three resolution paths: FormatAdapterService, ECRFImportService, and approve/route.ts.

### How to test
- Upload a CRF-format inventory file (e.g. the Toronto 2015 CRF file) that contains transport sector rows with compound subsectors like "On-road > Other/uncategorized".
- Verify that transport rows are no longer marked as unresolved during validation — they should resolve to GPC ref II.1.1.
Complete the import and confirm you are redirected to the GHGI page with the correct total emissions displayed immediately (no manual page reload needed).

Tickets
- https://openearth.atlassian.net/browse/ON-5978?atlOrigin=eyJpIjoiZjZhMzFmNzRiMjhkNDE3NTgyNWE5YTI2ZDk0OTJmNmEiLCJwIjoiaiJ9
- https://openearth.atlassian.net/browse/ON-5982?atlOrigin=eyJpIjoiNzZhNWUxYzRiZDNkNGNiOGIyYjg0Njk5Y2E4NDZmNGQiLCJwIjoiaiJ9

