### PR TITLE
fix(e2e): dismiss toast notifications before Continue button clicks

### DIFF
--- a/app/e2e/helpers.ts
+++ b/app/e2e/helpers.ts
@@ -44,6 +44,28 @@ export async function dismissCookieConsent(page: Page) {
   }
 }
 
+/**
+ * Dismiss any visible toast notifications so they don't intercept pointer events.
+ * Toasts are rendered in a portal at bottom-end and can block button clicks.
+ */
+export async function dismissToasts(page: Page) {
+  // Try to click close buttons on any toasts that have them
+  const closeButtons = page.locator('[data-scope="toast"] [data-part="close-trigger"]');
+  const count = await closeButtons.count().catch(() => 0);
+  for (let i = 0; i < count; i++) {
+    await closeButtons.nth(i).click().catch(() => {});
+  }
+  // Disable pointer-events on all toast group containers so they can't block
+  // button clicks even if the toast persists (not all toasts are closable)
+  await page.evaluate(() => {
+    document.querySelectorAll('[data-part="group"][data-scope="toast"]').forEach((el) => {
+      (el as HTMLElement).style.pointerEvents = "none";
+    });
+  }).catch(() => {});
+  // Wait briefly for toasts to clear
+  await page.waitForTimeout(500);
+}
+
 export async function signup(
   request: APIRequestContext,
   email: string,
@@ -193,13 +215,9 @@ async function walkCitiesOnboardingWizard(
   }
 
   {
-    // Wait for any "year already exists" error toast to clear before clicking
-    // (toast appears when CI environment has a prior inventory for this year)
-    await page
-      .getByText(/already exists for this city/i)
-      .first()
-      .waitFor({ state: "hidden", timeout: 12000 })
-      .catch(() => {});
+    // Dismiss any toast notifications that may block the Continue button
+    // (e.g. "An inventory for 2025 already exists for this city")
+    await dismissToasts(page);
 
     const continueButton = page
       .getByRole("button", { name: /^Continue$/ })
@@ -374,6 +392,9 @@ export async function createInventoryThroughOnboarding(
 
   // Click Continue and wait for data to be submitted also add timeout to allow for data to be submitted
   {
+    // Dismiss any toast notifications that may block the Continue button
+    await dismissToasts(page);
+
     const continueBtn = page.getByRole("button", { name: /Continue/i });
     await expect(continueBtn).toBeEnabled({ timeout: 30000 });
     await continueBtn.click();


### PR DESCRIPTION
### Summary
Toast notifications rendered at bottom-end can intercept pointer events and block button clicks. Added dismissToasts helper that:
- Clicks close triggers on closable toasts
- Sets pointer-events: none on toast group containers as fallback Applied to both onboarding wizard flows where the 'inventory already exists' toast was blocking the Continue button.


