### PR TITLE
ON-6039: Silence HIAP Pydantic serializer warnings on structured parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,11 @@ climate-advisor/service/tests/output/
 # Cursor plans
 .cursor/plans/
 
+# Spec Kit (local personal workflow — do not publish)
+.specify/
+.cursor/skills/speckit-*/
+specs/
+
 .playwright-mcp/
 app/demo-recording/
 docs/design-references/

--- a/hiap/README.md
+++ b/hiap/README.md
@@ -92,6 +92,7 @@ The service loads `.env` at startup (see `app/main.py`). The variables below com
   - **`LANGCHAIN_PROJECT`**: Base LangSmith project name.
   - **`LANGCHAIN_PROJECT_NAME_PRIORITIZER`**: Project name override for prioritizer traces.
   - **`LANGCHAIN_PROJECT_NAME_PLAN_TRANSLATION`**: Project name override for plan translation traces.
+  - Structured-output helpers (`chat.completions.parse` for explanations / translations) use a plain OpenAI client plus function-level `@traceable`. They do **not** use `wrap_openai`, which would serialize the SDK `parsed` field and emit noisy Pydantic warnings.
 
 - **AWS / S3 (used by Docker startup + some scripts)**
   - **`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`**: Credentials for reading artefacts from S3.

--- a/hiap/app/plan_creator_bundle/plan_creator/utils/translate_plan.py
+++ b/hiap/app/plan_creator_bundle/plan_creator/utils/translate_plan.py
@@ -1,8 +1,15 @@
+"""
+Translate a PlanResponse from one language into another via OpenAI structured parse.
+
+The OpenAI client is intentionally not wrapped with LangSmith `wrap_openai` to
+avoid Pydantic serializer warnings on the SDK `parsed` field (ON-6039).
+Function-level `@traceable` still records helper inputs/outputs.
+"""
+
 import os
 from typing import Optional
 from plan_creator_bundle.plan_creator.models import PlanResponse
 from openai import OpenAI
-from langsmith.wrappers import wrap_openai
 from langsmith import traceable
 import logging
 from utils.logging_config import setup_logger
@@ -31,8 +38,8 @@ if not LANGCHAIN_PROJECT_NAME_PLAN_TRANSLATION:
     raise ValueError("LANGCHAIN_PROJECT_NAME_PLAN_TRANSLATION is not set")
 
 
-# Use OpenAI client and wrap it with LangSmith
-openai_client = wrap_openai(OpenAI(api_key=OPENAI_API_KEY))
+# Plain OpenAI client for structured parse — avoid wrap_openai serializing `parsed`
+openai_client = OpenAI(api_key=OPENAI_API_KEY)
 
 
 @traceable(run_type="llm", project_name=LANGCHAIN_PROJECT_NAME_PLAN_TRANSLATION)
@@ -41,6 +48,9 @@ def translate_plan(
 ) -> Optional[PlanResponse]:
     """
     Translate a plan from one language into another language.
+
+    Returns:
+        Translated PlanResponse, the original plan if languages match, or None on failure.
     """
 
     # Short-circuit if languages are identical
@@ -67,7 +77,16 @@ def translate_plan(
             temperature=0,
             response_format=PlanResponse,
         )
+        # Extract application-owned data immediately; do not log/serialize `completion`
         plan_response_obj = completion.choices[0].message.parsed
+
+        if plan_response_obj is None:
+            logger.error(
+                "OpenAI response did not contain a parsed plan for action '%s' and city '%s'",
+                input_plan.metadata.actionId,
+                input_plan.metadata.locode,
+            )
+            return None
 
         if not isinstance(plan_response_obj, PlanResponse):
             logger.error(

--- a/hiap/app/prioritizer/utils/add_explanations.py
+++ b/hiap/app/prioritizer/utils/add_explanations.py
@@ -1,9 +1,18 @@
+"""
+Generate multilingual explanations for prioritized climate actions.
+
+Uses OpenAI structured outputs (`chat.completions.parse`) and returns an
+application-owned `Explanation` model. The OpenAI client is intentionally
+not wrapped with LangSmith `wrap_openai` so SDK Completions with a populated
+`parsed` field are not auto-serialized (ON-6039). Function-level `@traceable`
+still records the helper's inputs/outputs.
+"""
+
 import os
 import json
 from typing import Optional, Type, Dict, Any, cast
 from pydantic import create_model, BaseModel
 from openai import OpenAI
-from langsmith.wrappers import wrap_openai
 from langsmith import traceable
 from dotenv import load_dotenv
 from utils.logging_config import setup_logger
@@ -23,7 +32,7 @@ load_dotenv()
 setup_logger()
 logger = logging.getLogger(__name__)
 
-# Initialize OpenAI and OpenRouter clients
+# Initialize OpenAI client
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 if not OPENAI_API_KEY:
     raise ValueError("OPENAI_API_KEY is not set")
@@ -41,6 +50,7 @@ if not LANGCHAIN_PROJECT_NAME_PRIORITIZER:
 
 # Use OpenAI client with client-level timeout and retries (overrideable via env)
 def _get_openai_timeout_seconds() -> float:
+    """Return OpenAI request timeout in seconds from env (default 60)."""
     try:
         return float(os.getenv("OPENAI_TIMEOUT_SECONDS", "60"))
     except Exception:
@@ -48,18 +58,18 @@ def _get_openai_timeout_seconds() -> float:
 
 
 def _get_openai_max_retries() -> int:
+    """Return OpenAI max retries from env (default 3)."""
     try:
         return int(os.getenv("OPENAI_MAX_RETRIES", "3"))
     except Exception:
         return 3
 
 
-openai_client = wrap_openai(
-    OpenAI(
-        api_key=OPENAI_API_KEY,
-        timeout=_get_openai_timeout_seconds(),
-        max_retries=_get_openai_max_retries(),
-    )
+# Plain OpenAI client for structured parse — avoid wrap_openai serializing `parsed`
+openai_client = OpenAI(
+    api_key=OPENAI_API_KEY,
+    timeout=_get_openai_timeout_seconds(),
+    max_retries=_get_openai_max_retries(),
 )
 
 
@@ -108,14 +118,18 @@ def generate_multilingual_explanation(
     Generate qualitative explanation for a single prioritized climate action in multiple languages.
 
     Args:
-        country_code (str): The country code of the city.
-        city_data (dict): Contextual data for the city.
-        single_action (dict): The action to explain.
-        rank (int): The action's rank among the top prioritized actions (1 = highest priority).
-        languages (list[str]): List of 2-letter ISO language codes for the explanation.
+        country_code: The country code of the city.
+        city_data: Contextual data for the city.
+        single_action: The action to explain.
+        rank: The action's rank among the top prioritized actions (1 = highest priority).
+        languages: List of 2-letter ISO language codes for the explanation.
 
     Returns:
-        Optional[dict[str, str]]: Dictionary mapping language codes to explanation strings, or None if generation fails.
+        Explanation with per-language text, or None if generation/parsing fails.
+
+    Side effects:
+        Calls OpenAI structured parse; may call vector-store retrieval; logs errors/debug.
+        LangSmith traces this function when tracing is enabled (@traceable).
     """
     logger.debug(
         f"Generating explanation for action_id={single_action['ActionID']}, rank={rank}, languages={languages}."
@@ -178,18 +192,31 @@ def generate_multilingual_explanation(
             # Per-request timeout (falls back to client default if omitted)
             timeout=_get_openai_timeout_seconds(),
         )
+        # Extract application-owned data immediately; do not log/serialize `completion`
         explanation_obj = completion.choices[0].message.parsed
+
+        if explanation_obj is None:
+            logger.error(
+                "OpenAI response did not contain a parsed explanation for action_id=%s",
+                single_action["ActionID"],
+            )
+            return None
 
         if not isinstance(explanation_obj, ExplanationModelDynamic):
             logger.error(
-                f"Parsed response is not an Explanation object: {explanation_obj}"
+                "Parsed response is not an Explanation object for action_id=%s: %s",
+                single_action["ActionID"],
+                explanation_obj,
             )
             return None
 
         # Wrap the flat fields into .explanations using the Explanation model
         wrapped_explanation = Explanation(explanations=explanation_obj.model_dump())
-
-        # Return the explanation object
+        logger.debug(
+            "Generated explanation for action_id=%s: %s",
+            single_action["ActionID"],
+            wrapped_explanation.model_dump(mode="json"),
+        )
         return wrapped_explanation
 
     except Exception as e:

--- a/hiap/app/prioritizer/utils/translate_explanations.py
+++ b/hiap/app/prioritizer/utils/translate_explanations.py
@@ -1,3 +1,13 @@
+"""
+Translate prioritizer explanation text into additional languages.
+
+Uses OpenAI structured outputs (`chat.completions.parse`) and returns an
+application-owned `Explanation`. The OpenAI client is intentionally not
+wrapped with LangSmith `wrap_openai` to avoid Pydantic serializer warnings on
+the SDK `parsed` field (ON-6039). Function-level `@traceable` still records
+helper inputs/outputs.
+"""
+
 import json
 import logging
 import os
@@ -5,7 +15,6 @@ from typing import Any, Dict, Optional, Type, cast
 
 from dotenv import load_dotenv
 from langsmith import traceable
-from langsmith.wrappers import wrap_openai
 from openai import OpenAI
 from pydantic import BaseModel, create_model
 
@@ -32,6 +41,7 @@ if not LANGCHAIN_PROJECT_NAME_PRIORITIZER:
 
 
 def _get_openai_timeout_seconds() -> float:
+    """Return OpenAI request timeout in seconds from env (default 60)."""
     try:
         return float(os.getenv("OPENAI_TIMEOUT_SECONDS", "60"))
     except Exception:
@@ -39,18 +49,18 @@ def _get_openai_timeout_seconds() -> float:
 
 
 def _get_openai_max_retries() -> int:
+    """Return OpenAI max retries from env (default 3)."""
     try:
         return int(os.getenv("OPENAI_MAX_RETRIES", "3"))
     except Exception:
         return 3
 
 
-openai_client = wrap_openai(
-    OpenAI(
-        api_key=OPENAI_API_KEY,
-        timeout=_get_openai_timeout_seconds(),
-        max_retries=_get_openai_max_retries(),
-    )
+# Plain OpenAI client for structured parse — avoid wrap_openai serializing `parsed`
+openai_client = OpenAI(
+    api_key=OPENAI_API_KEY,
+    timeout=_get_openai_timeout_seconds(),
+    max_retries=_get_openai_max_retries(),
 )
 
 
@@ -95,6 +105,9 @@ def translate_explanation_text(
 ) -> Optional[Explanation]:
     """
     Translate an existing explanation text from source_language into target_languages.
+
+    Returns:
+        Explanation with translated texts, or None if translation/parsing fails.
     """
     if not explanation_text.strip():
         logger.warning("translate_explanation_text received empty explanation text.")
@@ -137,6 +150,7 @@ def translate_explanation_text(
                 response_format=TranslationModel,
                 timeout=_get_openai_timeout_seconds(),
             )
+            # Extract application-owned data immediately; do not log/serialize `completion`
             parsed = completion.choices[0].message.parsed
 
             # If parsing into the expected Pydantic model fails (wrong type), we log

--- a/hiap/docs/architecture.md
+++ b/hiap/docs/architecture.md
@@ -49,6 +49,7 @@ flowchart TB
 - **Docs-first usage**: once the server is running, the canonical interface is `GET /docs` (Swagger UI).
 - **Async workflow**: many endpoints return a `taskId` and require polling a progress endpoint before fetching results.
 - **Task persistence**: task state is stored **in memory**, so restarting the server loses tasks.
+- **LLM tracing**: prioritizer/plan structured-output helpers keep LangSmith `@traceable` on the function, but use an unwrapped OpenAI client for `chat.completions.parse` so Completion objects with a populated `parsed` field are not auto-serialized.
 - **Upstream dependencies**:
   - Actions/context/CCRA data is fetched from the Global API host configured via `CCGLOBAL_API_BASE_URL` (defaults to `ccglobal.openearth.dev`; production uses `api.citycatalyst.io`).
   - LLM functionality requires OpenAI-related env vars from `.env`.

--- a/hiap/tests/conftest.py
+++ b/hiap/tests/conftest.py
@@ -18,9 +18,20 @@ if str(app_dir) not in sys.path:
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 
-# Provide dummy OPENAI_API_KEY for tests if missing or empty (CI may set empty string)
-if not os.getenv("OPENAI_API_KEY"):
-    os.environ["OPENAI_API_KEY"] = "sk-test"
+# Provide dummy OpenAI / LangSmith config for tests if missing (CI sets real values)
+_TEST_ENV_DEFAULTS = {
+    "OPENAI_API_KEY": "sk-test",
+    "OPENAI_MODEL_NAME_EXPLANATIONS": "gpt-test",
+    "OPENAI_MODEL_NAME_EXPLANATIONS_TRANSLATION": "gpt-test",
+    "OPENAI_MODEL_NAME_PLAN_CREATOR": "gpt-test",
+    "OPENAI_MODEL_NAME_PLAN_CREATOR_LEGACY": "gpt-test",
+    "OPENAI_MODEL_NAME_PLAN_TRANSLATION": "gpt-test",
+    "LANGCHAIN_PROJECT_NAME_PRIORITIZER": "hiap-test-prioritizer",
+    "LANGCHAIN_PROJECT_NAME_PLAN_TRANSLATION": "hiap-test-plan-translation",
+}
+for _env_key, _env_value in _TEST_ENV_DEFAULTS.items():
+    if not os.getenv(_env_key):
+        os.environ[_env_key] = _env_value
 
 # Import the FastAPI app from main (unqualified), matching production layout
 import main  # type: ignore

--- a/hiap/tests/unit/test_add_explanations.py
+++ b/hiap/tests/unit/test_add_explanations.py
@@ -1,0 +1,160 @@
+"""Unit tests for prioritizer explanation generation (ON-6039)."""
+
+from __future__ import annotations
+
+import inspect
+import warnings
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import prioritizer.utils.add_explanations as add_explanations_module
+from prioritizer.models import Explanation
+from prioritizer.utils.add_explanations import generate_multilingual_explanation
+
+
+def _mock_completion(parsed) -> SimpleNamespace:
+    """Build a minimal OpenAI-like completion with message.parsed."""
+    message = SimpleNamespace(parsed=parsed)
+    choice = SimpleNamespace(message=message)
+    return SimpleNamespace(choices=[choice])
+
+
+@pytest.mark.unit
+def test_module_does_not_use_wrap_openai_for_parse_client() -> None:
+    """Structured parse must use a plain OpenAI client (no wrap_openai import)."""
+    source = inspect.getsource(add_explanations_module)
+    assert "from langsmith.wrappers import wrap_openai" not in source
+    assert "traceable" in source
+    assert isinstance(add_explanations_module.openai_client, add_explanations_module.OpenAI)
+
+
+@pytest.mark.unit
+def test_generate_multilingual_explanation_returns_explanation_content() -> None:
+    """Successful parse should return Explanation with expected language fields."""
+    languages = ["en", "pt"]
+    expected_en = "Restoring mangroves helps against climate impacts."
+    expected_pt = "Restaurar manguezais ajuda contra impactos climáticos."
+    action = {
+        "ActionID": "c40_0010",
+        "ActionType": ["mitigation"],
+        "ActionName": "Mangrove restoration",
+        "Description": "Restore coastal mangroves",
+    }
+
+    def _fake_parse(**kwargs):
+        # Use the same dynamic model class the helper passes as response_format
+        model_cls = kwargs["response_format"]
+        return _mock_completion(model_cls(en=expected_en, pt=expected_pt))
+
+    with (
+        patch.object(
+            add_explanations_module,
+            "get_national_strategy_for_prompt",
+            return_value=[],
+        ),
+        patch.object(
+            add_explanations_module,
+            "build_prompt_inputs",
+            return_value=({}, action),
+        ),
+        patch.object(
+            add_explanations_module.openai_client.beta.chat.completions,
+            "parse",
+            side_effect=_fake_parse,
+        ) as mock_parse,
+    ):
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            result = generate_multilingual_explanation(
+                country_code="BR",
+                city_data={"locode": "BR RIO"},
+                single_action=action,
+                rank=1,
+                languages=languages,
+            )
+
+    assert isinstance(result, Explanation)
+    assert result.explanations["en"] == expected_en
+    assert result.explanations["pt"] == expected_pt
+    mock_parse.assert_called_once()
+    warning_text = " ".join(str(item.message) for item in captured)
+    assert "PydanticSerializationUnexpectedValue" not in warning_text
+    assert "Expected none" not in warning_text or "field_name='parsed'" not in warning_text
+
+
+@pytest.mark.unit
+def test_generate_multilingual_explanation_returns_none_when_parsed_is_none() -> None:
+    """Missing parsed payload must return None (explicit failure)."""
+    action = {
+        "ActionID": "c40_0010",
+        "ActionType": ["mitigation"],
+        "ActionName": "Test",
+        "Description": "Test",
+    }
+
+    with (
+        patch.object(
+            add_explanations_module,
+            "get_national_strategy_for_prompt",
+            return_value=[],
+        ),
+        patch.object(
+            add_explanations_module,
+            "build_prompt_inputs",
+            return_value=({}, action),
+        ),
+        patch.object(
+            add_explanations_module.openai_client.beta.chat.completions,
+            "parse",
+            return_value=_mock_completion(None),
+        ),
+    ):
+        result = generate_multilingual_explanation(
+            country_code="BR",
+            city_data={},
+            single_action=action,
+            rank=1,
+            languages=["en"],
+        )
+
+    assert result is None
+
+
+@pytest.mark.unit
+def test_generate_multilingual_explanation_returns_none_for_wrong_parsed_type() -> None:
+    """Wrong parsed type must return None instead of inventing an explanation."""
+    action = {
+        "ActionID": "c40_0010",
+        "ActionType": ["mitigation"],
+        "ActionName": "Test",
+        "Description": "Test",
+    }
+
+    with (
+        patch.object(
+            add_explanations_module,
+            "get_national_strategy_for_prompt",
+            return_value=[],
+        ),
+        patch.object(
+            add_explanations_module,
+            "build_prompt_inputs",
+            return_value=({}, action),
+        ),
+        patch.object(
+            add_explanations_module.openai_client.beta.chat.completions,
+            "parse",
+            return_value=_mock_completion({"en": "not a model"}),
+        ),
+    ):
+        result = generate_multilingual_explanation(
+            country_code="BR",
+            city_data={},
+            single_action=action,
+            rank=1,
+            languages=["en"],
+        )
+
+    assert result is None

--- a/hiap/tests/unit/test_translate_explanations.py
+++ b/hiap/tests/unit/test_translate_explanations.py
@@ -1,0 +1,71 @@
+"""Unit tests for explanation translation structured-output path (ON-6039)."""
+
+from __future__ import annotations
+
+import inspect
+import warnings
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import prioritizer.utils.translate_explanations as translate_module
+from prioritizer.models import Explanation
+from prioritizer.utils.translate_explanations import translate_explanation_text
+
+
+def _mock_completion(parsed) -> SimpleNamespace:
+    """Build a minimal OpenAI-like completion with message.parsed."""
+    message = SimpleNamespace(parsed=parsed)
+    choice = SimpleNamespace(message=message)
+    return SimpleNamespace(choices=[choice])
+
+
+@pytest.mark.unit
+def test_translate_module_does_not_use_wrap_openai() -> None:
+    """Structured parse must use a plain OpenAI client (no wrap_openai import)."""
+    source = inspect.getsource(translate_module)
+    assert "from langsmith.wrappers import wrap_openai" not in source
+    assert "traceable" in source
+
+
+@pytest.mark.unit
+def test_translate_explanation_text_returns_explanation() -> None:
+    """Successful parse should return Explanation with translated fields."""
+    languages = ["es", "pt"]
+    expected_es = "Texto en español"
+    expected_pt = "Texto em português"
+
+    def _fake_parse(**kwargs):
+        model_cls = kwargs["response_format"]
+        return _mock_completion(model_cls(es=expected_es, pt=expected_pt))
+
+    with patch.object(
+        translate_module.openai_client.beta.chat.completions,
+        "parse",
+        side_effect=_fake_parse,
+    ):
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            result = translate_explanation_text(
+                explanation_text="English explanation",
+                source_language="en",
+                target_languages=languages,
+            )
+
+    assert isinstance(result, Explanation)
+    assert result.explanations["es"] == expected_es
+    assert result.explanations["pt"] == expected_pt
+    warning_text = " ".join(str(item.message) for item in captured)
+    assert "PydanticSerializationUnexpectedValue" not in warning_text
+
+
+@pytest.mark.unit
+def test_translate_explanation_text_returns_none_for_empty_input() -> None:
+    """Empty source text should short-circuit without calling OpenAI."""
+    result = translate_explanation_text(
+        explanation_text="   ",
+        source_language="en",
+        target_languages=["pt"],
+    )
+    assert result is None

--- a/hiap/tests/unit/test_translate_plan.py
+++ b/hiap/tests/unit/test_translate_plan.py
@@ -1,0 +1,118 @@
+"""Unit tests for plan translation structured-output path (ON-6039)."""
+
+from __future__ import annotations
+
+import inspect
+import warnings
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import plan_creator_bundle.plan_creator.utils.translate_plan as translate_plan_module
+from plan_creator_bundle.plan_creator.models import (
+    AdaptationList,
+    CostBudget,
+    InstitutionList,
+    Introduction,
+    MerIndicatorList,
+    MilestoneList,
+    MitigationList,
+    PlanContent,
+    PlanCreatorMetadata,
+    PlanResponse,
+    SDGList,
+    SubactionList,
+    Timeline,
+)
+from plan_creator_bundle.plan_creator.utils.translate_plan import translate_plan
+
+
+def _sample_plan(language: str = "en") -> PlanResponse:
+    """Build a minimal valid plan response for translation tests."""
+    return PlanResponse(
+        metadata=PlanCreatorMetadata(
+            locode="BR RIO",
+            cityName="Rio de Janeiro",
+            actionId="MIT001",
+            actionName="Solar Installation",
+            language=language,
+            createdAt=datetime.now(UTC),
+        ),
+        content=PlanContent(
+            introduction=Introduction(
+                city_description="Rio is a coastal city.",
+                action_description="Install solar on public buildings.",
+                national_strategy_explanation="Aligned with national climate policy.",
+            ),
+            subactions=SubactionList(items=[]),
+            institutions=InstitutionList(items=[]),
+            milestones=MilestoneList(items=[]),
+            timeline=[Timeline()],
+            costBudget=[CostBudget()],
+            merIndicators=MerIndicatorList(items=[]),
+            mitigations=MitigationList(items=[]),
+            adaptations=AdaptationList(items=[]),
+            sdgs=SDGList(items=[]),
+        ),
+    )
+
+
+def _mock_completion(parsed) -> SimpleNamespace:
+    """Build a minimal OpenAI-like completion with message.parsed."""
+    message = SimpleNamespace(parsed=parsed)
+    choice = SimpleNamespace(message=message)
+    return SimpleNamespace(choices=[choice])
+
+
+@pytest.mark.unit
+def test_translate_plan_module_does_not_use_wrap_openai() -> None:
+    """Structured parse must use a plain OpenAI client (no wrap_openai import)."""
+    source = inspect.getsource(translate_plan_module)
+    assert "from langsmith.wrappers import wrap_openai" not in source
+    assert "traceable" in source
+
+
+@pytest.mark.unit
+def test_translate_plan_extracts_parsed_plan_response() -> None:
+    """Successful parse should return PlanResponse with updated language."""
+    input_plan = _sample_plan("en")
+    parsed_plan = _sample_plan("en")
+
+    with patch.object(
+        translate_plan_module.openai_client.beta.chat.completions,
+        "parse",
+        return_value=_mock_completion(parsed_plan),
+    ):
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            result = translate_plan(input_plan, "en", "pt")
+
+    assert isinstance(result, PlanResponse)
+    assert result.metadata.language == "pt"
+    warning_text = " ".join(str(item.message) for item in captured)
+    assert "PydanticSerializationUnexpectedValue" not in warning_text
+
+
+@pytest.mark.unit
+def test_translate_plan_returns_none_when_parsed_is_none() -> None:
+    """Missing parsed plan must return None."""
+    input_plan = _sample_plan("en")
+
+    with patch.object(
+        translate_plan_module.openai_client.beta.chat.completions,
+        "parse",
+        return_value=_mock_completion(None),
+    ):
+        result = translate_plan(input_plan, "en", "pt")
+
+    assert result is None
+
+
+@pytest.mark.unit
+def test_translate_plan_skips_when_languages_match() -> None:
+    """Identical languages should return the input plan without calling OpenAI."""
+    input_plan = _sample_plan("en")
+    result = translate_plan(input_plan, "en", "en")
+    assert result is input_plan


### PR DESCRIPTION
## Summary

Removes noisy `PydanticSerializationUnexpectedValue` warnings from HIAP prioritization/translation logs when OpenAI structured outputs populate `message.parsed`. Prioritization behavior and explanation content stay the same; logs become usable again.

## Changes

- Use a plain OpenAI client (no LangSmith `wrap_openai`) for `chat.completions.parse` in explanation and translation helpers; keep function-level `@traceable`
- Extract application-owned `Explanation` / `PlanResponse` immediately; do not serialize the SDK Completion
- Add unit regression tests; document tracing pattern in HIAP README/architecture
- Ignore local Spec Kit paths in `.gitignore`

## Before / After (logs)

| Aspect | Before | After |
|--------|--------|--------|
| Pydantic warning | Repeated per explanation: `PydanticSerializationUnexpectedValue` / `Expected none` on `field_name='parsed'` with `Explanation(...)` | **0** occurrences of that warning |
| Noise per run | One warning block **per** generated explanation | Progress/HTTP/task logs only — no serializer spam |
| Product outcome | Task `completed`, explanations OK | Unchanged: task `completed`, explanations OK |
| Root cause | `wrap_openai` auto-serialized SDK Completions with populated `parsed` | Plain OpenAI client for `.parse` + `@traceable` on the helper |

### Before (from ON-6039 production evidence)

```text
2026-07-07 17:38:30 _client.py:1025 - INFO - HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"

/app/.venv/lib/python3.12/site-packages/pydantic/main.py:475: UserWarning:
Pydantic serializer warnings:
  PydanticSerializationUnexpectedValue(
    Expected none - serialized value may not be as expected
    [field_name='parsed',
     input_value=Explanation(en='Restoring...ainst climate impacts.'),
     input_type=Explanation]
  )

# …same warning repeated for each explanation…
2026-07-07 17:38:34 tasks.py:258 - INFO - Task …: Prioritization completed in 87.94s
```

### After (expected)

```text
2026-07-07 17:38:30 _client.py:1025 - INFO - HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
2026-07-07 17:38:34 tasks.py:258 - INFO - Task …: Prioritization completed in 87.94s
# no UserWarning / PydanticSerializationUnexpectedValue
```

### Gains

| Gain | Detail |
|------|--------|
| Log signal | Real errors are no longer buried under per-explanation serializer spam |
| Observability | LangSmith still traces via `@traceable`; SDK Completion is not dumped |
| Regression safety | New unit tests + HIAP `pytest -m "not external"` green (45 passed) |

## How to test

1. From `hiap/`: `uv run pytest tests/unit/test_add_explanations.py tests/unit/test_translate_explanations.py tests/unit/test_translate_plan.py -q`
2. Optionally: `uv run pytest -m "not external" -q`
3. After deploy: run a prioritization with explanations enabled and confirm logs have **zero** `PydanticSerializationUnexpectedValue` / `field_name='parsed'` lines while the task still completes with explanations.

## Ticket

[ON-6039](https://openearth.atlassian.net/browse/ON-6039)

## Notes

- “Before” logs are from the production evidence in ON-6039; “After” is the expected contract validated by unit tests (confirm on staging/prod after deploy).
- Offline script `update_adaptation_effectiveness.py` already used a plain OpenAI client — no change.

Made with [Cursor](https://cursor.com)

[ON-6039]: https://openearth.atlassian.net/browse/ON-6039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ