### PR TITLE
Restore PDF OCR job processors across environments

### DIFF
--- a/.github/workflows/web-develop.yml
+++ b/.github/workflows/web-develop.yml
@@ -15,6 +15,7 @@ on:
       - k8s/cc-ca-smoke-fixture.yml
       - k8s/cc-web-deploy.yml
       - k8s/cc-web.yml
+      - k8s/cc-process-pdf-ocr-jobs.yml
       - .github/scripts/cc-ca-post-deploy-smoke.sh
       - .github/workflows/web-develop.yml
   pull_request:
@@ -24,6 +25,7 @@ on:
       - k8s/cc-ca-smoke-fixture.yml
       - k8s/cc-web-deploy.yml
       - k8s/cc-web.yml
+      - k8s/cc-process-pdf-ocr-jobs.yml
       - .github/scripts/cc-ca-post-deploy-smoke.sh
       - .github/workflows/web-develop.yml
 
@@ -459,6 +461,7 @@ jobs:
             RESET_TOKEN_SECRET=${{secrets.RESET_TOKEN_SECRET}} \
             VERIFICATION_TOKEN_SECRET=${{secrets.VERIFICATION_TOKEN_SECRET}} \
             OPENAI_API_KEY=${{secrets.OPENAI_API_KEY_DEV}} \
+            MISTRAL_API_KEY=${{secrets.MISTRAL_API_KEY_DEV}} \
             "OPENAI_ASSISTANT_ID=asst_saoKNCVqCX7adTMoLqPxPHvB" \
             LLM_PROVIDER=openai \
             LLM_MODEL=gpt-4o-mini \
@@ -500,6 +503,9 @@ jobs:
           kubectl set env cronjob/citycatalyst-check-hiap-jobs \
             "CC_CRON_JOB_API_KEY=${{secrets.CC_CRON_JOB_API_KEY}}"
           kubectl apply -f k8s/cc-check-hiap-jobs.yml -n default
+          kubectl apply -f k8s/cc-process-pdf-ocr-jobs.yml -n default
+          kubectl set env cronjob/citycatalyst-process-pdf-ocr-jobs \
+            "CC_CRON_JOB_API_KEY=${{secrets.CC_CRON_JOB_API_KEY}}"
           kubectl rollout restart deployment cc-web-deploy -n default
           kubectl rollout status deployment/cc-web-deploy -n default --timeout=300s
 

--- a/.github/workflows/web-tag.yml
+++ b/.github/workflows/web-tag.yml
@@ -21,6 +21,7 @@ on:
       - k8s/prod/cc-prod-ca-smoke-fixture.yml
       - k8s/cc-web.yml
       - k8s/cc-web-deploy.yml
+      - k8s/prod/cc-prod-process-pdf-ocr-jobs.yml
       - .github/scripts/cc-ca-post-deploy-smoke.sh
       - .github/workflows/web-tag.yml
     tags:
@@ -222,6 +223,7 @@ jobs:
             RESET_TOKEN_SECRET=${{secrets.RESET_TOKEN_SECRET}} \
             VERIFICATION_TOKEN_SECRET=${{secrets.VERIFICATION_TOKEN_SECRET}} \
             OPENAI_API_KEY=${{secrets.OPENAI_API_KEY_PROD}} \
+            MISTRAL_API_KEY=${{secrets.MISTRAL_API_KEY_PROD}} \
             "OPENAI_ASSISTANT_ID=asst_FCZ1wta3NElIFXCxDO1KME9I" \
             LLM_PROVIDER=openai \
             LLM_MODEL=gpt-4o-mini \
@@ -258,6 +260,9 @@ jobs:
           kubectl set env cronjob/citycatalyst-check-hiap-jobs \
             "CC_CRON_JOB_API_KEY=${{secrets.CC_CRON_JOB_API_KEY}}"
           kubectl apply -f k8s/cc-check-hiap-jobs.yml -n default
+          kubectl apply -f k8s/prod/cc-prod-process-pdf-ocr-jobs.yml -n default
+          kubectl set env cronjob/citycatalyst-prod-process-pdf-ocr-jobs \
+            "CC_CRON_JOB_API_KEY=${{secrets.CC_CRON_JOB_API_KEY}}"
           kubectl rollout restart deployment cc-web-deploy -n default
           kubectl rollout status deployment/cc-web-deploy -n default --timeout=300s
 

--- a/.github/workflows/web-test.yml
+++ b/.github/workflows/web-test.yml
@@ -14,6 +14,7 @@ on:
       - k8s/test/cc-test-ca-smoke-fixture.yml
       - k8s/test/cc-test-web-deploy.yml
       - k8s/test/cc-test-web.yml
+      - k8s/test/cc-test-process-pdf-ocr-jobs.yml
       - .github/scripts/cc-ca-post-deploy-smoke.sh
       - .github/workflows/web-test.yml
     branches: ["main"]
@@ -239,6 +240,7 @@ jobs:
             RESET_TOKEN_SECRET=${{secrets.RESET_TOKEN_SECRET}} \
             VERIFICATION_TOKEN_SECRET=${{secrets.VERIFICATION_TOKEN_SECRET}} \
             OPENAI_API_KEY=${{secrets.OPENAI_API_KEY_TEST}} \
+            MISTRAL_API_KEY=${{secrets.MISTRAL_API_KEY_TEST}} \
             "OPENAI_ASSISTANT_ID=asst_4if8qn6W8Vlxwbf2cuyH8OFU" \
             LLM_PROVIDER=openai \
             LLM_MODEL=gpt-4o-mini \
@@ -275,6 +277,9 @@ jobs:
           kubectl set env cronjob/citycatalyst-test-check-hiap-jobs \
             "CC_CRON_JOB_API_KEY=${{secrets.CC_CRON_JOB_API_KEY}}"
           kubectl apply -f k8s/cc-check-hiap-jobs.yml -n default
+          kubectl apply -f k8s/test/cc-test-process-pdf-ocr-jobs.yml -n default
+          kubectl set env cronjob/citycatalyst-test-process-pdf-ocr-jobs \
+            "CC_CRON_JOB_API_KEY=${{secrets.CC_CRON_JOB_API_KEY}}"
           kubectl rollout restart deployment cc-test-web-deploy -n default
           kubectl rollout status deployment/cc-test-web-deploy -n default --timeout=300s
 

--- a/app/tests/pdf-ocr-deployment-contract.jest.ts
+++ b/app/tests/pdf-ocr-deployment-contract.jest.ts
@@ -7,30 +7,48 @@ function readRepoFile(path: string): string {
   return readFileSync(resolve(repoRoot, path), "utf8");
 }
 
-describe("PDF OCR dev deployment contract", () => {
-  const cronPath = "k8s/cc-process-pdf-ocr-jobs.yml";
-  const workflowPath = ".github/workflows/web-develop.yml";
+describe("PDF OCR deployment contract", () => {
+  const environments = [
+    {
+      name: "dev",
+      cronPath: "k8s/cc-process-pdf-ocr-jobs.yml",
+      cronName: "citycatalyst-process-pdf-ocr-jobs",
+      workflowPath: ".github/workflows/web-develop.yml",
+      mistralSecret: "MISTRAL_API_KEY_DEV",
+    },
+    {
+      name: "test",
+      cronPath: "k8s/test/cc-test-process-pdf-ocr-jobs.yml",
+      cronName: "citycatalyst-test-process-pdf-ocr-jobs",
+      workflowPath: ".github/workflows/web-test.yml",
+      mistralSecret: "MISTRAL_API_KEY_TEST",
+    },
+    {
+      name: "prod",
+      cronPath: "k8s/prod/cc-prod-process-pdf-ocr-jobs.yml",
+      cronName: "citycatalyst-prod-process-pdf-ocr-jobs",
+      workflowPath: ".github/workflows/web-tag.yml",
+      mistralSecret: "MISTRAL_API_KEY_PROD",
+    },
+  ] as const;
 
-  test("runs an authenticated, non-overlapping OCR processor every minute", () => {
-    const cron = readRepoFile(cronPath);
+  test.each(environments)(
+    "$name runs and deploys an authenticated, non-overlapping OCR processor",
+    ({ cronPath, cronName, workflowPath, mistralSecret }) => {
+      const cron = readRepoFile(cronPath);
+      const workflow = readRepoFile(workflowPath);
 
-    expect(cron).toContain("kind: CronJob");
-    expect(cron).toContain('schedule: "* * * * *"');
-    expect(cron).toContain("concurrencyPolicy: Forbid");
-    expect(cron).toContain("Authorization: Bearer $CC_CRON_JOB_API_KEY");
-    expect(cron).toContain("/api/v1/cron/process-pdf-ocr-jobs");
-  });
-
-  test("deploys the processor and configures the dev Mistral key", () => {
-    const workflow = readRepoFile(workflowPath);
-
-    expect(workflow).toContain(`- ${cronPath}`);
-    expect(workflow).toContain(`kubectl apply -f ${cronPath} -n default`);
-    expect(workflow).toContain(
-      "kubectl set env cronjob/citycatalyst-process-pdf-ocr-jobs",
-    );
-    expect(workflow).toContain(
-      "MISTRAL_API_KEY=${{secrets.MISTRAL_API_KEY_DEV}}",
-    );
-  });
+      expect(cron).toContain("kind: CronJob");
+      expect(cron).toContain('schedule: "* * * * *"');
+      expect(cron).toContain("concurrencyPolicy: Forbid");
+      expect(cron).toContain("Authorization: Bearer $CC_CRON_JOB_API_KEY");
+      expect(cron).toContain("/api/v1/cron/process-pdf-ocr-jobs");
+      expect(workflow).toContain(`- ${cronPath}`);
+      expect(workflow).toContain(`kubectl apply -f ${cronPath} -n default`);
+      expect(workflow).toContain(`kubectl set env cronjob/${cronName}`);
+      expect(workflow).toContain(
+        `MISTRAL_API_KEY=\${{secrets.${mistralSecret}}}`,
+      );
+    },
+  );
 });

--- a/app/tests/pdf-ocr-deployment-contract.jest.ts
+++ b/app/tests/pdf-ocr-deployment-contract.jest.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const repoRoot = resolve(process.cwd(), "..");
+
+function readRepoFile(path: string): string {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+describe("PDF OCR dev deployment contract", () => {
+  const cronPath = "k8s/cc-process-pdf-ocr-jobs.yml";
+  const workflowPath = ".github/workflows/web-develop.yml";
+
+  test("runs an authenticated, non-overlapping OCR processor every minute", () => {
+    const cron = readRepoFile(cronPath);
+
+    expect(cron).toContain("kind: CronJob");
+    expect(cron).toContain('schedule: "* * * * *"');
+    expect(cron).toContain("concurrencyPolicy: Forbid");
+    expect(cron).toContain("Authorization: Bearer $CC_CRON_JOB_API_KEY");
+    expect(cron).toContain("/api/v1/cron/process-pdf-ocr-jobs");
+  });
+
+  test("deploys the processor and configures the dev Mistral key", () => {
+    const workflow = readRepoFile(workflowPath);
+
+    expect(workflow).toContain(`- ${cronPath}`);
+    expect(workflow).toContain(`kubectl apply -f ${cronPath} -n default`);
+    expect(workflow).toContain(
+      "kubectl set env cronjob/citycatalyst-process-pdf-ocr-jobs",
+    );
+    expect(workflow).toContain(
+      "MISTRAL_API_KEY=${{secrets.MISTRAL_API_KEY_DEV}}",
+    );
+  });
+});

--- a/k8s/cc-process-pdf-ocr-jobs.yml
+++ b/k8s/cc-process-pdf-ocr-jobs.yml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: citycatalyst-process-pdf-ocr-jobs
+  namespace: default
+spec:
+  schedule: "* * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 590
+      template:
+        metadata:
+          labels:
+            app: citycatalyst-cron
+            job: process-pdf-ocr-jobs
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: process-pdf-ocr-jobs
+              image: curlimages/curl:latest
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  test -n "$CC_CRON_JOB_API_KEY"
+                  curl --fail --location --max-time 585 \
+                    --request POST \
+                    --header "Authorization: Bearer $CC_CRON_JOB_API_KEY" \
+                    http://cc-web:3000/api/v1/cron/process-pdf-ocr-jobs

--- a/k8s/prod/cc-prod-process-pdf-ocr-jobs.yml
+++ b/k8s/prod/cc-prod-process-pdf-ocr-jobs.yml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: citycatalyst-prod-process-pdf-ocr-jobs
+  namespace: default
+spec:
+  schedule: "* * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 590
+      template:
+        metadata:
+          labels:
+            app: citycatalyst-prod-cron
+            job: process-pdf-ocr-jobs
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: process-pdf-ocr-jobs
+              image: curlimages/curl:latest
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  test -n "$CC_CRON_JOB_API_KEY"
+                  curl --fail --location --max-time 585 \
+                    --request POST \
+                    --header "Authorization: Bearer $CC_CRON_JOB_API_KEY" \
+                    http://cc-web:3000/api/v1/cron/process-pdf-ocr-jobs

--- a/k8s/test/cc-test-process-pdf-ocr-jobs.yml
+++ b/k8s/test/cc-test-process-pdf-ocr-jobs.yml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: citycatalyst-test-process-pdf-ocr-jobs
+  namespace: default
+spec:
+  schedule: "* * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 590
+      template:
+        metadata:
+          labels:
+            app: citycatalyst-test-cron
+            job: process-pdf-ocr-jobs
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: process-pdf-ocr-jobs
+              image: curlimages/curl:latest
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  test -n "$CC_CRON_JOB_API_KEY"
+                  curl --fail --location --max-time 585 \
+                    --request POST \
+                    --header "Authorization: Bearer $CC_CRON_JOB_API_KEY" \
+                    http://cc-test-web:3000/api/v1/cron/process-pdf-ocr-jobs


### PR DESCRIPTION
## What changed

- restore the Kubernetes PDF OCR processor CronJob in dev, test, and production
- configure every CronJob with the existing `CC_CRON_JOB_API_KEY` deployment secret
- provide the environment-specific Mistral key to each web deployment
- add each OCR manifest to its deployment workflow path filters
- add a three-environment deployment contract covering the scheduler, authentication, endpoint, and secret wiring

## Why

PDF uploads enqueue durable OCR jobs, but none of the deployed environments had a scheduler calling `POST /api/v1/cron/process-pdf-ocr-jobs`. Jobs therefore remained queued and the UI stayed on "Breaking file into smaller chunks". The web deployments also did not receive the Mistral keys required by the OCR processor.

## Impact

After the relevant environment is deployed, it will claim queued PDF OCR jobs once per minute and process them without overlapping CronJob runs. The same deployment contract now protects dev, test, and production from losing this wiring independently.

## Validation

- 6 PDF OCR Jest suites passed
- 30 tests passed
- all three workflow and CronJob YAML pairs parsed successfully
- Prettier check passed for the deployment contract and CronJob manifests
- `git diff --check` passed
- confirmed `CC_CRON_JOB_API_KEY` and all three environment-specific Mistral secrets exist in GitHub
