### PR TITLE
fix(ON-5952): email error when changing the user role

### DIFF
--- a/app/src/app/api/v1/organizations/[organization]/role/route.ts
+++ b/app/src/app/api/v1/organizations/[organization]/role/route.ts
@@ -58,6 +58,7 @@ export const PATCH = apiHandler(async (req, { params, session }) => {
   const user = await db.models.User.findOne({ where: { email } });
 
   const transaction = await db.sequelize!.transaction();
+  let committed = false;
   try {
     if (user) {
       // Step 1: Promote to OrganizationAdmin
@@ -125,17 +126,22 @@ export const PATCH = apiHandler(async (req, { params, session }) => {
       });
 
       await transaction.commit();
+      committed = true;
 
-      // Send role upgrade email after successful commit
-      await EmailService.sendRoleUpdateNotification({
-        email,
-        brandInformation: {
-          color: org.theme.primaryColor,
-          logoUrl: org.logoUrl as string,
-        },
-        organizationName: org.name as string,
-        user,
-      });
+      // Send role upgrade email after successful commit (non-fatal)
+      try {
+        await EmailService.sendRoleUpdateNotification({
+          email,
+          brandInformation: {
+            color: org.theme.primaryColor,
+            logoUrl: org.logoUrl as string,
+          },
+          organizationName: org.name as string,
+          user,
+        });
+      } catch (emailErr) {
+        logger.error({ err: emailErr, email }, "Failed to send role update notification email (role was updated successfully)");
+      }
 
       return NextResponse.json({ success: true });
     }
@@ -190,7 +196,9 @@ export const PATCH = apiHandler(async (req, { params, session }) => {
     }
 
     await transaction.commit();
+    committed = true;
 
+    // Send invite email after successful commit (non-fatal)
     const emailSent = await EmailService.sendOrganizationInvitationEmail(
       {
         email,
@@ -202,13 +210,15 @@ export const PATCH = apiHandler(async (req, { params, session }) => {
     );
 
     if (!emailSent) {
-      logger.error({ email }, "Failed to send org invite email");
-      throw createHttpError.InternalServerError("email-error");
+      logger.error({ email }, "Failed to send org invite email (invite was created successfully)");
+      return NextResponse.json({ success: true, emailSent: false }, { status: 200 });
     }
 
     return NextResponse.json({ success: true });
   } catch (err) {
-    await transaction.rollback();
+    if (!committed) {
+      await transaction.rollback();
+    }
     logger.error(err, "Transaction failed in PATCH /organization/:id/role");
     throw err;
   }

--- a/app/src/i18n/locales/de/admin.json
+++ b/app/src/i18n/locales/de/admin.json
@@ -142,6 +142,7 @@
   "change-to-admin": "Wechseln zu Admin",
   "user-removed": "Benutzer erfolgreich entfernt",
   "role-update-success-toast-title": "Rolle erfolgreich aktualisiert",
+  "updating-role": "Rolle wird aktualisiert...",
   "frozen": "Eingefroren",
   "already-registered-admin": "{{email}} ist bereits ein registrierter Administrator",
   "error-invite": "Einladungsfehler",

--- a/app/src/i18n/locales/en/admin.json
+++ b/app/src/i18n/locales/en/admin.json
@@ -144,6 +144,7 @@
   "change-to-admin": "Change to admin",
   "user-removed": "User removed successfully",
   "role-update-success-toast-title": "Role updated successfully",
+  "updating-role": "Updating role...",
   "frozen": "Frozen",
   "already-registered-admin": "{{email}} is already a registered admin",
   "error-invite": "Invitation error",

--- a/app/src/i18n/locales/es/admin.json
+++ b/app/src/i18n/locales/es/admin.json
@@ -141,6 +141,7 @@
   "download-error": "Hubo un error durante la descarga",
   "change-to-admin": "Cambiar a administrador",
   "role-update-success-toast-title": "Rol actualizado con éxito",
+  "updating-role": "Actualizando rol...",
   "user-removed": "Usuario eliminado con éxito",
   "frozen": "Congelado",
   "already-registered-admin": "{{email}} ya está registrado como administrador",

--- a/app/src/i18n/locales/fr/admin.json
+++ b/app/src/i18n/locales/fr/admin.json
@@ -142,6 +142,7 @@
   "change-to-admin": "Changer en admin",
   "user-removed": "Utilisateur supprimé avec succès",
   "role-update-success-toast-title": "Rôle mis à jour avec succès",
+  "updating-role": "Mise à jour du rôle...",
   "frozen": "Gelé",
   "already-registered-admin": "{{email}} est déjà un administrateur enregistré",
   "error-invite": "Erreur d'invitation",

--- a/app/src/i18n/locales/pt/admin.json
+++ b/app/src/i18n/locales/pt/admin.json
@@ -143,6 +143,7 @@
   "user-removed": "Usuário removido com sucesso",
   "frozen": "Congelado",
   "role-update-success-toast-title": "Função atualizada com sucesso",
+  "updating-role": "Atualizando função...",
   "already-registered-admin": "{{email}} já está registrado como administrador",
   "error-invite": "Erro de convite",
   "modules": "Módulos",


### PR DESCRIPTION
### Summary
Fixes a 500 error when changing a user's role to organization admin. The PATCH /organizations/{id}/role endpoint crashed with "Transaction cannot be rolled back because it has been finished with state: commit" when email sending failed after the database transaction had already been committed.

### Changes
Track committed state on the transaction and only call rollback() if the transaction is still pending
Wrap post-commit email sends in try/catch so email failures don't crash the request after a successful DB change
Return { success: true, emailSent: false } instead of throwing 500 when the invite email fails (the invite/role was already persisted)
Add missing "updating-role" i18n key to all 5 locale files (en, fr, es, de, pt)

### How to test
Go to Admin → Organization → Team
Promote an existing user to organization admin (or invite a new email)
Verify the role change succeeds and a loading toast shows "Updating role..." (localized)
To reproduce the original bug: temporarily misconfigure SMTP credentials — the role change should still succeed with a logged warning, instead of returning a 500 error
Ticket
ON-5952