### PR TITLE
fix(ON-5958): hide Ask Clima AI button on city onboarding page

### DIFF
--- a/app/src/components/ChatBot/chat-popover.tsx
+++ b/app/src/components/ChatBot/chat-popover.tsx
@@ -116,8 +116,12 @@ export default function ChatPopover({
     "/draft/stationary-energy",
   );
 
+  // Hide the global launcher on the initial city onboarding page (not the GHGI onboarding).
+  // The pathname for the first onboarding is "/<lng>/cities/onboarding" (no cityId).
+  const isCityOnboardingRoute = /^\/[^/]+\/cities\/onboarding(\/|$)/.test(pathname);
+
   // Hide the global launcher where Clima is embedded as the primary workflow.
-  if (pathname.startsWith(`/${lng}/auth`) || isStationaryEnergyAgenticRoute) {
+  if (pathname.startsWith(`/${lng}/auth`) || isStationaryEnergyAgenticRoute || isCityOnboardingRoute) {
     return null;
   }
 


### PR DESCRIPTION
### Summary
Hides the "Ask Clima AI" floating button on the initial city onboarding page (/cities/onboarding/) where the AI assistant is not relevant. The button remains visible on the GHGI onboarding page (/cities/{cityId}/GHGI/onboarding/) and all other pages.

### Changes
- Added a pathname check in chat-popover.tsx that matches /<lng>/cities/onboarding (no cityId) and returns null to hide the button
- Uses a regex pattern to distinguish the initial onboarding route from the GHGI onboarding route which includes a cityId segment

### How to test
- Navigate to the city onboarding page: http://localhost:3000/en/cities/onboarding/?project=<projectId>
- Verify the "Ask Clima AI" button is not visible
- Navigate to the GHGI onboarding page: http://localhost:3000/en/cities/<cityId>/GHGI/onboarding/
- Verify the "Ask Clima AI" button is still visible
- Navigate to any other page (e.g. dashboard) and confirm the button is visible

### Ticket
ON-5958