### PR TITLE
CC-580: Use Decimal in ByScopeView percentage calculation

### DIFF
--- a/app/src/components/GHGI/inventory-result/ByScopeView.tsx
+++ b/app/src/components/GHGI/inventory-result/ByScopeView.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import Decimal from "decimal.js";
 import { Box, Table, useDisclosure, Icon } from "@chakra-ui/react";
 import { ActivityDataByScope } from "@/util/types";
 import type { TFunction } from "i18next";
@@ -52,10 +53,13 @@ const ByScopeView: React.FC<ByScopeViewProps> = ({
     groupedData[subsector].push(item);
   });
 
-  // Calculate sector total emissions for correct percentage calculation
+  // Calculate sector total emissions for correct percentage calculation.
+  // Uses Decimal (matching ResultsService.ts's calculatePercentage) instead of
+  // Number, since AFOLU-style negative/offsetting subsectors need the same
+  // precision the backend percentages were computed with.
   const sectorTotalEmissions = data.reduce(
-    (sum, item) => sum + Number(item.totalEmissions),
-    0,
+    (sum, item) => sum.plus(new Decimal(item.totalEmissions)),
+    new Decimal(0),
   );
 
   const toggleSubsector = (subsector: string) => {
@@ -131,11 +135,18 @@ const ByScopeView: React.FC<ByScopeViewProps> = ({
 
     // Multiple activities - create manual accordion
     const totalEmissions = activities.reduce(
-      (sum, item) => sum + Number(item.totalEmissions),
-      0,
+      (sum, item) => sum.plus(new Decimal(item.totalEmissions)),
+      new Decimal(0),
     );
-    // Calculate correct percentage based on subsector total emissions relative to sector total
-    const totalPercentage = (totalEmissions / sectorTotalEmissions) * 100;
+    // Calculate correct percentage based on subsector total emissions relative
+    // to sector total, matching ResultsService.ts's calculatePercentage
+    const totalPercentage = sectorTotalEmissions.lessThanOrEqualTo(0)
+      ? 0
+      : totalEmissions
+          .times(100)
+          .div(sectorTotalEmissions)
+          .round()
+          .toNumber();
     const uniqueSources = [
       ...new Set(activities.map((item) => item.datasource_name)),
     ];
@@ -172,8 +183,8 @@ const ByScopeView: React.FC<ByScopeViewProps> = ({
               <BodyMedium color="content.secondary">
                 {convertKgToTonnes(
                   activities.reduce(
-                    (sum, item) => sum + Number(item.scopes[s] || 0),
-                    0,
+                    (sum, item) => sum.plus(new Decimal(item.scopes[s] || 0)),
+                    new Decimal(0),
                   ),
                   numberFormat,
                 )}


### PR DESCRIPTION
## Summary

The AFOLU sector dashboard showed sub-sector percentages exceeding ±100% (e.g. -140%, 106%, 135%) because the frontend recalculated percentages independently with plain `Number` arithmetic instead of using the backend's already-correct `Decimal`-based value. This aligns the two so they can no longer diverge.

## Changes

- `ByScopeView.tsx`: sub-sector emissions and percentage totals (for subsectors that group multiple data sources) now use `decimal.js`, matching the exact formula and rounding of `calculatePercentage` in `ResultsService.ts`, instead of casting to plain `Number`.

## How to test

1. Open a sector breakdown table with a subsector that has multiple data sources (`activities.length > 1` in `ByScopeView.tsx`) and confirm the displayed "% of sector emissions" matches `co2eq / sectorTotal * 100` for that group.
2. Confirm `npx tsc --noEmit` passes for `app/src/components/GHGI/inventory-result/ByScopeView.tsx`.

## Ticket

CC-580

## Notes

**What this PR does NOT fix:** the reported dashboard screenshot (AFOLU sector showing -239,500.19 t / -140% for "Emissions from land") has exactly one data source per sub-sector, so it never hits the multi-datasource code path touched here — it was already rendering the backend's `item.percentage` directly, unchanged by this PR.

**Still needs investigation:** the underlying -239,500.19 t value looks ~1000x too large for a plausible land-use carbon sink relative to the sector total (170.87 kt). Tracing the pipeline: `global-api`'s `modelled.emissions` table has a DB check constraint (`check_emissions_units_kg`) that only validates the `emissions_units` **label** equals `'kg'` — it does not validate that the numeric value was actually converted to kg. The SEEG (Brazilian) data source that populated this row is ingested by a pipeline that isn't part of this repo, so I couldn't locate or fix the ETL step directly. Someone with access to the `citycatalyst-test` staging DB should compare the stored `emissions_value` for this inventory's AFOLU land row (gpc_reference_number `V.2`, SEEG datasource) against the original SEEG source spreadsheet to confirm/rule out a units mismatch.

There's also a structural duplication that's out of scope for this PR: the frontend re-groups backend rows into subsector "buckets" client-side (`activityTitle.split("_")[0]`), so when a bucket spans multiple data sources it still computes its own combined percentage rather than reusing a single backend value (the backend has no such combined value to give it — it returns one row per subsector+datasource pair). Fully removing that duplication would mean moving the bucket grouping into `ResultsService.ts` so it returns one pre-aggregated row per bucket.
