### PR TITLE
fix: prevent toast from freezing in headless CI (pauseOnPageIdle)

### DIFF
--- a/app/e2e/helpers.ts
+++ b/app/e2e/helpers.ts
@@ -193,6 +193,14 @@ async function walkCitiesOnboardingWizard(
   }
 
   {
+    // Wait for any "year already exists" error toast to clear before clicking
+    // (toast appears when CI environment has a prior inventory for this year)
+    await page
+      .getByText(/already exists for this city/i)
+      .first()
+      .waitFor({ state: "hidden", timeout: 12000 })
+      .catch(() => {});
+
     const continueButton = page
       .getByRole("button", { name: /^Continue$/ })
       .last();

--- a/app/src/components/ui/toaster.tsx
+++ b/app/src/components/ui/toaster.tsx
@@ -11,7 +11,7 @@ import {
 
 export const toaster = createToaster({
   placement: "bottom-end",
-  pauseOnPageIdle: true,
+  pauseOnPageIdle: false,
 });
 
 export const Toaster = () => {


### PR DESCRIPTION
## Root cause

The Chakra UI `Toaster` was configured with `pauseOnPageIdle: true`. In headless CI (Chromium), the page is treated as idle/hidden, so toast timers freeze permanently — toasts never auto-dismiss.

## Why this wasn't a problem before

`pauseOnPageIdle: true` was always there but was harmless — no toast appeared during the onboarding wizard flow in E2E tests, so the frozen timer never mattered.

The `yearAlreadyExists` check and its error toast were introduced in PR #2835 (ON-6013). Once that shipped, CI runs that already had a Chicago + 2025 inventory from a prior test run started showing the toast during `walkCitiesOnboardingWizard`. Because the toast timer was frozen by `pauseOnPageIdle`, it never dismissed, blocking the population step's Continue button for the full 120s test timeout (214 Playwright retries).

## Changes

- **`app/src/components/ui/toaster.tsx`**: `pauseOnPageIdle: false` — toasts always auto-dismiss after their duration regardless of page visibility state
- **`app/e2e/helpers.ts`**: defensive wait for any "already exists for this city" toast to clear before clicking the population Continue button in `walkCitiesOnboardingWizard`

## Test plan
- [ ] E2E `third-party-datasets.spec.ts` passes in CI without timing out
- [ ] Toasts still appear and dismiss normally in the browser (6s for errors)