### PR TITLE
fix(ui): ON-5920 align GrowthRatesExplanationModal with design

### DIFF
--- a/app/src/components/GHGI/inventory-result/EmissionsForecast/EmissionsForecastCard.tsx
+++ b/app/src/components/GHGI/inventory-result/EmissionsForecast/EmissionsForecastCard.tsx
@@ -44,31 +44,24 @@ export const EmissionsForecastCard = ({
               {t("no-action-emissions-forecast-by-sector")}
             </TitleMedium>
             {" | "}
-            <HStack
+            <TitleMedium
               onClick={() => setIsExplanationModalOpen(true)}
               cursor="pointer"
+              _hover={{ textDecoration: "underline" }}
+              color="content.link"
+              fontWeight="normal"
             >
-              <TitleMedium color="content.link">{t("learn-more")}</TitleMedium>
-              <IconButton
-                padding={0}
-                width={"20px"}
-                height={"20px"}
-                variant="plain"
-                rounded="full"
-                aria-label={"growth-rates-explanation"}
-              >
-                <Icon as={MdInfoOutline} boxSize={5} />
-              </IconButton>
-            </HStack>
+              {t("learn-more")}
+              <Icon as={MdInfoOutline} boxSize={5} ml={2} />
+            </TitleMedium>
           </HStack>
         </CardHeader>
         <CardBody
-          paddingTop="0px"
-          paddingBottom={6}
+          py={6}
           paddingLeft={4}
           paddingRight={0}
           minHeight="600px"
-          width="100%"
+          w="full"
         >
           <EmissionsForecastChart
             forecast={forecast}

--- a/app/src/components/GHGI/inventory-result/EmissionsForecast/GrowthRatesExplanationModal.tsx
+++ b/app/src/components/GHGI/inventory-result/EmissionsForecast/GrowthRatesExplanationModal.tsx
@@ -32,12 +32,12 @@ export function GrowthRatesExplanationModal({
       open={isOpen}
       onOpenChange={onClose}
       placement="center"
-      size={"xl"}
+      size="xl"
     >
       <DialogContent>
         <DialogHeader>
           <HStack>
-            <MdBarChart size={"24px"} fontSize={"24px"} />
+            <MdBarChart size="24px" fontSize="24px" />
             <Text
               color="content.primary"
               fontWeight="bold"
@@ -52,7 +52,7 @@ export function GrowthRatesExplanationModal({
         </DialogHeader>
         <Box divideX="1px" borderColor="border.overlay" borderWidth="1px" />
         <DialogBody>
-          <VStack alignItems={"left"} justifyItems={"end"} p="24px">
+          <VStack alignItems="left" justifyItems="end" p="24px">
             <Text
               color="content.primary"
               fontWeight="bold"
@@ -64,7 +64,7 @@ export function GrowthRatesExplanationModal({
               {t("city-typology-and-clusters")}
             </Text>
             <Text
-              my={"12px"}
+              my="12px"
               color="content.primary"
               lineHeight="24px"
               fontSize="16px"
@@ -74,17 +74,12 @@ export function GrowthRatesExplanationModal({
               {t("city-typology-and-clusters-description")}
             </Text>
           </VStack>
-          <HStack
-            my={"12px"}
-            mx={"24px"}
-            marginTop={"48px"}
-            alignItems={"flex-end"}
-          >
-            <VStack alignItems={"center"} justifyItems={"end"} p="24px">
+          <HStack my="12px" mx="24px" marginTop="48px" alignItems="flex-end">
+            <VStack alignItems="center" justifyItems="end" p="24px">
               <DisplayLarge color="black">{cluster?.id}</DisplayLarge>
-              <LabelLarge textWrap={"nowrap"}>{t("cluster-#")}</LabelLarge>
+              <LabelLarge textWrap="nowrap">{t("cluster-#")}</LabelLarge>
             </VStack>
-            <VStack alignItems={"left"} justifyItems={"end"} p="24px">
+            <VStack alignItems="left" justifyItems="end" p="24px">
               <DisplayLarge
                 fontSize="body.xl"
                 color="content.primary"
@@ -96,7 +91,7 @@ export function GrowthRatesExplanationModal({
               <LabelLarge>{t("description")}</LabelLarge>
             </VStack>
           </HStack>
-          <VStack alignItems={"left"} justifyItems={"end"} p="24px">
+          <VStack alignItems="left" justifyItems="end" p="24px">
             <Text
               color="content.primary"
               fontWeight="bold"
@@ -108,7 +103,7 @@ export function GrowthRatesExplanationModal({
               {t("methodology-and-assumptions")}
             </Text>
             <Text
-              my={"12px"}
+              my="12px"
               color="content.primary"
               lineHeight="24px"
               fontSize="16px"
@@ -119,7 +114,7 @@ export function GrowthRatesExplanationModal({
             </Text>
           </VStack>
           <Box>
-            <Box display="flex" justifySelf={"center"} width="100%" px="24px">
+            <Box display="flex" justifySelf="center" width="100%" px="24px">
               <GrowthRatesExplanationModalTable
                 growthRates={growthRates}
                 t={t}

--- a/app/src/components/GHGI/inventory-result/EmissionsForecast/GrowthRatesExplanationModal.tsx
+++ b/app/src/components/GHGI/inventory-result/EmissionsForecast/GrowthRatesExplanationModal.tsx
@@ -1,4 +1,3 @@
-import { DisplayLarge } from "@/components/package/Texts/Display";
 import { LabelLarge } from "@/components/package/Texts/Label";
 import {
   DialogBody,
@@ -12,6 +11,7 @@ import { Box, HStack, Icon, Text, VStack } from "@chakra-ui/react";
 import { TFunction } from "i18next";
 import { MdBarChart } from "react-icons/md";
 import { GrowthRatesExplanationModalTable } from "./GrowthRatesExplanationModalTable";
+import { BodyLarge, DisplayLarge } from "@/components/package";
 
 export function GrowthRatesExplanationModal({
   t,
@@ -35,10 +35,10 @@ export function GrowthRatesExplanationModal({
       size="xl"
       scrollBehavior="inside"
     >
-      <DialogContent maxHeight="90%">
+      <DialogContent maxHeight="calc(100vh - 56px * 2)">
         <DialogHeader>
           <HStack>
-            <Icon as={MdBarChart} boxSize="24px" color="content.tertiary" />
+            <Icon as={MdBarChart} boxSize="24px" color="interactive.control" />
             <Text
               color="content.primary"
               fontWeight="bold"
@@ -66,7 +66,7 @@ export function GrowthRatesExplanationModal({
             </Text>
             <Text
               my="12px"
-              color="content.primary"
+              color="content.tertiary"
               lineHeight="24px"
               fontSize="16px"
               fontStyle="normal"
@@ -75,20 +75,17 @@ export function GrowthRatesExplanationModal({
               {t("city-typology-and-clusters-description")}
             </Text>
           </VStack>
-          <HStack my="12px" mx="24px" marginTop="48px" alignItems="flex-end">
+          <HStack alignItems="flex-end" color="content.tertiary">
             <VStack alignItems="center" justifyItems="end" p="24px">
-              <DisplayLarge color="black">{cluster?.id}</DisplayLarge>
+              <DisplayLarge color="content.tertiary">
+                {cluster?.id}
+              </DisplayLarge>
               <LabelLarge textWrap="nowrap">{t("cluster-#")}</LabelLarge>
             </VStack>
             <VStack alignItems="left" justifyItems="end" p="24px">
-              <DisplayLarge
-                fontSize="body.xl"
-                color="content.primary"
-                lineHeight="32px"
-                fontWeight="regular"
-              >
+              <BodyLarge fontWeight="regular">
                 {cluster?.description?.[lng]}
-              </DisplayLarge>
+              </BodyLarge>
               <LabelLarge>{t("description")}</LabelLarge>
             </VStack>
           </HStack>
@@ -105,7 +102,7 @@ export function GrowthRatesExplanationModal({
             </Text>
             <Text
               my="12px"
-              color="content.primary"
+              color="content.tertiary"
               lineHeight="24px"
               fontSize="16px"
               fontStyle="normal"
@@ -114,13 +111,8 @@ export function GrowthRatesExplanationModal({
               {t("methodology-and-assumptions-description")}
             </Text>
           </VStack>
-          <Box>
-            <Box display="flex" justifySelf="center" width="100%" px="24px">
-              <GrowthRatesExplanationModalTable
-                growthRates={growthRates}
-                t={t}
-              />
-            </Box>
+          <Box display="flex" justifySelf="center" width="100%" px="24px">
+            <GrowthRatesExplanationModalTable growthRates={growthRates} t={t} />
           </Box>
         </DialogBody>
         <DialogCloseTrigger />

--- a/app/src/components/GHGI/inventory-result/EmissionsForecast/GrowthRatesExplanationModal.tsx
+++ b/app/src/components/GHGI/inventory-result/EmissionsForecast/GrowthRatesExplanationModal.tsx
@@ -8,7 +8,7 @@ import {
   DialogRoot,
 } from "@/components/ui/dialog";
 import { EmissionsForecastData } from "@/util/types";
-import { Box, HStack, Text, VStack } from "@chakra-ui/react";
+import { Box, HStack, Icon, Text, VStack } from "@chakra-ui/react";
 import { TFunction } from "i18next";
 import { MdBarChart } from "react-icons/md";
 import { GrowthRatesExplanationModalTable } from "./GrowthRatesExplanationModalTable";
@@ -38,7 +38,7 @@ export function GrowthRatesExplanationModal({
       <DialogContent maxHeight="90%">
         <DialogHeader>
           <HStack>
-            <MdBarChart size="24px" fontSize="24px" />
+            <Icon as={MdBarChart} boxSize="24px" color="content.tertiary" />
             <Text
               color="content.primary"
               fontWeight="bold"

--- a/app/src/components/GHGI/inventory-result/EmissionsForecast/GrowthRatesExplanationModal.tsx
+++ b/app/src/components/GHGI/inventory-result/EmissionsForecast/GrowthRatesExplanationModal.tsx
@@ -37,7 +37,7 @@ export function GrowthRatesExplanationModal({
     >
       <DialogContent maxHeight="calc(100vh - 56px * 2)">
         <DialogHeader>
-          <HStack>
+          <HStack ml="24px">
             <Icon as={MdBarChart} boxSize="24px" color="interactive.control" />
             <Text
               color="content.primary"

--- a/app/src/components/GHGI/inventory-result/EmissionsForecast/GrowthRatesExplanationModal.tsx
+++ b/app/src/components/GHGI/inventory-result/EmissionsForecast/GrowthRatesExplanationModal.tsx
@@ -33,8 +33,9 @@ export function GrowthRatesExplanationModal({
       onOpenChange={onClose}
       placement="center"
       size="xl"
+      scrollBehavior="inside"
     >
-      <DialogContent>
+      <DialogContent maxHeight="90%">
         <DialogHeader>
           <HStack>
             <MdBarChart size="24px" fontSize="24px" />


### PR DESCRIPTION
## Summary

- changes font sizes, font and icon colors, paddings/ margins to align with design
- adds max size to dialog and allows it to scroll

<img width="1541" height="853" alt="image" src="https://github.com/user-attachments/assets/4360960c-7867-4037-af71-1a856c7753c5" />

## How to test

- Go to emissions and look at sector emissions forecast (might be only available for Brazil cities?)
- Click on "learn more" above the diagram
- Verify modal aligns with the design specifications

## Ticket

https://openearth.atlassian.net/browse/ON-5977
