### PR TITLE
fix: block inventory import when inventory already contains data

### DIFF
--- a/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/import/page.tsx
+++ b/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/import/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useTranslation } from "@/i18n/client";
-import { MdArrowBack, MdArrowForward } from "react-icons/md";
-import { Box, Icon, Text, useSteps } from "@chakra-ui/react";
+import { MdArrowBack, MdArrowForward, MdWarning } from "react-icons/md";
+import { Box, HStack, Icon, Text, useSteps } from "@chakra-ui/react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import React, { use, useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
@@ -246,6 +246,18 @@ export default function ImportPage(props: {
   const { data: inventory } = api.useGetInventoryQuery(inventoryId ?? "", {
     skip: !inventoryId,
   });
+  const { data: inventoryProgress } = api.useGetInventoryProgressQuery(
+    inventoryId ?? "",
+    { skip: !inventoryId },
+  );
+
+  // Check if the inventory already contains data (any InventoryValue records)
+  const inventoryHasData = useMemo(() => {
+    if (!inventoryProgress?.totalProgress) return false;
+    const { thirdParty, uploaded, reasonNE, reasonNO } =
+      inventoryProgress.totalProgress;
+    return thirdParty + uploaded + reasonNE + reasonNO > 0;
+  }, [inventoryProgress]);
 
   const canContinueMapping = useMemo(() => {
     const cols = mappingStepData?.columnMappings?.columns ?? [];
@@ -661,11 +673,35 @@ export default function ImportPage(props: {
                   transition={{ duration: 0.2, ease: "easeInOut" }}
                 >
                   <Box w="full" display="flex" flexDirection="column" gap="24px">
+                    {inventoryHasData && (
+                      <HStack
+                        gap={3}
+                        px={4}
+                        py={3}
+                        bg="orange.50"
+                        border="1px solid"
+                        borderColor="orange.200"
+                        borderRadius="md"
+                        align="flex-start"
+                      >
+                        <Icon as={MdWarning} boxSize={5} color="orange.500" mt="2px" />
+                        <Box>
+                          <Text fontWeight="semibold" color="orange.800" fontSize="sm">
+                            {t("inventory-already-has-data-title")}
+                          </Text>
+                          <Text color="orange.700" fontSize="sm" mt={1}>
+                            {t("inventory-already-has-data-description", {
+                              year: inventoryYear,
+                            })}
+                          </Text>
+                        </Box>
+                      </HStack>
+                    )}
                     <UploadFileStep
                       t={t}
                       cityName={inventory?.city?.name}
                       uploadedFile={uploadedFile}
-                      onFileUpload={handleFileUpload}
+                      onFileUpload={inventoryHasData ? () => {} : handleFileUpload}
                       onRemoveFile={handleRemoveFile}
                       isUploading={isUploadingFile || isUploadPolling}
                     />
@@ -851,6 +887,7 @@ export default function ImportPage(props: {
                   }
                   h="64px"
                   disabled={
+                    inventoryHasData ||
                     !uploadedFile ||
                     !importedFileId ||
                     (pdfPendingExtraction && (isExtracting || isExtractInProgress)) ||

--- a/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/setup/page.tsx
+++ b/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/setup/page.tsx
@@ -438,7 +438,6 @@ export default function OnboardingSetup(props: {
                   onClick={handleSubmit(onSubmit)}
                   h="64px"
                   type="submit"
-                  disabled={yearAlreadyExists}
                 >
                   <Text
                     fontFamily="button.md"

--- a/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/setup/page.tsx
+++ b/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/setup/page.tsx
@@ -15,7 +15,7 @@ import { MdArrowBack, MdArrowForward } from "react-icons/md";
 import { Box, Icon, Text, useSteps } from "@chakra-ui/react";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import React, { use, useEffect, useState } from "react";
+import React, { use, useEffect, useMemo, useState } from "react";
 import type { SubmitHandler } from "react-hook-form";
 import { useForm } from "react-hook-form";
 import SetInventoryDetailsStep from "@/components/steps/GHGI/set-inventory-details-step";
@@ -141,6 +141,12 @@ export default function OnboardingSetup(props: {
   });
   const { data: userInfo } = api.useGetUserInfoQuery();
 
+  // Fetch existing inventories for this city to check for duplicate years
+  const { data: existingInventories } = api.useGetInventoriesQuery(
+    { cityId },
+    { skip: !cityId },
+  );
+
   useEffect(() => {
     if (CCCityData) {
       setOcCityData({
@@ -161,6 +167,14 @@ export default function OnboardingSetup(props: {
     selectedGlobalWarmingPotentialValue,
     setSelectedGlobalWarmingPotentialValue,
   ] = useState("");
+
+  // Check if the selected year already has an inventory
+  const selectedYear =
+    selectedYearArray.length > 0 ? parseInt(selectedYearArray[0], 10) : null;
+  const yearAlreadyExists = useMemo(() => {
+    if (!selectedYear || !existingInventories) return false;
+    return existingInventories.some((inv) => inv.year === selectedYear);
+  }, [selectedYear, existingInventories]);
   const [thirdPartyDataChoice, setThirdPartyDataChoice] = useState<
     string | null
   >(null);
@@ -169,6 +183,16 @@ export default function OnboardingSetup(props: {
     const { showErrorToast } = UseErrorToast({ description, title });
     showErrorToast();
   };
+
+  // Show error toast when user selects a year that already has an inventory
+  useEffect(() => {
+    if (yearAlreadyExists && selectedYear) {
+      makeErrorToast(
+        t("inventory-year-already-exists-title"),
+        t("inventory-year-already-exists-description", { year: selectedYear }),
+      );
+    }
+  }, [yearAlreadyExists, selectedYear]);
 
   // Population data
 
@@ -414,6 +438,7 @@ export default function OnboardingSetup(props: {
                   onClick={handleSubmit(onSubmit)}
                   h="64px"
                   type="submit"
+                  disabled={yearAlreadyExists}
                 >
                   <Text
                     fontFamily="button.md"

--- a/app/src/app/[lng]/cities/onboarding/setup/page.tsx
+++ b/app/src/app/[lng]/cities/onboarding/setup/page.tsx
@@ -16,7 +16,7 @@ import { MdArrowBack, MdArrowForward } from "react-icons/md";
 import { Box, Icon, Text, useSteps } from "@chakra-ui/react";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import React, { use, useEffect, useState } from "react";
+import React, { use, useEffect, useMemo, useState } from "react";
 import type {
   Control,
   FieldErrors,
@@ -139,6 +139,30 @@ export default function OnboardingSetup(props: {
     const { showErrorToast } = UseErrorToast({ description, title });
     showErrorToast();
   };
+
+  // Fetch existing inventories for the created city to check for duplicate years
+  const { data: existingInventories } = api.useGetInventoriesQuery(
+    { cityId: createdCityId! },
+    { skip: !createdCityId },
+  );
+
+  // Check if the selected year already has an inventory
+  const selectedYear =
+    selectedYearArray.length > 0 ? parseInt(selectedYearArray[0], 10) : null;
+  const yearAlreadyExists = useMemo(() => {
+    if (!selectedYear || !existingInventories) return false;
+    return existingInventories.some((inv) => inv.year === selectedYear);
+  }, [selectedYear, existingInventories]);
+
+  // Show error toast when user selects a year that already has an inventory
+  useEffect(() => {
+    if (yearAlreadyExists && selectedYear) {
+      makeErrorToast(
+        t("inventory-year-already-exists-title"),
+        t("inventory-year-already-exists-description", { year: selectedYear }),
+      );
+    }
+  }, [yearAlreadyExists, selectedYear]);
 
   const makeWarningToast = (title: string, description?: string) => {
     const { showWarningToast } = UseWarningToast({ description, title });
@@ -464,7 +488,7 @@ export default function OnboardingSetup(props: {
                     disabled={
                       isCreatingCity ||
                       (activeStep === 0 && !ocCityData) ||
-                      (activeStep === 1 && !isInventoryDetailsValid) ||
+                      (activeStep === 1 && (!isInventoryDetailsValid || yearAlreadyExists)) ||
                       (activeStep === 2 && !isPopulationValid)
                     }
                   >

--- a/app/src/app/[lng]/cities/onboarding/setup/page.tsx
+++ b/app/src/app/[lng]/cities/onboarding/setup/page.tsx
@@ -488,7 +488,7 @@ export default function OnboardingSetup(props: {
                     disabled={
                       isCreatingCity ||
                       (activeStep === 0 && !ocCityData) ||
-                      (activeStep === 1 && (!isInventoryDetailsValid || yearAlreadyExists)) ||
+                      (activeStep === 1 && !isInventoryDetailsValid) ||
                       (activeStep === 2 && !isPopulationValid)
                     }
                   >

--- a/app/src/app/api/v1/city/[city]/inventory/[inventory]/import/approve/route.ts
+++ b/app/src/app/api/v1/city/[city]/inventory/[inventory]/import/approve/route.ts
@@ -597,6 +597,17 @@ export const POST = apiHandler(
       );
     }
 
+    // Check if this inventory already contains data (InventoryValue records)
+    // to prevent duplicate imports
+    const existingValueCount = await db.models.InventoryValue.count({
+      where: { inventoryId },
+    });
+    if (existingValueCount > 0) {
+      throw new createHttpError.Conflict(
+        "This inventory already contains data. Clear existing data before importing again.",
+      );
+    }
+
     // Update mapping configuration if overrides provided
     let mappingConfiguration = importedFile.mappingConfiguration || {};
     if (mappingOverrides) {

--- a/app/src/i18n/locales/de/onboarding.json
+++ b/app/src/i18n/locales/de/onboarding.json
@@ -53,6 +53,8 @@
   "inventory-not-found-for-target-year": "Inventar für das Zieljahr nicht gefunden",
   "file-year-mismatch-title": "Dateijahr stimmt nicht mit Inventar überein",
   "file-year-mismatch": "Das Datenjahr der Datei stimmt nicht mit dem Zieljahr des Inventars überein. Bitte laden Sie eine Datei mit Daten für {{year}} hoch.",
+  "inventory-already-has-data-title": "Inventar enthält bereits Daten",
+  "inventory-already-has-data-description": "Dieses Inventar für {{year}} enthält bereits Daten. Ein erneuter Import kann zu doppelten Einträgen führen. Bitte löschen Sie zuerst die vorhandenen Daten oder verwenden Sie ein anderes Inventar.",
   "import-completed": "Import abgeschlossen",
   "import-completed-description": "Ihre Inventardaten wurden erfolgreich importiert.",
   "extracting-chunk-progress": "Extraktion läuft... (Teil {{current}} von {{total}})",

--- a/app/src/i18n/locales/de/onboarding.json
+++ b/app/src/i18n/locales/de/onboarding.json
@@ -55,6 +55,8 @@
   "file-year-mismatch": "Das Datenjahr der Datei stimmt nicht mit dem Zieljahr des Inventars überein. Bitte laden Sie eine Datei mit Daten für {{year}} hoch.",
   "inventory-already-has-data-title": "Inventar enthält bereits Daten",
   "inventory-already-has-data-description": "Dieses Inventar für {{year}} enthält bereits Daten. Ein erneuter Import kann zu doppelten Einträgen führen. Bitte löschen Sie zuerst die vorhandenen Daten oder verwenden Sie ein anderes Inventar.",
+  "inventory-year-already-exists-title": "Ein Inventar für dieses Jahr existiert bereits",
+  "inventory-year-already-exists-description": "Ein Inventar für {{year}} existiert bereits für diese Stadt. Bitte wählen Sie ein anderes Jahr.",
   "import-completed": "Import abgeschlossen",
   "import-completed-description": "Ihre Inventardaten wurden erfolgreich importiert.",
   "extracting-chunk-progress": "Extraktion läuft... (Teil {{current}} von {{total}})",

--- a/app/src/i18n/locales/en/onboarding.json
+++ b/app/src/i18n/locales/en/onboarding.json
@@ -19,6 +19,8 @@
   "inventory-not-found-for-target-year": "Inventory not found for the target year",
   "file-year-mismatch-title": "File year does not match inventory",
   "file-year-mismatch": "The file's data year does not match the inventory target year. Please upload a file with data for {{year}}.",
+  "inventory-already-has-data-title": "Inventory already contains data",
+  "inventory-already-has-data-description": "This inventory for {{year}} already contains data. Importing again may cause duplicate entries. Please clear existing data first or use a different inventory.",
   "import-completed": "Import completed",
   "import-completed-description": "Your inventory data has been imported successfully.",
   "extracting-chunk-progress": "Extracting... (chunk {{current}} of {{total}})",

--- a/app/src/i18n/locales/en/onboarding.json
+++ b/app/src/i18n/locales/en/onboarding.json
@@ -21,6 +21,8 @@
   "file-year-mismatch": "The file's data year does not match the inventory target year. Please upload a file with data for {{year}}.",
   "inventory-already-has-data-title": "Inventory already contains data",
   "inventory-already-has-data-description": "This inventory for {{year}} already contains data. Importing again may cause duplicate entries. Please clear existing data first or use a different inventory.",
+  "inventory-year-already-exists-title": "An inventory for this year already exists",
+  "inventory-year-already-exists-description": "An inventory for {{year}} already exists for this city. Please select a different year.",
   "import-completed": "Import completed",
   "import-completed-description": "Your inventory data has been imported successfully.",
   "extracting-chunk-progress": "Extracting... (chunk {{current}} of {{total}})",

--- a/app/src/i18n/locales/es/onboarding.json
+++ b/app/src/i18n/locales/es/onboarding.json
@@ -53,6 +53,8 @@
   "inventory-not-found-for-target-year": "Inventario no encontrado para el año objetivo",
   "file-year-mismatch-title": "El año del archivo no coincide con el inventario",
   "file-year-mismatch": "El año de los datos del archivo no coincide con el año objetivo del inventario. Suba un archivo con datos de {{year}}.",
+  "inventory-already-has-data-title": "El inventario ya contiene datos",
+  "inventory-already-has-data-description": "Este inventario para {{year}} ya contiene datos. Importar de nuevo puede causar entradas duplicadas. Elimine los datos existentes primero o use un inventario diferente.",
   "import-completed": "Importación completada",
   "import-completed-description": "Los datos de su inventario se han importado correctamente.",
   "extracting-chunk-progress": "Extrayendo... (parte {{current}} de {{total}})",

--- a/app/src/i18n/locales/es/onboarding.json
+++ b/app/src/i18n/locales/es/onboarding.json
@@ -55,6 +55,8 @@
   "file-year-mismatch": "El año de los datos del archivo no coincide con el año objetivo del inventario. Suba un archivo con datos de {{year}}.",
   "inventory-already-has-data-title": "El inventario ya contiene datos",
   "inventory-already-has-data-description": "Este inventario para {{year}} ya contiene datos. Importar de nuevo puede causar entradas duplicadas. Elimine los datos existentes primero o use un inventario diferente.",
+  "inventory-year-already-exists-title": "Ya existe un inventario para este año",
+  "inventory-year-already-exists-description": "Ya existe un inventario para {{year}} en esta ciudad. Seleccione un año diferente.",
   "import-completed": "Importación completada",
   "import-completed-description": "Los datos de su inventario se han importado correctamente.",
   "extracting-chunk-progress": "Extrayendo... (parte {{current}} de {{total}})",

--- a/app/src/i18n/locales/fr/onboarding.json
+++ b/app/src/i18n/locales/fr/onboarding.json
@@ -17,6 +17,8 @@
   "inventory-not-found-for-target-year": "Inventaire introuvable pour l'année cible",
   "file-year-mismatch-title": "L'année du fichier ne correspond pas à l'inventaire",
   "file-year-mismatch": "L'année des données du fichier ne correspond pas à l'année cible de l'inventaire. Veuillez télécharger un fichier avec des données pour {{year}}.",
+  "inventory-already-has-data-title": "L'inventaire contient déjà des données",
+  "inventory-already-has-data-description": "Cet inventaire pour {{year}} contient déjà des données. Importer à nouveau peut entraîner des doublons. Veuillez d'abord supprimer les données existantes ou utiliser un autre inventaire.",
   "import-completed": "Importation terminée",
   "import-completed-description": "Les données de votre inventaire ont été importées avec succès.",
   "extracting-chunk-progress": "Extraction en cours... (partie {{current}} sur {{total}})",

--- a/app/src/i18n/locales/fr/onboarding.json
+++ b/app/src/i18n/locales/fr/onboarding.json
@@ -19,6 +19,8 @@
   "file-year-mismatch": "L'année des données du fichier ne correspond pas à l'année cible de l'inventaire. Veuillez télécharger un fichier avec des données pour {{year}}.",
   "inventory-already-has-data-title": "L'inventaire contient déjà des données",
   "inventory-already-has-data-description": "Cet inventaire pour {{year}} contient déjà des données. Importer à nouveau peut entraîner des doublons. Veuillez d'abord supprimer les données existantes ou utiliser un autre inventaire.",
+  "inventory-year-already-exists-title": "Un inventaire pour cette année existe déjà",
+  "inventory-year-already-exists-description": "Un inventaire pour {{year}} existe déjà pour cette ville. Veuillez sélectionner une autre année.",
   "import-completed": "Importation terminée",
   "import-completed-description": "Les données de votre inventaire ont été importées avec succès.",
   "extracting-chunk-progress": "Extraction en cours... (partie {{current}} sur {{total}})",

--- a/app/src/i18n/locales/pt/onboarding.json
+++ b/app/src/i18n/locales/pt/onboarding.json
@@ -54,6 +54,8 @@
   "file-year-mismatch": "O ano dos dados do arquivo não corresponde ao ano-alvo do inventário. Envie um arquivo com dados de {{year}}.",
   "inventory-already-has-data-title": "O inventário já contém dados",
   "inventory-already-has-data-description": "Este inventário para {{year}} já contém dados. Importar novamente pode causar entradas duplicadas. Limpe os dados existentes primeiro ou use um inventário diferente.",
+  "inventory-year-already-exists-title": "Já existe um inventário para este ano",
+  "inventory-year-already-exists-description": "Já existe um inventário para {{year}} nesta cidade. Selecione um ano diferente.",
   "import-completed": "Importação concluída",
   "import-completed-description": "Os dados do seu inventário foram importados com sucesso.",
   "extracting-chunk-progress": "Extraindo... (parte {{current}} de {{total}})",

--- a/app/src/i18n/locales/pt/onboarding.json
+++ b/app/src/i18n/locales/pt/onboarding.json
@@ -52,6 +52,8 @@
   "inventory-not-found-for-target-year": "Inventário não encontrado para o ano-alvo",
   "file-year-mismatch-title": "O ano do arquivo não corresponde ao inventário",
   "file-year-mismatch": "O ano dos dados do arquivo não corresponde ao ano-alvo do inventário. Envie um arquivo com dados de {{year}}.",
+  "inventory-already-has-data-title": "O inventário já contém dados",
+  "inventory-already-has-data-description": "Este inventário para {{year}} já contém dados. Importar novamente pode causar entradas duplicadas. Limpe os dados existentes primeiro ou use um inventário diferente.",
   "import-completed": "Importação concluída",
   "import-completed-description": "Os dados do seu inventário foram importados com sucesso.",
   "extracting-chunk-progress": "Extraindo... (parte {{current}} de {{total}})",


### PR DESCRIPTION
### Summary
Prevents duplicate inventory imports by blocking the upload wizard when the current inventory already contains data (InventoryValue records), with both a frontend warning banner and a backend safety net.

### Changes
- Frontend (import page): Query getInventoryProgress to detect existing InventoryValue records. When data exists (thirdParty + uploaded + reasonNE + reasonNO > 0), show an orange warning banner on the upload step, disable file upload, and disable the Continue button

- Backend (approve route): Count InventoryValue records for the inventory before approving import. Return 409 Conflict if any records exist, preventing duplicate imports even if the frontend is bypassed
- i18n: Added inventory-already-has-data-title and inventory-already-has-data-description keys to all 5 locale onboarding.json files (en/fr/es/de/pt)
- 
### How to test
Navigate to the import wizard for an inventory that already has data (e.g. connected third-party sources or uploaded values)