### PR TITLE
fix: cursor jump in FormattedNumberInput and layout adjustments

### DIFF
--- a/app/src/components/Modals/activity-modal/sections/ActivityDataSection.tsx
+++ b/app/src/components/Modals/activity-modal/sections/ActivityDataSection.tsx
@@ -56,14 +56,14 @@ export const ActivityDataSection = ({
         label={<Text truncate>{t(title)}</Text>}
         flex="2"
       >
-        <HStack>
+        <HStack w="full">
           <FormattedNumberInput
             control={control}
             name={`activity.${title}`}
             defaultValue="0"
             t={t}
             miniAddon
-            minWidth="300px"
+            w="full"
             flex={2}
           />
           {(units?.length as number) > 0 && (

--- a/app/src/components/Modals/activity-modal/sections/EmissionFactorsSection.tsx
+++ b/app/src/components/Modals/activity-modal/sections/EmissionFactorsSection.tsx
@@ -46,7 +46,7 @@ export const EmissionFactorsSection = ({
         </LabelLarge>
       </Heading>
       <HStack alignItems="flex-start" gap={4} mb={5}>
-        <Box>
+       
           <Field label={t("co2-emission-factor")}>
             <FormattedNumberInput
               miniAddon
@@ -54,7 +54,6 @@ export const EmissionFactorsSection = ({
               control={control}
               name="activity.CO2EmissionFactor"
               defaultValue="0"
-              w="110px"
               isDisabled={isEmissionFactorInputDisabled}
             >
               {areEmissionFactorsLoading ? (
@@ -65,8 +64,7 @@ export const EmissionFactorsSection = ({
                 </Text>
               )}
             </FormattedNumberInput>
-          </Field>
-          {errors?.activity?.["CO2EmissionFactor"] ? (
+            {errors?.activity?.["CO2EmissionFactor"] ? (
             <Box display="flex" gap="6px" alignItems="center" mt="6px">
               <Icon as={MdWarning} color="sentiment.negativeDefault" />
               <BodyMedium>
@@ -82,7 +80,7 @@ export const EmissionFactorsSection = ({
               h="16px"
             />
           )}
-        </Box>
+          </Field>
         <Field label={t("n2o-emission-factor")}>
           <FormattedNumberInput
             miniAddon

--- a/app/src/components/formatted-number-input.tsx
+++ b/app/src/components/formatted-number-input.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useLayoutEffect, useRef } from "react";
 import {
   Control,
   Controller,
@@ -6,12 +6,8 @@ import {
   Path,
   PathValue,
 } from "react-hook-form";
-import { Group, InputAddon } from "@chakra-ui/react";
-import {
-  NumberInputField,
-  NumberInputProps,
-  NumberInputRoot,
-} from "./ui/number-input";
+import { Group, Input, InputAddon } from "@chakra-ui/react";
+import { NumberInputProps } from "./ui/number-input";
 import { decimalSeparators, formatNumber } from "@/util/helpers";
 import { NumberFormatEnum } from "@/util/enums";
 
@@ -35,6 +31,26 @@ interface FormattedNumberInputProps<T extends FieldValues>
   numberFormat?: string;
 }
 
+/**
+ * Count how many group (thousands) separator characters appear in `str`
+ * up to position `pos`. Group separators are any character that is not
+ * a digit, not the decimal separator, and not a minus sign.
+ */
+function countSeparatorsBefore(
+  str: string,
+  pos: number,
+  decimalSep: string,
+): number {
+  let count = 0;
+  for (let i = 0; i < pos && i < str.length; i++) {
+    const ch = str[i];
+    if (ch !== decimalSep && ch !== "-" && !/\d/.test(ch)) {
+      count++;
+    }
+  }
+  return count;
+}
+
 function FormattedNumberInput<T extends FieldValues>({
   control,
   setError,
@@ -55,50 +71,98 @@ function FormattedNumberInput<T extends FieldValues>({
 }: FormattedNumberInputProps<T>) {
   const normalizedFormat = numberFormat ?? NumberFormatEnum.COMMA_AND_DOT;
   const decimalSeparator = decimalSeparators[normalizedFormat];
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const pendingCursorRef = useRef<number | null>(null);
 
-  const format = (nval: number | string) => {
-    nval = nval.toString();
+  const format = useCallback(
+    (nval: number | string) => {
+      if (nval == null || nval === "") return "";
+      nval = nval.toString();
 
-    // Check if the input ends with a decimal separator
-    const endsWithSeparator = nval.toString().slice(-1) === decimalSeparator;
+      // Check if the input ends with a decimal separator
+      const endsWithSeparator = nval.toString().slice(-1) === decimalSeparator;
 
-    // Replace the locale-specific separator with a dot for parsing
-    const normalizedValue = nval.replace(decimalSeparator, ".");
+      // Replace the locale-specific separator with a dot for parsing
+      const normalizedValue = nval.replace(decimalSeparator, ".");
 
-    // Parse the number
-    const numericValue = parseFloat(normalizedValue);
+      // Parse the number
+      const numericValue = parseFloat(normalizedValue);
 
-    // If the input is not a valid number, return it as is
-    if (isNaN(numericValue)) return nval;
+      // If the input is not a valid number, return it as is
+      if (isNaN(numericValue)) return nval;
 
-    // Format the number part
-    const formattedNumber = formatNumber(numericValue, numberFormat, 20);
+      // Format the number part
+      const formattedNumber = formatNumber(numericValue, numberFormat, 20);
 
-    // If the input ends with a separator, add it back to the formatted string
-    return endsWithSeparator
-      ? `${formattedNumber}${decimalSeparator}`
-      : formattedNumber;
-  };
+      // If the input ends with a separator, add it back to the formatted string
+      return endsWithSeparator
+        ? `${formattedNumber}${decimalSeparator}`
+        : formattedNumber;
+    },
+    [decimalSeparator, numberFormat],
+  );
 
   // Parse the formatted string into a raw number
-  const parse = (val: string) => {
-    const normalizedVal = val.replace(
-      new RegExp(`[^0-9${decimalSeparator}-]`, "g"),
-      "",
-    ); // Keep only numbers and separators
-    const normalizedNumber = normalizedVal.replace(decimalSeparator, ".");
-    return isNaN(parseFloat(normalizedNumber))
-      ? ""
-      : normalizedNumber.toString();
-  };
+  const parse = useCallback(
+    (val: string) => {
+      const normalizedVal = val.replace(
+        new RegExp(`[^0-9${decimalSeparator}-]`, "g"),
+        "",
+      ); // Keep only numbers and separators
+      const normalizedNumber = normalizedVal.replace(decimalSeparator, ".");
+      return isNaN(parseFloat(normalizedNumber))
+        ? ""
+        : normalizedNumber.toString();
+    },
+    [decimalSeparator],
+  );
 
-  const isCharacterValid = (char: string) => {
-    // Build the regex dynamically to include the decimal separator
-    const validRegex = new RegExp(`^[0-9${decimalSeparator}]$`);
+  // Restore cursor position synchronously after DOM updates
+  useLayoutEffect(() => {
+    if (pendingCursorRef.current != null && inputRef.current) {
+      const pos = pendingCursorRef.current;
+      inputRef.current.setSelectionRange(pos, pos);
+      pendingCursorRef.current = null;
+    }
+  });
 
-    // Check if the character matches the valid regex
-    return validRegex.test(char);
-  };
+  /**
+   * Handle input changes while preserving cursor position.
+   * We compute the new cursor position by comparing separator counts
+   * in the old vs new formatted strings.
+   */
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>, fieldOnChange: (v: any) => void) => {
+      const input = e.target;
+      const oldValue = input.value;
+      const cursorPos = input.selectionStart ?? oldValue.length;
+
+      const parsedValue = parse(oldValue);
+
+      // Compute what the new formatted value will be
+      const newFormatted = format(parsedValue);
+
+      // Count separators before cursor in old vs new string
+      const oldSeps = countSeparatorsBefore(oldValue, cursorPos, decimalSeparator);
+      const newSeps = countSeparatorsBefore(
+        newFormatted,
+        cursorPos + (newFormatted.length - oldValue.length),
+        decimalSeparator,
+      );
+
+      // Adjust cursor: shift by the difference in separator count
+      const newCursorPos = Math.max(
+        0,
+        Math.min(cursorPos + (newSeps - oldSeps), newFormatted.length),
+      );
+
+      // Store the desired cursor position for useLayoutEffect to apply
+      pendingCursorRef.current = newCursorPos;
+
+      fieldOnChange(parsedValue);
+    },
+    [parse, format, decimalSeparator],
+  );
 
   return (
     <Controller
@@ -111,64 +175,59 @@ function FormattedNumberInput<T extends FieldValues>({
           if (value === "" || isNaN(value)) {
             return t("value-required");
           }
-          if (min && value < min) {
+          if (min != null && value < min) {
             return t("value-too-low", { min });
           }
-          if (max && value > max) {
+          if (max != null && value > max) {
             return t("value-too-high", { max });
           }
         },
       }}
-      render={({ field }) => (
-        <Group>
-          <NumberInputRoot
-            disabled={isDisabled}
-            value={format(field.value)}
-            shadow="1dp"
-            w="full"
-            hideWheelControls
-            borderRightRadius={children ? 0 : "md"} // Adjust border radius
-            bgColor={isDisabled ? "background.neutral" : "base.light"}
-            pos="relative"
-            zIndex={3}
-            min={min}
-            max={max}
-            {...rest}
-          >
-            <NumberInputField
-              value={format(field.value)}
+      render={({ field }) => {
+        const formatted = format(field.value);
+        return (
+          <Group w="full">
+            <Input
+              ref={inputRef}
+              type="text"
+              inputMode="decimal"
+              disabled={isDisabled}
+              value={formatted}
               data-testid={testId}
-              onChange={(e: any) => {
-                const parsedValue = parse(e.target.value);
-                field.onChange(parsedValue);
-              }}
-              onBlur={(e: any) => {
+              onChange={(e) => handleChange(e, field.onChange)}
+              onBlur={(e) => {
                 e.preventDefault();
                 const parsedValue = parse(e.target.value);
                 field.onChange(parseFloat(parsedValue));
               }}
               placeholder={placeholder}
-            />
-          </NumberInputRoot>
-          {children && (
-            <InputAddon
-              bgColor={isDisabled ? "background.neutral" : "base.light"}
-              color="content.tertiary"
-              h="40px"
-              fontSize="14px"
               shadow="1dp"
+              w="full"
+              borderRightRadius={children ? 0 : "md"}
+              bgColor={isDisabled ? "background.neutral" : "base.light"}
               pos="relative"
-              zIndex={10}
-              pr={2}
-              pl={2}
-              w={miniAddon ? "100px" : "auto"}
-              overflowX={miniAddon ? "hidden" : "visible"}
-            >
-              {children}
-            </InputAddon>
-          )}
-        </Group>
-      )}
+              zIndex={3}
+            />
+            {children && (
+              <InputAddon
+                bgColor={isDisabled ? "background.neutral" : "base.light"}
+                color="content.tertiary"
+                h="40px"
+                fontSize="14px"
+                shadow="1dp"
+                pos="relative"
+                zIndex={10}
+                pr={2}
+                pl={2}
+                w={miniAddon ? "100px" : "auto"}
+                overflowX={miniAddon ? "hidden" : "visible"}
+              >
+                {children}
+              </InputAddon>
+            )}
+          </Group>
+        );
+      }}
     />
   );
 }


### PR DESCRIPTION
## Summary

Fixes a cursor jump bug in `FormattedNumberInput` where the caret would land at the second-to-last position while typing (e.g. `1,11|1` instead of `1,111|`), causing data entry errors across all numeric input fields.

## Changes

<img width="768" height="462" alt="Screenshot 2026-07-17 183234" src="https://github.com/user-attachments/assets/5ef059a3-d584-410d-aab9-7b00b35272ac" />
<img width="772" height="607" alt="Screenshot 2026-07-17 183148" src="https://github.com/user-attachments/assets/3275ce86-0b6d-4ec6-ab57-a3ff6a39af0f" />


- Replaced Chakra `NumberInputRoot`/`NumberInputField` with a plain `Input` (`type="text"`, `inputMode="decimal"`) to avoid Chakra's internal cursor management overriding our position restoration
- Added `useLayoutEffect` + `pendingCursorRef` to synchronously restore cursor position after React commits DOM changes
- Added `countSeparatorsBefore()` helper to accurately compute cursor offset when formatting adds/removes thousand separators
- Fixed `min`/`max` validation silently skipping when value is `0` (`if (min && ...)` → `if (min != null && ...)`)
- Removed unused `isCharacterValid()` function
- Fixed layout widths in `ActivityDataSection` and `EmissionFactorsSection`

## How to test

1. Open any activity modal (e.g. Stationary Energy → add activity)
2. Type a number into any numeric field (activity data, emission factors)
3. Verify the cursor stays at the end while typing — no jumping to the middle
4. Verify thousand separators format correctly (e.g. `1234` → `1,234`)
5. Verify decimal input works (e.g. `1,234.56`)
6. Verify emission factor fields display correctly with their unit addons

## Notes

- Root cause: Chakra's `NumberInput` has internal value/cursor state management that fires after `requestAnimationFrame`, overriding any cursor restoration. Switching to a plain `Input` eliminates the conflict entirely.
- The `inputMode="decimal"` attribute preserves the numeric keyboard on mobile devices.
