### PR TITLE
feat: adopt prefix-based naming convention for Cursor skills

### DIFF
--- a/.cursor/CONVENTIONS.md
+++ b/.cursor/CONVENTIONS.md
@@ -1,0 +1,67 @@
+# Cursor Skills and Rules Naming Convention
+
+This document defines the naming convention for Cursor skills and rules in CityCatalyst and related Open Earth Foundation repositories.
+
+## Purpose
+
+Consistent prefixes make skills discoverable, group related functionality, and clarify the domain/purpose at a glance.
+
+## Taxonomy
+
+### Skill Prefixes
+
+| Prefix | Purpose | Examples |
+|--------|---------|----------|
+| `ticket-*` | Ticket and issue management workflows | `ticket-create`, `ticket-refine` |
+| `nontech-*` | Non-technical contributor workflows | `nontech-contribute` |
+| `dev-*` | Developer workflows (PR review, code quality, standards) | `dev-pr-review-gate`, `dev-pull-request-standards`, `dev-script-quality-gate` |
+| `impl-*` | Implementation tasks (create components, endpoints, features) | `impl-create-component`, `impl-create-api-endpoint`, `impl-full-feature` |
+| `docs-*` | Documentation tasks | `docs-after-change`, `docs-simplify-after-change` |
+| `ai-*` | AI/LLM-specific operations | `ai-prompt-schema-authoring` |
+| `k8s-*` | Kubernetes operations | `k8s-health-audit`, `k8s-readonly-query` |
+| `repo-*` | Repository-wide operations and audits | `repo-doc-audit` |
+
+### Rule Naming
+
+Rules use descriptive kebab-case names that indicate their scope:
+
+- Domain-specific: `nextjs-frontend.mdc`, `python-fastapi.mdc`, `sequelize-database.mdc`
+- Component-specific: `chakra-ui-components.mdc`, `forms-validation.mdc`
+- General: `general.mdc`, `project-architecture.mdc`, `testing.mdc`
+
+Rules may also use prefixes when they are tightly coupled to a specific area (e.g., `api-routes.mdc`, `auth-permissions.mdc`, `rtk-query.mdc`).
+
+## Benefits
+
+1. **Discoverability** — Type `ticket-` in Cursor and see all ticket-related skills
+2. **Grouping** — Related skills appear together in alphabetical listings
+3. **Clarity** — The prefix signals the domain before reading the description
+4. **Consistency** — Same convention across all OEF repositories (CityCatalyst, agentic-coder, etc.)
+
+## Migration Notes
+
+Skills were renamed in CC-505 to adopt this convention. Internal references (cross-skill links) were updated accordingly.
+
+- Old: `create-ticket`, `refine-ticket`, `non-tech-contribute`
+- New: `ticket-create`, `ticket-refine`, `nontech-contribute`
+
+Skills that already followed a good prefix pattern (`k8s-*`, `repo-*`) were kept as-is.
+
+## Adding New Skills
+
+When creating a new skill:
+
+1. Choose the appropriate prefix from the taxonomy above
+2. Use kebab-case for the rest of the name
+3. Update this document if introducing a new prefix category
+4. Ensure the `name:` field in the skill's YAML frontmatter matches the directory name
+
+## Cross-Repository Adoption
+
+This convention applies to:
+
+- **CityCatalyst** (this repo)
+- **agentic-coder** (OEF's autonomous coding agent)
+- Other OEF repositories using Cursor skills
+
+When adding skills to a new repo, follow this taxonomy to maintain consistency across the organization.

--- a/.cursor/skills/ai-prompt-schema-authoring/SKILL.md
+++ b/.cursor/skills/ai-prompt-schema-authoring/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: prompt-schema-authoring
+name: ai-prompt-schema-authoring
 description: Create or update any LLM-related prompt file in this repository using the required `<role>`, `<task>`, `<input>`, and `<output>` structure, with optional `<tools>` when tool policy is needed, and explicit model-aligned field contracts. Use for prompts stored in markdown, Python prompt templates, YAML/JSON config prompts, and any other runtime prompt definitions for large language models (LLMs).
 ---
 

--- a/.cursor/skills/dev-pr-review-gate/SKILL.md
+++ b/.cursor/skills/dev-pr-review-gate/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: pr-review-gate
+name: dev-pr-review-gate
 description: Review pull requests for high-impact issues only. Use when the user asks to review a PR, especially requests like "do a review of PR <id>", "review PR <id>", or "PR review". Evaluate security, AGENTS.md alignment, repository structure, reuse over reimplementation, complexity, and regression risk. Return only actionable comments worth changing.
 ---
 

--- a/.cursor/skills/dev-pull-request-standards/SKILL.md
+++ b/.cursor/skills/dev-pull-request-standards/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: pull-request-standards
+name: dev-pull-request-standards
 description: Create or update pull requests with repository-derived context and concise title/body standards. Use when creating, updating, automating, drafting, or polishing PRs, or preparing GitHub PR tool payloads.
 ---
 

--- a/.cursor/skills/dev-script-quality-gate/SKILL.md
+++ b/.cursor/skills/dev-script-quality-gate/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: script-quality-gate
+name: dev-script-quality-gate
 description: Apply when adding or modifying runnable scripts/entrypoints. Ensures docstring, argparse, __main__, logging, and import/path conventions are correct.
 ---
 

--- a/.cursor/skills/docs-simplify-after-change/SKILL.md
+++ b/.cursor/skills/docs-simplify-after-change/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: docs-simplify-after-change
+description: After any code change, simplify the changed code so it is boring, readable, and minimal while preserving behavior.
+---
+
 # simplify-after-change
 
 ## Purpose

--- a/.cursor/skills/impl-add-rtk-endpoint/SKILL.md
+++ b/.cursor/skills/impl-add-rtk-endpoint/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: add-rtk-endpoint
+name: impl-add-rtk-endpoint
 description: Add a new RTK Query endpoint to CityCatalyst's API service. Use when the user asks to add data fetching, create a query hook, add a mutation, or connect frontend to a new API endpoint.
 ---
 

--- a/.cursor/skills/impl-create-api-endpoint/SKILL.md
+++ b/.cursor/skills/impl-create-api-endpoint/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: create-api-endpoint
+name: impl-create-api-endpoint
 description: Create a new REST API endpoint in CityCatalyst. Use when the user asks to create, add, or implement a new API route, endpoint, or backend handler.
 ---
 

--- a/.cursor/skills/impl-create-component/SKILL.md
+++ b/.cursor/skills/impl-create-component/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: create-component
+name: impl-create-component
 description: Create a new React component in CityCatalyst using Chakra UI v3, i18n, and project conventions. Use when the user asks to create, add, or build a new UI component, page section, or widget.
 ---
 

--- a/.cursor/skills/impl-create-migration/SKILL.md
+++ b/.cursor/skills/impl-create-migration/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: create-migration
+name: impl-create-migration
 description: Create a Sequelize database migration and model for CityCatalyst. Use when the user asks to add a database table, column, index, modify the schema, or create a new model.
 ---
 

--- a/.cursor/skills/impl-full-feature/SKILL.md
+++ b/.cursor/skills/impl-full-feature/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: full-feature
+name: impl-full-feature
 description: End-to-end feature development workflow for CityCatalyst covering database, API, frontend, and tests. Use when the user asks to build a complete feature, implement a full user story, or create an end-to-end functionality.
 ---
 
@@ -13,7 +13,7 @@ A complete feature in CityCatalyst touches up to 7 layers. Follow this order to 
 
 ### Phase 1: Database Layer
 
-1. **Migration**: Create migration file in `app/migrations/` (see [create-migration skill](../create-migration/SKILL.md))
+1. **Migration**: Create migration file in `app/migrations/` (see [impl-create-migration skill](../impl-create-migration/SKILL.md))
 2. **Model**: Create Sequelize model in `app/src/models/`
 3. **Register**: Add to `app/src/models/init-models.ts`
 4. **Run**: `cd app && npm run db:migrate`

--- a/.cursor/skills/nontech-contribute/SKILL.md
+++ b/.cursor/skills/nontech-contribute/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: non-tech-contribute
+name: nontech-contribute
 description: Guide non-technical contributors through making safe code changes to CityCatalyst. Use when someone without coding experience wants to update text, translations, colors, copy, or small UI details, and needs the agent to handle git, verification, and PR creation for them.
 ---
 
@@ -100,7 +100,7 @@ Do not ask the user to type git commands.
    git push -u origin <branch-name>
    ```
 
-3. Open the PR by **delegating to the [pull-request-standards skill](../pull-request-standards/SKILL.md)**. Do not hand-roll a title or body here — that skill owns the format, uses `.github/PULL_REQUEST_TEMPLATE.md`, and picks the right GitHub tool. Give it the plain-language description you got from the user so it can fill:
+3. Open the PR by **delegating to the [dev-pull-request-standards skill](../dev-pull-request-standards/SKILL.md)**. Do not hand-roll a title or body here — that skill owns the format, uses `.github/PULL_REQUEST_TEMPLATE.md`, and picks the right GitHub tool. Give it the plain-language description you got from the user so it can fill:
 
    - **Summary** — the outcome in the user's own words (1–3 sentences).
    - **Changes** — the minimal bullet list of what was touched.

--- a/.cursor/skills/ticket-create/SKILL.md
+++ b/.cursor/skills/ticket-create/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: create-ticket
+name: ticket-create
 description: Generate structured Linear tickets (stories, tasks, bugs, spikes) with AI-enriched code references and acceptance criteria from a brief description. Use when the product team asks to create a ticket, write a story, draft a task, report a bug, or plan a spike for CityCatalyst.
 ---
 

--- a/.cursor/skills/ticket-create/reference.md
+++ b/.cursor/skills/ticket-create/reference.md
@@ -1,6 +1,6 @@
 # Ticket Taxonomy & Conventions
 
-Reference material for the `create-ticket` skill. The agent reads this file when it needs taxonomy details, Linear conventions, or estimation guidance.
+Reference material for the `ticket-create` skill. The agent reads this file when it needs taxonomy details, Linear conventions, or estimation guidance.
 
 ## Issue Types
 

--- a/.cursor/skills/ticket-refine/SKILL.md
+++ b/.cursor/skills/ticket-refine/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: refine-ticket
+name: ticket-refine
 description: Enrich an existing ticket with detailed technical breakdown, sub-tasks, code references, and estimation guidance. Use when an engineer asks to refine a ticket, break down a story, add technical details, estimate a task, or decompose work into sub-tasks.
 ---
 
@@ -7,7 +7,7 @@ description: Enrich an existing ticket with detailed technical breakdown, sub-ta
 
 Take an existing ticket (pasted markdown or description) and enrich it with engineering-specific details: sub-task breakdown, precise code references, implementation approach, and estimation rationale.
 
-For ticket taxonomy and estimation conventions, see [../create-ticket/reference.md](../create-ticket/reference.md).
+For ticket taxonomy and estimation conventions, see [../ticket-create/reference.md](../ticket-create/reference.md).
 
 ## Workflow
 
@@ -136,7 +136,7 @@ Brief description of the recommended approach, referencing existing patterns.
 ## Conventions
 
 - Always verify file paths by searching the codebase — never invent paths.
-- Reference the [full-feature skill](../full-feature/SKILL.md) layer order for consistency.
+- Reference the [impl-full-feature skill](../impl-full-feature/SKILL.md) layer order for consistency.
 - Sub-tasks should map to potential PRs (reviewable independently).
 - If total estimate exceeds 13 points, recommend splitting into multiple tickets.
 - For Spikes: instead of sub-tasks, output a list of investigation steps and expected deliverables (decision doc, PoC, etc.).


### PR DESCRIPTION
## Summary

- Implemented Mirco's skills/rules prefix convention across all CityCatalyst Cursor skills
- Added comprehensive documentation of the naming convention
- Updated all skill frontmatter and internal cross-references to match the new convention
- All skills now follow documented prefix taxonomy for discoverability and grouping

## Changes

### Skills Renamed (directory + frontmatter)
- `create-ticket` → `ticket-create`
- `refine-ticket` → `ticket-refine`
- `non-tech-contribute` → `nontech-contribute`
- `prompt-schema-authoring` → `ai-prompt-schema-authoring`
- `pr-review-gate` → `dev-pr-review-gate`
- `pull-request-standards` → `dev-pull-request-standards`
- `script-quality-gate` → `dev-script-quality-gate`
- `simplify-after-change` → `docs-simplify-after-change`
- `add-rtk-endpoint` → `impl-add-rtk-endpoint`
- `create-api-endpoint` → `impl-create-api-endpoint`
- `create-component` → `impl-create-component`
- `create-migration` → `impl-create-migration`
- `full-feature` → `impl-full-feature`

### Documentation Added
- Created `.cursor/CONVENTIONS.md` documenting:
  - Prefix taxonomy (`ticket-*`, `nontech-*`, `dev-*`, `impl-*`, `docs-*`, `ai-*`, `k8s-*`, `repo-*`)
  - Benefits (discoverability, grouping, clarity, consistency)
  - Migration notes and guidelines for adding new skills
  - Cross-repository adoption (CityCatalyst, agentic-coder, other OEF repos)

### Internal References Fixed
- Updated cross-skill references to use new directory names
- Fixed skill name references in documentation (e.g., `reference.md`)
- All internal links now point to correctly named directories

## Test plan

- [x] All skill directory names follow the documented prefix convention
- [x] All skill frontmatter `name:` fields match their directory names
- [x] All internal cross-references between skills are valid
- [x] Git properly detected renames (not delete+add)
- [x] CONVENTIONS.md accurately documents all prefix categories

## Tests added

N/A - This is a documentation and organizational change with no runtime code.

## Next Steps

- [ ] Team notification about new skill names (can reference skills by prefix now)
- [ ] Apply same convention to agentic-coder repository (separate PR)
- [ ] Update any Notion docs that reference old skill names by their full path