### PR TITLE
fix(email): fix TypeError in role update notification

### DIFF
--- a/app/src/app/api/v1/organizations/[organization]/role/route.ts
+++ b/app/src/app/api/v1/organizations/[organization]/role/route.ts
@@ -133,7 +133,7 @@ export const PATCH = apiHandler(async (req, { params, session }) => {
         await EmailService.sendRoleUpdateNotification({
           email,
           brandInformation: {
-            color: org.theme.primaryColor,
+            color: org.theme?.primaryColor,
             logoUrl: org.logoUrl as string,
           },
           organizationName: org.name as string,

--- a/app/src/backend/EmailService.ts
+++ b/app/src/backend/EmailService.ts
@@ -391,8 +391,8 @@ export default class EmailService {
     email: string;
     organizationName: string;
     brandInformation?: {
-      color: string;
-      logoUrl: string;
+      color?: string;
+      logoUrl?: string;
     };
     user: User | null;
   }) {

--- a/app/src/lib/emails/RoleUpdateNotificationTemplate.tsx
+++ b/app/src/lib/emails/RoleUpdateNotificationTemplate.tsx
@@ -26,8 +26,8 @@ export function RoleUpdateNotificationTemplate({
   email: string;
   organizationName: string;
   brandInformation?: {
-    color: string;
-    logoUrl: string;
+    color?: string;
+    logoUrl?: string;
   };
   language?: string;
 }) {


### PR DESCRIPTION
## Summary
Fixes a backend crash when trying to send a role update notification email to a user. This occurs when the associated organization does not have a theme set (`org.theme` is `null`), resulting in a `TypeError: Cannot read properties of null (reading 'primaryColor')`.
## Changes
- **route.ts**: Added optional chaining (`org.theme?.primaryColor`) when retrieving the brand color to prevent a runtime exception when the organization theme is null.
- **EmailService.ts**: Updated the typescript parameter type of `sendRoleUpdateNotification` to mark the `color` and `logoUrl` fields as optional.
- **RoleUpdateNotificationTemplate.tsx**: Adjusted the template props typescript definitions to allow optional `color` and `logoUrl`.
## How to test
1. Ensure an organization exists without any custom theme selected (where the theme relation is null/empty).
2. Upgrade a user to the organization admin role to trigger the email dispatch logic in `route.ts`.
3. Verify that the PATCH request succeeds and that the email is dispatched using the default white background fallback color (`#ffffff`) without throwing any `TypeError`.
## Ticket
ON-5964
## Notes
- Uses fallback value (`brandInformation.color || "#ffffff"`) defined in the template when the theme color is not provided.