### PR TITLE
https://linear.app/openearth/review/on-5941-reframe-hiap-adaptation-tab-tip-around-climate-risk-assessment-6c678f3a118a

### DIFF
--- a/app/src/components/HomePageJN/ModuleCard.tsx
+++ b/app/src/components/HomePageJN/ModuleCard.tsx
@@ -142,7 +142,7 @@ export function ModuleCard({
         </VStack>
         <BodySmall lineClamp={1}>{t("by", { author: author })}</BodySmall>
         <Card.Description as="div">
-          <BodyMedium >
+          <BodyMedium lineClamp={3}>
             {getTranslationInLanguage(tagline)}
           </BodyMedium>
         </Card.Description>

--- a/app/src/components/HomePageJN/ModuleCard.tsx
+++ b/app/src/components/HomePageJN/ModuleCard.tsx
@@ -142,7 +142,7 @@ export function ModuleCard({
         </VStack>
         <BodySmall lineClamp={1}>{t("by", { author: author })}</BodySmall>
         <Card.Description as="div">
-          <BodyMedium lineClamp={2}>
+          <BodyMedium >
             {getTranslationInLanguage(tagline)}
           </BodyMedium>
         </Card.Description>


### PR DESCRIPTION
## Summary

Some module card taglines where cut off and did not show full module information to the user/client. 

## Changes
<img width="1097" height="528" alt="image" src="https://github.com/user-attachments/assets/98897544-8e70-452d-8cc9-58f991ff2cfa" />


Removes line clamp prop to reveal full tagline text

## How to test

Check module card on the homepage ensure all languages show full tagline without ellipsis

## Ticket

ON-6047

