### PR TITLE
adds inventory id to ghgi  push route

### DIFF
--- a/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/import/page.tsx
+++ b/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/import/page.tsx
@@ -1002,7 +1002,7 @@ export default function ImportPage(props: {
                     importedFileId={importedFileId}
                     mappingOverrides={mappingOverrides}
                     onImport={() => {
-                      router.push(`/${lng}/cities/${cityId}/GHGI`);
+                      router.push(`/${lng}/cities/${cityId}/GHGI/${inventoryId}`);
                     }}
                     t={t}
                   />


### PR DESCRIPTION
## Summary

Routes users directly to the specific GHGI inventory created prior to file upload once the import process completes, rather than redirecting to the generic city GHGI landing route.

## Changes

- Updated the `onImport` callback in [page.tsx](file:///c:/Users/frank/Desktop/Workspace/oef/CityCatalyst/app/src/app/%5Blng%5D/cities/%5BcityId%5D/GHGI/onboarding/import/page.tsx#L1005) to navigate to `/${lng}/cities/${cityId}/GHGI/${inventoryId}` instead of `/${lng}/cities/${cityId}/GHGI`.

## How to test

1. Start the onboarding or import flow (e.g. navigate to `http://localhost:3000/en/cities/<cityId>/GHGI/onboarding/import/?inventory=<inventoryId>`).
2. Upload a valid inventory file and proceed through mapping and confirmation.
3. Click **Import Inventory**.
4. Verify that upon successful import completion, you are navigated directly to `http://localhost:3000/en/cities/<cityId>/GHGI/<inventoryId>` matching the created inventory ID.

## Ticket

CC-561

## Notes

- Previously, redirecting to `/${lng}/cities/${cityId}/GHGI` relied on automatic redirection logic to pick the most recent inventory, which could resolve to a different inventory year or fail if the cache was not yet populated.
