### PR TITLE
fix(ui): show total emissions on datasource cards when non-zero

### DIFF
--- a/app/src/components/GHGI/inventory-pages/add-data-steps-page.tsx
+++ b/app/src/components/GHGI/inventory-pages/add-data-steps-page.tsx
@@ -34,6 +34,7 @@ import {
   Card,
   Center,
   Flex,
+  Grid,
   Heading,
   HStack,
   Icon,
@@ -1088,343 +1089,336 @@ export default function AddDataSteps() {
                             {sourcesForSubsector.length} {t("datasets")}
                           </Text>
                         </HStack>
-                        <VStack align="stretch" gap={6}>
+                        <HStack align="stretch" gap={6} w="full">
                           {groupedByScope.map(([scopeName, scopeSources]) => (
-                            <Box key={`${subSectorId}-${scopeName}`}>
-                              <SimpleGrid
-                                columns={{
-                                  base: 1,
-                                  md: 2,
-                                  lg: 3,
-                                }}
-                                gap="16px"
-                              >
-                                {scopeSources.map(({ source, data }) => {
-                                  const isHovered =
-                                    hoverStates[source.datasourceId];
-                                  return (
-                                    <Card.Root
-                                      key={source.datasourceId}
-                                      data-testid="source-card"
-                                      variant="outline"
-                                      borderWidth="1px"
-                                      borderColor={
-                                        isSourceConnected(source) &&
-                                          source.inventoryValues?.length
-                                          ? "interactive.tertiary"
-                                          : "border.overlay"
-                                      }
-                                      shadow="none"
-                                      _hover={{ shadow: "xl" }}
-                                      transition="all 300ms"
-                                      w="full"
-                                      p="24px"
-                                      gap="4px"
+                            <Grid
+                              templateColumns="repeat(3, 1fr)"
+                              gap="16px"
+                              key={`${subSectorId}-${scopeName}`}
+                            >
+                              {scopeSources.map(({ source, data }) => {
+                                const isHovered =
+                                  hoverStates[source.datasourceId];
+                                return (
+                                  <Card.Root
+                                    key={source.datasourceId}
+                                    data-testid="source-card"
+                                    variant="outline"
+                                    borderWidth="1px"
+                                    borderColor={
+                                      isSourceConnected(source) &&
+                                        source.inventoryValues?.length
+                                        ? "interactive.tertiary"
+                                        : "border.overlay"
+                                    }
+                                    shadow="none"
+                                    _hover={{ shadow: "xl" }}
+                                    transition="all 300ms"
+                                    w="330px"
+                                    p="24px"
+                                    gap="4px"
+                                  >
+                                    <Card.Header
+                                      p="0"
+                                      display="flex"
+                                      flexDirection="column"
+                                      gap="0"
                                     >
-                                      <Card.Header
-                                        p="0"
-                                        display="flex"
-                                        flexDirection="column"
-                                        gap="0"
+                                      <Icon
+                                        as={
+                                          {
+                                            I: MdOutlineHomeWork,
+                                            II: MdOutlineLocalShipping,
+                                            III: MdOutlineDelete,
+                                            IV: MdOutlineFactory,
+                                            V: LuWheat,
+                                          }[
+                                          currentStep.referenceNumber
+                                          ] ?? MdOutlineHomeWork
+                                        }
+                                        boxSize={9}
+                                        color="content.tertiary-light"
+                                        mb="10px"
+                                      />
+                                      <Flex
+                                        direction="row"
+                                        align="center"
+                                        gap="8px"
                                       >
-                                        <Icon
-                                          as={
-                                            {
-                                              I: MdOutlineHomeWork,
-                                              II: MdOutlineLocalShipping,
-                                              III: MdOutlineDelete,
-                                              IV: MdOutlineFactory,
-                                              V: LuWheat,
-                                            }[
-                                            currentStep.referenceNumber
-                                            ] ?? MdOutlineHomeWork
+                                        <Badge
+                                          variant="plain"
+                                          fontSize="label.sm"
+                                          fontWeight="medium"
+                                          fontFamily="heading"
+                                          letterSpacing="widest"
+                                          bg="background.graySubtle"
+                                          color="content.secondary"
+                                          px="8px"
+                                          py="1px"
+                                          borderRadius="md"
+                                          lineHeight="1.2"
+                                          borderWidth="0"
+                                        >
+                                          {source.subCategory
+                                            ?.referenceNumber ||
+                                            source.subSector?.referenceNumber}
+                                        </Badge>
+                                        <Tooltip
+                                          showArrow
+                                          content={
+                                            source.subSector?.subsectorName
                                           }
-                                          boxSize={9}
-                                          color="content.tertiary-light"
-                                          mb="10px"
-                                        />
+                                        >
+                                          <Text
+                                            fontSize="overline"
+                                            fontWeight="bold"
+                                            color="content.primary"
+                                            textTransform="uppercase"
+                                            letterSpacing="widest"
+                                            lineHeight="24"
+                                            fontFamily="heading"
+                                            lineClamp={1}
+                                          >
+                                            {source.subSector?.subsectorName}
+                                          </Text>
+                                        </Tooltip>
+                                      </Flex>
+                                      <Heading
+                                        fontSize="title.md"
+                                        lineClamp={2}
+                                        minHeight={10}
+                                        mt="6px"
+                                        lineHeight={24}
+                                      >
+                                        {getTranslationFromDict(
+                                          source.datasetName,
+                                        )}
+                                      </Heading>
+                                      <Text fontSize="label.md" mt="4px">
+                                        {t("by-data-source")}{" "}
+                                        <Link
+                                          href={source.publisher?.url}
+                                          target="_blank"
+                                          textDecoration="underline"
+                                          color="content.link"
+                                          rel="noreferrer noopener"
+                                        >
+                                          {source.publisher?.name}
+                                        </Link>
+                                      </Text>
+                                    </Card.Header>
+                                    <Card.Body
+                                      justifyContent="space-between"
+                                      p="0"
+                                    >
+                                      <Flex
+                                        direction="row"
+                                        mb={0}
+                                        wrap="wrap"
+                                        gap={2}
+                                      >
+                                        {data?.totals?.emissions?.co2eq_100yr != null &&
+                                          data.totals.emissions.co2eq_100yr !== 0n && (
+                                            <Text
+                                              fontSize="display.sm"
+                                              fontWeight="semibold"
+                                            >
+                                              {convertKgToTonnes(
+                                                bigIntToDecimal(
+                                                  data.totals.emissions.co2eq_100yr,
+                                                ).toNumber(),
+                                              )}
+                                            </Text>
+                                          )}
                                         <Flex
                                           direction="row"
-                                          align="center"
-                                          gap="8px"
+                                          gap="4px"
+                                          flexWrap="nowrap"
                                         >
                                           <Badge
-                                            variant="plain"
-                                            fontSize="label.sm"
-                                            fontWeight="medium"
-                                            fontFamily="heading"
-                                            letterSpacing="widest"
-                                            bg="background.graySubtle"
-                                            color="content.secondary"
-                                            px="8px"
-                                            py="1px"
-                                            borderRadius="md"
-                                            lineHeight="1.2"
-                                            borderWidth="0"
+                                            fontSize={12}
+                                            borderColor="border.overlay"
+                                            w="fit-content"
                                           >
-                                            {source.subCategory
-                                              ?.referenceNumber ||
-                                              source.subSector?.referenceNumber}
-                                          </Badge>
-                                          <Tooltip
-                                            showArrow
-                                            content={
-                                              source.subSector?.subsectorName
-                                            }
-                                          >
-                                            <Text
-                                              fontSize="overline"
-                                              fontWeight="bold"
-                                              color="content.primary"
-                                              textTransform="uppercase"
-                                              letterSpacing="widest"
-                                              lineHeight="24"
-                                              fontFamily="heading"
-                                              lineClamp={1}
-                                            >
-                                              {source.subSector?.subsectorName}
-                                            </Text>
-                                          </Tooltip>
-                                        </Flex>
-                                        <Heading
-                                          fontSize="title.md"
-                                          lineClamp={2}
-                                          minHeight={10}
-                                          mt="6px"
-                                          lineHeight={24}
-                                        >
-                                          {getTranslationFromDict(
-                                            source.datasetName,
-                                          )}
-                                        </Heading>
-                                        <Text fontSize="label.md" mt="4px">
-                                          {t("by-data-source")}{" "}
-                                          <Link
-                                            href={source.publisher?.url}
-                                            target="_blank"
-                                            textDecoration="underline"
-                                            color="content.link"
-                                            rel="noreferrer noopener"
-                                          >
-                                            {source.publisher?.name}
-                                          </Link>
-                                        </Text>
-                                      </Card.Header>
-                                      <Card.Body
-                                        justifyContent="space-between"
-                                        p="0"
-                                      >
-                                        <Flex
-                                          direction="row"
-                                          mb={0}
-                                          wrap="wrap"
-                                          gap={2}
-                                        >
-                                          {!isSourceConnected(source) &&
-                                            !source.inventoryValues
-                                              ?.length && (
-                                              <Text
-                                                fontSize="display.sm"
-                                                fontWeight="semibold"
-                                              >
-                                                {convertKgToTonnes(
-                                                  bigIntToDecimal(
-                                                    data?.totals?.emissions
-                                                      ?.co2eq_100yr ?? 0n,
-                                                  ).toNumber(),
-                                                )}
-                                              </Text>
+                                            <Icon
+                                              as={DataCheckIcon}
+                                              boxSize={5}
+                                              color="content.tertiary"
+                                            />
+                                            {t("data-quality")}:{" "}
+                                            {t(
+                                              "quality-" + source.dataQuality,
                                             )}
-                                          <Flex
-                                            direction="row"
-                                            gap="4px"
-                                            flexWrap="nowrap"
-                                          >
+                                          </Badge>
+                                          {source.subCategory?.scope && (
                                             <Badge
                                               fontSize={12}
                                               borderColor="border.overlay"
                                               w="fit-content"
                                             >
                                               <Icon
-                                                as={DataCheckIcon}
-                                                boxSize={5}
+                                                as={FiTarget}
+                                                boxSize={4}
                                                 color="content.tertiary"
                                               />
-                                              {t("data-quality")}:{" "}
-                                              {t(
-                                                "quality-" + source.dataQuality,
-                                              )}
+                                              {t("scope")}:{" "}
+                                              {
+                                                source.subCategory.scope
+                                                  .scopeName
+                                              }
                                             </Badge>
-                                            {source.subCategory?.scope && (
-                                              <Badge
-                                                fontSize={12}
-                                                borderColor="border.overlay"
-                                                w="fit-content"
-                                              >
-                                                <Icon
-                                                  as={FiTarget}
-                                                  boxSize={4}
-                                                  color="content.tertiary"
-                                                />
-                                                {t("scope")}:{" "}
-                                                {
-                                                  source.subCategory.scope
-                                                    .scopeName
-                                                }
-                                              </Badge>
-                                            )}
-                                          </Flex>
+                                          )}
                                         </Flex>
-                                        <Text
-                                          textOverflow="ellipsis"
-                                          whiteSpace="nowrap"
-                                          overflow="hidden"
-                                          color="content.tertiary"
-                                          lineClamp={
-                                            isSourceConnected(source) &&
-                                              source.inventoryValues?.length
-                                              ? 0
-                                              : 4
+                                      </Flex>
+                                      <Text
+                                        textOverflow="ellipsis"
+                                        whiteSpace="nowrap"
+                                        overflow="hidden"
+                                        color="content.tertiary"
+                                        lineClamp={
+                                          isSourceConnected(source) &&
+                                            source.inventoryValues?.length
+                                            ? 0
+                                            : 4
+                                        }
+                                        maxHeight={
+                                          isSourceConnected(source) &&
+                                            source.inventoryValues?.length
+                                            ? "100px"
+                                            : "184px"
+                                        }
+                                        fontFamily="body"
+                                        fontSize="body.md"
+                                        lineHeight="20px"
+                                        fontWeight="regular"
+                                        marginTop="8px"
+                                      >
+                                        {getTranslationFromDict(
+                                          source.datasetDescription,
+                                        ) ||
+                                          getTranslationFromDict(
+                                            source.methodologyDescription,
+                                          )}
+                                      </Text>
+                                      <VStack w="full" mb="16px">
+                                        <Link
+                                          textDecoration="underline"
+                                          mt={4}
+                                          mb={2}
+                                          onClick={() =>
+                                            onSourceClick(source, data)
                                           }
-                                          maxHeight={
-                                            isSourceConnected(source) &&
-                                              source.inventoryValues?.length
-                                              ? "100px"
-                                              : "184px"
-                                          }
-                                          fontFamily="body"
-                                          fontSize="body.md"
-                                          lineHeight="20px"
-                                          fontWeight="regular"
-                                          marginTop="8px"
+                                          alignSelf="flex-start"
+                                          fontSize="label.lg"
+                                          fontWeight="medium"
+                                          letterSpacing="wide"
                                         >
-                                          {getTranslationFromDict(
-                                            source.datasetDescription,
-                                          ) ||
-                                            getTranslationFromDict(
-                                              source.methodologyDescription,
-                                            )}
-                                        </Text>
-                                        <VStack w="full" mb="16px">
-                                          <Link
-                                            textDecoration="underline"
-                                            mt={4}
-                                            mb={2}
-                                            onClick={() =>
-                                              onSourceClick(source, data)
+                                          {t("see-more-details")}
+                                        </Link>
+                                        {isSourceConnected(source) &&
+                                          source.inventoryValues?.length ? (
+                                          <Button
+                                            variant="outline"
+                                            w="full"
+                                            h="50px"
+                                            bg={
+                                              isHovered
+                                                ? "semantic.dangerOverlay"
+                                                : "semantic.successOverlay"
                                             }
-                                            alignSelf="flex-start"
-                                            fontSize="label.lg"
-                                            fontWeight="medium"
-                                            letterSpacing="wide"
+                                            borderColor={
+                                              isHovered
+                                                ? "semantic.danger"
+                                                : "semantic.success"
+                                            }
+                                            borderWidth="1px"
+                                            color={
+                                              isHovered
+                                                ? "semantic.danger"
+                                                : "semantic.success"
+                                            }
+                                            fontWeight="semibold"
+                                            fontSize="14px"
+                                            onClick={() =>
+                                              isFrozenCheck()
+                                                ? null
+                                                : onDisconnectThirdPartyData(
+                                                  source,
+                                                )
+                                            }
+                                            loading={
+                                              isDisconnectLoading &&
+                                              source.datasourceId ===
+                                              disconnectingDataSourceId
+                                            }
+                                            onMouseEnter={() =>
+                                              onButtonHover(source)
+                                            }
+                                            onMouseLeave={() =>
+                                              onMouseLeave(source)
+                                            }
                                           >
-                                            {t("see-more-details")}
-                                          </Link>
-                                          {isSourceConnected(source) &&
-                                            source.inventoryValues?.length ? (
+                                            <Icon as={MdCheckCircleOutline} />
+                                            {isHovered
+                                              ? t("disconnect-data")
+                                              : t("data-connected")}
+                                          </Button>
+                                        ) : isSourceGpcBlocked(source) ? (
+                                          <Tooltip
+                                            showArrow
+                                            content={t(
+                                              "data-already-added-connected",
+                                            )}
+                                          >
                                             <Button
                                               variant="outline"
                                               w="full"
                                               h="50px"
-                                              bg={
-                                                isHovered
-                                                  ? "semantic.dangerOverlay"
-                                                  : "semantic.successOverlay"
-                                              }
-                                              borderColor={
-                                                isHovered
-                                                  ? "semantic.danger"
-                                                  : "semantic.success"
-                                              }
-                                              borderWidth="1px"
-                                              color={
-                                                isHovered
-                                                  ? "semantic.danger"
-                                                  : "semantic.success"
-                                              }
+                                              borderWidth="0"
+                                              bgColor="background.graySubtle"
+                                              disabled
+                                              color="interactive.control"
                                               fontWeight="semibold"
                                               fontSize="14px"
-                                              onClick={() =>
-                                                isFrozenCheck()
-                                                  ? null
-                                                  : onDisconnectThirdPartyData(
-                                                    source,
-                                                  )
-                                              }
-                                              loading={
-                                                isDisconnectLoading &&
-                                                source.datasourceId ===
-                                                disconnectingDataSourceId
-                                              }
-                                              onMouseEnter={() =>
-                                                onButtonHover(source)
-                                              }
-                                              onMouseLeave={() =>
-                                                onMouseLeave(source)
-                                              }
-                                            >
-                                              <Icon as={MdCheckCircleOutline} />
-                                              {isHovered
-                                                ? t("disconnect-data")
-                                                : t("data-connected")}
-                                            </Button>
-                                          ) : isSourceGpcBlocked(source) ? (
-                                            <Tooltip
-                                              showArrow
-                                              content={t(
-                                                "data-already-added-connected",
-                                              )}
-                                            >
-                                              <Button
-                                                variant="outline"
-                                                w="full"
-                                                h="50px"
-                                                borderWidth="0"
-                                                bgColor="background.graySubtle"
-                                                disabled
-                                                color="interactive.control"
-                                                fontWeight="semibold"
-                                                fontSize="14px"
-                                              >
-                                                {t("connect-data")}
-                                                <Icon
-                                                  as={MdInfoOutline}
-                                                  boxSize={4}
-                                                />
-                                              </Button>
-                                            </Tooltip>
-                                          ) : (
-                                            <Button
-                                              variant="outline"
-                                              w="full"
-                                              h="50px"
-                                              borderWidth="1px"
-                                              borderColor="border.overlay"
-                                              bgColor="background.neutral"
-                                              color="interactive.secondary"
-                                              fontWeight="semibold"
-                                              fontSize="14px"
-                                              onClick={() =>
-                                                onConnectClick(source)
-                                              }
-                                              loading={
-                                                isConnectDataSourceLoading &&
-                                                source.datasourceId ===
-                                                connectingDataSourceId
-                                              }
                                             >
                                               {t("connect-data")}
+                                              <Icon
+                                                as={MdInfoOutline}
+                                                boxSize={4}
+                                              />
                                             </Button>
-                                          )}
-                                        </VStack>
-                                      </Card.Body>
-                                    </Card.Root>
-                                  );
-                                })}
-                              </SimpleGrid>
-                            </Box>
+                                          </Tooltip>
+                                        ) : (
+                                          <Button
+                                            variant="outline"
+                                            w="full"
+                                            h="50px"
+                                            borderWidth="1px"
+                                            borderColor="border.overlay"
+                                            bgColor="background.neutral"
+                                            color="interactive.secondary"
+                                            fontWeight="semibold"
+                                            fontSize="14px"
+                                            onClick={() =>
+                                              onConnectClick(source)
+                                            }
+                                            loading={
+                                              isConnectDataSourceLoading &&
+                                              source.datasourceId ===
+                                              connectingDataSourceId
+                                            }
+                                          >
+                                            {t("connect-data")}
+                                          </Button>
+                                        )}
+                                      </VStack>
+                                    </Card.Body>
+                                  </Card.Root>
+                                );
+                              })}
+                            </Grid>
                           ))}
-                        </VStack>
+                        </HStack>
                       </Box>
                     );
                   },

--- a/app/src/components/Tabs/Activity/activity-tab.tsx
+++ b/app/src/components/Tabs/Activity/activity-tab.tsx
@@ -727,11 +727,12 @@ const ActivityTab: FC<ActivityTabProps> = ({
                   </Card.Header>
                   <Card.Body justifyContent="space-between" p="0" mt="12px">
                     <Flex direction="row" mb={0} wrap="wrap" gap={2}>
-                      {!isConnected && (
+                      {data?.totals?.emissions?.co2eq_100yr != null &&
+                        data.totals.emissions.co2eq_100yr !== 0n && (
                         <Text fontSize="display.sm" fontWeight="semibold">
                           {convertKgToTonnes(
                             bigIntToDecimal(
-                              data?.totals?.emissions?.co2eq_100yr ?? 0n,
+                              data.totals.emissions.co2eq_100yr,
                             ).toNumber(),
                           )}
                         </Text>


### PR DESCRIPTION
### Summary
Improves the third-party datasource cards layout and emissions data visibility across the GHGI data steps page and the activity tab.

### Changes

Grid layout: Replaced SimpleGrid with CSS Grid using templateColumns="repeat(3, 1fr)" for a consistent 3-column card layout
Card container: Changed VStack to HStack for scope group layout
Emissions visibility: Always display total emissions (co2eq_100yr) on datasource cards, including connected ones — hidden only when the value is null, undefined, or 0
activity-tab.tsx
Emissions visibility: Same logic — show total emissions regardless of connection status, hide only when value is null, undefined, or 0