### PR TITLE
CC-546: Fix HIAP action selections across languages

### DIFF
--- a/app/src/app/[lng]/cities/[cityId]/HIAP/HiapTab/index.tsx
+++ b/app/src/app/[lng]/cities/[cityId]/HIAP/HiapTab/index.tsx
@@ -330,6 +330,7 @@ export function HiapTab({
       await updateHiapSelection({
         inventoryId: inventory.inventoryId,
         selectedActionIds: allSelectedIds,
+        actionType: type,
       }).unwrap();
 
       setRowSelection(newRowSelection);
@@ -427,6 +428,7 @@ export function HiapTab({
       await updateHiapSelection({
         inventoryId: inventory.inventoryId,
         selectedActionIds: allSelectedIds,
+        actionType: type,
       }).unwrap();
 
       setUnrankedRowSelection(newUnrankedRowSelection);
@@ -919,6 +921,7 @@ export function HiapTab({
       await updateHiapSelection({
         inventoryId: inventory.inventoryId,
         selectedActionIds: [],
+        actionType: type,
       }).unwrap();
 
       setRowSelection({});

--- a/app/src/app/api/v1/inventory/[inventory]/hiap/route.ts
+++ b/app/src/app/api/v1/inventory/[inventory]/hiap/route.ts
@@ -106,18 +106,18 @@
 import { apiHandler } from "@/util/api";
 import { LANGUAGES } from "@/util/types";
 import { ACTION_TYPES } from "@/util/types";
-import { fetchRanking } from "@/backend/hiap/HiapService";
+import {
+  fetchRanking,
+  updateHiapActionSelections,
+} from "@/backend/hiap/HiapService";
 import { NextRequest, NextResponse } from "next/server";
 import UserService from "@/backend/UserService";
 import { logger } from "@/services/logger";
 import { db } from "@/models";
 import { z } from "zod";
 import GlobalAPIService from "@/backend/GlobalAPIService";
-import VersionHistoryService from "@/backend/VersionHistoryService";
-import { Op } from "sequelize";
-
-const UUID_REGEX =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+import createHttpError from "http-errors";
+import { getTranslationFromDictionary } from "@/util/helpers";
 
 export const GET = apiHandler(async (req: NextRequest, { params, session }) => {
   if (!session) {
@@ -164,12 +164,11 @@ export const GET = apiHandler(async (req: NextRequest, { params, session }) => {
       ),
     );
 
-    // Get unranked action selections from database
+    // Get unranked action selections from database (any language — selections are shared)
     const unrankedSelections = await db.models.UnrankedActionSelection.findAll({
       where: {
         inventoryId: params.inventory,
         actionType: type,
-        lang: lng,
         isSelected: true,
       },
     });
@@ -189,9 +188,15 @@ export const GET = apiHandler(async (req: NextRequest, { params, session }) => {
         const baseAction = {
           id: action.ActionID,
           actionId: action.ActionID,
-          name: action.ActionName,
+          name:
+            getTranslationFromDictionary(action.ActionName, lng) ??
+            action.ActionName ??
+            "",
           rank: ((rankingData as any).rankedActions || []).length + index + 1,
-          description: action.Description || "",
+          description:
+            getTranslationFromDictionary(action.Description, lng) ??
+            action.Description ??
+            "",
           explanation: action.Explanation || {},
           isSelected: selectedUnrankedActionIds.has(action.ActionID),
           hiaRankingId: "", // Not applicable for unranked
@@ -227,7 +232,12 @@ export const GET = apiHandler(async (req: NextRequest, { params, session }) => {
             qualitativeEffectivenessEvidence: "",
             quantitativeEffectivenessEvidence: "",
             equityAndInclusionConsiderations:
-              action.EquityAndInclusionConsiderations || "",
+              getTranslationFromDictionary(
+                action.EquityAndInclusionConsiderations,
+                lng,
+              ) ??
+              action.EquityAndInclusionConsiderations ??
+              "",
             vulnerabilityAnalysisEvidence: "",
             riskReductionEvidence: "",
             socioEconomicImpacts: "",
@@ -250,7 +260,12 @@ export const GET = apiHandler(async (req: NextRequest, { params, session }) => {
             qualitativeEffectivenessEvidence: "",
             quantitativeEffectivenessEvidence: "",
             equityAndInclusionConsiderations:
-              action.EquityAndInclusionConsiderations || "",
+              getTranslationFromDictionary(
+                action.EquityAndInclusionConsiderations,
+                lng,
+              ) ??
+              action.EquityAndInclusionConsiderations ??
+              "",
             vulnerabilityAnalysisEvidence: "",
             riskReductionEvidence: "",
             socioEconomicImpacts: "",
@@ -296,8 +311,12 @@ const updateSelectionRequest = z.object({
  *       - inventory
  *       - hiap
  *     operationId: patchInventoryHiap
- *     summary: Update selection status of ranked actions.
- *     description: Updates the isSelected field for ranked actions. All actions not in the selectedActionIds array will be set to false.
+ *     summary: Update selection status of ranked and unranked actions.
+ *     description: >
+ *       Updates isSelected for the given action type. Ranked selections are
+ *       applied by stable actionId across all language rows. Unranked
+ *       selections are written for every supported language. Actions not in
+ *       selectedActionIds are cleared for this inventory + actionType.
  *     parameters:
  *       - in: path
  *         name: inventory
@@ -305,6 +324,12 @@ const updateSelectionRequest = z.object({
  *         schema:
  *           type: string
  *           format: uuid
+ *       - in: query
+ *         name: actionType
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: [mitigation, adaptation]
  *     requestBody:
  *       required: true
  *       content:
@@ -317,7 +342,7 @@ const updateSelectionRequest = z.object({
  *                 type: array
  *                 items:
  *                   type: string
- *                   format: uuid
+ *                   description: Ranked row UUID or unranked Global API action ID
  *     responses:
  *       200:
  *         description: Selection updated successfully.
@@ -344,117 +369,31 @@ export const PATCH = apiHandler(
     );
     const authorId = session.user.id;
     const inventoryId = params.inventory;
+    const actionType = req.nextUrl.searchParams.get(
+      "actionType",
+    ) as ACTION_TYPES | null;
+
+    if (
+      !actionType ||
+      !Object.values(ACTION_TYPES).includes(actionType)
+    ) {
+      throw new createHttpError.BadRequest(
+        "Missing or invalid required query parameter: actionType",
+      );
+    }
 
     try {
-      // Get all ranked actions for this inventory
-      const rankings = await db.models.HighImpactActionRanking.findAll({
-        where: { inventoryId: params.inventory },
+      const updatedCount = await updateHiapActionSelections({
+        inventoryId,
+        actionType,
+        selectedIds: body.selectedActionIds,
+        authorId,
       });
-
-      const rankingIds = rankings.map((r) => r.id);
-
-      // Separate ranked action IDs (UUIDs) from unranked action IDs (regular strings)
-      const rankedActionIds: string[] = [];
-      const unrankedActionIds: string[] = [];
-
-      for (const actionId of body.selectedActionIds) {
-        // Check if it's a UUID (ranked action database record ID)
-        const isUuid = UUID_REGEX.test(actionId);
-
-        if (isUuid) {
-          rankedActionIds.push(actionId);
-        } else {
-          unrankedActionIds.push(actionId);
-        }
-      }
-
-      let updatedCount = 0;
-
-      // Handle ranked actions (existing logic)
-      if (rankings.length > 0) {
-        // First, set all ranked actions to not selected
-        const [_affectedCount, changedDeselectedEntries] =
-          await db.models.HighImpactActionRanked.update(
-            { isSelected: false },
-            {
-              where: {
-                id: { [Op.not]: rankedActionIds },
-                hiaRankingId: rankingIds,
-              },
-              returning: true,
-            },
-          );
-        await VersionHistoryService.bulkCreateVersions(
-          inventoryId,
-          "HighImpactActionRanked",
-          authorId,
-          changedDeselectedEntries,
-          false,
-          undefined,
-          "hiap",
-        );
-
-        // Then, set selected ranked actions to true
-        if (rankedActionIds.length > 0) {
-          const [affectedCount, changedEntries] =
-            await db.models.HighImpactActionRanked.update(
-              { isSelected: true },
-              {
-                where: {
-                  id: rankedActionIds,
-                  hiaRankingId: rankingIds,
-                },
-                returning: true,
-              },
-            );
-          updatedCount += affectedCount;
-
-          await VersionHistoryService.bulkCreateVersions(
-            inventoryId,
-            "HighImpactActionRanked",
-            authorId,
-            changedEntries,
-            false,
-            undefined,
-            "hiap",
-          );
-        }
-      }
-
-      // Handle unranked actions
-      // First, clear all existing unranked selections for this inventory
-      await db.models.UnrankedActionSelection.destroy({
-        where: {
-          inventoryId: params.inventory,
-        },
-      });
-
-      // Then, create new selections for selected unranked actions
-      if (unrankedActionIds.length > 0) {
-        // We need to determine the action type and language for unranked actions
-        // For now, we'll create records for all supported languages and types
-        // In a real implementation, you might want to be more specific
-        const searchParams = req.nextUrl.searchParams;
-        const type = searchParams.get("actionType") || "mitigation";
-        const lng = searchParams.get("lng") || "en";
-
-        const unrankedSelections = unrankedActionIds.map((actionId) => ({
-          inventoryId: params.inventory,
-          actionId,
-          actionType: type,
-          lang: lng,
-          isSelected: true,
-        }));
-
-        await db.models.UnrankedActionSelection.bulkCreate(unrankedSelections);
-        updatedCount += unrankedActionIds.length;
-      }
 
       logger.info(
         {
-          inventoryId: params.inventory,
-          rankedActionIds,
-          unrankedActionIds,
+          inventoryId,
+          actionType,
           totalSelected: body.selectedActionIds.length,
           updatedCount,
         },

--- a/app/src/backend/hiap/ActionService.ts
+++ b/app/src/backend/hiap/ActionService.ts
@@ -2,8 +2,9 @@ import { logger } from "@/services/logger";
 import { db } from "@/models";
 import { InventoryService } from "@/backend/InventoryService";
 import { Op } from "sequelize";
-import { copyRankedActionsToLang } from "@/backend/hiap/HiapService";
+import { copyRankedActionsToLang, syncRankedActionSelectionsAcrossLanguages, normalizeRankedActionForLang } from "@/backend/hiap/HiapService";
 import GlobalAPIService from "@/backend/GlobalAPIService";
+import { getTranslationFromDictionary } from "@/util/helpers";
 import {
   HighImpactActionRankingStatus,
   type LANGUAGES,
@@ -62,6 +63,9 @@ export default class ActionService {
     }
 
     // Get existing actions for this language and type
+    // Repair any pre-existing per-language selection drift before reading
+    await syncRankedActionSelectionsAcrossLanguages(ranking.id);
+
     let rankedActions = await db.models.HighImpactActionRanked.findAll({
       where: {
         hiaRankingId: ranking.id,
@@ -70,6 +74,9 @@ export default class ActionService {
       },
       order: [["rank", "ASC"]],
     });
+    rankedActions = rankedActions.map((action) =>
+      normalizeRankedActionForLang(action, lng),
+    );
 
     // If ranking is successful but no actions exist for this language, copy them synchronously
     const hasActionsForLang = rankedActions.length > 0;
@@ -129,13 +136,12 @@ export default class ActionService {
         rankedActions.map((action: any) => action.actionId),
       );
 
-      // Get unranked action selections from database
+      // Get unranked action selections (any language — selections are shared)
       const unrankedSelections =
         await db.models.UnrankedActionSelection.findAll({
           where: {
             inventoryId: inventoryId,
             actionType: type,
-            lang: lng,
             isSelected: true,
           },
         });
@@ -154,9 +160,15 @@ export default class ActionService {
         const baseAction = {
           id: action.ActionID,
           actionId: action.ActionID,
-          name: action.ActionName,
+          name:
+            getTranslationFromDictionary(action.ActionName, lng) ??
+            action.ActionName ??
+            "",
           rank: rankedActions.length + index + 1,
-          description: action.Description || "",
+          description:
+            getTranslationFromDictionary(action.Description, lng) ??
+            action.Description ??
+            "",
           explanation: action.Explanation || {},
           isSelected: selectedUnrankedActionIds.has(action.ActionID),
           hiaRankingId: "", // Not applicable for unranked
@@ -192,7 +204,12 @@ export default class ActionService {
             qualitativeEffectivenessEvidence: "",
             quantitativeEffectivenessEvidence: "",
             equityAndInclusionConsiderations:
-              action.EquityAndInclusionConsiderations || "",
+              getTranslationFromDictionary(
+                action.EquityAndInclusionConsiderations,
+                lng,
+              ) ??
+              action.EquityAndInclusionConsiderations ??
+              "",
             vulnerabilityAnalysisEvidence: "",
             riskReductionEvidence: "",
             socioEconomicImpacts: "",
@@ -215,7 +232,12 @@ export default class ActionService {
             qualitativeEffectivenessEvidence: "",
             quantitativeEffectivenessEvidence: "",
             equityAndInclusionConsiderations:
-              action.EquityAndInclusionConsiderations || "",
+              getTranslationFromDictionary(
+                action.EquityAndInclusionConsiderations,
+                lng,
+              ) ??
+              action.EquityAndInclusionConsiderations ??
+              "",
             vulnerabilityAnalysisEvidence: "",
             riskReductionEvidence: "",
             socioEconomicImpacts: "",

--- a/app/src/backend/hiap/HiapService.ts
+++ b/app/src/backend/hiap/HiapService.ts
@@ -24,6 +24,7 @@ import { getSession } from "next-auth/react";
 import { AppSession } from "@/lib/auth";
 import { Op } from "sequelize";
 import VersionHistoryService from "../VersionHistoryService";
+import { getTranslationFromDictionary } from "@/util/helpers";
 
 const HIAP_API_URL = process.env.HIAP_API_URL || "http://hiap-service";
 logger.info(`Using HIAP API at ${HIAP_API_URL}`);
@@ -579,12 +580,27 @@ function extractLocalizedString(
   field: string | Record<string, string> | null | undefined,
   lang: LANGUAGES,
 ): string | undefined {
-  if (!field) return undefined;
-  if (typeof field === "string") return field;
-  if (typeof field === "object" && field[lang]) return field[lang];
-  // Fallback to English if requested language not available
-  if (typeof field === "object" && field["en"]) return field["en"];
-  return undefined;
+  return getTranslationFromDictionary(field ?? undefined, lang);
+}
+
+/** Ensure ranked action text fields are strings for the requested language. */
+export function normalizeRankedActionForLang(action: any, lang: LANGUAGES) {
+  const plain = typeof action.toJSON === "function" ? action.toJSON() : action;
+  return {
+    ...plain,
+    name: getTranslationFromDictionary(plain.name, lang) ?? plain.name ?? "",
+    description:
+      getTranslationFromDictionary(plain.description, lang) ??
+      plain.description ??
+      "",
+    equityAndInclusionConsiderations:
+      getTranslationFromDictionary(
+        plain.equityAndInclusionConsiderations,
+        lang,
+      ) ??
+      plain.equityAndInclusionConsiderations ??
+      "",
+  };
 }
 
 async function fetchAndMergeRankedActions(
@@ -729,6 +745,8 @@ async function createRankedActionRecord(
         adaptationEffectivenessPerHazard:
           rankedAction.adaptationEffectivenessPerHazard,
         biome: rankedAction.biome,
+        // Keep selection in sync when copying ranked rows into a new language
+        isSelected: Boolean(rankedAction.isSelected),
       },
       { returning: true },
     );
@@ -1085,6 +1103,9 @@ async function getRankedActionsForLang(
   lang: LANGUAGES,
   type?: ACTION_TYPES,
 ) {
+  // Repair any pre-existing per-language selection drift before reading
+  await syncRankedActionSelectionsAcrossLanguages(ranking.id);
+
   const whereClause: any = { hiaRankingId: ranking.id, lang };
 
   // Add type filter only if type is provided
@@ -1097,7 +1118,7 @@ async function getRankedActionsForLang(
     order: [["rank", "ASC"]],
   });
 
-  return actions;
+  return actions.map((action) => normalizeRankedActionForLang(action, lang));
 }
 
 // Helper: Copy actions from any existing language to the requested language
@@ -1157,11 +1178,19 @@ export async function copyRankedActionsToLang(
     );
   }
 
+  // Propagate selection flags: an action selected in any language stays selected in the new one
+  const selectedActionIds = new Set(
+    allLangRanked
+      .filter((action) => action.isSelected)
+      .map((action) => action.actionId),
+  );
+
   const rankedActions = uniqueActions.map((r) => ({
     actionId: r.actionId,
     rank: r.rank,
     explanation: r.explanation, // Pass through explanation object with available languages
     type: r.type as ACTION_TYPES,
+    isSelected: selectedActionIds.has(r.actionId),
   }));
 
   // Fetch and merge action details in the requested language
@@ -1380,6 +1409,188 @@ export const readSelectedActionsFile = async (
     return [];
   }
 };
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Sync ranked action selection across all language rows for a ranking.
+ * Selection is keyed by stable actionId, not per-language row UUID.
+ */
+export async function syncRankedActionSelectionsAcrossLanguages(
+  hiaRankingId: string,
+): Promise<void> {
+  const rows = await db.models.HighImpactActionRanked.findAll({
+    where: { hiaRankingId },
+    attributes: ["actionId", "isSelected"],
+  });
+
+  const selectedActionIds = [
+    ...new Set(
+      rows.filter((row) => row.isSelected).map((row) => row.actionId),
+    ),
+  ];
+
+  if (selectedActionIds.length === 0) {
+    await db.models.HighImpactActionRanked.update(
+      { isSelected: false },
+      { where: { hiaRankingId } },
+    );
+    return;
+  }
+
+  await db.models.HighImpactActionRanked.update(
+    { isSelected: true },
+    {
+      where: {
+        hiaRankingId,
+        actionId: { [Op.in]: selectedActionIds },
+      },
+    },
+  );
+  await db.models.HighImpactActionRanked.update(
+    { isSelected: false },
+    {
+      where: {
+        hiaRankingId,
+        actionId: { [Op.notIn]: selectedActionIds },
+      },
+    },
+  );
+}
+
+/**
+ * Persist HIAP action selections for an inventory + action type.
+ * Ranked selections are applied by stable actionId across every language row.
+ * Unranked selections are written for all supported languages.
+ */
+export async function updateHiapActionSelections({
+  inventoryId,
+  actionType,
+  selectedIds,
+  authorId,
+}: {
+  inventoryId: string;
+  actionType: ACTION_TYPES;
+  selectedIds: string[];
+  authorId: string;
+}): Promise<number> {
+  const rankings = await db.models.HighImpactActionRanking.findAll({
+    where: { inventoryId, type: actionType },
+  });
+  const rankingIds = rankings.map((ranking) => ranking.id);
+
+  const rankedRecordIds: string[] = [];
+  const unrankedActionIds: string[] = [];
+
+  for (const selectedId of selectedIds) {
+    if (UUID_REGEX.test(selectedId)) {
+      rankedRecordIds.push(selectedId);
+    } else {
+      unrankedActionIds.push(selectedId);
+    }
+  }
+
+  let updatedCount = 0;
+
+  if (rankingIds.length > 0) {
+    // Resolve current-language row UUIDs to stable actionIds
+    const selectedRankedRows =
+      rankedRecordIds.length > 0
+        ? await db.models.HighImpactActionRanked.findAll({
+            where: {
+              id: rankedRecordIds,
+              hiaRankingId: rankingIds,
+            },
+            attributes: ["actionId"],
+          })
+        : [];
+
+    const selectedActionIds = [
+      ...new Set(selectedRankedRows.map((row) => row.actionId)),
+    ];
+
+    // Deselect every language row whose actionId is not selected
+    const deselectWhere =
+      selectedActionIds.length > 0
+        ? {
+            hiaRankingId: rankingIds,
+            actionId: { [Op.notIn]: selectedActionIds },
+          }
+        : { hiaRankingId: rankingIds };
+
+    const [_deselectedCount, changedDeselectedEntries] =
+      await db.models.HighImpactActionRanked.update(
+        { isSelected: false },
+        {
+          where: deselectWhere,
+          returning: true,
+        },
+      );
+
+    await VersionHistoryService.bulkCreateVersions(
+      inventoryId,
+      "HighImpactActionRanked",
+      authorId,
+      changedDeselectedEntries,
+      false,
+      undefined,
+      "hiap",
+    );
+
+    if (selectedActionIds.length > 0) {
+      // Select matching actionIds in every language for this action type
+      const [affectedCount, changedEntries] =
+        await db.models.HighImpactActionRanked.update(
+          { isSelected: true },
+          {
+            where: {
+              hiaRankingId: rankingIds,
+              actionId: { [Op.in]: selectedActionIds },
+            },
+            returning: true,
+          },
+        );
+      updatedCount += affectedCount;
+
+      await VersionHistoryService.bulkCreateVersions(
+        inventoryId,
+        "HighImpactActionRanked",
+        authorId,
+        changedEntries,
+        false,
+        undefined,
+        "hiap",
+      );
+    }
+  }
+
+  // Replace unranked selections for this inventory + action type only
+  await db.models.UnrankedActionSelection.destroy({
+    where: {
+      inventoryId,
+      actionType,
+    },
+  });
+
+  if (unrankedActionIds.length > 0) {
+    const languages = Object.values(LANGUAGES);
+    const unrankedSelections = unrankedActionIds.flatMap((actionId) =>
+      languages.map((lang) => ({
+        inventoryId,
+        actionId,
+        actionType,
+        lang,
+        isSelected: true,
+      })),
+    );
+
+    await db.models.UnrankedActionSelection.bulkCreate(unrankedSelections);
+    updatedCount += unrankedActionIds.length;
+  }
+
+  return updatedCount;
+}
 
 /**
  * Migrates HIAP action selections for all cities in a project.

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -1429,10 +1429,14 @@ export const api = createApi({
       }),
       updateHiapSelection: builder.mutation<
         { success: boolean; updated: number },
-        { inventoryId: string; selectedActionIds: string[] }
+        {
+          inventoryId: string;
+          selectedActionIds: string[];
+          actionType: ACTION_TYPES;
+        }
       >({
-        query: ({ inventoryId, selectedActionIds }) => ({
-          url: `inventory/${inventoryId}/hiap`,
+        query: ({ inventoryId, selectedActionIds, actionType }) => ({
+          url: `inventory/${inventoryId}/hiap?actionType=${actionType}`,
           method: "PATCH",
           body: { selectedActionIds },
         }),

--- a/app/src/util/helpers.ts
+++ b/app/src/util/helpers.ts
@@ -13,21 +13,22 @@ export const getTranslationFromDictionary = (
   translations: Record<string, string> | string | undefined,
   lng?: string,
 ): string | undefined => {
-  if (!!translations) {
-    if (translations instanceof String) {
-      return translations as string;
-    }
-    if (
-      typeof translations === "object" &&
-      !!Object.keys(translations).length
-    ) {
-      return (
-        (lng && translations[lng]) ||
-        translations["user"] ||
-        translations["en"] ||
-        Object.values(translations).find((t) => !!t)
-      );
-    }
+  if (!translations) {
+    return undefined;
+  }
+  if (typeof translations === "string") {
+    return translations;
+  }
+  if (
+    typeof translations === "object" &&
+    !!Object.keys(translations).length
+  ) {
+    return (
+      (lng && translations[lng]) ||
+      translations["user"] ||
+      translations["en"] ||
+      Object.values(translations).find((t) => !!t)
+    );
   }
 };
 

--- a/app/tests/api/city-hiap.jest.ts
+++ b/app/tests/api/city-hiap.jest.ts
@@ -264,7 +264,7 @@ describe("Inventory HIAP API", () => {
       });
 
       const body = { selectedActionIds: [ranked1.id] };
-      const req = mockRequest(body);
+      const req = mockRequest(body, { actionType: ACTION_TYPES.Mitigation });
       const res = await PATCH(req, {
         params: Promise.resolve({ inventory: inventoryId }),
       });
@@ -293,8 +293,153 @@ describe("Inventory HIAP API", () => {
       });
     });
 
-    it("is a no-op when there are no rankings for inventory", async () => {
+    it("syncs ranked selection across language rows by actionId", async () => {
+      const ranking = await db.models.HighImpactActionRanking.create({
+        id: randomUUID(),
+        inventoryId,
+        locode: "XX-TST",
+        type: ACTION_TYPES.Mitigation,
+        langs: ["en", "pt"],
+        jobId: randomUUID(),
+        status: HighImpactActionRankingStatus.SUCCESS,
+        userId: testData.userId,
+      });
+
+      const sharedActionId = "shared-action-1";
+      const otherActionId = "other-action-2";
+
+      const enSelected = await db.models.HighImpactActionRanked.create({
+        id: randomUUID(),
+        hiaRankingId: ranking.id,
+        actionId: sharedActionId,
+        rank: 1,
+        explanation: { en: "EN", pt: "PT" } as any,
+        lang: "en",
+        type: "mitigation",
+        name: "Shared Action EN",
+        isSelected: false,
+      });
+
+      const ptSelected = await db.models.HighImpactActionRanked.create({
+        id: randomUUID(),
+        hiaRankingId: ranking.id,
+        actionId: sharedActionId,
+        rank: 1,
+        explanation: { en: "EN", pt: "PT" } as any,
+        lang: "pt",
+        type: "mitigation",
+        name: "Shared Action PT",
+        isSelected: false,
+      });
+
+      const enOther = await db.models.HighImpactActionRanked.create({
+        id: randomUUID(),
+        hiaRankingId: ranking.id,
+        actionId: otherActionId,
+        rank: 2,
+        explanation: { en: "EN", pt: "PT" } as any,
+        lang: "en",
+        type: "mitigation",
+        name: "Other Action EN",
+        isSelected: true,
+      });
+
+      const ptOther = await db.models.HighImpactActionRanked.create({
+        id: randomUUID(),
+        hiaRankingId: ranking.id,
+        actionId: otherActionId,
+        rank: 2,
+        explanation: { en: "EN", pt: "PT" } as any,
+        lang: "pt",
+        type: "mitigation",
+        name: "Other Action PT",
+        isSelected: true,
+      });
+
+      // Select EN row UUID only — PT row for same actionId should also become selected
+      const req = mockRequest(
+        { selectedActionIds: [enSelected.id] },
+        { actionType: ACTION_TYPES.Mitigation },
+      );
+      const res = await PATCH(req, {
+        params: Promise.resolve({ inventory: inventoryId }),
+      });
+
+      await expectStatusCode(res, 200);
+
+      const refreshedEn = await db.models.HighImpactActionRanked.findByPk(
+        enSelected.id,
+      );
+      const refreshedPt = await db.models.HighImpactActionRanked.findByPk(
+        ptSelected.id,
+      );
+      const refreshedEnOther = await db.models.HighImpactActionRanked.findByPk(
+        enOther.id,
+      );
+      const refreshedPtOther = await db.models.HighImpactActionRanked.findByPk(
+        ptOther.id,
+      );
+
+      expect(refreshedEn?.isSelected).toBe(true);
+      expect(refreshedPt?.isSelected).toBe(true);
+      expect(refreshedEnOther?.isSelected).toBe(false);
+      expect(refreshedPtOther?.isSelected).toBe(false);
+
+      await db.models.HighImpactActionRanked.destroy({
+        where: {
+          id: [enSelected.id, ptSelected.id, enOther.id, ptOther.id],
+        },
+      });
+      await db.models.HighImpactActionRanking.destroy({
+        where: { id: ranking.id },
+      });
+    });
+
+    it("writes unranked selections for all languages", async () => {
+      const unrankedActionId = "UNRANKED_ACTION_1";
+      const req = mockRequest(
+        { selectedActionIds: [unrankedActionId] },
+        { actionType: ACTION_TYPES.Mitigation },
+      );
+      const res = await PATCH(req, {
+        params: Promise.resolve({ inventory: inventoryId }),
+      });
+
+      await expectStatusCode(res, 200);
+
+      const selections = await db.models.UnrankedActionSelection.findAll({
+        where: {
+          inventoryId,
+          actionId: unrankedActionId,
+          actionType: ACTION_TYPES.Mitigation,
+        },
+      });
+
+      expect(selections.length).toBeGreaterThan(1);
+      expect(selections.every((s) => s.isSelected)).toBe(true);
+      expect(new Set(selections.map((s) => s.lang)).size).toBe(
+        selections.length,
+      );
+
+      await db.models.UnrankedActionSelection.destroy({
+        where: { inventoryId, actionId: unrankedActionId },
+      });
+    });
+
+    it("rejects PATCH without actionType", async () => {
       const req = mockRequest({ selectedActionIds: [] });
+      const res = await PATCH(req, {
+        params: Promise.resolve({ inventory: inventoryId }),
+      });
+
+      await expectStatusCode(res, 400);
+    });
+
+    it("is a no-op when there are no rankings for inventory", async () => {
+      const req = mockRequest(
+        { selectedActionIds: [] },
+        { actionType: ACTION_TYPES.Mitigation },
+      );
       // Use the actual inventory ID which exists but has no rankings
       const res = await PATCH(req, {
         params: Promise.resolve({ inventory: inventoryId }),


### PR DESCRIPTION
## Summary

Fixes HIAP action selections not persisting when switching languages. Selections are now keyed by stable `actionId` across all language rows (ranked and unranked), and multilingual action fields are localized before reaching the UI.

## Changes

- Add `updateHiapActionSelections` and `syncRankedActionSelectionsAcrossLanguages` in `HiapService` to persist selections by `actionId` across every language row
- Require `actionType` on PATCH `/inventory/{id}/hiap`; update RTK mutation and `HiapTab` callers
- Propagate `isSelected` when copying ranked actions to a new language
- Localize unranked action name/description via `getTranslationFromDictionary`; normalize ranked action text on read
- Fix `getTranslationFromDictionary` to handle plain strings (prevents React crash on language switch)
- Add API tests for cross-language ranked sync, unranked all-language writes, and missing `actionType` rejection

## How to test

1. Open a city HIAP tab with a completed ranking (mitigation or adaptation).
2. Select one or more ranked and unranked actions in English.
3. Switch language (e.g. EN → PT → DE) and confirm the same actions remain selected.
4. Deselect/reselect actions in another language and confirm the change persists when switching back.
5. Run `npm run jest -- tests/api/city-hiap.jest.ts` (requires local Postgres).

## Ticket

CC-546
