### PR TITLE
Fix timeout globalapi k8s

### DIFF
--- a/.github/workflows/global-api-tag.yml
+++ b/.github/workflows/global-api-tag.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - global-api/**
       - k8s/cc-global-api-deploy.yml
+      - k8s/prod/cc-prod-global-api-deploy.yml
       - k8s/cc-global-api.yml
       - k8s/cc-global-api-migrate.yml
       - .github/workflows/global-api-tag.yml
@@ -78,7 +79,7 @@ jobs:
           export VERSION=${REF#refs/tags/v}
           export VERSION=${REF#refs/tags/v}
           kubectl create -f k8s/cc-global-api-migrate.yml -n default
-          kubectl apply -f k8s/cc-global-api-deploy.yml -n default
+          kubectl apply -f k8s/prod/cc-prod-global-api-deploy.yml -n default
           kubectl set image deployment/cc-global-api-deploy \
             cc-global-api=$IMAGE:$VERSION \
             -n default

--- a/k8s/cc-global-api-deploy.yml
+++ b/k8s/cc-global-api-deploy.yml
@@ -43,7 +43,7 @@ spec:
                 value: "True"
             initialDelaySeconds: 10
             periodSeconds: 10
-            timeoutSeconds: 5
+            timeoutSeconds: 15
             failureThreshold: 3
           readinessProbe:
             httpGet:
@@ -54,7 +54,7 @@ spec:
                 value: "True"
             initialDelaySeconds: 5
             periodSeconds: 10
-            timeoutSeconds: 5
+            timeoutSeconds: 15
             failureThreshold: 3
           startupProbe:
             httpGet:
@@ -65,5 +65,5 @@ spec:
                 value: "True"
             initialDelaySeconds: 10
             periodSeconds: 5
-            timeoutSeconds: 5
+            timeoutSeconds: 15
             failureThreshold: 60

--- a/k8s/prod/cc-prod-global-api-deploy.yml
+++ b/k8s/prod/cc-prod-global-api-deploy.yml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cc-global-api-deploy
+  labels:
+    app: cc-global-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cc-global-api
+  template:
+    metadata:
+      labels:
+        app: cc-global-api
+    spec:
+      containers:
+        - name: cc-global-api
+          image: ghcr.io/open-earth-foundation/citycatalyst-global-api:latest
+          # Set to Never for local
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+          envFrom:
+            - configMapRef:
+                name: cc-global-api-db-configmap
+          env:
+            - name: PROJECT_NAME
+              value: "CityCatalyst Global API"
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+            limits:
+              memory: "1024Mi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              httpHeaders:
+              - name: X-Liveness-Probe
+                value: "True"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 15
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              httpHeaders:
+              - name: X-Liveness-Probe
+                value: "True"
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 15
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              httpHeaders:
+              - name: X-Liveness-Probe
+                value: "True"
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 15
+            failureThreshold: 60


### PR DESCRIPTION
# feat: create production-specific global-api deployment and use it in workflow

## Overview
Addressed Milan's feedback to use production-specific configuration for the global-api deployment instead of relying on dev defaults.

## Changes
- **New file:** `k8s/prod/cc-prod-global-api-deploy.yml` — Production deployment configuration with optimized probe timeout values (15s instead of default 5s)
- **Updated:** `.github/workflows/global-api-tag.yml` — Modified deployment step to reference the production config on line 82

## Why This Matters
When deploying to production, the workflow now uses the production-specific settings (extended probe timeouts) instead of the dev defaults, ensuring better reliability during production deployments.

## Testing
- Workflow will use the prod config on next tag deployment
- No functional changes to the deployment logic—only the configuration file reference