### PR TITLE
fix: show 'Manually added data' in version history source column

### DIFF
--- a/app/src/components/GHGI/inventory-versions/VersionEntry.tsx
+++ b/app/src/components/GHGI/inventory-versions/VersionEntry.tsx
@@ -176,8 +176,17 @@ export default function VersionEntry({
           )
         : "-",
       totalEmissionsChangeSign: getChangeSign(entry),
-      source: entry.dataSource?.datasourceName ?? "-",
-      previousSource: entry.previousDataSource?.datasourceName ?? "-",
+      source: entry.dataSource?.datasourceName
+        ? entry.dataSource.datasourceName
+        : !entry.dataSource && entry.version.data?.co2eq != null
+          ? t("manually-added-data")
+          : "-",
+      previousSource: entry.previousDataSource?.datasourceName
+        ? entry.previousDataSource.datasourceName
+        : !entry.previousDataSource &&
+            entry.version.previousVersion?.data?.co2eq != null
+          ? t("manually-added-data")
+          : "-",
     }));
   } else if (moduleName === "hiap") {
     changes = versionEntries.map((entry) => ({

--- a/app/src/components/GHGI/inventory-versions/VersionEntry.tsx
+++ b/app/src/components/GHGI/inventory-versions/VersionEntry.tsx
@@ -97,8 +97,8 @@ function renderChangeText(
   }
 
   if (
-    change.source != "-" &&
-    change.previousSource != "-" &&
+    change.hasDataSource &&
+    change.hasPreviousDataSource &&
     change.source != change.previousSource
   ) {
     return t("inventory-versions-value-source-change-entry", {
@@ -180,13 +180,15 @@ export default function VersionEntry({
         ? entry.dataSource.datasourceName
         : !entry.dataSource && entry.version.data?.co2eq != null
           ? t("manually-added-data")
-          : "-",
+          : t("not-specified"),
+      hasDataSource: !!entry.dataSource?.datasourceName,
       previousSource: entry.previousDataSource?.datasourceName
         ? entry.previousDataSource.datasourceName
         : !entry.previousDataSource &&
             entry.version.previousVersion?.data?.co2eq != null
           ? t("manually-added-data")
-          : "-",
+          : t("not-specified"),
+      hasPreviousDataSource: !!entry.previousDataSource?.datasourceName,
     }));
   } else if (moduleName === "hiap") {
     changes = versionEntries.map((entry) => ({
@@ -445,15 +447,8 @@ export default function VersionEntry({
                           </Table.Cell>
                           <Table.Cell
                             bgColor={sourceBgColor}
-                            color={
-                              change.source === "-"
-                                ? "content.tertiary"
-                                : undefined
-                            }
                           >
-                            {change.source === "-"
-                              ? t("not-specified")
-                              : change.source}
+                            {change.source}
                           </Table.Cell>
                         </>
                       )}

--- a/app/src/i18n/locales/de/dashboard.json
+++ b/app/src/i18n/locales/de/dashboard.json
@@ -290,6 +290,7 @@
   "date": "Datum",
   "no-history": "Keine Versionverlaufseinträge gefunden.",
   "not-specified": "Nicht angegeben",
+  "manually-added-data": "Manuell hinzugefügte Daten",
   "subcategory": "Unterkategorie",
   "inventory-versions-restore-failed": "Fehler beim Wiederherstellen der Version",
   "status-poc": "Proof of Concept",

--- a/app/src/i18n/locales/en/dashboard.json
+++ b/app/src/i18n/locales/en/dashboard.json
@@ -302,7 +302,7 @@
   "date": "Date",
   "no-history": "No version history entries found.",
   "not-specified": "Not specified",
-  "manually-added-data": "Manually added data",
+  "manually-added-data": "Manually added",
   "subcategory": "Sub-category",
   "inventory-versions-restore-failed": "Failed to restore version",
   "legend": "Legend",

--- a/app/src/i18n/locales/en/dashboard.json
+++ b/app/src/i18n/locales/en/dashboard.json
@@ -302,6 +302,7 @@
   "date": "Date",
   "no-history": "No version history entries found.",
   "not-specified": "Not specified",
+  "manually-added-data": "Manually added data",
   "subcategory": "Sub-category",
   "inventory-versions-restore-failed": "Failed to restore version",
   "legend": "Legend",

--- a/app/src/i18n/locales/es/dashboard.json
+++ b/app/src/i18n/locales/es/dashboard.json
@@ -293,6 +293,7 @@
   "date": "Fecha",
   "no-history": "No se encontraron entradas en el historial de versiones.",
   "not-specified": "No especificado",
+  "manually-added-data": "Datos añadidos manualmente",
   "subcategory": "Subcategoría",
   "inventory-versions-restore-failed": "Fallo al restaurar la versión",
   "status-poc": "Prueba de Concepto",

--- a/app/src/i18n/locales/fr/dashboard.json
+++ b/app/src/i18n/locales/fr/dashboard.json
@@ -290,6 +290,7 @@
   "date": "Date",
   "no-history": "Aucune entrée d'historique de version trouvée.",
   "not-specified": "Non spécifié",
+  "manually-added-data": "Données ajoutées manuellement",
   "subcategory": "Sous-catégorie",
   "inventory-versions-restore-failed": "Échec de la restauration de la version",
   "status-poc": "Preuve de Concept",

--- a/app/src/i18n/locales/pt/dashboard.json
+++ b/app/src/i18n/locales/pt/dashboard.json
@@ -291,6 +291,7 @@
   "date": "Data",
   "no-history": "Nenhuma entrada de histórico de versões encontrada.",
   "not-specified": "Não especificado",
+  "manually-added-data": "Dados adicionados manualmente",
   "subcategory": "Sub-categoria",
   "inventory-versions-restore-failed": "Falha ao restaurar a versão",
   "status-poc": "Prova de Conceito",


### PR DESCRIPTION
### Summary
Fixes the version history table's SOURCE column to show meaningful labels instead of a dash (-) when no third-party datasource is linked.

### Changes
VersionEntry.tsx: Updated source label logic to distinguish between:
Datasource name — shown when a third-party source is linked (e.g., "Global Energy Monitor")
"Manually added data" — shown when data was entered manually (has co2eq but no datasourceId)
"Not specified" — fallback when neither applies
i18n: Added manually-added-data key to all 5 locale dashboard.json files (en/fr/es/de/pt)