### PR TITLE
ON-6002: Add legal evidence details to prioritizer response

### DIFF
--- a/hiap-meed/.gitignore
+++ b/hiap-meed/.gitignore
@@ -18,3 +18,6 @@ logs/
 
 # Implementation plan
 implementation-plan.md
+
+# Legal SSG data
+data/4_legal/legal-classification-v2.csv

--- a/hiap-meed/README.md
+++ b/hiap-meed/README.md
@@ -566,8 +566,21 @@ Example response:
             "feasibility": {
               "feasibility_score": 0.59,
               "legal": {
+                "assessment_present": true,
+                "verdict_category": "conditional",
                 "component_score": 0.5,
-                "component_source": "neutral_fallback"
+                "component_source": "verdict_score",
+                "ownership_category": "enabled",
+                "ownership_score": 1.0,
+                "ownership_description": "Municipality has explicit legal authority to act directly.",
+                "ownership_description_es": "El municipio cuenta con competencia legal expresa para actuar de forma directa.",
+                "restrictions_category": "conditional",
+                "restrictions_score": 0.5,
+                "restrictions_description": "Moderate legal risk; may require prior authorization or face potential legal challenge.",
+                "restrictions_description_es": "Riesgo juridico moderado; puede requerir autorizacion previa o enfrentar un eventual desafio judicial.",
+                "legal_justification": "Texto de razonamiento juridico en espanol desde la fuente de clasificacion legal.",
+                "legal_justification_en": "English legal reasoning text from the legal classification source.",
+                "references": ["Ley 18.695 (LOCM) - BCN"]
               },
               "mitigation_feasibility": {
                 "component_score": 0.78,

--- a/hiap-meed/README.md
+++ b/hiap-meed/README.md
@@ -580,7 +580,7 @@ Example response:
                 "restrictions_description_es": "Riesgo juridico moderado; puede requerir autorizacion previa o enfrentar un eventual desafio judicial.",
                 "legal_justification": "Texto de razonamiento juridico en espanol desde la fuente de clasificacion legal.",
                 "legal_justification_en": "English legal reasoning text from the legal classification source.",
-                "references": ["Ley 18.695 (LOCM) - BCN"]
+                "legal_references": ["Ley 18.695 (LOCM) - BCN"]
               },
               "mitigation_feasibility": {
                 "component_score": 0.78,

--- a/hiap-meed/app/modules/prioritizer/blocks/feasibility.py
+++ b/hiap-meed/app/modules/prioritizer/blocks/feasibility.py
@@ -203,11 +203,38 @@ def run(
             "ownership_score": (
                 assessment.ownership_score if assessment is not None else None
             ),
+            "ownership_description": (
+                assessment.ownership_description if assessment is not None else None
+            ),
+            "ownership_description_es": (
+                assessment.ownership_description_i18n.get("es")
+                if assessment is not None
+                else None
+            ),
             "restrictions_category": (
                 assessment.restrictions_category if assessment is not None else None
             ),
             "restrictions_score": (
                 assessment.restrictions_score if assessment is not None else None
+            ),
+            "restrictions_description": (
+                assessment.restrictions_description if assessment is not None else None
+            ),
+            "restrictions_description_es": (
+                assessment.restrictions_description_i18n.get("es")
+                if assessment is not None
+                else None
+            ),
+            "legal_justification": (
+                assessment.legal_justification_i18n.get("es")
+                or assessment.legal_justification
+                if assessment is not None
+                else None
+            ),
+            "legal_justification_en": (
+                assessment.legal_justification_i18n.get("en")
+                if assessment is not None
+                else None
             ),
             "legal_analysis_date": (
                 assessment.analysis_date if assessment is not None else None

--- a/hiap-meed/app/modules/prioritizer/models.py
+++ b/hiap-meed/app/modules/prioritizer/models.py
@@ -1130,6 +1130,50 @@ class RankedActionFeasibilityLegalEvidence(BaseModel):
         default=None,
         description="Source used for the legal component score.",
     )
+    ownership_category: str | None = Field(
+        default=None,
+        description="Legal authority category for who can implement the action.",
+    )
+    ownership_score: float | None = Field(
+        default=None,
+        description="Normalized ownership authority score when present.",
+    )
+    ownership_description: str | None = Field(
+        default=None,
+        description="English plain-language description of who has legal authority.",
+    )
+    ownership_description_es: str | None = Field(
+        default=None,
+        description="Spanish plain-language description of who has legal authority.",
+    )
+    restrictions_category: str | None = Field(
+        default=None,
+        description="Legal restriction category for the action.",
+    )
+    restrictions_score: float | None = Field(
+        default=None,
+        description="Normalized restrictions score when present.",
+    )
+    restrictions_description: str | None = Field(
+        default=None,
+        description="English plain-language description of legal barriers or restrictions.",
+    )
+    restrictions_description_es: str | None = Field(
+        default=None,
+        description="Spanish plain-language description of legal barriers or restrictions.",
+    )
+    legal_justification: str | None = Field(
+        default=None,
+        description="Full Spanish legal reasoning for the verdict when present.",
+    )
+    legal_justification_en: str | None = Field(
+        default=None,
+        description="Full English legal reasoning for the verdict when present.",
+    )
+    references: list[str] = Field(
+        default_factory=list,
+        description="Legal reference strings supporting the verdict.",
+    )
 
 
 class RankedActionFeasibilityMitigationEvidence(BaseModel):

--- a/hiap-meed/app/modules/prioritizer/models.py
+++ b/hiap-meed/app/modules/prioritizer/models.py
@@ -1170,7 +1170,7 @@ class RankedActionFeasibilityLegalEvidence(BaseModel):
         default=None,
         description="Full English legal reasoning for the verdict when present.",
     )
-    references: list[str] = Field(
+    legal_references: list[str] = Field(
         default_factory=list,
         description="Legal reference strings supporting the verdict.",
     )

--- a/hiap-meed/app/modules/prioritizer/orchestrator.py
+++ b/hiap-meed/app/modules/prioritizer/orchestrator.py
@@ -147,8 +147,14 @@ def _group_feasibility_evidence(evidence: dict[str, object]) -> dict[str, object
             ),
             "ownership_category": evidence.get("ownership_category"),
             "ownership_score": evidence.get("ownership_score"),
+            "ownership_description": evidence.get("ownership_description"),
+            "ownership_description_es": evidence.get("ownership_description_es"),
             "restrictions_category": evidence.get("restrictions_category"),
             "restrictions_score": evidence.get("restrictions_score"),
+            "restrictions_description": evidence.get("restrictions_description"),
+            "restrictions_description_es": evidence.get("restrictions_description_es"),
+            "legal_justification": evidence.get("legal_justification"),
+            "legal_justification_en": evidence.get("legal_justification_en"),
             "analysis_date": evidence.get("legal_analysis_date"),
             "generation_method": evidence.get("legal_generation_method"),
             "references": list(evidence.get("legal_references", [])),
@@ -300,6 +306,39 @@ def _build_evidence_summary(
                 ),
                 "component_source": feasibility_evidence.get("legal", {}).get(
                     "component_source"
+                ),
+                "ownership_category": feasibility_evidence.get("legal", {}).get(
+                    "ownership_category"
+                ),
+                "ownership_score": feasibility_evidence.get("legal", {}).get(
+                    "ownership_score"
+                ),
+                "ownership_description": feasibility_evidence.get("legal", {}).get(
+                    "ownership_description"
+                ),
+                "ownership_description_es": feasibility_evidence.get(
+                    "legal", {}
+                ).get("ownership_description_es"),
+                "restrictions_category": feasibility_evidence.get("legal", {}).get(
+                    "restrictions_category"
+                ),
+                "restrictions_score": feasibility_evidence.get("legal", {}).get(
+                    "restrictions_score"
+                ),
+                "restrictions_description": feasibility_evidence.get("legal", {}).get(
+                    "restrictions_description"
+                ),
+                "restrictions_description_es": feasibility_evidence.get(
+                    "legal", {}
+                ).get("restrictions_description_es"),
+                "legal_justification": feasibility_evidence.get("legal", {}).get(
+                    "legal_justification"
+                ),
+                "legal_justification_en": feasibility_evidence.get("legal", {}).get(
+                    "legal_justification_en"
+                ),
+                "references": list(
+                    feasibility_evidence.get("legal", {}).get("references", [])
                 ),
             },
             "mitigation_feasibility": {

--- a/hiap-meed/app/modules/prioritizer/orchestrator.py
+++ b/hiap-meed/app/modules/prioritizer/orchestrator.py
@@ -157,7 +157,7 @@ def _group_feasibility_evidence(evidence: dict[str, object]) -> dict[str, object
             "legal_justification_en": evidence.get("legal_justification_en"),
             "analysis_date": evidence.get("legal_analysis_date"),
             "generation_method": evidence.get("legal_generation_method"),
-            "references": list(evidence.get("legal_references", [])),
+            "legal_references": list(evidence.get("legal_references", [])),
         },
         "mitigation_feasibility": {
             "component_score": _safe_float(
@@ -337,8 +337,8 @@ def _build_evidence_summary(
                 "legal_justification_en": feasibility_evidence.get("legal", {}).get(
                     "legal_justification_en"
                 ),
-                "references": list(
-                    feasibility_evidence.get("legal", {}).get("references", [])
+                "legal_references": list(
+                    feasibility_evidence.get("legal", {}).get("legal_references", [])
                 ),
             },
             "mitigation_feasibility": {

--- a/hiap-meed/docs/pipeline-description.md
+++ b/hiap-meed/docs/pipeline-description.md
@@ -1059,8 +1059,14 @@ Key evidence fields in `012_feasibility.json` are grouped per component:
   - `verdict_score_missing`
   - `ownership_category`
   - `ownership_score`
+  - `ownership_description`
+  - `ownership_description_es`
   - `restrictions_category`
   - `restrictions_score`
+  - `restrictions_description`
+  - `restrictions_description_es`
+  - `legal_justification`
+  - `legal_justification_en`
   - `analysis_date`
   - `generation_method`
   - `references`
@@ -1195,6 +1201,7 @@ For each ranked action, the output includes:
 Important current behavior:
 
 - `evidence_summary.feasibility` keeps `feasibility_score` at the top level and groups detailed component evidence under `legal`, `mitigation_feasibility`, and `financial_feasibility`
+- `evidence_summary.feasibility.legal` includes the public legal authority/restriction categories and scores, plain-language ownership and restriction descriptions in English and Spanish, legal justification in Spanish and English, and normalized legal reference strings from the S3 legal classification source when a row is available.
 - `explanations` is `{}` unless `requestData.createExplanations=true` and the explanation call succeeds
 - Explanations are generated only after ranking is finished; they do not change scores or ranks
 - The explanation stage uses the ranked actions plus curated evidence from the Impact, Alignment, and Feasibility blocks

--- a/hiap-meed/tests/integration/test_api_health.py
+++ b/hiap-meed/tests/integration/test_api_health.py
@@ -50,4 +50,20 @@ class TestAPIHealth:
         assert feasibility_properties["financial_feasibility"]["$ref"].endswith(
             "/RankedActionFeasibilityFinancialEvidence"
         )
-
+        legal_schema = data["components"]["schemas"][
+            "RankedActionFeasibilityLegalEvidence"
+        ]
+        legal_properties = legal_schema["properties"]
+        assert {
+            "ownership_category",
+            "ownership_score",
+            "ownership_description",
+            "ownership_description_es",
+            "restrictions_category",
+            "restrictions_score",
+            "restrictions_description",
+            "restrictions_description_es",
+            "legal_justification",
+            "legal_justification_en",
+            "references",
+        }.issubset(legal_properties.keys())

--- a/hiap-meed/tests/integration/test_api_health.py
+++ b/hiap-meed/tests/integration/test_api_health.py
@@ -65,5 +65,5 @@ class TestAPIHealth:
             "restrictions_description_es",
             "legal_justification",
             "legal_justification_en",
-            "references",
+            "legal_references",
         }.issubset(legal_properties.keys())

--- a/hiap-meed/tests/integration/test_prioritize_e2e_mock_api_data.py
+++ b/hiap-meed/tests/integration/test_prioritize_e2e_mock_api_data.py
@@ -132,6 +132,28 @@ def test_prioritize_e2e_with_mock_api_payloads(
             feasibility_summary["financial_feasibility"]["route"],
             str,
         )
+        legal_summary = feasibility_summary["legal"]
+        assert {
+            "ownership_category",
+            "ownership_score",
+            "ownership_description",
+            "ownership_description_es",
+            "restrictions_category",
+            "restrictions_score",
+            "restrictions_description",
+            "restrictions_description_es",
+            "legal_justification",
+            "legal_justification_en",
+            "references",
+        }.issubset(legal_summary.keys())
+        assert isinstance(legal_summary["ownership_description"], str)
+        assert isinstance(legal_summary["ownership_description_es"], str)
+        assert isinstance(legal_summary["restrictions_description"], str)
+        assert isinstance(legal_summary["restrictions_description_es"], str)
+        assert isinstance(legal_summary["legal_justification"], str)
+        assert isinstance(legal_summary["legal_justification_en"], str)
+        assert isinstance(legal_summary["references"], list)
+        assert legal_summary["references"]
 
         blocked_evidence = metadata["hard_filter_evidence_by_action_id"]["c40_0013"]
         missing_evidence_rows = [

--- a/hiap-meed/tests/integration/test_prioritize_e2e_mock_api_data.py
+++ b/hiap-meed/tests/integration/test_prioritize_e2e_mock_api_data.py
@@ -144,7 +144,7 @@ def test_prioritize_e2e_with_mock_api_payloads(
             "restrictions_description_es",
             "legal_justification",
             "legal_justification_en",
-            "references",
+            "legal_references",
         }.issubset(legal_summary.keys())
         assert isinstance(legal_summary["ownership_description"], str)
         assert isinstance(legal_summary["ownership_description_es"], str)
@@ -152,8 +152,8 @@ def test_prioritize_e2e_with_mock_api_payloads(
         assert isinstance(legal_summary["restrictions_description_es"], str)
         assert isinstance(legal_summary["legal_justification"], str)
         assert isinstance(legal_summary["legal_justification_en"], str)
-        assert isinstance(legal_summary["references"], list)
-        assert legal_summary["references"]
+        assert isinstance(legal_summary["legal_references"], list)
+        assert legal_summary["legal_references"]
 
         blocked_evidence = metadata["hard_filter_evidence_by_action_id"]["c40_0013"]
         missing_evidence_rows = [

--- a/hiap-meed/tests/unit/test_prioritizer_blocks.py
+++ b/hiap-meed/tests/unit/test_prioritizer_blocks.py
@@ -816,6 +816,50 @@ def test_feasibility_block_with_mock_api_data() -> None:
     assert first_action_evidence["financial_feasibility_links"]["detail"].endswith(
         "/climate-finance/actions/c40_0034"
     )
+    first_action_legal_assessment = legal_assessments["c40_0034"]
+    assert (
+        first_action_evidence["ownership_category"]
+        == first_action_legal_assessment.ownership_category
+    )
+    assert (
+        first_action_evidence["ownership_score"]
+        == first_action_legal_assessment.ownership_score
+    )
+    assert (
+        first_action_evidence["ownership_description"]
+        == first_action_legal_assessment.ownership_description
+    )
+    assert (
+        first_action_evidence["ownership_description_es"]
+        == first_action_legal_assessment.ownership_description_i18n["es"]
+    )
+    assert (
+        first_action_evidence["restrictions_category"]
+        == first_action_legal_assessment.restrictions_category
+    )
+    assert (
+        first_action_evidence["restrictions_score"]
+        == first_action_legal_assessment.restrictions_score
+    )
+    assert (
+        first_action_evidence["restrictions_description"]
+        == first_action_legal_assessment.restrictions_description
+    )
+    assert (
+        first_action_evidence["restrictions_description_es"]
+        == first_action_legal_assessment.restrictions_description_i18n["es"]
+    )
+    assert (
+        first_action_evidence["legal_justification"]
+        == first_action_legal_assessment.legal_justification_i18n["es"]
+    )
+    assert (
+        first_action_evidence["legal_justification_en"]
+        == first_action_legal_assessment.legal_justification_i18n["en"]
+    )
+    assert first_action_evidence["legal_references"] == (
+        first_action_legal_assessment.legal_references
+    )
     missing_score_action_ids = result.metadata[
         "missing_mitigation_feasibility_score_action_ids"
     ]


### PR DESCRIPTION
## Summary

Adds richer legal evidence details to the HIAP MEED prioritizer output so downstream consumers can surface clearer legal rationale. Also updates tests and docs to cover the new response behavior.

## Changes

- Extend prioritizer feasibility/legal processing to return more legal evidence details
- Update prioritizer models and orchestrator wiring for the enriched payload
- Add/adjust unit and integration tests for the new legal evidence fields
- Document the pipeline/behavior updates and align ignore rules

## Commits (1)

- chore: added more legal evidence to the response