### PR TITLE
ON-6046: Add Clima project inventory breakdown and role-scoped access

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -132,6 +132,27 @@ The standard port is 3000 and the application can be opend at http://localhost:3
 
 Use `johndoe@example.com` and `password` to login.
 
+#### Climate Advisor multi-role fixtures (ON-6046)
+
+To validate Clima inventory totals by role against the smoke organization demos:
+
+```bash
+# Requires the CA smoke org + demo projects/cities already in the DB
+CA_ROLE_FIXTURE_PASSWORD='password' npm run upsert-ca-role-fixtures
+npm run validate-ca-inventory-access-by-role
+```
+
+UI logins (password from `CA_ROLE_FIXTURE_PASSWORD`, default `password`):
+
+| Role | Email | Expected access |
+| --- | --- | --- |
+| Collaborator | `ca-collaborator@citycatalyst.local` | 3 assigned cities in Demo Project 1 |
+| Project admin | `ca-project-admin@citycatalyst.local` | Demo Project 2 only |
+| Org admin | `ca-org-admin@citycatalyst.local` | All projects in the smoke org |
+| System admin | `ca-system-admin@citycatalyst.local` | Platform-wide (`access_scope: platform`) |
+
+Ask Clima: *How many inventories do I have?* — answers should use “you have access to…” and match All projects for that user.
+
 #### HIAP
 To connect to the HIAP prioritizer/plan creator, run
 kubectl port-forward svc/hiap-service-dev 8080:8080

--- a/app/README.md
+++ b/app/README.md
@@ -132,27 +132,6 @@ The standard port is 3000 and the application can be opend at http://localhost:3
 
 Use `johndoe@example.com` and `password` to login.
 
-#### Climate Advisor multi-role fixtures (ON-6046)
-
-To validate Clima inventory totals by role against the smoke organization demos:
-
-```bash
-# Requires the CA smoke org + demo projects/cities already in the DB
-CA_ROLE_FIXTURE_PASSWORD='password' npm run upsert-ca-role-fixtures
-npm run validate-ca-inventory-access-by-role
-```
-
-UI logins (password from `CA_ROLE_FIXTURE_PASSWORD`, default `password`):
-
-| Role | Email | Expected access |
-| --- | --- | --- |
-| Collaborator | `ca-collaborator@citycatalyst.local` | 3 assigned cities in Demo Project 1 |
-| Project admin | `ca-project-admin@citycatalyst.local` | Demo Project 2 only |
-| Org admin | `ca-org-admin@citycatalyst.local` | All projects in the smoke org |
-| System admin | `ca-system-admin@citycatalyst.local` | Platform-wide (`access_scope: platform`) |
-
-Ask Clima: *How many inventories do I have?* — answers should use “you have access to…” and match All projects for that user.
-
 #### HIAP
 To connect to the HIAP prioritizer/plan creator, run
 kubectl port-forward svc/hiap-service-dev 8080:8080

--- a/app/package.json
+++ b/app/package.json
@@ -35,6 +35,8 @@
     "email": "email dev --dir src/lib/emails",
     "create-admin": "tsx scripts/create-admin.ts",
     "upsert-ca-smoke-fixture": "tsx scripts/upsert-ca-smoke-fixture.ts",
+    "upsert-ca-role-fixtures": "tsx scripts/upsert-ca-role-fixtures.ts",
+    "validate-ca-inventory-access-by-role": "tsx scripts/validate-ca-inventory-access-by-role.ts",
     "update-brazil-emissions": "tsx scripts/update-country-emissions.ts",
     "generate:changelog": "node scripts/generate-changelog.js",
     "upgrade:ui": "npm uninstall @emotion/styled framer-motion && npm install @chakra-ui/react@latest @emotion/react@latest",

--- a/app/scripts/upsert-ca-role-fixtures.ts
+++ b/app/scripts/upsert-ca-role-fixtures.ts
@@ -1,0 +1,433 @@
+/**
+ * Upsert deterministic CityCatalyst users for ON-6046 multi-role Clima validation.
+ *
+ * Brief: Creates collaborator, project admin, org admin, and system admin users
+ * with distinct project/city access against the CA smoke organization.
+ *
+ * Inputs:
+ * - Env vars (optional):
+ *   - `CA_ROLE_FIXTURE_PASSWORD`: shared login password (default: `password`)
+ *   - `CA_SMOKE_ORGANIZATION_ID`: org that owns the demo projects
+ *     (default: smoke org `99999999-9999-4999-8999-999999999999`)
+ *   - `CA_ROLE_PROJECT_ADMIN_PROJECT_ID`: project for the project-admin user
+ *     (default: Demo Project 2 id from local demo seed)
+ *   - `CA_ROLE_COLLABORATOR_CITY_LIMIT`: cities assigned to collaborator (default: 3)
+ * - DB: existing Organization / Project / City / Inventory rows in the smoke org
+ *
+ * Outputs:
+ * - Upserts User + role association rows (CityUser / ProjectAdmin / OrganizationAdmin)
+ * - Prints UI login credentials and expected access scope to stdout/logger
+ *
+ * Usage (from `app/`):
+ * - `CA_ROLE_FIXTURE_PASSWORD='password' npm run upsert-ca-role-fixtures`
+ */
+
+import { randomUUID } from "node:crypto";
+
+import { db } from "@/models";
+import { logger } from "@/services/logger";
+import { Roles } from "@/util/types";
+import env from "@next/env";
+import bcrypt from "bcrypt";
+import type { Transaction } from "sequelize";
+
+const DEFAULT_ORG_ID = "99999999-9999-4999-8999-999999999999";
+/** Demo Project 2 from the local ON-6046 demo seed (67 cities). */
+const DEFAULT_PROJECT_ADMIN_PROJECT_ID =
+  "f8c1192c-4eaa-4de9-a11b-24a70b14c755";
+
+const FIXTURES = {
+  collaborator: {
+    userId: "a1111111-1111-4111-8111-111111111101",
+    email: "ca-collaborator@citycatalyst.local",
+    name: "CA Collaborator",
+    organizationAdminId: "b1111111-1111-4111-8111-111111111101",
+    projectAdminId: "c1111111-1111-4111-8111-111111111101",
+  },
+  projectAdmin: {
+    userId: "a1111111-1111-4111-8111-111111111102",
+    email: "ca-project-admin@citycatalyst.local",
+    name: "CA Project Admin",
+    organizationAdminId: "b1111111-1111-4111-8111-111111111102",
+    projectAdminId: "c1111111-1111-4111-8111-111111111102",
+  },
+  orgAdmin: {
+    userId: "a1111111-1111-4111-8111-111111111103",
+    email: "ca-org-admin@citycatalyst.local",
+    name: "CA Org Admin",
+    organizationAdminId: "b1111111-1111-4111-8111-111111111103",
+    projectAdminId: "c1111111-1111-4111-8111-111111111103",
+  },
+  systemAdmin: {
+    userId: "a1111111-1111-4111-8111-111111111104",
+    email: "ca-system-admin@citycatalyst.local",
+    name: "CA System Admin",
+    organizationAdminId: "b1111111-1111-4111-8111-111111111104",
+    projectAdminId: "c1111111-1111-4111-8111-111111111104",
+  },
+} as const;
+
+function envValue(name: string, fallback: string): string {
+  const value = process.env[name]?.trim();
+  return value && value.length > 0 ? value : fallback;
+}
+
+function envInteger(name: string, fallback: number): number {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+/** Ensure email is owned by the expected fixture user id. */
+async function assertEmailOwner(
+  email: string,
+  expectedUserId: string,
+  transaction: Transaction,
+) {
+  const existing = await db.models.User.findOne({
+    where: { email },
+    transaction,
+  });
+  if (existing && existing.userId !== expectedUserId) {
+    throw new Error(
+      `Email ${email} already belongs to a different user (${existing.userId})`,
+    );
+  }
+}
+
+/** Create or update a credentials user with the given platform role. */
+async function upsertUser(params: {
+  userId: string;
+  email: string;
+  name: string;
+  role: Roles;
+  passwordHash: string;
+  defaultCityId?: string | null;
+  defaultInventoryId?: string | null;
+  transaction: Transaction;
+}) {
+  await assertEmailOwner(params.email, params.userId, params.transaction);
+
+  const existing = await db.models.User.findByPk(params.userId, {
+    transaction: params.transaction,
+  });
+  const payload = {
+    name: params.name,
+    email: params.email,
+    role: params.role,
+    passwordHash: params.passwordHash,
+    defaultCityId: params.defaultCityId ?? null,
+    defaultInventoryId: params.defaultInventoryId ?? null,
+  };
+
+  if (existing) {
+    await existing.update(payload, { transaction: params.transaction });
+    return existing;
+  }
+
+  return db.models.User.create(
+    {
+      userId: params.userId,
+      ...payload,
+    },
+    { transaction: params.transaction },
+  );
+}
+
+/** Remove prior role associations for a fixture user so re-runs stay deterministic. */
+async function clearRoleAssociations(
+  userId: string,
+  transaction: Transaction,
+) {
+  await db.models.CityUser.destroy({ where: { userId }, transaction });
+  await db.models.ProjectAdmin.destroy({ where: { userId }, transaction });
+  await db.models.OrganizationAdmin.destroy({ where: { userId }, transaction });
+}
+
+async function upsertCaRoleFixtures() {
+  env.loadEnvConfig(process.cwd());
+
+  if (!db.initialized) {
+    await db.initialize();
+  }
+
+  const organizationId = envValue(
+    "CA_SMOKE_ORGANIZATION_ID",
+    DEFAULT_ORG_ID,
+  );
+  const projectAdminProjectId = envValue(
+    "CA_ROLE_PROJECT_ADMIN_PROJECT_ID",
+    DEFAULT_PROJECT_ADMIN_PROJECT_ID,
+  );
+  const collaboratorCityLimit = envInteger(
+    "CA_ROLE_COLLABORATOR_CITY_LIMIT",
+    3,
+  );
+  const password = envValue("CA_ROLE_FIXTURE_PASSWORD", "password");
+  const passwordHash = await bcrypt.hash(password, 12);
+
+  try {
+    const summary = await db.sequelize!.transaction(async (transaction) => {
+      const organization = await db.models.Organization.findByPk(
+        organizationId,
+        { transaction },
+      );
+      if (!organization) {
+        throw new Error(
+          `Organization ${organizationId} not found. Run the CA smoke + demo project seed first.`,
+        );
+      }
+
+      const projectAdminProject = await db.models.Project.findOne({
+        where: { projectId: projectAdminProjectId, organizationId },
+        transaction,
+      });
+      if (!projectAdminProject) {
+        throw new Error(
+          `Project ${projectAdminProjectId} not found in org ${organizationId}`,
+        );
+      }
+
+      // Collaborator gets a small explicit city set inside Demo Project 1 (or first non-admin project).
+      const collaboratorProject =
+        (await db.models.Project.findOne({
+          where: { organizationId, name: "Demo Project 1" },
+          transaction,
+        })) ??
+        (await db.models.Project.findOne({
+          where: { organizationId },
+          order: [["name", "ASC"]],
+          transaction,
+        }));
+      if (!collaboratorProject) {
+        throw new Error(`No projects found in organization ${organizationId}`);
+      }
+
+      const collaboratorCities = await db.models.City.findAll({
+        where: { projectId: collaboratorProject.projectId },
+        include: [{ model: db.models.Inventory, as: "inventories" }],
+        order: [["name", "ASC"]],
+        limit: collaboratorCityLimit,
+        transaction,
+      });
+      if (collaboratorCities.length === 0) {
+        throw new Error(
+          `No cities found in project ${collaboratorProject.projectId}`,
+        );
+      }
+
+      const projectAdminCities = await db.models.City.findAll({
+        where: { projectId: projectAdminProject.projectId },
+        include: [{ model: db.models.Inventory, as: "inventories" }],
+        order: [["name", "ASC"]],
+        limit: 1,
+        transaction,
+      });
+
+      const orgInventoryCount = await db.models.Inventory.count({
+        include: [
+          {
+            model: db.models.City,
+            as: "city",
+            required: true,
+            include: [
+              {
+                model: db.models.Project,
+                as: "project",
+                required: true,
+                where: { organizationId },
+              },
+            ],
+          },
+        ],
+        transaction,
+      });
+
+      const projectAdminInventoryCount = await db.models.Inventory.count({
+        include: [
+          {
+            model: db.models.City,
+            as: "city",
+            required: true,
+            where: { projectId: projectAdminProject.projectId },
+          },
+        ],
+        transaction,
+      });
+
+      // --- Collaborator: only the selected cities ---
+      await clearRoleAssociations(FIXTURES.collaborator.userId, transaction);
+      const collaboratorDefaultCity = collaboratorCities[0];
+      const collaboratorDefaultInventory =
+        collaboratorDefaultCity.inventories?.[0];
+      await upsertUser({
+        userId: FIXTURES.collaborator.userId,
+        email: FIXTURES.collaborator.email,
+        name: FIXTURES.collaborator.name,
+        role: Roles.User,
+        passwordHash,
+        defaultCityId: collaboratorDefaultCity.cityId,
+        defaultInventoryId: collaboratorDefaultInventory?.inventoryId ?? null,
+        transaction,
+      });
+      for (const city of collaboratorCities) {
+        await db.models.CityUser.create(
+          {
+            cityUserId: randomUUID(),
+            userId: FIXTURES.collaborator.userId,
+            cityId: city.cityId,
+          },
+          { transaction },
+        );
+      }
+
+      // --- Project admin: full Demo Project 2 ---
+      await clearRoleAssociations(FIXTURES.projectAdmin.userId, transaction);
+      const projectAdminDefaultCity = projectAdminCities[0];
+      const projectAdminDefaultInventory =
+        projectAdminDefaultCity?.inventories?.[0];
+      await upsertUser({
+        userId: FIXTURES.projectAdmin.userId,
+        email: FIXTURES.projectAdmin.email,
+        name: FIXTURES.projectAdmin.name,
+        role: Roles.User,
+        passwordHash,
+        defaultCityId: projectAdminDefaultCity?.cityId ?? null,
+        defaultInventoryId: projectAdminDefaultInventory?.inventoryId ?? null,
+        transaction,
+      });
+      await db.models.ProjectAdmin.create(
+        {
+          projectAdminId: FIXTURES.projectAdmin.projectAdminId,
+          projectId: projectAdminProject.projectId,
+          userId: FIXTURES.projectAdmin.userId,
+        },
+        { transaction },
+      );
+
+      // --- Org admin: entire smoke organization ---
+      await clearRoleAssociations(FIXTURES.orgAdmin.userId, transaction);
+      await upsertUser({
+        userId: FIXTURES.orgAdmin.userId,
+        email: FIXTURES.orgAdmin.email,
+        name: FIXTURES.orgAdmin.name,
+        role: Roles.User,
+        passwordHash,
+        defaultCityId: collaboratorDefaultCity.cityId,
+        defaultInventoryId: collaboratorDefaultInventory?.inventoryId ?? null,
+        transaction,
+      });
+      await db.models.OrganizationAdmin.create(
+        {
+          organizationAdminId: FIXTURES.orgAdmin.organizationAdminId,
+          organizationId,
+          userId: FIXTURES.orgAdmin.userId,
+        },
+        { transaction },
+      );
+
+      // --- System / super admin: platform-wide Roles.Admin ---
+      await clearRoleAssociations(FIXTURES.systemAdmin.userId, transaction);
+      await upsertUser({
+        userId: FIXTURES.systemAdmin.userId,
+        email: FIXTURES.systemAdmin.email,
+        name: FIXTURES.systemAdmin.name,
+        role: Roles.Admin,
+        passwordHash,
+        defaultCityId: collaboratorDefaultCity.cityId,
+        defaultInventoryId: collaboratorDefaultInventory?.inventoryId ?? null,
+        transaction,
+      });
+
+      return {
+        password,
+        organizationId,
+        organizationName: organization.name,
+        collaborator: {
+          ...FIXTURES.collaborator,
+          projectId: collaboratorProject.projectId,
+          projectName: collaboratorProject.name,
+          cityIds: collaboratorCities.map((city) => city.cityId),
+          expectedInventories: collaboratorCities.reduce(
+            (sum, city) => sum + (city.inventories?.length ?? 0),
+            0,
+          ),
+          expectedCities: collaboratorCities.length,
+        },
+        projectAdmin: {
+          ...FIXTURES.projectAdmin,
+          projectId: projectAdminProject.projectId,
+          projectName: projectAdminProject.name,
+          expectedInventories: projectAdminInventoryCount,
+          expectedCities: projectAdminInventoryCount,
+        },
+        orgAdmin: {
+          ...FIXTURES.orgAdmin,
+          expectedInventories: orgInventoryCount,
+          expectedCities: orgInventoryCount,
+        },
+        systemAdmin: {
+          ...FIXTURES.systemAdmin,
+          expectedAccessScope: "platform" as const,
+          expectedMinInventories: orgInventoryCount,
+        },
+      };
+    });
+
+    logger.info(
+      {
+        organizationId: summary.organizationId,
+        collaboratorEmail: summary.collaborator.email,
+        projectAdminEmail: summary.projectAdmin.email,
+        orgAdminEmail: summary.orgAdmin.email,
+        systemAdminEmail: summary.systemAdmin.email,
+      },
+      "Upserted CA multi-role fixtures",
+    );
+
+    // Intentional CLI UX: print a copy-pasteable UI checklist.
+    console.log(`
+=== ON-6046 multi-role fixtures ready ===
+Password (all users): ${summary.password}
+Organization: ${summary.organizationName} (${summary.organizationId})
+
+UI logins + expected Clima answer for "How many inventories do I have?":
+
+1) Collaborator  ${summary.collaborator.email}
+   Access: ${summary.collaborator.expectedInventories} inventories / ${summary.collaborator.expectedCities} cities
+   Project: ${summary.collaborator.projectName} only (assigned cities)
+
+2) Project admin ${summary.projectAdmin.email}
+   Access: ${summary.projectAdmin.expectedInventories} inventories / ${summary.projectAdmin.expectedCities} cities
+   Project: ${summary.projectAdmin.projectName} only
+   access_scope: projects
+
+3) Org admin     ${summary.orgAdmin.email}
+   Access: ${summary.orgAdmin.expectedInventories} inventories / ${summary.orgAdmin.expectedCities} cities
+   All projects in the smoke organization
+   access_scope: projects
+
+4) System admin  ${summary.systemAdmin.email}
+   Access: platform-wide (>= ${summary.systemAdmin.expectedMinInventories} inventories)
+   access_scope: platform
+   Copy: "you have access to…"
+
+Validate via script:
+  npm run validate-ca-inventory-access-by-role
+`);
+  } finally {
+    await db.sequelize?.close();
+  }
+}
+
+upsertCaRoleFixtures().catch(async (error) => {
+  logger.error({ err: error }, "Failed to upsert CA multi-role fixtures");
+  await db.sequelize?.close();
+  process.exitCode = 1;
+});

--- a/app/scripts/validate-ca-inventory-access-by-role.ts
+++ b/app/scripts/validate-ca-inventory-access-by-role.ts
@@ -114,6 +114,16 @@ async function countInventoriesForProjects(
   });
 }
 
+/** Count distinct cities in the given project ids. */
+async function countCitiesForProjects(projectIds: string[]): Promise<number> {
+  if (projectIds.length === 0) {
+    return 0;
+  }
+  return db.models.City.count({
+    where: { projectId: { [Op.in]: projectIds } },
+  });
+}
+
 /** Count inventories for cities explicitly assigned to a collaborator. */
 async function countCollaboratorInventories(userId: string): Promise<{
   inventoryCount: number;
@@ -179,7 +189,11 @@ async function validateRoleAccess() {
     const orgProjectIds = orgProjects.map((project) => project.projectId);
     const orgInventoryCount =
       await countInventoriesForProjects(orgProjectIds);
+    const orgCityCount = await countCitiesForProjects(orgProjectIds);
     const projectAdminInventoryCount = await countInventoriesForProjects([
+      projectAdminProjectId,
+    ]);
+    const projectAdminCityCount = await countCitiesForProjects([
       projectAdminProjectId,
     ]);
 
@@ -252,10 +266,10 @@ async function validateRoleAccess() {
           `total_inventories=${list.total_inventories}, expected ${projectAdminInventoryCount}`,
         );
       }
-      if (list.total_cities !== projectAdminInventoryCount) {
+      if (list.total_cities !== projectAdminCityCount) {
         ok = false;
         details.push(
-          `total_cities=${list.total_cities}, expected ${projectAdminInventoryCount}`,
+          `total_cities=${list.total_cities}, expected ${projectAdminCityCount}`,
         );
       }
       const onlyExpectedProject =
@@ -297,10 +311,10 @@ async function validateRoleAccess() {
           `total_inventories=${list.total_inventories}, expected ${orgInventoryCount}`,
         );
       }
-      if (list.total_cities !== orgInventoryCount) {
+      if (list.total_cities !== orgCityCount) {
         ok = false;
         details.push(
-          `total_cities=${list.total_cities}, expected ${orgInventoryCount}`,
+          `total_cities=${list.total_cities}, expected ${orgCityCount}`,
         );
       }
       if (list.by_project.length !== orgProjects.length) {

--- a/app/scripts/validate-ca-inventory-access-by-role.ts
+++ b/app/scripts/validate-ca-inventory-access-by-role.ts
@@ -1,0 +1,382 @@
+/**
+ * Validate ON-6046 accessible-inventory totals/breakdown per role fixture.
+ *
+ * Brief: Calls `buildAccessibleInventoryList` for collaborator, project admin,
+ * org admin, and system admin fixtures and asserts expected counts/scope.
+ *
+ * Inputs:
+ * - Env vars (optional):
+ *   - `CA_SMOKE_ORGANIZATION_ID`: smoke organization id
+ *   - `CA_ROLE_PROJECT_ADMIN_PROJECT_ID`: project-admin project id
+ *   - `CA_ROLE_COLLABORATOR_CITY_LIMIT`: expected collaborator city count
+ * - DB: role fixtures from `npm run upsert-ca-role-fixtures`
+ *
+ * Outputs:
+ * - Pass/fail report on stdout (exit code 0 on success, 1 on failure)
+ *
+ * Usage (from `app/`):
+ * - `npm run upsert-ca-role-fixtures`
+ * - `npm run validate-ca-inventory-access-by-role`
+ */
+
+import { buildAccessibleInventoryList } from "@/backend/agentic/ghgi/inventory/context";
+import { db } from "@/models";
+import { logger } from "@/services/logger";
+import env from "@next/env";
+import { Op } from "sequelize";
+
+const DEFAULT_ORG_ID = "99999999-9999-4999-8999-999999999999";
+const DEFAULT_PROJECT_ADMIN_PROJECT_ID =
+  "f8c1192c-4eaa-4de9-a11b-24a70b14c755";
+
+const USERS = {
+  collaborator: {
+    userId: "a1111111-1111-4111-8111-111111111101",
+    email: "ca-collaborator@citycatalyst.local",
+    roleLabel: "collaborator",
+  },
+  projectAdmin: {
+    userId: "a1111111-1111-4111-8111-111111111102",
+    email: "ca-project-admin@citycatalyst.local",
+    roleLabel: "project_admin",
+  },
+  orgAdmin: {
+    userId: "a1111111-1111-4111-8111-111111111103",
+    email: "ca-org-admin@citycatalyst.local",
+    roleLabel: "org_admin",
+  },
+  systemAdmin: {
+    userId: "a1111111-1111-4111-8111-111111111104",
+    email: "ca-system-admin@citycatalyst.local",
+    roleLabel: "system_admin",
+  },
+} as const;
+
+type CheckResult = {
+  role: string;
+  email: string;
+  ok: boolean;
+  details: string[];
+};
+
+function envValue(name: string, fallback: string): string {
+  const value = process.env[name]?.trim();
+  return value && value.length > 0 ? value : fallback;
+}
+
+function envInteger(name: string, fallback: number): number {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+/** Format by_project rows for readable assertion output. */
+function formatBreakdown(
+  byProject: Array<{
+    project_name: string | null;
+    total_inventories: number;
+    total_cities: number;
+  }>,
+): string {
+  if (byProject.length === 0) {
+    return "(empty)";
+  }
+  return byProject
+    .map(
+      (row) =>
+        `${row.project_name ?? "unknown"}: ${row.total_inventories} inv / ${row.total_cities} cities`,
+    )
+    .join("; ");
+}
+
+/** Count inventories linked to cities in the given project ids. */
+async function countInventoriesForProjects(
+  projectIds: string[],
+): Promise<number> {
+  if (projectIds.length === 0) {
+    return 0;
+  }
+  return db.models.Inventory.count({
+    include: [
+      {
+        model: db.models.City,
+        as: "city",
+        required: true,
+        where: { projectId: { [Op.in]: projectIds } },
+      },
+    ],
+  });
+}
+
+/** Count inventories for cities explicitly assigned to a collaborator. */
+async function countCollaboratorInventories(userId: string): Promise<{
+  inventoryCount: number;
+  cityCount: number;
+  projectIds: string[];
+}> {
+  const cityUsers = await db.models.CityUser.findAll({
+    where: { userId },
+    include: [
+      {
+        model: db.models.City,
+        as: "city",
+        include: [
+          { model: db.models.Inventory, as: "inventories" },
+          { model: db.models.Project, as: "project" },
+        ],
+      },
+    ],
+  });
+
+  const projectIds = [
+    ...new Set(
+      cityUsers
+        .map((row) => row.city?.project?.projectId)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  ];
+
+  return {
+    cityCount: cityUsers.length,
+    inventoryCount: cityUsers.reduce(
+      (sum, row) => sum + (row.city?.inventories?.length ?? 0),
+      0,
+    ),
+    projectIds,
+  };
+}
+
+async function validateRoleAccess() {
+  env.loadEnvConfig(process.cwd());
+
+  if (!db.initialized) {
+    await db.initialize();
+  }
+
+  const organizationId = envValue("CA_SMOKE_ORGANIZATION_ID", DEFAULT_ORG_ID);
+  const projectAdminProjectId = envValue(
+    "CA_ROLE_PROJECT_ADMIN_PROJECT_ID",
+    DEFAULT_PROJECT_ADMIN_PROJECT_ID,
+  );
+  const collaboratorCityLimit = envInteger(
+    "CA_ROLE_COLLABORATOR_CITY_LIMIT",
+    3,
+  );
+
+  const results: CheckResult[] = [];
+
+  try {
+    const orgProjects = await db.models.Project.findAll({
+      where: { organizationId },
+      attributes: ["projectId", "name"],
+    });
+    const orgProjectIds = orgProjects.map((project) => project.projectId);
+    const orgInventoryCount =
+      await countInventoriesForProjects(orgProjectIds);
+    const projectAdminInventoryCount = await countInventoriesForProjects([
+      projectAdminProjectId,
+    ]);
+
+    // Collaborator
+    {
+      const fixture = USERS.collaborator;
+      const expected = await countCollaboratorInventories(fixture.userId);
+      const list = await buildAccessibleInventoryList({
+        userId: fixture.userId,
+        includeAllCityYears: true,
+      });
+      const details: string[] = [];
+      let ok = true;
+
+      if (expected.cityCount !== collaboratorCityLimit) {
+        ok = false;
+        details.push(
+          `fixture city associations=${expected.cityCount}, expected ${collaboratorCityLimit} (re-run upsert-ca-role-fixtures)`,
+        );
+      }
+      if (list.access_scope !== "projects") {
+        ok = false;
+        details.push(`access_scope=${list.access_scope}, expected projects`);
+      }
+      if (list.total_inventories !== expected.inventoryCount) {
+        ok = false;
+        details.push(
+          `total_inventories=${list.total_inventories}, expected ${expected.inventoryCount}`,
+        );
+      }
+      if (list.total_cities !== expected.cityCount) {
+        ok = false;
+        details.push(
+          `total_cities=${list.total_cities}, expected ${expected.cityCount}`,
+        );
+      }
+      if (list.by_project.length !== expected.projectIds.length) {
+        ok = false;
+        details.push(
+          `by_project rows=${list.by_project.length}, expected ${expected.projectIds.length}`,
+        );
+      }
+      details.push(`got: ${list.total_inventories} inv / ${list.total_cities} cities`);
+      details.push(`by_project: ${formatBreakdown(list.by_project)}`);
+      results.push({
+        role: fixture.roleLabel,
+        email: fixture.email,
+        ok,
+        details,
+      });
+    }
+
+    // Project admin
+    {
+      const fixture = USERS.projectAdmin;
+      const list = await buildAccessibleInventoryList({
+        userId: fixture.userId,
+        includeAllCityYears: true,
+      });
+      const details: string[] = [];
+      let ok = true;
+
+      if (list.access_scope !== "projects") {
+        ok = false;
+        details.push(`access_scope=${list.access_scope}, expected projects`);
+      }
+      if (list.total_inventories !== projectAdminInventoryCount) {
+        ok = false;
+        details.push(
+          `total_inventories=${list.total_inventories}, expected ${projectAdminInventoryCount}`,
+        );
+      }
+      if (list.total_cities !== projectAdminInventoryCount) {
+        ok = false;
+        details.push(
+          `total_cities=${list.total_cities}, expected ${projectAdminInventoryCount}`,
+        );
+      }
+      const onlyExpectedProject =
+        list.by_project.length === 1 &&
+        list.by_project[0]?.project_id === projectAdminProjectId;
+      if (!onlyExpectedProject) {
+        ok = false;
+        details.push(
+          `by_project should be only project ${projectAdminProjectId}`,
+        );
+      }
+      details.push(`got: ${list.total_inventories} inv / ${list.total_cities} cities`);
+      details.push(`by_project: ${formatBreakdown(list.by_project)}`);
+      results.push({
+        role: fixture.roleLabel,
+        email: fixture.email,
+        ok,
+        details,
+      });
+    }
+
+    // Org admin
+    {
+      const fixture = USERS.orgAdmin;
+      const list = await buildAccessibleInventoryList({
+        userId: fixture.userId,
+        includeAllCityYears: true,
+      });
+      const details: string[] = [];
+      let ok = true;
+
+      if (list.access_scope !== "projects") {
+        ok = false;
+        details.push(`access_scope=${list.access_scope}, expected projects`);
+      }
+      if (list.total_inventories !== orgInventoryCount) {
+        ok = false;
+        details.push(
+          `total_inventories=${list.total_inventories}, expected ${orgInventoryCount}`,
+        );
+      }
+      if (list.total_cities !== orgInventoryCount) {
+        ok = false;
+        details.push(
+          `total_cities=${list.total_cities}, expected ${orgInventoryCount}`,
+        );
+      }
+      if (list.by_project.length !== orgProjects.length) {
+        ok = false;
+        details.push(
+          `by_project rows=${list.by_project.length}, expected ${orgProjects.length}`,
+        );
+      }
+      details.push(`got: ${list.total_inventories} inv / ${list.total_cities} cities`);
+      details.push(`by_project: ${formatBreakdown(list.by_project)}`);
+      results.push({
+        role: fixture.roleLabel,
+        email: fixture.email,
+        ok,
+        details,
+      });
+    }
+
+    // System admin
+    {
+      const fixture = USERS.systemAdmin;
+      const list = await buildAccessibleInventoryList({
+        userId: fixture.userId,
+        includeAllCityYears: true,
+      });
+      const details: string[] = [];
+      let ok = true;
+
+      if (list.access_scope !== "platform") {
+        ok = false;
+        details.push(`access_scope=${list.access_scope}, expected platform`);
+      }
+      if (list.total_inventories < orgInventoryCount) {
+        ok = false;
+        details.push(
+          `total_inventories=${list.total_inventories}, expected >= ${orgInventoryCount}`,
+        );
+      }
+      details.push(`got: ${list.total_inventories} inv / ${list.total_cities} cities`);
+      details.push(`by_project rows: ${list.by_project.length}`);
+      details.push(`by_project: ${formatBreakdown(list.by_project)}`);
+      results.push({
+        role: fixture.roleLabel,
+        email: fixture.email,
+        ok,
+        details,
+      });
+    }
+
+    const failed = results.filter((result) => !result.ok);
+    for (const result of results) {
+      const status = result.ok ? "PASS" : "FAIL";
+      console.log(`\n[${status}] ${result.role} <${result.email}>`);
+      for (const line of result.details) {
+        console.log(`  - ${line}`);
+      }
+    }
+
+    if (failed.length > 0) {
+      logger.error(
+        { failedRoles: failed.map((result) => result.role) },
+        "ON-6046 role access validation failed",
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    logger.info("ON-6046 role access validation passed for all fixtures");
+    console.log("\nAll role access checks passed.");
+  } finally {
+    await db.sequelize?.close();
+  }
+}
+
+validateRoleAccess().catch(async (error) => {
+  logger.error({ err: error }, "Failed to validate CA role inventory access");
+  await db.sequelize?.close();
+  process.exitCode = 1;
+});

--- a/app/src/app/api/v1/internal/ca/capabilities/ghgi/inventory/list-accessible/route.ts
+++ b/app/src/app/api/v1/internal/ca/capabilities/ghgi/inventory/list-accessible/route.ts
@@ -6,7 +6,7 @@
  *       - internal
  *     operationId: postInternalCaInventoryListAccessible
  *     summary: List accessible GHGI inventories for Climate Advisor
- *     description: Internal Climate Advisor capability route. Requires service-to-service headers plus a user-scoped bearer token, then returns the city/year inventories the authenticated user can access.
+ *     description: Internal Climate Advisor capability route. Requires service-to-service headers plus a user-scoped bearer token, then returns the city/year inventories the authenticated user can access, including organization/project metadata and a by_project breakdown for Clima summaries.
  *     parameters:
  *       - in: header
  *         name: X-Service-Name
@@ -52,7 +52,10 @@
 import createHttpError from "http-errors";
 import { NextResponse } from "next/server";
 
-import { buildAccessibleInventoryList } from "@/backend/agentic/ghgi/inventory/context";
+import {
+  buildAccessibleInventoryList,
+  summarizeAccessibleInventoryList,
+} from "@/backend/agentic/ghgi/inventory/context";
 import {
   INVENTORY_LIST_ACCESSIBLE_CAPABILITY,
   inventoryListAccessibleInputSchema,
@@ -96,6 +99,9 @@ export const POST = apiHandler(async (req, { session }) => {
   });
 });
 
+/**
+ * Drop inventories the session cannot access, then rebuild totals/`by_project`.
+ */
 async function filterByInventoryPermission(
   session: AppSession | null,
   list: AccessibleInventoryList,
@@ -122,15 +128,11 @@ async function filterByInventoryPermission(
 
   const permittedCities = cities.filter((city) => city.inventories.length > 0);
 
-  return {
-    ...list,
-    cities: permittedCities,
-    total_cities: permittedCities.length,
-    total_inventories: permittedCities.reduce(
-      (sum, city) => sum + city.inventories.length,
-      0,
-    ),
-  };
+  return summarizeAccessibleInventoryList(
+    permittedCities,
+    list.access_scope,
+    list.filters,
+  );
 }
 
 async function canAccessInventory(

--- a/app/src/backend/UserService.ts
+++ b/app/src/backend/UserService.ts
@@ -14,7 +14,10 @@ import { User } from "@/models/User";
 import { Includeable, QueryTypes, Transaction } from "sequelize";
 import { UserFile } from "@/models/UserFile";
 import { Project } from "@/models/Project";
-import { hasOrgOwnerLevelAccess } from "@/backend/RoleBasedAccessService";
+import {
+  hasOrgOwnerLevelAccess,
+  hasProjectOwnerLevelAccess,
+} from "@/backend/RoleBasedAccessService";
 import { logger } from "@/services/logger";
 import EmailService from "@/backend/EmailService";
 import uniqBy from "lodash/uniqBy";
@@ -92,6 +95,14 @@ export default class UserService {
       return city;
     }
 
+    // Project admins are not CityUser members, but own every city in their project.
+    const hasProjectLevelAccess = city.projectId
+      ? await hasProjectOwnerLevelAccess(city.projectId, session.user.id)
+      : false;
+    if (hasProjectLevelAccess) {
+      return city;
+    }
+
     if (
       (city.users.length === 0 ||
         !city.users.map((u) => u.userId).includes(session?.user?.id)) &&
@@ -156,12 +167,19 @@ export default class UserService {
       session.user?.id,
     );
 
+    const hasProjectLevelAccess = inventory.city?.projectId
+      ? await hasProjectOwnerLevelAccess(
+          inventory.city.projectId,
+          session.user.id,
+        )
+      : false;
+
     const hasNoCityAccess =
       inventory.city.users.length === 0 ||
       !session?.user?.id ||
       !inventory.city.users.map((u) => u.userId).includes(session?.user?.id);
 
-    if (!hasOrgLevelAccess && hasNoCityAccess) {
+    if (!hasOrgLevelAccess && !hasProjectLevelAccess && hasNoCityAccess) {
       throw new createHttpError.Unauthorized(
         "User is not part of this inventory's city",
       );
@@ -593,12 +611,18 @@ export default class UserService {
       include: {
         model: db.models.City,
         as: "city",
-        attributes: ["cityId", "name", "countryLocode", "country"],
+        attributes: ["cityId", "name", "countryLocode", "country", "locode"],
         include: [
           {
             model: db.models.Project,
             as: "project",
-            attributes: ["projectId", "name"],
+            attributes: [
+              "projectId",
+              "name",
+              "organizationId",
+              "cityCountLimit",
+              "description",
+            ],
           },
           {
             model: db.models.Inventory,
@@ -610,6 +634,10 @@ export default class UserService {
     });
   }
 
+  /**
+   * List projects (with cities) visible to the session user inside one organization.
+   * Org/system admins see every project; project admins and collaborators are scoped.
+   */
   public static async findUserProjectsAndCitiesInOrganization(
     organizationId: string,
     session: AppSession | null,
@@ -632,36 +660,63 @@ export default class UserService {
       UserService.findAllProjectForCollaborators(session.user.id),
     ]);
 
-    // Project admin can see projects they are admin of and the cities in those projects
-    const projectsAndCities: ProjectWithCitiesResponse = [];
+    // Seed with projects the user administers (concat returns a new array — do not discard it).
+    const projectsById: Record<string, ProjectWithCitiesResponse[0]> = {};
+    for (const projectAdmin of projectAdminProjects) {
+      const project = projectAdmin.project;
+      if (!project) {
+        continue;
+      }
+      projectsById[project.projectId] = {
+        projectId: project.projectId,
+        name: project.name,
+        organizationId: project.organizationId,
+        cityCountLimit: project.cityCountLimit,
+        description: project.description,
+        cities: (project.cities ?? []).map((city) => ({
+          name: city.name as string,
+          cityId: city.cityId as string,
+          inventories: city.inventories as any,
+          country: city.country as string,
+          countryLocode: city.countryLocode as string,
+          locode: city.locode as string,
+        })),
+      };
+    }
 
-    // @ts-ignore
-    projectsAndCities.concat(projectAdminProjects.map((pa) => pa.project));
-
-    const groupedByProject: Record<string, ProjectWithCitiesResponse[0]> = {};
-
+    // Merge collaborator city memberships for this organization only.
     for (const { city } of cityUsersProjects) {
-      const projectName = city.project.name;
-      const projectId = city.project.projectId;
-      if (!groupedByProject[projectId]) {
-        groupedByProject[projectId] = {
+      const project = city?.project;
+      if (!project || project.organizationId !== organizationId) {
+        continue;
+      }
+      const projectId = project.projectId;
+      if (!projectsById[projectId]) {
+        projectsById[projectId] = {
           projectId,
-          name: projectName,
-          cityCountLimit: city.project.cityCountLimit,
+          name: project.name,
+          organizationId: project.organizationId,
+          cityCountLimit: project.cityCountLimit,
+          description: project.description,
           cities: [],
         };
       }
-      groupedByProject[projectId].cities.push({
-        name: city.name as string,
-        cityId: city.cityId as string,
-        inventories: city.inventories as any,
-        country: city.country as string,
-        countryLocode: city.countryLocode as string,
-        locode: city.locode as string,
-      });
+      const alreadyListed = projectsById[projectId].cities.some(
+        (listed) => listed.cityId === city.cityId,
+      );
+      if (!alreadyListed) {
+        projectsById[projectId].cities.push({
+          name: city.name as string,
+          cityId: city.cityId as string,
+          inventories: city.inventories as any,
+          country: city.country as string,
+          countryLocode: city.countryLocode as string,
+          locode: city.locode as string,
+        });
+      }
     }
 
-    return projectsAndCities.concat(Object.values(groupedByProject));
+    return Object.values(projectsById);
   }
 
   public static async findUsersInProject(projectId: string) {
@@ -967,6 +1022,10 @@ export default class UserService {
     }
   }
 
+  /**
+   * Summarize the user's highest-privilege access path and the related org/project
+   * IDs used by navigation (e.g. All projects drawer link).
+   */
   public static async findUserAccessStatus(userId: string) {
     const responseObject: {
       isOrgOwner: boolean;
@@ -983,6 +1042,7 @@ export default class UserService {
     };
 
     const user = await db.models.User.findOne({ where: { userId } });
+    // System admins are treated as org owners for UI gates, without a single org.
     if (user?.role === Roles.Admin) {
       responseObject.isOrgOwner = true;
       return responseObject;
@@ -996,19 +1056,51 @@ export default class UserService {
       responseObject.organizationId = orgOwner.organizationId;
       return responseObject;
     }
+
     const projectAdmin = await db.models.ProjectAdmin.findOne({
       where: { userId },
+      include: [
+        {
+          model: db.models.Project,
+          as: "project",
+          attributes: ["projectId", "organizationId"],
+        },
+      ],
     });
     if (projectAdmin) {
       responseObject.isProjectAdmin = true;
+      responseObject.projectId = projectAdmin.projectId;
+      responseObject.organizationId =
+        projectAdmin.project?.organizationId ?? null;
       return responseObject;
     }
 
+    // Collaborators only have CityUser rows — resolve org/project via city.
     const collaborator = await db.models.CityUser.findOne({
       where: { userId },
+      include: [
+        {
+          model: db.models.City,
+          as: "city",
+          attributes: ["cityId", "projectId"],
+          include: [
+            {
+              model: db.models.Project,
+              as: "project",
+              attributes: ["projectId", "organizationId"],
+            },
+          ],
+        },
+      ],
     });
     if (collaborator) {
       responseObject.isCollaborator = true;
+      responseObject.projectId =
+        collaborator.city?.project?.projectId ??
+        collaborator.city?.projectId ??
+        null;
+      responseObject.organizationId =
+        collaborator.city?.project?.organizationId ?? null;
       return responseObject;
     }
     return responseObject;

--- a/app/src/backend/agentic/ghgi/inventory/context.ts
+++ b/app/src/backend/agentic/ghgi/inventory/context.ts
@@ -30,13 +30,33 @@ type AccessibleInventoryCity = {
   country: string | null;
   region: string | null;
   locode: string | null;
+  project_id: string | null;
+  project_name: string | null;
+  organization_id: string | null;
+  organization_name: string | null;
   inventories: AccessibleInventory[];
+};
+
+type AccessibleInventoryProjectBreakdown = {
+  organization_id: string | null;
+  organization_name: string | null;
+  project_id: string | null;
+  project_name: string | null;
+  total_cities: number;
+  total_inventories: number;
 };
 
 type AccessibleInventoryList = {
   cities: AccessibleInventoryCity[];
   total_cities: number;
   total_inventories: number;
+  /** Aggregated city/inventory counts grouped by organization + project. */
+  by_project: AccessibleInventoryProjectBreakdown[];
+  /**
+   * `platform` = system/super admin (all cities); `projects` = scoped via
+   * project/org admin or city membership.
+   */
+  access_scope: "platform" | "projects";
   filters: {
     city_query: string | null;
     year: number | null;
@@ -58,6 +78,10 @@ type InventoryListCity = {
   country?: string | null;
   region?: string | null;
   locode?: string | null;
+  projectId?: string | null;
+  projectName?: string | null;
+  organizationId?: string | null;
+  organizationName?: string | null;
   inventories?: InventoryListInventory[];
 };
 
@@ -165,6 +189,14 @@ const SECTOR_REFERENCE_BY_DB_NAME: Record<string, string> = {
   "Agriculture, Forestry, and Other Land Use (AFOLU)": "V",
 };
 
+/**
+ * List inventories the user can access, with org/project metadata for Clima
+ * breakdown answers ("you have access to …").
+ *
+ * System admins (`Roles.Admin`) get platform-wide cities (`access_scope:
+ * "platform"`). Everyone else uses `ProjectService.fetchUserProjects`
+ * (`access_scope: "projects"`).
+ */
 export async function buildAccessibleInventoryList({
   userId,
   cityQuery,
@@ -185,6 +217,8 @@ export async function buildAccessibleInventoryList({
     throw new createHttpError.NotFound("User not found");
   }
 
+  const accessScope: AccessibleInventoryList["access_scope"] =
+    user.role === Roles.Admin ? "platform" : "projects";
   const normalizedQuery = normalizeSearch(cityQuery);
   const cities = (await candidateCitiesForUser(user.userId, user.role))
     .filter((city) => cityMatchesQuery(city, normalizedQuery))
@@ -192,6 +226,22 @@ export async function buildAccessibleInventoryList({
     .filter((city) => city.inventories.length > 0)
     .sort((a, b) => citySortLabel(a).localeCompare(citySortLabel(b)));
 
+  return summarizeAccessibleInventoryList(cities, accessScope, {
+    city_query: cityQuery?.trim() || null,
+    year: year ?? null,
+    include_all_city_years: includeAllCityYears,
+  });
+}
+
+/**
+ * Recompute totals and `by_project` after permission filtering so the route
+ * and builder share one summary shape.
+ */
+export function summarizeAccessibleInventoryList(
+  cities: AccessibleInventoryCity[],
+  accessScope: AccessibleInventoryList["access_scope"],
+  filters: AccessibleInventoryList["filters"],
+): AccessibleInventoryList {
   return {
     cities,
     total_cities: cities.length,
@@ -199,11 +249,9 @@ export async function buildAccessibleInventoryList({
       (sum, city) => sum + city.inventories.length,
       0,
     ),
-    filters: {
-      city_query: cityQuery?.trim() || null,
-      year: year ?? null,
-      include_all_city_years: includeAllCityYears,
-    },
+    by_project: buildProjectBreakdown(cities),
+    access_scope: accessScope,
+    filters,
   };
 }
 
@@ -217,16 +265,80 @@ async function candidateCitiesForUser(
   }
 
   const projects = await ProjectService.fetchUserProjects(userId);
+  const organizationNames = await organizationNameById(
+    projects.map((project) => project.organizationId),
+  );
+
   return dedupeCities(
-    projects.flatMap((project) => project.cities as InventoryListCity[]),
+    projects.flatMap((project) =>
+      (project.cities as InventoryListCity[]).map((city) => ({
+        ...city,
+        projectId: project.projectId,
+        projectName: project.name,
+        organizationId: project.organizationId,
+        organizationName: organizationNames.get(project.organizationId) ?? null,
+      })),
+    ),
   );
 }
 
-/** Load all city candidates for system admins. */
+/** Load all city candidates for system admins, including org/project labels. */
 async function citiesWithInventories(): Promise<InventoryListCity[]> {
-  return (await db.models.City.findAll({
-    include: [{ model: db.models.Inventory, as: "inventories" }],
-  })) as InventoryListCity[];
+  const cities = await db.models.City.findAll({
+    include: [
+      { model: db.models.Inventory, as: "inventories" },
+      {
+        model: db.models.Project,
+        as: "project",
+        include: [
+          {
+            model: db.models.Organization,
+            as: "organization",
+            attributes: ["organizationId", "name"],
+          },
+        ],
+      },
+    ],
+  });
+
+  return cities.map((city) => {
+    const project = city.project;
+    const organization = project?.organization;
+    return {
+      cityId: city.cityId,
+      name: city.name,
+      country: city.country,
+      region: city.region,
+      locode: city.locode,
+      projectId: project?.projectId ?? null,
+      projectName: project?.name ?? null,
+      organizationId: organization?.organizationId ?? project?.organizationId ?? null,
+      organizationName: organization?.name ?? null,
+      inventories: city.inventories as InventoryListInventory[],
+    };
+  });
+}
+
+/** Resolve organization display names for the given IDs. */
+async function organizationNameById(
+  organizationIds: string[],
+): Promise<Map<string, string | null>> {
+  const uniqueIds = [...new Set(organizationIds.filter(Boolean))];
+  if (uniqueIds.length === 0) {
+    return new Map();
+  }
+
+  const organizations = await db.models.Organization.findAll({
+    attributes: ["organizationId", "name"],
+    where: { organizationId: uniqueIds },
+  });
+
+  return new Map(
+    organizations.map((organization) => [
+      organization.organizationId,
+      organization.name ?? null,
+    ]),
+  );
 }
 
 /** Keep the first candidate when access paths overlap. */
@@ -238,6 +350,42 @@ function dedupeCities(cities: InventoryListCity[]): InventoryListCity[] {
     }
     seen.add(city.cityId);
     return true;
+  });
+}
+
+/** Aggregate accessible cities into org/project totals for Clima summaries. */
+function buildProjectBreakdown(
+  cities: AccessibleInventoryCity[],
+): AccessibleInventoryProjectBreakdown[] {
+  const byProject = new Map<string, AccessibleInventoryProjectBreakdown>();
+
+  for (const city of cities) {
+    const key = city.project_id ?? `unassigned:${city.city_id}`;
+    const existing = byProject.get(key);
+    if (!existing) {
+      byProject.set(key, {
+        organization_id: city.organization_id,
+        organization_name: city.organization_name,
+        project_id: city.project_id,
+        project_name: city.project_name,
+        total_cities: 1,
+        total_inventories: city.inventories.length,
+      });
+      continue;
+    }
+
+    existing.total_cities += 1;
+    existing.total_inventories += city.inventories.length;
+  }
+
+  return [...byProject.values()].sort((a, b) => {
+    const orgCompare = (a.organization_name ?? "").localeCompare(
+      b.organization_name ?? "",
+    );
+    if (orgCompare !== 0) {
+      return orgCompare;
+    }
+    return (a.project_name ?? "").localeCompare(b.project_name ?? "");
   });
 }
 
@@ -337,6 +485,10 @@ function accessibleCity(
     country: city.country ?? null,
     region: city.region ?? null,
     locode: city.locode ?? null,
+    project_id: city.projectId ?? null,
+    project_name: city.projectName ?? null,
+    organization_id: city.organizationId ?? null,
+    organization_name: city.organizationName ?? null,
     inventories,
   };
 }

--- a/app/src/components/HomePage/JNDrawer.tsx
+++ b/app/src/components/HomePage/JNDrawer.tsx
@@ -536,6 +536,11 @@ const JNDrawer = ({
   const [selectedProject, setSelectedProject] = React.useState<string | null>();
   const [selectedCity, setSelectedCity] = React.useState<string>("");
 
+  // Prefer explicit org context, then access-status prop, then first accessible project.
+  const resolvedOrganizationId =
+    organizationId ||
+    projectsData?.find((project) => project.organizationId)?.organizationId;
+
   // Module data fetching
   const { data: allModules, isLoading: isAllModulesLoading } =
     useGetModulesQuery();
@@ -639,7 +644,9 @@ const JNDrawer = ({
                   {
                     label: "all-projects",
                     icon: LuLayoutGrid,
-                    href: `/${lng}/organization/${organizationId}/project`,
+                    href: resolvedOrganizationId
+                      ? `/${lng}/organization/${resolvedOrganizationId}/project`
+                      : `/${lng}/cities`,
                   },
                 ]}
                 t={t}

--- a/app/src/util/types.ts
+++ b/app/src/util/types.ts
@@ -497,6 +497,7 @@ export type CityResponse = {
 export type ProjectWithCities = {
   projectId: string;
   name: string;
+  organizationId: string;
   description?: string;
   cityCountLimit?: Number;
   cities: CityResponse[];

--- a/app/tests/agentic-inventory-capabilities.jest.ts
+++ b/app/tests/agentic-inventory-capabilities.jest.ts
@@ -236,14 +236,31 @@ describe("GHGI inventory internal CA capability routes", () => {
 
     expect(payload.action).toBe(INVENTORY_LIST_ACCESSIBLE_CAPABILITY);
     expect(payload.success).toBe(true);
+    expect(payload.data.access_scope).toBe("projects");
     expect(payload.data.total_cities).toBeGreaterThanOrEqual(1);
     expect(payload.data.total_inventories).toBeGreaterThanOrEqual(2);
+    expect(payload.data.by_project).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          organization_id: testData.organizationId,
+          organization_name: "Test Organization",
+          project_id: testData.projectId,
+          project_name: "Test Project",
+          total_cities: expect.any(Number),
+          total_inventories: expect.any(Number),
+        }),
+      ]),
+    );
     expect(payload.data.cities).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           city_id: city.cityId,
           name: "New York",
           country: "United States of America",
+          project_id: testData.projectId,
+          project_name: "Test Project",
+          organization_id: testData.organizationId,
+          organization_name: "Test Organization",
           inventories: expect.arrayContaining([
             expect.objectContaining({
               inventory_id: inventory.inventoryId,
@@ -257,6 +274,43 @@ describe("GHGI inventory internal CA capability routes", () => {
         }),
       ]),
     );
+  });
+
+  it("includes organization/project breakdown for project-admin cities", async () => {
+    const res = await listAccessibleRoute(listAccessibleRequest(), {
+      params: Promise.resolve({}),
+    });
+
+    await expectStatusCode(res, 200);
+    const payload = await res.json();
+    const matchingCity = payload.data.cities.find(
+      (candidate: { city_id: string }) =>
+        candidate.city_id === projectAdminOnlyCity.cityId,
+    );
+    const projectBreakdown = payload.data.by_project.find(
+      (entry: { project_id: string | null }) =>
+        entry.project_id === testData.projectId,
+    );
+
+    expect(matchingCity).toEqual(
+      expect.objectContaining({
+        city_id: projectAdminOnlyCity.cityId,
+        project_id: testData.projectId,
+        project_name: "Test Project",
+        organization_id: testData.organizationId,
+        organization_name: "Test Organization",
+      }),
+    );
+    expect(projectBreakdown).toEqual(
+      expect.objectContaining({
+        project_id: testData.projectId,
+        organization_id: testData.organizationId,
+        total_cities: expect.any(Number),
+        total_inventories: expect.any(Number),
+      }),
+    );
+    expect(projectBreakdown.total_cities).toBeGreaterThanOrEqual(2);
+    expect(projectBreakdown.total_inventories).toBeGreaterThanOrEqual(3);
   });
 
   it("treats null list filters as omitted filters", async () => {
@@ -362,6 +416,27 @@ describe("GHGI inventory internal CA capability routes", () => {
           candidate.inventory_id === priorYearInventory.inventoryId,
       ),
     ).toBe(false);
+
+    // by_project must match the permission-filtered city list.
+    const projectCities = payload.data.cities.filter(
+      (candidate: { project_id: string | null }) =>
+        candidate.project_id === testData.projectId,
+    );
+    const projectBreakdown = payload.data.by_project.find(
+      (entry: { project_id: string | null }) =>
+        entry.project_id === testData.projectId,
+    );
+    expect(projectBreakdown).toEqual(
+      expect.objectContaining({
+        project_id: testData.projectId,
+        total_cities: projectCities.length,
+        total_inventories: projectCities.reduce(
+          (sum: number, candidate: { inventories: unknown[] }) =>
+            sum + candidate.inventories.length,
+          0,
+        ),
+      }),
+    );
   });
 
   it("filters accessible inventories by city and year", async () => {

--- a/climate-advisor/README.md
+++ b/climate-advisor/README.md
@@ -173,6 +173,8 @@ data: {}
 
 - `inventory_list_accessible`
   - Lists all accessible city/year inventories, or filters by city and year.
+  - Returns organization/project metadata and a `by_project` breakdown so Clima
+    can answer count questions with an access summary.
   - Requires name, type, and GWP disambiguation when one city/year has multiple
     inventories.
 - `inventory_status_overview`
@@ -638,9 +640,12 @@ These tools:
 - construct requests to CityCatalyst inventory capability endpoints
 - automatically include the scoped JWT in the `Authorization` header
 - refresh and persist the token when needed
-- return compact, read-only inventory context to the agent
+- return compact, read-only inventory context to the agent, including
+  organization/project breakdown fields from `inventory_list_accessible`
 - require inventory name, type, and GWP disambiguation when city/year is not
   unique
+- answer inventory/city count questions as "you have access to" summaries using
+  totals plus `by_project`
 
 ### Stationary Energy Draft Review Boundary
 

--- a/climate-advisor/docs/architecture.md
+++ b/climate-advisor/docs/architecture.md
@@ -96,6 +96,9 @@ sequenceDiagram
   - `get_all_datasources` as the temporary legacy datasource lookup
   - The general prompt must disambiguate same-city/year inventories with
     inventory name, type, and GWP before calling inventory detail tools.
+  - `inventory_list_accessible` includes organization/project metadata and a
+    `by_project` breakdown so count answers use "access to" wording with
+    totals explained by project.
 - Added when the request is scoped to the Stationary Energy draft surface and
   no draft run is active:
   - `stationary_energy_start_draft`

--- a/climate-advisor/prompts/chat.md
+++ b/climate-advisor/prompts/chat.md
@@ -14,6 +14,7 @@ Input is runtime chat context with:
 
 <routing>
 - Use `inventory_list_accessible` first when the user asks about their inventories, their data, inventories for a named city, or inventories for a given year.
+- When the user asks how many inventories or cities they have, call `inventory_list_accessible` with no filters and summarize using `total_inventories`, `total_cities`, and the `by_project` breakdown.
 - Use `inventory_status_overview` after an inventory is selected when the user asks about inventory metadata, completion, or filled/missing sector state.
 - Use `inventory_emissions_context` after an inventory is selected when the user asks about emissions totals, sector shares, top emitters, or source mix.
 - If `inventory_list_accessible` returns multiple inventories for the same city/year, ask the user to choose using `inventory_name`, `type`, and `gwp` before calling inventory detail tools.
@@ -35,15 +36,23 @@ Return either:
 General chat output rules:
 - Exact tool argument contracts come from the registered runtime tool definitions and are not duplicated here.
 - For inventory exploration, follow this flow: `inventory_list_accessible` -> confirm the selected inventory -> `inventory_status_overview` and/or `inventory_emissions_context` -> optionally `get_all_datasources`.
+- When summarizing inventory/city counts, always say the user has **access to** those inventories/cities (never imply ownership). Include totals plus an organization/project breakdown from `by_project` when available.
+- If `access_scope` is `platform`, say they have platform-wide access and still show the org/project breakdown so large totals are explainable.
 - Confirm by city/year only when that pair identifies one inventory. If city/year is not unique, disambiguate with `inventory_name`, `type`, and `gwp` before selecting the internal inventory.
 - Do not ask the user for `inventory_id` before using inventory listing/search tools.
 - Never expose `inventory_id` values in user-facing output. Refer to inventories by city and year, adding inventory name, type, and GWP only when needed to distinguish same-city/year choices.
 - For `inventory_status_overview`, summarize metadata, completion, and filled/missing sector state.
 - For `inventory_emissions_context`, summarize total emissions, sector shares, top emitters, and source mix.
 - For `get_all_datasources`, summarize applicability, coverage years, retrieval method, and emissions summary.
-- For `climate_vector_search`, summarize up to 3 relevant excerpts and cite the source as "internal climate knowledge base."
+- For `climate_vector_search`, summarize up to 3 relevant excerpts and cite the source as "internal climate knowledge base".
 </output>
 
 <example_output>
-I found the matching inventory for Testopolis 2024. The inventory is partially complete: Stationary Energy has data, while Transport still needs activity rows. The largest reported emissions source is residential electricity.
+You have access to 4 inventories across 2 cities.
+
+Breakdown:
+- Test Organization / Test Project: 3 inventories across 2 cities
+- Sibling Org / Coastal Project: 1 inventory across 1 city
+
+I can open one of those inventories next if you want status or emissions details.
 </example_output>

--- a/climate-advisor/prompts/tools/default_tool_policy.md
+++ b/climate-advisor/prompts/tools/default_tool_policy.md
@@ -1,10 +1,12 @@
 Available tools:
 
 - `inventory_list_accessible`
-  - Use first when users ask about "my inventory", "my data", what inventories they have, or inventories for a named city/year.
+  - Use first when users ask about "my inventory", "my data", what inventories they have, how many inventories/cities they can access, or inventories for a named city/year.
   - With no filters, list all accessible inventories. With `city_query` and/or `year`, return matching accessible city/year choices.
   - Use `include_all_city_years` when the user asks for all inventory years for a matching city.
+  - Response includes `total_cities`, `total_inventories`, `by_project` (org/project breakdown), `access_scope` (`platform` or `projects`), and per-city `organization_*` / `project_*` fields.
   - Present inventories in user-facing text as city + year. If multiple inventories share the same city/year, use `inventory_name`, `type`, and `gwp` to disambiguate before selecting an internal ID.
+  - When answering count questions, prefer totals + `by_project` and say "you have access to".
 
 - `inventory_status_overview`
   - Use after an inventory is selected to summarize inventory metadata, completion, and filled/missing sector state.

--- a/climate-advisor/service/app/tools/inventory_context_tools.py
+++ b/climate-advisor/service/app/tools/inventory_context_tools.py
@@ -208,9 +208,10 @@ def build_inventory_capability_tools(
     ) -> str:
         """List city/year inventories the user can access.
 
-        Use optional city/year filters to narrow choices. Set
-        include_all_city_years when the user asks for every inventory year for a
-        matching city.
+        Returns totals plus organization/project breakdown fields so count
+        questions can be answered as access summaries. Use optional city/year
+        filters to narrow choices. Set include_all_city_years when the user asks
+        for every inventory year for a matching city.
         """
 
         request_payload: Dict[str, Any] = {


### PR DESCRIPTION
## Summary

Clima now answers inventory/city access questions with totals that match All projects for the same user, plus an organization/project breakdown and consistent “you have access to…” wording. Also fixes project-admin gaps that caused a blank city home and empty All projects list.

## Changes

- Enrich `inventory_list_accessible` with org/project metadata, `by_project` breakdown, and `access_scope` (`platform` vs `projects`)
- Align Climate Advisor prompts/tool docs with access-based copy and project breakdown
- Fix `UserService` project-admin access for city/org listing (`findUserCity`, `findUserInventory`, All projects concat bug)
- Resolve org id for drawer All projects navigation for collaborators/project admins
- Add multi-role local fixtures + validation scripts and README notes

## How to test

1. Seed role users: `cd app && CA_ROLE_FIXTURE_PASSWORD='password' npm run upsert-ca-role-fixtures`
2. Run: `npm run validate-ca-inventory-access-by-role` (expects PASS for all four roles)
3. UI: login as each fixture user and ask Clima “How many inventories do I have?”
4. Confirm totals/breakdown match All projects for that user
5. As project admin, open All projects and confirm Demo Project 2 appears (not empty / no white page)

## Ticket

https://openearth.atlassian.net/browse/ON-6046

## Notes

- System admin is platform-wide (`access_scope: platform`) and may exceed a single org’s All projects total when other seed orgs exist locally — expected.
- Evidence screenshots and role matrix are on the Jira ticket comments.


Made with [Cursor](https://cursor.com)