### PR TITLE
fix(ui): port emission factor display fixes to InventoryMappingStep

### DIFF
--- a/app/src/components/steps/GHGI/import/inventory-mapping-step.tsx
+++ b/app/src/components/steps/GHGI/import/inventory-mapping-step.tsx
@@ -18,6 +18,13 @@ import type { ColumnInfo, RequiredMappingOption } from "@/util/types";
 
 const MANDATORY_KEYS = new Set(["gpcRefNo", "sector", "subsector", "activityAmount"]);
 
+const EMISSION_FACTOR_KEYS = new Set([
+  "emissionFactorCO2",
+  "emissionFactorCH4",
+  "emissionFactorN2O",
+  "emissionFactorTotalCO2e",
+]);
+
 interface InventoryMappingStepProps {
   t: TFunction;
   cityId: string;
@@ -53,6 +60,22 @@ export default function InventoryMappingStep({
     return requiredMappings.find((r) => r.label === label)?.key ?? "";
   };
 
+  const formatExampleValue = (col: ColumnInfo): string | null => {
+    if (!col.exampleValue) return null;
+    if (EMISSION_FACTOR_KEYS.has(getKeyForLabel(col.interpretedAs))) {
+      const num = parseFloat(col.exampleValue);
+      if (!isNaN(num)) {
+        const tonnes = num / 1000;
+        const formatted =
+          tonnes < 0.0001
+            ? tonnes.toExponential(2)
+            : parseFloat(tonnes.toFixed(4)).toString();
+        return `${formatted} t CO2e`;
+      }
+    }
+    return col.exampleValue;
+  };
+
   const getEffectiveKey = (col: ColumnInfo): string => {
     if (col.columnName in mappingOverrides) return mappingOverrides[col.columnName];
     return getKeyForLabel(col.interpretedAs);
@@ -69,7 +92,8 @@ export default function InventoryMappingStep({
   const sortedColumns = [...columns].sort((a, b) => {
     const aReq = isMandatoryColumn(a) ? 0 : 1;
     const bReq = isMandatoryColumn(b) ? 0 : 1;
-    return aReq - bReq;
+    if (aReq !== bReq) return aReq - bReq;
+    return (b.interpretedAs ? 1 : 0) - (a.interpretedAs ? 1 : 0);
   });
 
   if (isLoading) {
@@ -218,9 +242,18 @@ export default function InventoryMappingStep({
                     </Text>
                   </Table.Cell>
                   <Table.Cell>
-                    <Text color="content.secondary">
-                      {col.exampleValue || "-"}
-                    </Text>
+                    {(() => {
+                      const displayValue = formatExampleValue(col);
+                      return (
+                        <Text
+                          color={
+                            displayValue ? "content.secondary" : "content.tertiary"
+                          }
+                        >
+                          {displayValue || t("not-specified")}
+                        </Text>
+                      );
+                    })()}
                   </Table.Cell>
                   <Table.Cell>
                     <Box>


### PR DESCRIPTION
## Summary

PR #2772 improved example value display in the import mapping screen, but those fixes targeted `mapping-columns-step.tsx` which was deleted by PR #2777 when the 4-step import flow was consolidated into `InventoryMappingStep`. The new component was left with the original `col.exampleValue || "-"` raw display.

- Port `EMISSION_FACTOR_KEYS` + `formatExampleValue` to convert CO2/CH4/N2O/TotalCO2e emission factor example values from raw units to metric tonnes (e.g. `63.1545` → `0.0632 t CO2e`)
- Replace `"-"` placeholder with `"Not specified"` in `content.tertiary` color so empty fields are visually distinct from actual data
- Update sort order: required fields first → auto-detected fields → undetected, so Activity data amount and other mandatory fields always group at the top

## Test plan

- [ ] Go to `/GHGI/onboarding/import/` and upload a GHGI file
- [ ] On the mapping step, confirm emission factor columns show values in `t CO2e` format
- [ ] Confirm columns with no example data show "Not specified" in grey instead of "-"
- [ ] Confirm required fields (GPC Ref No, Sector, Subsector, Activity Amount) appear at the top of the list
- [ ] Confirm auto-detected non-required fields appear above undetected fields