### PR TITLE
fix: update history tab Source and Total Emissions column styling

### DIFF
--- a/app/src/components/GHGI/inventory-versions/VersionEntry.tsx
+++ b/app/src/components/GHGI/inventory-versions/VersionEntry.tsx
@@ -30,8 +30,6 @@ function toEmissionsString(totalEmissions: number, format?: string): string {
   return `${value} ${unit}CO2e`;
 }
 
-// check if total emissions value was increased or decreased
-// returns 1 if increased, 0 if there was no change and -1 if decreased
 function getChangeSign(entry: VersionHistoryEntry): number {
   const previousVersion = entry.version.previousVersion;
   const co2eq = entry.version.data?.co2eq;
@@ -52,6 +50,7 @@ function getChangeSign(entry: VersionHistoryEntry): number {
 
   return co2eq < previousCo2eq ? 1 : -1;
 }
+
 
 function renderChangeText(
   t: TFunction,
@@ -422,19 +421,9 @@ export default function VersionEntry({
                       : change.totalEmissionsChangeSign === -1
                         ? "sentiment.negativeOverlay"
                         : undefined;
-                  const totalColor =
-                    change.totalEmissionsChangeSign === 1
-                      ? "sentiment.positiveDefault"
-                      : change.totalEmissionsChangeSign === -1
-                        ? "sentiment.negativeDefault"
-                        : undefined;
                   const sourceBgColor =
                     change.source != change.previousSource
                       ? "sentiment.warningOverlay"
-                      : undefined;
-                  const sourceColor =
-                    change.source != change.previousSource
-                      ? "sentiment.warningDefault"
                       : undefined;
 
                   return (
@@ -442,14 +431,20 @@ export default function VersionEntry({
                       {moduleName === "ghgi" && (
                         <>
                           <Table.Cell>{change.subCategory}</Table.Cell>
-                          <Table.Cell bgColor={totalBgColor} color={totalColor}>
+                          <Table.Cell bgColor={totalBgColor}>
                             {change.totalEmissions}
                           </Table.Cell>
                           <Table.Cell
                             bgColor={sourceBgColor}
-                            color={sourceColor}
+                            color={
+                              change.source === "-"
+                                ? "content.tertiary"
+                                : undefined
+                            }
                           >
-                            {change.source}
+                            {change.source === "-"
+                              ? t("not-specified")
+                              : change.source}
                           </Table.Cell>
                         </>
                       )}

--- a/app/src/i18n/locales/de/dashboard.json
+++ b/app/src/i18n/locales/de/dashboard.json
@@ -289,6 +289,7 @@
   "last-modified-by": "Zuletzt geändert von",
   "date": "Datum",
   "no-history": "Keine Versionverlaufseinträge gefunden.",
+  "not-specified": "Nicht angegeben",
   "subcategory": "Unterkategorie",
   "inventory-versions-restore-failed": "Fehler beim Wiederherstellen der Version",
   "status-poc": "Proof of Concept",

--- a/app/src/i18n/locales/en/dashboard.json
+++ b/app/src/i18n/locales/en/dashboard.json
@@ -301,6 +301,7 @@
   "last-modified-by": "Last modified by",
   "date": "Date",
   "no-history": "No version history entries found.",
+  "not-specified": "Not specified",
   "subcategory": "Sub-category",
   "inventory-versions-restore-failed": "Failed to restore version",
   "legend": "Legend",

--- a/app/src/i18n/locales/es/dashboard.json
+++ b/app/src/i18n/locales/es/dashboard.json
@@ -292,6 +292,7 @@
   "last-modified-by": "Última modificación realizada por",
   "date": "Fecha",
   "no-history": "No se encontraron entradas en el historial de versiones.",
+  "not-specified": "No especificado",
   "subcategory": "Subcategoría",
   "inventory-versions-restore-failed": "Fallo al restaurar la versión",
   "status-poc": "Prueba de Concepto",

--- a/app/src/i18n/locales/fr/dashboard.json
+++ b/app/src/i18n/locales/fr/dashboard.json
@@ -289,6 +289,7 @@
   "last-modified-by": "Dernière modification par",
   "date": "Date",
   "no-history": "Aucune entrée d'historique de version trouvée.",
+  "not-specified": "Non spécifié",
   "subcategory": "Sous-catégorie",
   "inventory-versions-restore-failed": "Échec de la restauration de la version",
   "status-poc": "Preuve de Concept",

--- a/app/src/i18n/locales/pt/dashboard.json
+++ b/app/src/i18n/locales/pt/dashboard.json
@@ -290,6 +290,7 @@
   "last-modified-by": "Última modificação feita por",
   "date": "Data",
   "no-history": "Nenhuma entrada de histórico de versões encontrada.",
+  "not-specified": "Não especificado",
   "subcategory": "Sub-categoria",
   "inventory-versions-restore-failed": "Falha ao restaurar a versão",
   "status-poc": "Prova de Conceito",


### PR DESCRIPTION
Summary
Update styling and content for the Total Emissions and Source columns in the GHGI inventory version history tab.

## Changes

- Replace "-" placeholder in the Source column with "Not specified" rendered in tertiary color when no data source is linked
- Remove sentiment text colors (red/green) from the Total Emissions column — background highlight is preserved, text uses primary color
- Remove sentiment text color (yellow) from the Source column — background highlight is preserved, text uses primary color
- Remove unused getChangeSign function and totalEmissionsChangeSign field now that text coloring is dropped
- Add not-specified i18n key to all 5 locales (en, pt, es, fr, de)

## How to test

1. Open an inventory that has version history entries.
2. Navigate to the History tab and expand a version entry.
3. Verify the Total Emissions column shows values in primary text color, with a green/red background only when emissions changed.
4. Verify the Source column shows values in primary text color, with a yellow background only when the source changed between versions.
5. Verify that rows with no linked data source display "Not specified" in tertiary color instead of "-".
6. Repeat steps 3–5 in pt, es, fr, and de locales to confirm translations render correctly.

## Ticket

[ON-5975](https://openearth.atlassian.net/browse/ON-5975)

## Notes

No API or data model changes — frontend display only.

[ON-5975]: https://openearth.atlassian.net/browse/ON-5975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ