### PR TITLE
fix(ON-6008): remove language select from signup, detect browser language

### DIFF
--- a/app/src/app/[lng]/auth/signup/page.tsx
+++ b/app/src/app/[lng]/auth/signup/page.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "@/i18n/client";
 import { Box, Heading, Icon, Input, Link, Text } from "@chakra-ui/react";
 import LabelLarge from "@/components/package/Texts/Label";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState, use, useEffect } from "react";
+import { useState, use } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { Trans } from "react-i18next/TransWithoutContext";
 import { logger } from "@/services/logger";
@@ -31,13 +31,6 @@ type Inputs = {
   preferredLanguage: LANGUAGES;
 };
 
-function resolveBrowserLanguage(): LANGUAGES {
-  if (typeof navigator === "undefined") return LANGUAGES.en;
-  const base = navigator.language.split("-")[0];
-  return Object.values(LANGUAGES).includes(base as LANGUAGES)
-    ? (base as LANGUAGES)
-    : LANGUAGES.en;
-}
 
 const normalizeInviteEmail = (value: string | null): string =>
   (value ?? "").replaceAll(" ", "+");
@@ -64,19 +57,14 @@ export default function Signup(props: { params: Promise<{ lng: string }> }) {
     handleSubmit,
     register,
     setError: setFormError,
-    setValue,
     formState: { errors, isSubmitting },
     watch,
   } = useForm<Inputs>({
     defaultValues: {
-      preferredLanguage: LANGUAGES.en,
+      preferredLanguage: lng,
       email: prefilledEmail,
     },
   });
-
-  useEffect(() => {
-    setValue("preferredLanguage", resolveBrowserLanguage());
-  }, [setValue]);
 
   const watchPassword = watch("password", "");
 

--- a/app/src/app/[lng]/auth/signup/page.tsx
+++ b/app/src/app/[lng]/auth/signup/page.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "@/i18n/client";
 import { Box, Heading, Icon, Input, Link, Text } from "@chakra-ui/react";
 import LabelLarge from "@/components/package/Texts/Label";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState, use } from "react";
+import { useState, use, useEffect } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { Trans } from "react-i18next/TransWithoutContext";
 import { logger } from "@/services/logger";
@@ -17,7 +17,6 @@ import { Field } from "@/components/ui/field";
 import { Checkbox } from "@/components/ui/checkbox";
 import { signIn } from "next-auth/react";
 import { LANGUAGES } from "@/util/types";
-import { LanguageSelector } from "./LanguageSelector";
 import i18next from "i18next";
 import { trackEvent, identifyUser } from "@/lib/analytics";
 import { getHomePath } from "@/util/routes";
@@ -31,6 +30,14 @@ type Inputs = {
   acceptTerms: boolean;
   preferredLanguage: LANGUAGES;
 };
+
+function resolveBrowserLanguage(): LANGUAGES {
+  if (typeof navigator === "undefined") return LANGUAGES.en;
+  const base = navigator.language.split("-")[0];
+  return Object.values(LANGUAGES).includes(base as LANGUAGES)
+    ? (base as LANGUAGES)
+    : LANGUAGES.en;
+}
 
 const normalizeInviteEmail = (value: string | null): string =>
   (value ?? "").replaceAll(" ", "+");
@@ -57,14 +64,19 @@ export default function Signup(props: { params: Promise<{ lng: string }> }) {
     handleSubmit,
     register,
     setError: setFormError,
+    setValue,
     formState: { errors, isSubmitting },
     watch,
   } = useForm<Inputs>({
     defaultValues: {
-      preferredLanguage: lng as LANGUAGES,
+      preferredLanguage: LANGUAGES.en,
       email: prefilledEmail,
     },
   });
+
+  useEffect(() => {
+    setValue("preferredLanguage", resolveBrowserLanguage());
+  }, [setValue]);
 
   const watchPassword = watch("password", "");
 
@@ -203,30 +215,7 @@ export default function Signup(props: { params: Promise<{ lng: string }> }) {
           id="confirmPassword"
           shouldValidate={false}
         />
-        <Field
-          label={<LabelLarge>{t("preferred-language")}</LabelLarge>}
-          invalid={!!errors.preferredLanguage}
-          errorText={
-            <Box display="flex" gap="6px">
-              <Icon as={MdWarning} />
-              <Text
-                fontSize="body.md"
-                lineHeight="20px"
-                letterSpacing="wide"
-                color="content.tertiary"
-              >
-                {errors.preferredLanguage?.message}
-              </Text>
-            </Box>
-          }
-        >
-          <LanguageSelector
-            register={register}
-            error={errors.preferredLanguage}
-            t={t}
-            defaultValue={lng as LANGUAGES}
-          />
-        </Field>
+        <input type="hidden" {...register("preferredLanguage")} />
         <Field
           invalid={!!errors.acceptTerms}
           errorText={


### PR DESCRIPTION
## Summary
Removes the preferred language dropdown from the signup form. Instead of asking users to explicitly select a language, the app now detects the browser's language via `navigator.language` and uses it as the `preferredLanguage` value submitted to the API. This simplifies the signup flow without changing the underlying data model or API contract.
## Changes
- Removed the visible `<LanguageSelector>` field from the signup form
- Added `resolveBrowserLanguage()` helper that maps `navigator.language` to a supported locale (`en`, `es`, `pt`, `de`, `fr`), falling back to `en` for unsupported languages
- Added a `useEffect` that sets `preferredLanguage` on mount via `react-hook-form`'s `setValue`
- Replaced the visible field with a `<input type="hidden">` so the value is still part of the form submission payload
- `LanguageSelector.tsx` is kept — it is still used in the account settings pages
## How to test
1. Navigate to `/auth/signup`
2. Confirm the preferred language dropdown is no longer visible on the form
3. Open DevTools → Network, submit the form, inspect the `/api/v1/auth/register` POST body — confirm `preferredLanguage` is present and matches your browser's language (or `en` as fallback)
4. To test fallback: temporarily override `navigator.language` in the console to an unsupported locale (e.g. `ja`) and re-submit — `preferredLanguage` should be `en`
## Ticket
ON-6008
## Notes
The API payload and Zod validation schema (`preferredLanguage: z.nativeEnum(LANGUAGES)`) are unchanged — the field is still required and validated server-side; it's just sourced from the browser instead of user input.