### PR TITLE
fix(ui): ON-6043 Total emissions not summed up

### DIFF
--- a/app/src/components/Tabs/Activity/activity-tab.tsx
+++ b/app/src/components/Tabs/Activity/activity-tab.tsx
@@ -267,12 +267,6 @@ const ActivityTab: FC<ActivityTabProps> = ({
     });
   }, [allDataSources, referenceNumber]);
 
-  let totalEmissions = 0;
-
-  activityData?.forEach((activity: any) => {
-    totalEmissions += parseInt(activity?.co2eq);
-  });
-
   const [isMethodologySelected, setIsMethodologySelected] =
     useState<boolean>(false);
   const [selectedMethodology, setSelectedMethodology] = useState("");
@@ -586,7 +580,6 @@ const ActivityTab: FC<ActivityTabProps> = ({
                 refNumberWithScope={referenceNumber}
                 activityValues={activityValues as unknown as ActivityValue[]}
                 suggestedActivities={suggestedActivities}
-                totalEmissions={totalEmissions}
                 changeMethodology={changeMethodology}
                 inventoryValue={inventoryValue as unknown as InventoryValue}
                 numberFormat={userInfo?.numberFormat}

--- a/app/src/components/Tabs/Activity/emission-data-section.tsx
+++ b/app/src/components/Tabs/Activity/emission-data-section.tsx
@@ -38,7 +38,6 @@ interface EmissionDataSectionProps {
   refNumberWithScope: string;
   activityValues: ActivityValue[];
   suggestedActivities: SuggestedActivity[];
-  totalEmissions: number;
   changeMethodology: () => void;
   inventoryValue: InventoryValue | null;
   numberFormat?: string;
@@ -52,7 +51,6 @@ const EmissionDataSection = ({
   refNumberWithScope,
   activityValues,
   suggestedActivities,
-  totalEmissions,
   changeMethodology,
   inventoryValue,
   numberFormat,
@@ -378,7 +376,10 @@ const EmissionDataSection = ({
                       fontSize="headline.md"
                     >
                       {convertKgToTonnes(
-                        inventoryValue?.co2eq as bigint,
+                        activityValues.reduce(
+                          (sum, av) => sum + BigInt(av.co2eq ?? 0n),
+                          0n,
+                        ),
                         numberFormat,
                       )}
                     </Text>


### PR DESCRIPTION
## Summary

Fixes Total Emissions showing `0 t CO2e` on sub-sector pages when activity data exists. The root cause was that `inventoryValue.co2eq` (a denormalized aggregate) was `0` in the database for inventory values imported before the co2eq accumulation fix. The display now computes the total directly from the individual `activityValues` rows, which are always correctly populated.

## Changes

- Compute Total Emissions from `activityValues.reduce(sum + av.co2eq)` in `EmissionDataSection` instead of reading `inventoryValue.co2eq` from the database
- Remove the now-unused `totalEmissions` prop from `EmissionDataSectionProps` and its calculation in `ActivityTab`

## How to test

1. Navigate to GHGI → any sub-sector that has existing activity data (especially data imported before the accumulation fix)
2. **Before**: Total Emissions showed `0 t CO2e` despite activities having non-zero emissions
3. **After**: Total Emissions correctly sums all activity rows and shows the right value
4. Add a new activity manually and confirm Total Emissions updates correctly

## Ticket

[ON-6043](https://openearth.atlassian.net/browse/ON-6043)

## Notes

`inventoryValue.co2eq` is a denormalized cache of the sum of child `activityValue.co2eq` values. Reading from the source of truth (`activityValues`) is more correct and resilient. A separate DB backfill migration can reconcile the stale `co2eq = 0` records for data integrity, but is not required for the display fix.

[ON-6043]: https://openearth.atlassian.net/browse/ON-6043