### PR TITLE
Fix inventory list accessible scope

### DIFF
--- a/.github/workflows/climate-advisor-tag.yml
+++ b/.github/workflows/climate-advisor-tag.yml
@@ -196,6 +196,7 @@ jobs:
             CA_LOG_LEVEL=info \
             CA_CORS_ORIGINS="*" \
             CC_BASE_URL=https://citycatalyst.io \
+            CA_FEATURE_FLAGS=STATIONARY_ENERGY_AGENTIC \
             MLFLOW_EXPERIMENT_NAME="${MLFLOW_EXPERIMENT_NAME}" \
             LANGSMITH_API_KEY=${{secrets.LANGSMITH_API_KEY}} \
             LANGSMITH_WORKSPACE_ID=${{secrets.LANGSMITH_WORKSPACE_ID}} \

--- a/.github/workflows/climate-advisor-test.yml
+++ b/.github/workflows/climate-advisor-test.yml
@@ -182,6 +182,7 @@ jobs:
             CA_LOG_LEVEL=info \
             CA_CORS_ORIGINS="*" \
             CC_BASE_URL=https://citycatalyst-test.openearth.dev \
+            CA_FEATURE_FLAGS=STATIONARY_ENERGY_AGENTIC \
             MLFLOW_EXPERIMENT_NAME="${MLFLOW_EXPERIMENT_NAME}" \
             LANGSMITH_API_KEY=${{secrets.LANGSMITH_API_KEY}} \
             LANGSMITH_WORKSPACE_ID=${{secrets.LANGSMITH_WORKSPACE_ID}} \

--- a/app/src/backend/ProjectsService.ts
+++ b/app/src/backend/ProjectsService.ts
@@ -117,6 +117,8 @@ export class ProjectService {
             inventories: city.inventories as any,
             country: city.country as string,
             countryLocode: city.countryLocode as string,
+            region: city.region as string,
+            regionLocode: city.regionLocode as string,
             locode: city.locode as string,
           })),
         })),
@@ -133,6 +135,8 @@ export class ProjectService {
             inventories: city.inventories as any,
             country: city.country as string,
             countryLocode: city.countryLocode as string,
+            region: city.region as string,
+            regionLocode: city.regionLocode as string,
             locode: city.locode as string,
           })),
         })),
@@ -158,6 +162,11 @@ export class ProjectService {
             name: cityUserAsocc.city.name as string,
             cityId: cityUserAsocc.city.cityId as string,
             inventories: cityUserAsocc.city.inventories as any,
+            country: cityUserAsocc.city.country as string,
+            countryLocode: cityUserAsocc.city.countryLocode as string,
+            region: cityUserAsocc.city.region as string,
+            regionLocode: cityUserAsocc.city.regionLocode as string,
+            locode: cityUserAsocc.city.locode as string,
           };
           if (!existingProject) {
             acc[projectId] = {

--- a/app/src/backend/agentic/ghgi/inventory/context.ts
+++ b/app/src/backend/agentic/ghgi/inventory/context.ts
@@ -1,12 +1,10 @@
 import createHttpError from "http-errors";
-import { Op } from "sequelize";
 
 import InventoryProgressService from "@/backend/InventoryProgressService";
+import { ProjectService } from "@/backend/ProjectsService";
 import { getEmissionResults } from "@/backend/ResultsService";
 import { db } from "@/models";
-import { City } from "@/models/City";
 import { Inventory } from "@/models/Inventory";
-import { User } from "@/models/User";
 import { Roles } from "@/util/types";
 
 type InventoryMetadata = {
@@ -44,6 +42,23 @@ type AccessibleInventoryList = {
     year: number | null;
     include_all_city_years: boolean;
   };
+};
+
+type InventoryListInventory = {
+  inventoryId: string;
+  inventoryName?: string | null;
+  year?: number | null;
+  inventoryType?: string | null;
+  globalWarmingPotentialType?: string | null;
+};
+
+type InventoryListCity = {
+  cityId: string;
+  name?: string | null;
+  country?: string | null;
+  region?: string | null;
+  locode?: string | null;
+  inventories?: InventoryListInventory[];
 };
 
 type DataState = {
@@ -164,13 +179,6 @@ export async function buildAccessibleInventoryList({
   const user = await db.models.User.findOne({
     attributes: ["userId", "role"],
     where: { userId },
-    include: [
-      {
-        model: db.models.City,
-        as: "cities",
-        include: [{ model: db.models.Inventory, as: "inventories" }],
-      },
-    ],
   });
 
   if (!user) {
@@ -178,9 +186,9 @@ export async function buildAccessibleInventoryList({
   }
 
   const normalizedQuery = normalizeSearch(cityQuery);
-  const cities = (await candidateCitiesForUser(user))
-    .filter((city: City) => cityMatchesQuery(city, normalizedQuery))
-    .map((city: City) => accessibleCity(city, year, includeAllCityYears))
+  const cities = (await candidateCitiesForUser(user.userId, user.role))
+    .filter((city) => cityMatchesQuery(city, normalizedQuery))
+    .map((city) => accessibleCity(city, year, includeAllCityYears))
     .filter((city) => city.inventories.length > 0)
     .sort((a, b) => citySortLabel(a).localeCompare(citySortLabel(b)));
 
@@ -199,85 +207,30 @@ export async function buildAccessibleInventoryList({
   };
 }
 
-/** Return city candidates broad enough to match PermissionService inventory checks. */
-async function candidateCitiesForUser(user: User): Promise<City[]> {
-  const directCities = user.cities ?? [];
-  if (user.role === Roles.Admin) {
-    return dedupeCities([...directCities, ...(await citiesWithInventories())]);
+/** Return city candidates using the same maintained project/city discovery as the CC drawer. */
+async function candidateCitiesForUser(
+  userId: string,
+  role?: string | null,
+): Promise<InventoryListCity[]> {
+  if (role === Roles.Admin) {
+    return citiesWithInventories();
   }
 
-  const accessScopes = await elevatedAccessScopes(user.userId);
-  if (
-    accessScopes.organizationIds.length === 0 &&
-    accessScopes.projectIds.length === 0
-  ) {
-    return dedupeCities(directCities);
-  }
-
-  return dedupeCities([
-    ...directCities,
-    ...(await citiesWithInventories(accessScopes)),
-  ]);
+  const projects = await ProjectService.fetchUserProjects(userId);
+  return dedupeCities(
+    projects.flatMap((project) => project.cities as InventoryListCity[]),
+  );
 }
 
-/** Return project and organization scopes that match the CC project drawer. */
-async function elevatedAccessScopes(userId: string): Promise<{
-  organizationIds: string[];
-  projectIds: string[];
-}> {
-  const [organizationAdmins, projectAdmins] = await Promise.all([
-    db.models.OrganizationAdmin.findAll({
-      attributes: ["organizationId"],
-      where: { userId },
-    }),
-    db.models.ProjectAdmin.findAll({
-      attributes: ["projectId"],
-      where: { userId },
-    }),
-  ]);
-
-  return {
-    organizationIds: Array.from(
-      new Set(organizationAdmins.map((admin) => admin.organizationId)),
-    ),
-    projectIds: Array.from(
-      new Set(projectAdmins.map((admin) => admin.projectId)),
-    ),
-  };
-}
-
-/** Load city candidates with their inventories, optionally scoped to projects/orgs. */
-async function citiesWithInventories(accessScopes?: {
-  organizationIds?: string[];
-  projectIds?: string[];
-}): Promise<City[]> {
-  const organizationIds = accessScopes?.organizationIds ?? [];
-  const projectIds = accessScopes?.projectIds ?? [];
-  const projectWhere = [
-    organizationIds.length
-      ? { organizationId: { [Op.in]: organizationIds } }
-      : null,
-    projectIds.length ? { projectId: { [Op.in]: projectIds } } : null,
-  ].filter(Boolean);
-
-  const projectInclude = {
-    model: db.models.Project,
-    as: "project",
-    attributes: ["projectId", "organizationId"],
-    required: projectWhere.length > 0,
-    ...(projectWhere.length > 0 ? { where: { [Op.or]: projectWhere } } : {}),
-  };
-
+/** Load all city candidates for system admins. */
+async function citiesWithInventories(): Promise<InventoryListCity[]> {
   return (await db.models.City.findAll({
-    include: [
-      { model: db.models.Inventory, as: "inventories" },
-      projectInclude,
-    ],
-  })) as City[];
+    include: [{ model: db.models.Inventory, as: "inventories" }],
+  })) as InventoryListCity[];
 }
 
 /** Keep the first candidate when access paths overlap. */
-function dedupeCities(cities: City[]): City[] {
+function dedupeCities(cities: InventoryListCity[]): InventoryListCity[] {
   const seen = new Set<string>();
   return cities.filter((city) => {
     if (seen.has(city.cityId)) {
@@ -358,18 +311,19 @@ async function loadInventoryForProgress(
 }
 
 function accessibleCity(
-  city: City,
+  city: InventoryListCity,
   year: number | undefined,
   includeAllCityYears: boolean,
 ): AccessibleInventoryCity {
   const inventories = (city.inventories ?? [])
-    .filter((inventory: Inventory) => {
+    .filter((inventory: InventoryListInventory) => {
       return includeAllCityYears || year == null || inventory.year === year;
     })
     .sort(
-      (a: Inventory, b: Inventory) => Number(b.year ?? 0) - Number(a.year ?? 0),
+      (a: InventoryListInventory, b: InventoryListInventory) =>
+        Number(b.year ?? 0) - Number(a.year ?? 0),
     )
-    .map((inventory: Inventory) => ({
+    .map((inventory: InventoryListInventory) => ({
       inventory_id: inventory.inventoryId,
       inventory_name: inventory.inventoryName ?? null,
       year: inventory.year ?? null,
@@ -556,7 +510,10 @@ function normalizeSearch(value: string | null | undefined): string | null {
   return normalized ? normalized : null;
 }
 
-function cityMatchesQuery(city: City, normalizedQuery: string | null): boolean {
+function cityMatchesQuery(
+  city: InventoryListCity,
+  normalizedQuery: string | null,
+): boolean {
   if (!normalizedQuery) {
     return true;
   }

--- a/app/src/backend/agentic/ghgi/inventory/context.ts
+++ b/app/src/backend/agentic/ghgi/inventory/context.ts
@@ -1,10 +1,13 @@
 import createHttpError from "http-errors";
+import { Op } from "sequelize";
 
 import InventoryProgressService from "@/backend/InventoryProgressService";
 import { getEmissionResults } from "@/backend/ResultsService";
 import { db } from "@/models";
 import { City } from "@/models/City";
 import { Inventory } from "@/models/Inventory";
+import { User } from "@/models/User";
+import { Roles } from "@/util/types";
 
 type InventoryMetadata = {
   city: string;
@@ -159,7 +162,7 @@ export async function buildAccessibleInventoryList({
   includeAllCityYears?: boolean;
 }): Promise<AccessibleInventoryList> {
   const user = await db.models.User.findOne({
-    attributes: [],
+    attributes: ["userId", "role"],
     where: { userId },
     include: [
       {
@@ -175,7 +178,7 @@ export async function buildAccessibleInventoryList({
   }
 
   const normalizedQuery = normalizeSearch(cityQuery);
-  const cities = user.cities
+  const cities = (await candidateCitiesForUser(user))
     .filter((city: City) => cityMatchesQuery(city, normalizedQuery))
     .map((city: City) => accessibleCity(city, year, includeAllCityYears))
     .filter((city) => city.inventories.length > 0)
@@ -194,6 +197,90 @@ export async function buildAccessibleInventoryList({
       include_all_city_years: includeAllCityYears,
     },
   };
+}
+
+/** Return city candidates broad enough to match PermissionService inventory checks. */
+async function candidateCitiesForUser(user: User): Promise<City[]> {
+  const directCities = user.cities ?? [];
+  if (user.role === Roles.Admin) {
+    return dedupeCities([...directCities, ...(await citiesWithInventories())]);
+  }
+
+  const organizationIds = await elevatedAccessOrganizationIds(user.userId);
+  if (organizationIds.length === 0) {
+    return dedupeCities(directCities);
+  }
+
+  return dedupeCities([
+    ...directCities,
+    ...(await citiesWithInventories(organizationIds)),
+  ]);
+}
+
+/** Return organizations where this user can access inventories beyond direct city rows. */
+async function elevatedAccessOrganizationIds(
+  userId: string,
+): Promise<string[]> {
+  const [organizationAdmins, projectAdmins] = await Promise.all([
+    db.models.OrganizationAdmin.findAll({
+      attributes: ["organizationId"],
+      where: { userId },
+    }),
+    db.models.ProjectAdmin.findAll({
+      attributes: ["projectId"],
+      where: { userId },
+      include: [
+        {
+          model: db.models.Project,
+          as: "project",
+          attributes: ["organizationId"],
+        },
+      ],
+    }),
+  ]);
+
+  return Array.from(
+    new Set([
+      ...organizationAdmins.map((admin) => admin.organizationId),
+      ...projectAdmins
+        .map((admin) => admin.project?.organizationId)
+        .filter(isPresentString),
+    ]),
+  );
+}
+
+/** Load city candidates with their inventories, optionally scoped to organizations. */
+async function citiesWithInventories(
+  organizationIds?: string[],
+): Promise<City[]> {
+  const projectInclude = {
+    model: db.models.Project,
+    as: "project",
+    attributes: ["projectId", "organizationId"],
+    required: Boolean(organizationIds?.length),
+    ...(organizationIds?.length
+      ? { where: { organizationId: { [Op.in]: organizationIds } } }
+      : {}),
+  };
+
+  return (await db.models.City.findAll({
+    include: [
+      { model: db.models.Inventory, as: "inventories" },
+      projectInclude,
+    ],
+  })) as City[];
+}
+
+/** Keep the first candidate when access paths overlap. */
+function dedupeCities(cities: City[]): City[] {
+  const seen = new Set<string>();
+  return cities.filter((city) => {
+    if (seen.has(city.cityId)) {
+      return false;
+    }
+    seen.add(city.cityId);
+    return true;
+  });
 }
 
 export async function buildInventoryStatusOverview(

--- a/app/src/backend/agentic/ghgi/inventory/context.ts
+++ b/app/src/backend/agentic/ghgi/inventory/context.ts
@@ -206,21 +206,25 @@ async function candidateCitiesForUser(user: User): Promise<City[]> {
     return dedupeCities([...directCities, ...(await citiesWithInventories())]);
   }
 
-  const organizationIds = await elevatedAccessOrganizationIds(user.userId);
-  if (organizationIds.length === 0) {
+  const accessScopes = await elevatedAccessScopes(user.userId);
+  if (
+    accessScopes.organizationIds.length === 0 &&
+    accessScopes.projectIds.length === 0
+  ) {
     return dedupeCities(directCities);
   }
 
   return dedupeCities([
     ...directCities,
-    ...(await citiesWithInventories(organizationIds)),
+    ...(await citiesWithInventories(accessScopes)),
   ]);
 }
 
-/** Return organizations where this user can access inventories beyond direct city rows. */
-async function elevatedAccessOrganizationIds(
-  userId: string,
-): Promise<string[]> {
+/** Return project and organization scopes that match the CC project drawer. */
+async function elevatedAccessScopes(userId: string): Promise<{
+  organizationIds: string[];
+  projectIds: string[];
+}> {
   const [organizationAdmins, projectAdmins] = await Promise.all([
     db.models.OrganizationAdmin.findAll({
       attributes: ["organizationId"],
@@ -229,38 +233,39 @@ async function elevatedAccessOrganizationIds(
     db.models.ProjectAdmin.findAll({
       attributes: ["projectId"],
       where: { userId },
-      include: [
-        {
-          model: db.models.Project,
-          as: "project",
-          attributes: ["organizationId"],
-        },
-      ],
     }),
   ]);
 
-  return Array.from(
-    new Set([
-      ...organizationAdmins.map((admin) => admin.organizationId),
-      ...projectAdmins
-        .map((admin) => admin.project?.organizationId)
-        .filter(isPresentString),
-    ]),
-  );
+  return {
+    organizationIds: Array.from(
+      new Set(organizationAdmins.map((admin) => admin.organizationId)),
+    ),
+    projectIds: Array.from(
+      new Set(projectAdmins.map((admin) => admin.projectId)),
+    ),
+  };
 }
 
-/** Load city candidates with their inventories, optionally scoped to organizations. */
-async function citiesWithInventories(
-  organizationIds?: string[],
-): Promise<City[]> {
+/** Load city candidates with their inventories, optionally scoped to projects/orgs. */
+async function citiesWithInventories(accessScopes?: {
+  organizationIds?: string[];
+  projectIds?: string[];
+}): Promise<City[]> {
+  const organizationIds = accessScopes?.organizationIds ?? [];
+  const projectIds = accessScopes?.projectIds ?? [];
+  const projectWhere = [
+    organizationIds.length
+      ? { organizationId: { [Op.in]: organizationIds } }
+      : null,
+    projectIds.length ? { projectId: { [Op.in]: projectIds } } : null,
+  ].filter(Boolean);
+
   const projectInclude = {
     model: db.models.Project,
     as: "project",
     attributes: ["projectId", "organizationId"],
-    required: Boolean(organizationIds?.length),
-    ...(organizationIds?.length
-      ? { where: { organizationId: { [Op.in]: organizationIds } } }
-      : {}),
+    required: projectWhere.length > 0,
+    ...(projectWhere.length > 0 ? { where: { [Op.or]: projectWhere } } : {}),
   };
 
   return (await db.models.City.findAll({

--- a/app/src/backend/agentic/ghgi/inventory/registry.ts
+++ b/app/src/backend/agentic/ghgi/inventory/registry.ts
@@ -46,8 +46,14 @@ export const inventoryCapabilityInputSchema = z.object({
 });
 
 export const inventoryListAccessibleInputSchema = z.object({
-  city_query: z.string().trim().min(1).optional(),
-  year: z.number().int().optional(),
+  city_query: z.preprocess(
+    (value) => (value === null ? undefined : value),
+    z.string().trim().min(1).optional(),
+  ),
+  year: z.preprocess(
+    (value) => (value === null ? undefined : value),
+    z.number().int().optional(),
+  ),
   include_all_city_years: z.boolean().optional().default(false),
 });
 

--- a/app/src/util/types.ts
+++ b/app/src/util/types.ts
@@ -483,6 +483,8 @@ export type CityResponse = {
   name: string;
   country: string;
   countryLocode: string;
+  region?: string;
+  regionLocode?: string;
   locode: string;
   inventories: {
     inventoryId: string;

--- a/app/tests/agentic-inventory-capabilities.jest.ts
+++ b/app/tests/agentic-inventory-capabilities.jest.ts
@@ -53,6 +53,9 @@ import {
 const serviceKey = "test-cc-service-key";
 const notEstimatedValueId = "58830000-0000-4000-8000-000000000501";
 const priorYearInventoryId = "58830000-0000-4000-8000-000000000502";
+const projectAdminOnlyCityId = "58830000-0000-4000-8000-000000000503";
+const projectAdminOnlyInventoryId = "58830000-0000-4000-8000-000000000504";
+const projectAdminId = "58830000-0000-4000-8000-000000000505";
 
 const serviceHeaders = {
   "X-Service-Name": "climate-advisor",
@@ -64,6 +67,8 @@ describe("GHGI inventory internal CA capability routes", () => {
   let city: City;
   let inventory: Inventory;
   let priorYearInventory: Inventory;
+  let projectAdminOnlyCity: City;
+  let projectAdminOnlyInventory: Inventory;
   let thirdPartySource: DataSourceI18n;
 
   beforeAll(async () => {
@@ -111,6 +116,27 @@ describe("GHGI inventory internal CA capability routes", () => {
       globalWarmingPotentialType: GlobalWarmingPotentialTypeEnum.ar6,
       year: 2023,
     });
+    projectAdminOnlyCity = await db.models.City.create({
+      cityId: projectAdminOnlyCityId,
+      name: "Project Admin Only City",
+      country: "United States of America",
+      locode: `US PAO ${randomUUID().slice(0, 8)}`,
+      projectId: testData.projectId,
+    });
+    projectAdminOnlyInventory = await db.models.Inventory.create({
+      inventoryId: projectAdminOnlyInventoryId,
+      ...baseInventory,
+      inventoryName: "ProjectAdminOnlyInventory",
+      cityId: projectAdminOnlyCity.cityId,
+      inventoryType: InventoryTypeEnum.GPC_BASIC,
+      globalWarmingPotentialType: GlobalWarmingPotentialTypeEnum.ar6,
+      year: 2024,
+    });
+    await db.models.ProjectAdmin.create({
+      projectAdminId,
+      projectId: testData.projectId,
+      userId: testUserID,
+    });
 
     await db.models.InventoryValue.bulkCreate(
       inventoryValuesData.map((value, index) => ({
@@ -150,6 +176,11 @@ describe("GHGI inventory internal CA capability routes", () => {
     await db.models.Inventory.destroy({
       where: { inventoryId: { [Op.in]: [inventoryId, priorYearInventoryId] } },
     });
+    await db.models.Inventory.destroy({
+      where: { inventoryId: projectAdminOnlyInventoryId },
+    });
+    await db.models.ProjectAdmin.destroy({ where: { projectAdminId } });
+    await db.models.City.destroy({ where: { cityId: projectAdminOnlyCityId } });
     if (thirdPartySource) {
       await db.models.DataSource.destroy({
         where: { datasourceId: thirdPartySource.datasourceId },
@@ -191,6 +222,37 @@ describe("GHGI inventory internal CA capability routes", () => {
           ]),
         }),
       ]),
+    );
+  });
+
+  it("lists project-admin inventories without direct city membership", async () => {
+    const directAssignmentCount = await db.models.CityUser.count({
+      where: { cityId: projectAdminOnlyCity.cityId, userId: testUserID },
+    });
+
+    const res = await listAccessibleRoute(listAccessibleRequest(), {
+      params: Promise.resolve({}),
+    });
+
+    await expectStatusCode(res, 200);
+    const payload = await res.json();
+    const matchingCity = payload.data.cities.find(
+      (candidate: { city_id: string }) =>
+        candidate.city_id === projectAdminOnlyCity.cityId,
+    );
+
+    expect(directAssignmentCount).toBe(0);
+    expect(matchingCity).toEqual(
+      expect.objectContaining({
+        city_id: projectAdminOnlyCity.cityId,
+        name: "Project Admin Only City",
+        inventories: expect.arrayContaining([
+          expect.objectContaining({
+            inventory_id: projectAdminOnlyInventory.inventoryId,
+            year: 2024,
+          }),
+        ]),
+      }),
     );
   });
 

--- a/app/tests/agentic-inventory-capabilities.jest.ts
+++ b/app/tests/agentic-inventory-capabilities.jest.ts
@@ -70,6 +70,9 @@ describe("GHGI inventory internal CA capability routes", () => {
   let projectAdminOnlyCity: City;
   let projectAdminOnlyInventory: Inventory;
   let thirdPartySource: DataSourceI18n;
+  let siblingProjectId = "";
+  let siblingProjectCityId = "";
+  let siblingProjectInventoryId = "";
 
   beforeAll(async () => {
     setupTests();
@@ -137,6 +140,32 @@ describe("GHGI inventory internal CA capability routes", () => {
       projectId: testData.projectId,
       userId: testUserID,
     });
+    siblingProjectId = randomUUID();
+    siblingProjectCityId = randomUUID();
+    siblingProjectInventoryId = randomUUID();
+    await db.models.Project.create({
+      projectId: siblingProjectId,
+      name: "Sibling Project",
+      description: "Sibling project for project-admin scope regression",
+      organizationId: testData.organizationId,
+      cityCountLimit: 10,
+    });
+    await db.models.City.create({
+      cityId: siblingProjectCityId,
+      name: "Sibling Project City",
+      country: "United States of America",
+      locode: `US SPC ${randomUUID().slice(0, 8)}`,
+      projectId: siblingProjectId,
+    });
+    await db.models.Inventory.create({
+      inventoryId: siblingProjectInventoryId,
+      ...baseInventory,
+      inventoryName: "SiblingProjectInventory",
+      cityId: siblingProjectCityId,
+      inventoryType: InventoryTypeEnum.GPC_BASIC,
+      globalWarmingPotentialType: GlobalWarmingPotentialTypeEnum.ar6,
+      year: 2024,
+    });
 
     await db.models.InventoryValue.bulkCreate(
       inventoryValuesData.map((value, index) => ({
@@ -181,6 +210,11 @@ describe("GHGI inventory internal CA capability routes", () => {
     });
     await db.models.ProjectAdmin.destroy({ where: { projectAdminId } });
     await db.models.City.destroy({ where: { cityId: projectAdminOnlyCityId } });
+    await db.models.Inventory.destroy({
+      where: { inventoryId: siblingProjectInventoryId },
+    });
+    await db.models.City.destroy({ where: { cityId: siblingProjectCityId } });
+    await db.models.Project.destroy({ where: { projectId: siblingProjectId } });
     if (thirdPartySource) {
       await db.models.DataSource.destroy({
         where: { datasourceId: thirdPartySource.datasourceId },
@@ -261,6 +295,10 @@ describe("GHGI inventory internal CA capability routes", () => {
       (candidate: { city_id: string }) =>
         candidate.city_id === projectAdminOnlyCity.cityId,
     );
+    const siblingProjectCity = payload.data.cities.find(
+      (candidate: { city_id: string }) =>
+        candidate.city_id === siblingProjectCityId,
+    );
 
     expect(directAssignmentCount).toBe(0);
     expect(matchingCity).toEqual(
@@ -275,6 +313,7 @@ describe("GHGI inventory internal CA capability routes", () => {
         ]),
       }),
     );
+    expect(siblingProjectCity).toBeUndefined();
   });
 
   it("filters listed inventories through the permission service", async () => {

--- a/app/tests/agentic-inventory-capabilities.jest.ts
+++ b/app/tests/agentic-inventory-capabilities.jest.ts
@@ -225,6 +225,27 @@ describe("GHGI inventory internal CA capability routes", () => {
     );
   });
 
+  it("treats null list filters as omitted filters", async () => {
+    const res = await listAccessibleRoute(
+      listAccessibleRequest({
+        city_query: null,
+        year: null,
+        include_all_city_years: false,
+      }),
+      { params: Promise.resolve({}) },
+    );
+
+    await expectStatusCode(res, 200);
+    const payload = await res.json();
+
+    expect(payload.data.total_cities).toBeGreaterThanOrEqual(1);
+    expect(payload.data.filters).toEqual({
+      city_query: null,
+      year: null,
+      include_all_city_years: false,
+    });
+  });
+
   it("lists project-admin inventories without direct city membership", async () => {
     const directAssignmentCount = await db.models.CityUser.count({
       where: { cityId: projectAdminOnlyCity.cityId, userId: testUserID },

--- a/climate-advisor/k8s/deployment-dev.yml
+++ b/climate-advisor/k8s/deployment-dev.yml
@@ -50,6 +50,8 @@ spec:
               value: "quiet"
             - name: MLFLOW_ASYNC_LOGGING_ENABLED
               value: "true"
+            - name: CA_FEATURE_FLAGS
+              value: "STATIONARY_ENERGY_AGENTIC"
           resources:
             requests:
               memory: "512Mi"

--- a/climate-advisor/k8s/deployment-prod.yml
+++ b/climate-advisor/k8s/deployment-prod.yml
@@ -50,6 +50,8 @@ spec:
               value: "quiet"
             - name: MLFLOW_ASYNC_LOGGING_ENABLED
               value: "true"
+            - name: CA_FEATURE_FLAGS
+              value: "STATIONARY_ENERGY_AGENTIC"
           resources:
             requests:
               memory: "512Mi"

--- a/climate-advisor/k8s/deployment-test.yml
+++ b/climate-advisor/k8s/deployment-test.yml
@@ -50,6 +50,8 @@ spec:
               value: "quiet"
             - name: MLFLOW_ASYNC_LOGGING_ENABLED
               value: "true"
+            - name: CA_FEATURE_FLAGS
+              value: "STATIONARY_ENERGY_AGENTIC"
           resources:
             requests:
               memory: "512Mi"

--- a/climate-advisor/service/tests/test_deployment_contract.py
+++ b/climate-advisor/service/tests/test_deployment_contract.py
@@ -63,6 +63,24 @@ def workflow_env_value(text: str, key: str) -> str:
     return match.group(1)
 
 
+def env_flag_set(raw_value: str) -> set[str]:
+    """Parse a comma-separated feature flag env var into names."""
+    return {
+        value.strip().strip("\"'")
+        for value in raw_value.split(",")
+        if value.strip().strip("\"'")
+    }
+
+
+def deployment_env_value(deployment: dict, key: str) -> str:
+    """Return a container env var value from a Kubernetes Deployment."""
+    containers = deployment["spec"]["template"]["spec"]["containers"]
+    for entry in containers[0].get("env", []):
+        if entry.get("name") == key:
+            return entry.get("value", "")
+    raise AssertionError(f"{key} was not set in deployment")
+
+
 def normalized_secret_reference(value: str) -> str:
     """Normalize GitHub expression spacing for secret-reference comparisons."""
     return re.sub(r"\s+", "", value)
@@ -148,6 +166,29 @@ def test_cc_and_ca_use_same_service_secret_reference(
     expected = "${{secrets.CC_SERVICE_API_KEY}}"
     assert normalized_secret_reference(workflow_env_value(web_workflow, "CC_SERVICE_API_KEY")) == expected
     assert normalized_secret_reference(workflow_env_value(ca_workflow, "CC_API_KEY")) == expected
+
+
+@pytest.mark.parametrize("environment, config", ENVIRONMENTS.items())
+def test_stationary_energy_flag_is_enabled_on_web_and_ca(
+    environment: str,
+    config: dict[str, str | list[str]],
+) -> None:
+    """Ensure CA serves Stationary Energy routes when web exposes the UI."""
+    deployment = load_yaml(str(config["deployment"]))
+    ca_workflow = workflow_text(str(config["ca_workflow"]))
+    web_workflow = workflow_text(str(config["web_workflow"]))
+
+    flag = "STATIONARY_ENERGY_AGENTIC"
+    web_flags = env_flag_set(workflow_env_value(web_workflow, "NEXT_PUBLIC_FEATURE_FLAGS"))
+    ca_workflow_flags = env_flag_set(workflow_env_value(ca_workflow, "CA_FEATURE_FLAGS"))
+    ca_deployment_flags = env_flag_set(deployment_env_value(deployment, "CA_FEATURE_FLAGS"))
+
+    assert (flag in ca_workflow_flags) == (flag in web_flags), (
+        f"{environment} web and CA workflow disagree on {flag}"
+    )
+    assert (flag in ca_deployment_flags) == (flag in web_flags), (
+        f"{environment} web and CA deployment manifest disagree on {flag}"
+    )
 
 
 @pytest.mark.parametrize("environment, config", ENVIRONMENTS.items())


### PR DESCRIPTION
## Summary

- make `inventory_list_accessible` use the maintained CityCatalyst project discovery path via `ProjectService.fetchUserProjects(userId)`
- keep the internal CA route response tailored for tool use: city/inventory IDs, year, inventory name, type, GWP, filters, and totals
- keep the final per-inventory `PermissionService.canAccessInventory(..., { includeResource: false })` filter in place
- accept explicit `null` list filters from tool calls and treat them as omitted filters
- add regressions for project-admin inventory visibility without a direct `CityUser` row, while excluding sibling projects in the same org
- enable `CA_FEATURE_FLAGS=STATIONARY_ENERGY_AGENTIC` in CA dev/test/prod deployment manifests and test/prod workflows so web does not expose the Stationary Energy draft UI while CA returns 404

## Root cause

The inventory list route originally seeded inventory candidates from direct `CityUser` city assignments only. In production, valid access can come through the same project/org/city membership model used by the CityCatalyst project drawer, so the route could return a successful empty list even when the user had inventories visible in CC.

Separately, the Stationary Energy draft-start 404 was deployment wiring: prod web had `STATIONARY_ENERGY_AGENTIC` enabled, but prod CA did not set the server-side `CA_FEATURE_FLAGS`, so `/v1/stationary-energy-drafts/start` intentionally returned `404 Not found`.

## Current approach

The inventory list route now reuses `ProjectService.fetchUserProjects(userId)`, which is the maintained access path behind `/api/v1/user/projects`. That removes the duplicated project/org access query from the inventory helper and keeps future access-rule changes centralized in the existing CC service. The only local discovery path left is the system-admin all-cities case.

The CA deployment contracts now also verify that the Stationary Energy feature flag is enabled consistently on web and CA for each environment.

## Validation

- `npx jest tests/agentic-inventory-capabilities.jest.ts --runInBand --coverage=false`
- `npx eslint src/backend/agentic/ghgi/inventory/context.ts src/backend/ProjectsService.ts src/util/types.ts src/backend/agentic/ghgi/inventory/registry.ts tests/agentic-inventory-capabilities.jest.ts`
- `git diff --check -- app/src/backend/agentic/ghgi/inventory/context.ts app/src/backend/ProjectsService.ts app/src/util/types.ts app/src/backend/agentic/ghgi/inventory/registry.ts app/tests/agentic-inventory-capabilities.jest.ts`
- `uv run --directory service pytest tests/test_deployment_contract.py -q`
- `git diff --check -- .github/workflows/climate-advisor-tag.yml .github/workflows/climate-advisor-test.yml climate-advisor/k8s/deployment-dev.yml climate-advisor/k8s/deployment-test.yml climate-advisor/k8s/deployment-prod.yml climate-advisor/service/tests/test_deployment_contract.py`

Full `npx tsc --noEmit --pretty false` is still blocked locally by unrelated stale `.next/types` stationary-energy route entries and the pre-existing untracked `app/tests/stationary-energy-notation-keys.jest.ts` file. The previous inventory-helper type error is gone.
