### PR TITLE
Feat/on 5903 third party data improvements

### DIFF
--- a/app/src/components/GHGI/inventory-pages/add-data-steps-page.tsx
+++ b/app/src/components/GHGI/inventory-pages/add-data-steps-page.tsx
@@ -658,6 +658,11 @@ export default function AddDataSteps() {
     return getSourceSubsectorId(source) === selectedSubsectorId;
   });
 
+  // Check if any data sources were excluded because they only carry notation keys
+  const hasNotationKeySources = dataSources?.some(
+    ({ source }) => source.retrievalMethod === "global_api_notation_key",
+  ) ?? false;
+
   const visibleDataSources = filteredDataSources?.slice(
     0,
     isDataSectionExpanded ? filteredDataSources.length : 6,
@@ -1440,6 +1445,32 @@ export default function AddDataSteps() {
                   as={isDataSectionExpanded ? MdArrowDropUp : MdArrowDropDown}
                 />
               </Button>
+            )}
+            {hasNotationKeySources && dataSources && dataSources.length > 0 && (
+              <HStack
+                gap={2}
+                mt={6}
+                px={4}
+                py={3}
+                bg="background.neutral"
+                borderRadius="md"
+                color="content.tertiary"
+                fontSize="body.md"
+              >
+                <Icon as={MdInfoOutline} boxSize={5} flexShrink={0} />
+                <Text>
+                  {t("notation-key-no-notice")}{" "}
+                  <Link
+                    href={pathname.replace(/\/data\/.*$/, "/manage-sectors")}
+                    target="_blank"
+                    color="content.link"
+                    textDecoration="underline"
+                    fontWeight="medium"
+                  >
+                    {t("manage-missing-sub-sectors")}
+                  </Link>
+                </Text>
+              </HStack>
             )}
           </Card.Body>
         </Card.Root>

--- a/app/src/components/GHGI/inventory-pages/add-data-steps-page.tsx
+++ b/app/src/components/GHGI/inventory-pages/add-data-steps-page.tsx
@@ -320,11 +320,11 @@ export default function AddDataSteps() {
 
   const totalStepCompletion = currentStep
     ? clamp(
-        currentStep.connectedProgress +
-          currentStep.addedProgress +
-          currentStep.reasonNEProgress +
-          currentStep.reasonNOProgress,
-      )
+      currentStep.connectedProgress +
+      currentStep.addedProgress +
+      currentStep.reasonNEProgress +
+      currentStep.reasonNOProgress,
+    )
     : 0;
   const formatPercentage = (percentage: number) =>
     Math.round(percentage * 1000) / 10;
@@ -647,6 +647,11 @@ export default function AddDataSteps() {
   const selectedSubsectorId = selectedSubsector[0];
 
   const filteredDataSources = dataSources?.filter(({ source }) => {
+    // Hide data sources that only contain notation keys (e.g. "NO" = not occurring)
+    // and no actual emissions data
+    if (source.retrievalMethod === "global_api_notation_key") {
+      return false;
+    }
     if (!selectedSubsectorId || selectedSubsectorId === allSubsectorsValue) {
       return true;
     }
@@ -899,7 +904,7 @@ export default function AddDataSteps() {
                         justify="space-between"
                       >
                         {subSector.completedCount > 0 &&
-                        subSector.completedCount < subSector.totalCount ? (
+                          subSector.completedCount < subSector.totalCount ? (
                           <ProgressCircle.Root
                             size="xs"
                             mr={1}
@@ -1100,7 +1105,7 @@ export default function AddDataSteps() {
                                       borderWidth="1px"
                                       borderColor={
                                         isSourceConnected(source) &&
-                                        source.inventoryValues?.length
+                                          source.inventoryValues?.length
                                           ? "interactive.tertiary"
                                           : "border.overlay"
                                       }
@@ -1126,7 +1131,7 @@ export default function AddDataSteps() {
                                               IV: MdOutlineFactory,
                                               V: LuWheat,
                                             }[
-                                              currentStep.referenceNumber
+                                            currentStep.referenceNumber
                                             ] ?? MdOutlineHomeWork
                                           }
                                           boxSize={9}
@@ -1272,13 +1277,13 @@ export default function AddDataSteps() {
                                           color="content.tertiary"
                                           lineClamp={
                                             isSourceConnected(source) &&
-                                            source.inventoryValues?.length
+                                              source.inventoryValues?.length
                                               ? 0
                                               : 4
                                           }
                                           maxHeight={
                                             isSourceConnected(source) &&
-                                            source.inventoryValues?.length
+                                              source.inventoryValues?.length
                                               ? "100px"
                                               : "184px"
                                           }
@@ -1311,7 +1316,7 @@ export default function AddDataSteps() {
                                             {t("see-more-details")}
                                           </Link>
                                           {isSourceConnected(source) &&
-                                          source.inventoryValues?.length ? (
+                                            source.inventoryValues?.length ? (
                                             <Button
                                               variant="outline"
                                               w="full"
@@ -1338,13 +1343,13 @@ export default function AddDataSteps() {
                                                 isFrozenCheck()
                                                   ? null
                                                   : onDisconnectThirdPartyData(
-                                                      source,
-                                                    )
+                                                    source,
+                                                  )
                                               }
                                               loading={
                                                 isDisconnectLoading &&
                                                 source.datasourceId ===
-                                                  disconnectingDataSourceId
+                                                disconnectingDataSourceId
                                               }
                                               onMouseEnter={() =>
                                                 onButtonHover(source)
@@ -1400,7 +1405,7 @@ export default function AddDataSteps() {
                                               loading={
                                                 isConnectDataSourceLoading &&
                                                 source.datasourceId ===
-                                                  connectingDataSourceId
+                                                connectingDataSourceId
                                               }
                                             >
                                               {t("connect-data")}

--- a/app/src/components/GHGI/inventory-pages/add-data-steps-page.tsx
+++ b/app/src/components/GHGI/inventory-pages/add-data-steps-page.tsx
@@ -1092,10 +1092,10 @@ export default function AddDataSteps() {
                           {groupedByScope.map(([scopeName, scopeSources]) => (
                             <Box key={`${subSectorId}-${scopeName}`}>
                               <SimpleGrid
-                                templateColumns={{
-                                  base: "1fr",
-                                  md: "repeat(2, 1fr)",
-                                  lg: "repeat(3, 1fr)",
+                                columns={{
+                                  base: 1,
+                                  md: 2,
+                                  lg: 3,
                                 }}
                                 gap="16px"
                               >

--- a/app/src/i18n/locales/de/data.json
+++ b/app/src/i18n/locales/de/data.json
@@ -30,6 +30,8 @@
   "edit-subsector": "Teilsektor bearbeiten",
   "more-datasets": "Mehr Datensätze anzeigen",
   "less-datasets": "Weniger Datensätze anzeigen",
+  "notation-key-no-notice": "Um die Datenschlüssel \"Nicht aufgetreten\" anzuzeigen, prüfen Sie:",
+  "manage-missing-sub-sectors": "Fehlende Teilsektoren verwalten",
   "add-data-heading": "Fügen Sie manuell Ihre eigenen lokalen Werte hinzu",
   "add-data-details": "Fügen Sie manuell Ihre berechneten Werte für erforderliche Teilsektoren in die Inventur ein.",
   "select-subsector": "Teilsektor auswählen",

--- a/app/src/i18n/locales/en/data.json
+++ b/app/src/i18n/locales/en/data.json
@@ -122,6 +122,8 @@
   "edit-subsector": "Edit subsector",
   "more-datasets": "View more datasets",
   "less-datasets": "View less datasets",
+  "notation-key-no-notice": "To view \"Not Occurring\" data keys, check:",
+  "manage-missing-sub-sectors": "Manage missing sub-sectors",
   "add-data-heading": "Add Data to Your Inventory Data",
   "add-data-details": "These are the subsectors to be completed according to the GPC methodology for the current sector. Select a sub-sector and fill in the information to complete your inventory.",
   "select-subsector": "Select sub-sector",

--- a/app/src/i18n/locales/es/data.json
+++ b/app/src/i18n/locales/es/data.json
@@ -116,6 +116,8 @@
   "edit-subsector": "Editar subsector",
   "more-datasets": "Ver más conjuntos de datos",
   "less-datasets": "Ver menos conjuntos de datos",
+  "notation-key-no-notice": "Para ver las claves de datos \"No Ocurrido\", consulte:",
+  "manage-missing-sub-sectors": "Gestionar subsectores faltantes",
   "add-data-heading": "Añade Datos a Tu Inventario",
   "add-data-details": "Estos son los subsectores que deben ser completados de acuerdo a la metodología GPC para el sector de transporte. Selecciona un subsector y completa la información para completar tu inventario.",
   "select-subsector": "Selecciona subsector",

--- a/app/src/i18n/locales/fr/data.json
+++ b/app/src/i18n/locales/fr/data.json
@@ -119,6 +119,8 @@
   "edit-subsector": "Modifier le sous-secteur",
   "more-datasets": "Voir plus de jeux de données",
   "less-datasets": "Voir moins de jeux de données",
+  "notation-key-no-notice": "Pour voir les clés de données \"Non Survenu\", consultez :",
+  "manage-missing-sub-sectors": "Gérer les sous-secteurs manquants",
   "add-data-heading": "Ajoutez des données à votre inventaire de données",
   "add-data-details": "Ce sont les sous-secteurs à compléter selon la méthodologie GPC pour le secteur des transports. Sélectionnez un sous-secteur et remplissez les informations pour compléter votre inventaire.",
   "select-subsector": "Sélectionnez le sous-secteur",

--- a/app/src/i18n/locales/pt/data.json
+++ b/app/src/i18n/locales/pt/data.json
@@ -117,6 +117,8 @@
   "edit-subsector": "Editar Subsetor",
   "more-datasets": "Ver mais conjuntos de dados",
   "less-datasets": "Ver menos conjuntos de dados",
+  "notation-key-no-notice": "Para visualizar as chaves de dados \"Não Ocorrido\", consulte:",
+  "manage-missing-sub-sectors": "Gerenciar subsetores ausentes",
   "add-data-heading": "Adicionar Dados aos Seus Dados de Inventário",
   "add-data-details": "Estes são os subsetores a serem completados de acordo com a metodologia GPC para o setor de transporte. Selecione um subsetor e preencha as informações para completar seu inventário.",
   "select-subsector": "Selecionar Subsetor",


### PR DESCRIPTION
### Summary
Improves the third-party data source section on the GHGI data steps page by filtering out noise from notation-key-only sources, adding a user-friendly info notice, and fixing the card grid layout.

### Changes
- Hide notation-key-only data source cards: Filter out data sources with retrievalMethod === "global_api_notation_key" (e.g. "NO" = Not Occurring) from the third-party data section — these carry no emissions data and cluttered the UI
- Add info notice for filtered sources: When notation-key sources are hidden, display an ⓘ info banner directing users to the - -- Manage missing sub-sectors page (opens in a new tab) to view those entries
- Fix card grid layout: Replace templateColumns (not recognized by Chakra's SimpleGrid) with the columns prop so data source cards render in a responsive 3-column grid instead of stacking vertically
- i18n: Added notation-key-no-notice and manage-missing-sub-sectors keys to all 5 locale data.json files (en/fr/es/de/pt)

### How to test
- Navigate to any GHGI data step page (e.g. Stationary Energy)
- Click Search for datasets to load third-party data sources
- Verify that data source cards with only notation keys (NO/NE) are not shown
- Verify an info notice appears below the cards: 'To view "Not Occurring" data keys, check: Manage missing sub-sectors'
- Click the Manage missing sub-sectors link and verify it opens in a new tab
- Verify the data source cards are displayed in a 3-column grid (not stacked vertically)

### Ticket
- ON-5903

Notes
The global_api_notation_key retrieval method is used specifically for sources that report notation keys like "NO" (not occurring) or "NE" (not estimated) with no actual emissions values. These are still accessible via the Manage missing sub-sectors page.