### PR TITLE
feat(api): ON-5916 implement public project actions endpoint

### DIFF
--- a/app/src/app/api/v1/public/project/[projectId]/actions/route.ts
+++ b/app/src/app/api/v1/public/project/[projectId]/actions/route.ts
@@ -91,7 +91,7 @@ export const GET = apiHandler(async (_req, { params }) => {
     include: [
       {
         model: db.models.HighImpactActionRanked,
-        as: "highImpactActionsRanked",
+        as: "highImpactActionRanked",
       },
     ],
   });
@@ -102,7 +102,7 @@ export const GET = apiHandler(async (_req, { params }) => {
       actionsByInventoryId[ranking.inventoryId] = [];
     }
     actionsByInventoryId[ranking.inventoryId].push(
-      ranking.highImpactActionsRanked,
+      ranking.highImpactActionRanked,
     );
   });
 

--- a/app/src/app/api/v1/public/project/[projectId]/actions/route.ts
+++ b/app/src/app/api/v1/public/project/[projectId]/actions/route.ts
@@ -1,0 +1,119 @@
+/**
+ * @swagger
+ * /api/v1/public/project/{projectId}/actions:
+ *   get:
+ *     tags:
+ *       - public
+ *     operationId: getPublicProjectActions
+ *     summary: Get climate actions for all public cities in a project
+ *     description: Public endpoint that returns climate action details only if the city has at least one public inventory. No authentication is required. Response is wrapped in '{' data '}'.
+ *     parameters:
+ *       - in: path
+ *         name: projectId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Climate action details wrapped in data.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     locode:
+ *                       type: string
+ *                     cityName:
+ *                       type: string
+ *                     regionName:
+ *                       type: string
+ *                       nullable: true
+ *                     actions:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *       400:
+ *         description: Invalid project ID.
+ *       401:
+ *         description: No public data available for this project.
+ */
+import { NextResponse } from "next/server";
+import { apiHandler } from "@/util/api";
+import createHttpError from "http-errors";
+import { validate } from "uuid";
+import { db } from "@/models";
+import { Op } from "sequelize";
+
+export const GET = apiHandler(async (_req, { params }) => {
+  const { projectId } = params;
+
+  if (!validate(projectId)) {
+    throw new createHttpError.BadRequest(
+      `'${projectId}' is not a valid project id (uuid)`,
+    );
+  }
+
+  // First check if city has any public inventories before fetching city data
+  const publicInventories = await db.models.Inventory.findAll({
+    where: {
+      isPublic: true,
+    },
+    include: [
+      {
+        model: db.models.City,
+        as: "city",
+        where: {
+          projectId,
+        },
+        required: true,
+        order: ["name"],
+      },
+    ],
+  });
+
+  if (publicInventories.length === 0) {
+    throw new createHttpError.Unauthorized(
+      "No public city inventories available for this project",
+    );
+  }
+
+  const inventoryIds = publicInventories.map(
+    (inventory) => inventory.inventoryId,
+  );
+  const actionRankings = await db.models.HighImpactActionRanking.findAll({
+    where: {
+      inventoryId: { [Op.in]: inventoryIds },
+    },
+    include: [
+      {
+        model: db.models.HighImpactActionRanked,
+        as: "highImpactActionsRanked",
+      },
+    ],
+  });
+  const actionsByInventoryId: Record<string, any[]> = {};
+
+  actionRankings.map((ranking) => {
+    if (!(ranking.inventoryId in actionsByInventoryId)) {
+      actionsByInventoryId[ranking.inventoryId] = [];
+    }
+    actionsByInventoryId[ranking.inventoryId].push(
+      ranking.highImpactActionsRanked,
+    );
+  });
+
+  const results = publicInventories.map((inventory) => {
+    return {
+      locode: inventory.city.locode,
+      cityName: inventory.city.name,
+      regionName: inventory.city.region,
+      actions: actionsByInventoryId[inventory.inventoryId] ?? [],
+    };
+  });
+
+  return NextResponse.json({ data: results });
+});

--- a/app/src/models/HighImpactActionRanking.ts
+++ b/app/src/models/HighImpactActionRanking.ts
@@ -46,7 +46,7 @@ export class HighImpactActionRanking
   declare isBulk?: boolean;
   declare userId?: string;
 
-  declare highImpactActionsRanked: HighImpactActionRanked[];
+  declare highImpactActionRanked: HighImpactActionRanked[];
 
   static initModel(
     sequelize: Sequelize.Sequelize,

--- a/app/src/models/HighImpactActionRanking.ts
+++ b/app/src/models/HighImpactActionRanking.ts
@@ -1,6 +1,7 @@
 import * as Sequelize from "sequelize";
 import { DataTypes, Model, Optional } from "sequelize";
 import { ACTION_TYPES, HighImpactActionRankingStatus } from "@/util/types";
+import { HighImpactActionRanked } from "./HighImpactActionRanked";
 
 export interface HighImpactActionRankingAttributes {
   id: string;
@@ -44,6 +45,8 @@ export class HighImpactActionRanking
   declare errorMessage?: string | null;
   declare isBulk?: boolean;
   declare userId?: string;
+
+  declare highImpactActionsRanked: HighImpactActionRanked[];
 
   static initModel(
     sequelize: Sequelize.Sequelize,
@@ -135,4 +138,3 @@ export class HighImpactActionRanking
     );
   }
 }
-

--- a/app/src/models/init-models.ts
+++ b/app/src/models/init-models.ts
@@ -1087,7 +1087,7 @@ export function initModels(sequelize: Sequelize) {
     foreignKey: "hiaRankingId",
   });
   HighImpactActionRankingModel.hasMany(HighImpactActionRankedModel, {
-    as: "highImpactActionsRanked",
+    as: "highImpactActionRanked",
     foreignKey: "hiaRankingId",
   });
 

--- a/app/src/models/init-models.ts
+++ b/app/src/models/init-models.ts
@@ -233,7 +233,6 @@ import {
   OAuthClientI18NOptionalAttributes,
   OAuthClientI18N,
 } from "./OAuthClientI18N";
-import { se } from "date-fns/locale";
 
 import { OAuthClientAuthz as _OAuthClientAuthz } from "./OAuthClientAuthz";
 import {
@@ -1088,7 +1087,7 @@ export function initModels(sequelize: Sequelize) {
     foreignKey: "hiaRankingId",
   });
   HighImpactActionRankingModel.hasMany(HighImpactActionRankedModel, {
-    as: "highImpactActionRanked",
+    as: "highImpactActionsRanked",
     foreignKey: "hiaRankingId",
   });
 


### PR DESCRIPTION
## Summary

Creates new API route `/api/v1/public/project/PROJECT_ID/actions` for use with the CityClimateCompass dashboard. It returns the ranked climate actions that are part of public inventories that belong to the project.

## How to test

1. Find out the project ID of a project by looking e.g. at network requests or performing a database query. The project should have public inventories and climate actions created in the Actions & Plans module.
2. Make an API request to `/api/v1/public/project/PROJECT_ID/actions`, replacing PROJECT_ID with the project's ID.
3. Validate that actions are being returned correctly.

## Ticket

https://openearth.atlassian.net/browse/ON-5859
