### PR TITLE
fix: show "No data yet" instead of 0kg when inventory has no emissions

### DIFF
--- a/app/src/components/GHGIHomePage/Hero.tsx
+++ b/app/src/components/GHGIHomePage/Hero.tsx
@@ -216,8 +216,10 @@ export function Hero({
                       >
                         <>
                           {value}{" "}
-                          {/* eslint-disable-next-line i18next/no-literal-string */}
-                          <span style={{ fontSize: "16px" }}>{unit}CO2e</span>
+                          {unit && (
+                            // eslint-disable-next-line i18next/no-literal-string
+                            <span style={{ fontSize: "16px" }}>{unit}CO2e</span>
+                          )}
                         </>
                       </Text>
                       <Tooltip

--- a/app/src/components/GHGIHomePage/HomePage.tsx
+++ b/app/src/components/GHGIHomePage/HomePage.tsx
@@ -198,9 +198,9 @@ export default function HomePage({
   );
 
   const formattedEmissions =
-    inventory?.totalEmissions != null
+    inventory?.totalEmissions
       ? formatEmissions(inventory.totalEmissions, userInfo?.numberFormat)
-      : { value: t("N/A"), unit: "" };
+      : { value: t("no-data-for-inventory-yet"), unit: "" };
 
   const inventoriesForCurrentCity = useMemo(() => {
     if (!cityYears) return [];


### PR DESCRIPTION
## Summary
- When a user has an inventory but hasn't entered any emissions data yet, `totalEmissions` is `0`. Previously this was passed to `formatEmissions(0)` which rendered `0.0 kg CO2e` in the hero.
- Changed the condition from `!= null` to a truthy check so `0` falls through to the no-data fallback.
- Updated the fallback text from `N/A` to the existing `no-data-for-inventory-yet` translation key ("No data for inventory yet"), already translated in all 5 languages.
- Conditionally hides the `CO2e` unit label in the Hero when there's no real emissions data.

## Test plan
- [ ] Create an inventory with no data entered — hero should display "No data for inventory yet" (no "0kg CO2e")
- [ ] Verify that inventories with real emissions data still display correctly with value + unit + CO2e