### PR TITLE
fix: global API prod k8s timeout config

### DIFF
--- a/k8s/cc-global-api-deploy.yml
+++ b/k8s/cc-global-api-deploy.yml
@@ -43,7 +43,7 @@ spec:
                 value: "True"
             initialDelaySeconds: 10
             periodSeconds: 10
-            timeoutSeconds: 5
+            timeoutSeconds: 15
             failureThreshold: 3
           readinessProbe:
             httpGet:
@@ -54,7 +54,7 @@ spec:
                 value: "True"
             initialDelaySeconds: 5
             periodSeconds: 10
-            timeoutSeconds: 5
+            timeoutSeconds: 15
             failureThreshold: 3
           startupProbe:
             httpGet:
@@ -65,5 +65,5 @@ spec:
                 value: "True"
             initialDelaySeconds: 10
             periodSeconds: 5
-            timeoutSeconds: 5
+            timeoutSeconds: 15
             failureThreshold: 60


### PR DESCRIPTION
## Increase Global API Health Check Timeouts

### Description
Updated the health check probe timeouts for the global-api service from 5 seconds to 15 seconds to provide more time for the service to respond under load or during initialization.

### Changes
- **File:** `k8s/cc-global-api-deploy.yml`
- **Liveness Probe:** `timeoutSeconds: 5` → `15`
- **Readiness Probe:** `timeoutSeconds: 5` → `15`
- **Startup Probe:** `timeoutSeconds: 5` → `15`

### Why
The current 5-second timeout was too aggressive and could cause unnecessary pod restarts when the global-api service experiences latency or slow startup times. Extending to 15 seconds provides a better buffer for:
- Initial service startup
- Response time under load
- Database connection delays

### Impact
- ✅ Reduces false-positive health check failures
- ✅ Improves stability during peak traffic
- ✅ Allows more time for graceful responses to health checks
- ℹ️ No performance degradation; only extends timeout window

### Testing
- Deploy to dev/staging environment first
- Monitor pod restart rates post-deployment
- Verify health check endpoints respond within the new 15-second window