### PR TITLE
Include legal evidence for hard-filter removed actions in HIAP-meed

### DIFF
--- a/hiap-meed/README.md
+++ b/hiap-meed/README.md
@@ -596,6 +596,25 @@ Example response:
           "explanations": {}
         }
       ],
+      "removed_actions": [
+        {
+          "action_id": "c40_0013",
+          "action_name": "Electrify public bus fleets",
+          "removal_reason": "legal_verdict_blocked",
+          "removal_source": "legal_hard_filter",
+          "legal": {
+            "verdict_category": "blocked",
+            "verdict_score": 0.0,
+            "ownership_description": "Authority belongs to another level of government; municipality cannot act alone.",
+            "ownership_description_es": "La competencia pertenece a otro nivel de gobierno; el municipio no puede actuar por si solo.",
+            "restrictions_description": "There is a legal prohibition/restriction, or legal reform is needed.",
+            "restrictions_description_es": "Existe una prohibicion o restriccion legal, o se requiere una reforma legislativa.",
+            "legal_justification": "Texto de razonamiento juridico en espanol.",
+            "legal_justification_en": "English legal reasoning text.",
+            "legal_references": ["Ley 18.695 (LOCM) - BCN"]
+          }
+        }
+      ],
       "warnings": [],
       "metadata": {
         "internal_request_id": "d1db6269-4cf9-4d62-8f4c-8f4ce631fbd2",
@@ -628,6 +647,15 @@ Example response:
   ]
 }
 ```
+
+When actions are removed before ranking, the prioritization response includes
+them in `removed_actions` for frontend display. Legally blocked rows include a
+`legal` object with the same public legal detail fields used by ranked actions,
+including `ownership_description`, `ownership_description_es`,
+`restrictions_description`, `restrictions_description_es`,
+`legal_justification`, `legal_justification_en`, and `legal_references`.
+The diagnostic `metadata.hard_filter_evidence_by_action_id` map remains
+available for artifact/debug views.
 
 Common validation errors:
 

--- a/hiap-meed/app/modules/prioritizer/api.py
+++ b/hiap-meed/app/modules/prioritizer/api.py
@@ -477,6 +477,7 @@ def prioritize(
                         locode=city_input.locode,
                         ranked_action_ids=per_city_result.ranked_action_ids,
                         ranked_actions=per_city_result.ranked_actions,
+                        removed_actions=per_city_result.removed_actions,
                         metadata=per_city_result.metadata,
                         warnings=per_city_result.warnings,
                     )

--- a/hiap-meed/app/modules/prioritizer/blocks/hard_filter.py
+++ b/hiap-meed/app/modules/prioritizer/blocks/hard_filter.py
@@ -91,8 +91,20 @@ def _apply_legal_hard_filter(
             "gpc_sector": assessment.gpc_sector,
             "ownership_category": assessment.ownership_category,
             "ownership_score": assessment.ownership_score,
+            "ownership_description": assessment.ownership_description,
+            "ownership_description_es": assessment.ownership_description_i18n.get("es"),
             "restrictions_category": assessment.restrictions_category,
             "restrictions_score": assessment.restrictions_score,
+            "restrictions_description": assessment.restrictions_description,
+            "restrictions_description_es": (
+                assessment.restrictions_description_i18n.get("es")
+            ),
+            "legal_justification": (
+                assessment.legal_justification_i18n.get("es")
+                or assessment.legal_justification
+            ),
+            "legal_justification_en": assessment.legal_justification_i18n.get("en"),
+            "legal_references": list(assessment.legal_references),
             "analysis_date": assessment.analysis_date,
             "generation_method": assessment.generation_method,
         }

--- a/hiap-meed/app/modules/prioritizer/models.py
+++ b/hiap-meed/app/modules/prioritizer/models.py
@@ -1301,6 +1301,73 @@ class PrioritizationExplanationMetadata(BaseModel):
     )
 
 
+class HardFilterLegalAssessmentSummary(BaseModel):
+    """Legal row details returned for hard-filter decisions."""
+
+    model_config = ConfigDict(extra="allow")
+
+    country_code: str | None = Field(
+        default=None,
+        description="Country code used to select the legal assessment row.",
+    )
+    gpc_sector: str | None = Field(
+        default=None,
+        description="GPC sector associated with the legal assessment row.",
+    )
+    ownership_category: str | None = Field(
+        default=None,
+        description="Legal authority category for who can implement the action.",
+    )
+    ownership_score: float | None = Field(
+        default=None,
+        description="Normalized ownership authority score when present.",
+    )
+    ownership_description: str | None = Field(
+        default=None,
+        description="English plain-language description of who has legal authority.",
+    )
+    ownership_description_es: str | None = Field(
+        default=None,
+        description="Spanish plain-language description of who has legal authority.",
+    )
+    restrictions_category: str | None = Field(
+        default=None,
+        description="Legal restriction category for the action.",
+    )
+    restrictions_score: float | None = Field(
+        default=None,
+        description="Normalized restrictions score when present.",
+    )
+    restrictions_description: str | None = Field(
+        default=None,
+        description="English plain-language description of legal barriers or restrictions.",
+    )
+    restrictions_description_es: str | None = Field(
+        default=None,
+        description="Spanish plain-language description of legal barriers or restrictions.",
+    )
+    legal_justification: str | None = Field(
+        default=None,
+        description="Full Spanish legal reasoning for the verdict when present.",
+    )
+    legal_justification_en: str | None = Field(
+        default=None,
+        description="Full English legal reasoning for the verdict when present.",
+    )
+    legal_references: list[str] = Field(
+        default_factory=list,
+        description="Legal reference strings supporting the verdict.",
+    )
+    analysis_date: str | None = Field(
+        default=None,
+        description="Date when the legal assessment was produced.",
+    )
+    generation_method: str | None = Field(
+        default=None,
+        description="Method used to produce the legal assessment.",
+    )
+
+
 class HardFilterEvidenceSummary(BaseModel):
     """Per-action hard-filter evidence returned in prioritization metadata."""
 
@@ -1317,6 +1384,85 @@ class HardFilterEvidenceSummary(BaseModel):
     legal_verdict_category: str | None = Field(
         default=None,
         description="Legal verdict category observed by the hard filter when present.",
+    )
+    legal_assessment_summary: HardFilterLegalAssessmentSummary | None = Field(
+        default=None,
+        description="Legal row details used by the hard filter when present.",
+    )
+
+
+class RemovedActionLegalEvidence(BaseModel):
+    """Frontend-facing legal evidence for an action removed before ranking."""
+
+    verdict_category: str | None = Field(
+        default=None,
+        description="Legal verdict category that caused or informed removal.",
+    )
+    verdict_score: float | None = Field(
+        default=None,
+        description="Legal verdict score when present.",
+    )
+    ownership_category: str | None = Field(
+        default=None,
+        description="Legal authority category for who can implement the action.",
+    )
+    ownership_score: float | None = Field(
+        default=None,
+        description="Normalized ownership authority score when present.",
+    )
+    ownership_description: str | None = Field(
+        default=None,
+        description="English plain-language description of who has legal authority.",
+    )
+    ownership_description_es: str | None = Field(
+        default=None,
+        description="Spanish plain-language description of who has legal authority.",
+    )
+    restrictions_category: str | None = Field(
+        default=None,
+        description="Legal restriction category for the action.",
+    )
+    restrictions_score: float | None = Field(
+        default=None,
+        description="Normalized restrictions score when present.",
+    )
+    restrictions_description: str | None = Field(
+        default=None,
+        description="English plain-language description of legal barriers or restrictions.",
+    )
+    restrictions_description_es: str | None = Field(
+        default=None,
+        description="Spanish plain-language description of legal barriers or restrictions.",
+    )
+    legal_justification: str | None = Field(
+        default=None,
+        description="Full Spanish legal reasoning for the verdict when present.",
+    )
+    legal_justification_en: str | None = Field(
+        default=None,
+        description="Full English legal reasoning for the verdict when present.",
+    )
+    legal_references: list[str] = Field(
+        default_factory=list,
+        description="Legal reference strings supporting the verdict.",
+    )
+
+
+class RemovedActionSummary(BaseModel):
+    """Frontend-facing summary for an action removed before ranking."""
+
+    action_id: str = Field(description="Stable action identifier.")
+    action_name: str = Field(description="Human-readable action name.")
+    removal_reason: str | None = Field(
+        default=None,
+        description="Reason the action was removed before ranking.",
+    )
+    removal_source: str = Field(
+        description="Pipeline source that removed the action.",
+    )
+    legal: RemovedActionLegalEvidence | None = Field(
+        default=None,
+        description="Legal evidence for legal hard-filter removals.",
     )
 
 
@@ -1357,6 +1503,10 @@ class PrioritizationResponse(BaseModel):
 
     ranked_action_ids: list[str] = Field(default_factory=list)
     ranked_actions: list[RankedActionResult] = Field(default_factory=list)
+    removed_actions: list[RemovedActionSummary] = Field(
+        default_factory=list,
+        description="Actions removed before ranking, shaped for frontend display.",
+    )
     metadata: PrioritizationMetadata = Field(
         description="Stable diagnostics and metadata for the ranked city."
     )
@@ -1415,6 +1565,10 @@ class PrioritizerApiCityResult(BaseModel):
     ranked_actions: list[RankedActionResult] = Field(
         default_factory=list,
         description="Detailed ranked actions with scores, evidence, and explanations.",
+    )
+    removed_actions: list[RemovedActionSummary] = Field(
+        default_factory=list,
+        description="Actions removed before ranking, shaped for frontend display.",
     )
     metadata: PrioritizationMetadata = Field(
         description="Diagnostics, timings, counts, and artifact-oriented metadata.",

--- a/hiap-meed/app/modules/prioritizer/orchestrator.py
+++ b/hiap-meed/app/modules/prioritizer/orchestrator.py
@@ -14,7 +14,11 @@ from app.modules.prioritizer.blocks import (
 )
 from app.modules.prioritizer.scoring_config import validate_weights
 from app.modules.prioritizer.internal_models import Action, CityEmissionsContext
-from app.modules.prioritizer.models import PrioritizationResponse, RankedActionResult
+from app.modules.prioritizer.models import (
+    PrioritizationResponse,
+    RankedActionResult,
+    RemovedActionSummary,
+)
 from app.modules.prioritizer.services.explanations import generate_explanations
 from app.modules.prioritizer.services.translation import translate_explanations
 from app.services.data_clients import (
@@ -129,6 +133,63 @@ def _legal_fetch_source_descriptor(
         "source": fallback_descriptor["source"],
         "source_metadata": dict(first_source_metadata),
     }
+
+
+def _removed_action_source(discard_reason: object) -> str:
+    """Return the public source label for one hard-filter removal reason."""
+    if discard_reason == "legal_verdict_blocked":
+        return "legal_hard_filter"
+    if discard_reason == "user_excluded":
+        return "user_exclusion"
+    return "hard_filter"
+
+
+def _build_removed_action_legal_evidence(
+    evidence: dict[str, object],
+) -> dict[str, object] | None:
+    """Return frontend-facing legal evidence for a removed action when present."""
+    summary = evidence.get("legal_assessment_summary")
+    if not isinstance(summary, dict):
+        return None
+    return {
+        "verdict_category": evidence.get("legal_verdict_category"),
+        "verdict_score": evidence.get("legal_verdict_score"),
+        "ownership_category": summary.get("ownership_category"),
+        "ownership_score": summary.get("ownership_score"),
+        "ownership_description": summary.get("ownership_description"),
+        "ownership_description_es": summary.get("ownership_description_es"),
+        "restrictions_category": summary.get("restrictions_category"),
+        "restrictions_score": summary.get("restrictions_score"),
+        "restrictions_description": summary.get("restrictions_description"),
+        "restrictions_description_es": summary.get("restrictions_description_es"),
+        "legal_justification": summary.get("legal_justification"),
+        "legal_justification_en": summary.get("legal_justification_en"),
+        "legal_references": list(summary.get("legal_references", [])),
+    }
+
+
+def _build_removed_actions(
+    *,
+    discarded_actions: list[Action],
+    evidence_by_action_id: dict[str, dict[str, object]],
+) -> list[RemovedActionSummary]:
+    """Return frontend-facing summaries for actions removed before ranking."""
+    removed_actions: list[RemovedActionSummary] = []
+    for action in discarded_actions:
+        evidence = evidence_by_action_id.get(action.action_id, {})
+        removal_reason = evidence.get("discard_reason")
+        removed_actions.append(
+            RemovedActionSummary(
+                action_id=action.action_id,
+                action_name=action.action_name,
+                removal_reason=(
+                    removal_reason if isinstance(removal_reason, str) else None
+                ),
+                removal_source=_removed_action_source(removal_reason),
+                legal=_build_removed_action_legal_evidence(evidence),
+            )
+        )
+    return removed_actions
 
 
 def _group_feasibility_evidence(evidence: dict[str, object]) -> dict[str, object]:
@@ -1455,6 +1516,13 @@ def run_prioritization(
         )
 
     ranked_action_ids = [item.action.action_id for item in scored_actions]
+    removed_actions = _build_removed_actions(
+        discarded_actions=[
+            *hard_filter_result.discarded_excluded,
+            *hard_filter_result.discarded_legal,
+        ],
+        evidence_by_action_id=hard_filter_result.evidence,
+    )
     generated_languages = _collect_generated_languages(
         requested_languages=requested_languages,
         explanations_by_action_id=explanations_by_action_id,
@@ -1492,6 +1560,10 @@ def run_prioritization(
                 "ranked_actions": [
                     ranked_action.model_dump(mode="json")
                     for ranked_action in ranked_actions
+                ],
+                "removed_actions": [
+                    removed_action.model_dump(mode="json")
+                    for removed_action in removed_actions
                 ],
                 "metadata": metadata,
                 "warnings": translation_warnings,
@@ -1578,6 +1650,7 @@ def run_prioritization(
     return PrioritizationResponse(
         ranked_action_ids=ranked_action_ids,
         ranked_actions=ranked_actions,
+        removed_actions=removed_actions,
         metadata=metadata,
         warnings=translation_warnings,
     )

--- a/hiap-meed/docs/pipeline-description.md
+++ b/hiap-meed/docs/pipeline-description.md
@@ -1227,6 +1227,16 @@ Key metadata includes:
 - `counts.ranked_actions`
 - `hard_filter_evidence_by_action_id`
 
+The response also includes top-level `removed_actions` beside `ranked_actions`.
+This is the frontend-facing list for actions removed before scoring. For legally
+blocked actions, each item uses `removal_source = legal_hard_filter` and includes
+a `legal` object with the verdict, public ownership and restriction
+categories/scores, English and Spanish ownership and restriction descriptions,
+Spanish and English legal justification, and normalized legal reference strings
+from the legal classification source. The metadata
+`hard_filter_evidence_by_action_id` map remains available as the diagnostic
+hard-filter trace.
+
 ## 9. How the Final Ranked List Is Created
 
 The final ranked list is produced in this sequence:

--- a/hiap-meed/tests/integration/test_api_health.py
+++ b/hiap-meed/tests/integration/test_api_health.py
@@ -36,6 +36,30 @@ class TestAPIHealth:
         assert evidence_summary_property["$ref"].endswith(
             "/RankedActionEvidenceSummary"
         )
+        city_result_schema = data["components"]["schemas"]["PrioritizerApiCityResult"]
+        assert city_result_schema["properties"]["removed_actions"]["items"][
+            "$ref"
+        ].endswith("/RemovedActionSummary")
+        removed_action_schema = data["components"]["schemas"]["RemovedActionSummary"]
+        removed_action_properties = removed_action_schema["properties"]
+        assert removed_action_properties["legal"]["anyOf"][0]["$ref"].endswith(
+            "/RemovedActionLegalEvidence"
+        )
+        removed_action_legal_schema = data["components"]["schemas"][
+            "RemovedActionLegalEvidence"
+        ]
+        removed_action_legal_properties = removed_action_legal_schema["properties"]
+        assert {
+            "verdict_category",
+            "verdict_score",
+            "ownership_description",
+            "ownership_description_es",
+            "restrictions_description",
+            "restrictions_description_es",
+            "legal_justification",
+            "legal_justification_en",
+            "legal_references",
+        }.issubset(removed_action_legal_properties.keys())
 
         feasibility_schema = data["components"]["schemas"][
             "RankedActionFeasibilityEvidenceSummary"
@@ -67,3 +91,22 @@ class TestAPIHealth:
             "legal_justification_en",
             "legal_references",
         }.issubset(legal_properties.keys())
+        hard_filter_schema = data["components"]["schemas"][
+            "HardFilterEvidenceSummary"
+        ]
+        assert hard_filter_schema["properties"]["legal_assessment_summary"][
+            "anyOf"
+        ][0]["$ref"].endswith("/HardFilterLegalAssessmentSummary")
+        hard_filter_legal_schema = data["components"]["schemas"][
+            "HardFilterLegalAssessmentSummary"
+        ]
+        hard_filter_legal_properties = hard_filter_legal_schema["properties"]
+        assert {
+            "ownership_description",
+            "ownership_description_es",
+            "restrictions_description",
+            "restrictions_description_es",
+            "legal_justification",
+            "legal_justification_en",
+            "legal_references",
+        }.issubset(hard_filter_legal_properties.keys())

--- a/hiap-meed/tests/integration/test_prioritize_e2e_mock_api_data.py
+++ b/hiap-meed/tests/integration/test_prioritize_e2e_mock_api_data.py
@@ -90,6 +90,7 @@ def test_prioritize_e2e_with_mock_api_payloads(
 
         ranked_action_ids = result["ranked_action_ids"]
         ranked_actions = result["ranked_actions"]
+        removed_actions = result["removed_actions"]
 
         assert result["locode"] == "CL IQQ"
         assert metadata["weights"] == {"impact": 0.5, "alignment": 0.3, "feasibility": 0.2}
@@ -103,6 +104,10 @@ def test_prioritize_e2e_with_mock_api_payloads(
         )
         assert metadata["counts"]["ranked_actions"] == 20
         assert len(ranked_actions) == 20
+        assert len(removed_actions) == (
+            metadata["counts"]["discarded_excluded"]
+            + metadata["counts"]["discarded_legal"]
+        )
         discarded_legal_action_ids = set(
             metadata["hard_filter_evidence_by_action_id"].keys()
         )
@@ -163,6 +168,55 @@ def test_prioritize_e2e_with_mock_api_payloads(
         ]
         assert blocked_evidence["discard_reason"] == "legal_verdict_blocked"
         assert blocked_evidence["legal_verdict_category"] == "blocked"
+        blocked_legal_summary = blocked_evidence["legal_assessment_summary"]
+        assert {
+            "ownership_description",
+            "ownership_description_es",
+            "restrictions_description",
+            "restrictions_description_es",
+            "legal_justification",
+            "legal_justification_en",
+            "legal_references",
+        }.issubset(blocked_legal_summary.keys())
+        assert isinstance(blocked_legal_summary["ownership_description"], str)
+        assert isinstance(blocked_legal_summary["ownership_description_es"], str)
+        assert isinstance(blocked_legal_summary["restrictions_description"], str)
+        assert isinstance(blocked_legal_summary["restrictions_description_es"], str)
+        assert isinstance(blocked_legal_summary["legal_justification"], str)
+        assert isinstance(blocked_legal_summary["legal_justification_en"], str)
+        assert isinstance(blocked_legal_summary["legal_references"], list)
+        assert blocked_legal_summary["legal_references"]
+        removed_blocked_action = next(
+            item for item in removed_actions if item["action_id"] == "c40_0013"
+        )
+        assert removed_blocked_action["removal_reason"] == "legal_verdict_blocked"
+        assert removed_blocked_action["removal_source"] == "legal_hard_filter"
+        assert isinstance(removed_blocked_action["action_name"], str)
+        assert removed_blocked_action["legal"]["verdict_category"] == "blocked"
+        assert removed_blocked_action["legal"]["verdict_score"] == pytest.approx(
+            blocked_evidence["legal_verdict_score"]
+        )
+        assert removed_blocked_action["legal"]["ownership_description"] == (
+            blocked_legal_summary["ownership_description"]
+        )
+        assert removed_blocked_action["legal"]["ownership_description_es"] == (
+            blocked_legal_summary["ownership_description_es"]
+        )
+        assert removed_blocked_action["legal"]["restrictions_description"] == (
+            blocked_legal_summary["restrictions_description"]
+        )
+        assert removed_blocked_action["legal"]["restrictions_description_es"] == (
+            blocked_legal_summary["restrictions_description_es"]
+        )
+        assert removed_blocked_action["legal"]["legal_justification"] == (
+            blocked_legal_summary["legal_justification"]
+        )
+        assert removed_blocked_action["legal"]["legal_justification_en"] == (
+            blocked_legal_summary["legal_justification_en"]
+        )
+        assert removed_blocked_action["legal"]["legal_references"] == (
+            blocked_legal_summary["legal_references"]
+        )
         assert missing_evidence_rows
 
         # Verify artifact naming and full-response persistence.

--- a/hiap-meed/tests/unit/test_prioritizer_blocks.py
+++ b/hiap-meed/tests/unit/test_prioritizer_blocks.py
@@ -188,6 +188,27 @@ def test_hard_filter_block_with_mock_api_data() -> None:
     assert len(result.valid_actions) == len(actions) - len(discarded_legal_ids)
 
     assert result.evidence["c40_0013"]["discard_reason"] == "legal_verdict_blocked"
+    blocked_summary = result.evidence["c40_0013"]["legal_assessment_summary"]
+    blocked_assessment = legal_assessments["c40_0013"]
+    assert blocked_summary["ownership_description"] == (
+        blocked_assessment.ownership_description
+    )
+    assert blocked_summary["ownership_description_es"] == (
+        blocked_assessment.ownership_description_i18n["es"]
+    )
+    assert blocked_summary["restrictions_description"] == (
+        blocked_assessment.restrictions_description
+    )
+    assert blocked_summary["restrictions_description_es"] == (
+        blocked_assessment.restrictions_description_i18n["es"]
+    )
+    assert blocked_summary["legal_justification"] == (
+        blocked_assessment.legal_justification_i18n["es"]
+    )
+    assert blocked_summary["legal_justification_en"] == (
+        blocked_assessment.legal_justification_i18n["en"]
+    )
+    assert blocked_summary["legal_references"] == blocked_assessment.legal_references
     assert result.evidence["c40_0012"]["legal_verdict_category"] == "enabled"
     missing_action_id = next(
         action.action_id


### PR DESCRIPTION
## Summary

This PR adds `removed_actions` to the HIAP-meed prioritization API response, including public legal hard-filter explanations for actions removed before ranking.

## Changes

- Extend hard-filter legal evidence models with i18n ownership/restrictions descriptions, legal justification (en/es), and legal reference strings.
- Add `removed_actions` (with `removal_reason`, `removal_source`, and optional `legal` evidence) to `PrioritizerApiCityResult` / response schema.
- Update API wiring and HIAP-meed documentation/README examples to reflect the new response shape.
- Add unit/integration tests validating OpenAPI schema and evidence consistency.

## How to test

1. `pytest hiap-meed/tests/unit/test_prioritizer_blocks.py`
2. `pytest hiap-meed/tests/integration/test_api_health.py`
3. `pytest hiap-meed/tests/integration/test_prioritize_e2e_mock_api_data.py`
