### PR TITLE
fix(ON-5907): fix data source card grid and badge layout for narrow viewports

### DIFF
--- a/app/src/components/GHGI/inventory-pages/add-data-steps-page.tsx
+++ b/app/src/components/GHGI/inventory-pages/add-data-steps-page.tsx
@@ -1233,12 +1233,12 @@ export default function AddDataSteps() {
                                         <Flex
                                           direction="row"
                                           gap="4px"
-                                          flexWrap="nowrap"
+                                          flexWrap="wrap"
                                         >
                                           <Badge
                                             fontSize={12}
                                             borderColor="border.overlay"
-                                            w="fit-content"
+                                            flex="1"
                                           >
                                             <Icon
                                               as={DataCheckIcon}
@@ -1254,7 +1254,7 @@ export default function AddDataSteps() {
                                             <Badge
                                               fontSize={12}
                                               borderColor="border.overlay"
-                                              w="fit-content"
+                                              flex="1"
                                             >
                                               <Icon
                                                 as={FiTarget}


### PR DESCRIPTION
[Fixing QA feedback here](https://openearth.atlassian.net/browse/ON-5907?focusedCommentId=27061)

## Summary
- Lower grid breakpoint from `lg` (1024px) to `md` (768px) using `minChildWidth="280px"`, preventing single-column collapse on Windows machines with high DPI scaling where the effective CSS viewport is narrower than the physical pixel width
- Allow Data Quality and Scope badges to wrap when cards are narrow, with each badge stretching to full width when stacked

## Test plan
- [ ] At 900px viewport: cards show 3 columns
- [ ] At 780px viewport: cards show 2 columns (cards readable, badges wrap cleanly)
- [ ] At 480px viewport: cards show 1 column
- [ ] When badges wrap (narrow card), each badge spans full card width
- [ ] When badges fit side by side (wide card), they share the row