### PR TITLE
docs: Concept Note Builder UI handoff (v3) + backend requests

### DIFF
--- a/docs/ConceptNoteBuilderBackendRequests.md
+++ b/docs/ConceptNoteBuilderBackendRequests.md
@@ -1,6 +1,6 @@
 # CNB — SSE events the UI needs
 
-**From:** Carlos (design) · **To:** Piotr (backend) · **Date:** 2026-07-24
+**From:** Carlos (design) · **To:** Piotr (backend) · **Date:** 2026-07-24 · **Updated:** 2026-07-28 (v4 first handoff — §D rewritten, §F–H added)
 **Companion to:** the UI Development Spec v2 and the two fixtures in [`fixtures/`](fixtures/).
 
 The architecture emits **eleven** SSE events, and states plainly that
@@ -126,9 +126,18 @@ which is the highest-severity UX problem today.
 
 # Tools / endpoints requested (beyond events)
 
-Added 2026-07-28 after the v3 design review. Each spot in the Figma file that depends on
-one of these carries an amber **NEEDS BACKEND** flag. Rationale is written in plain terms
-on purpose — it's the argument, not just the ask.
+§A–E added 2026-07-28 after the v3 design review; §D rewritten and §F–H added the same
+day after the **v4 first handoff** (Figma page "CNB v4 –– First Handoff", secs 18–19 —
+the amber "v4 backend deltas" card in sec 19 mirrors F–H). Each spot in the Figma file
+that depends on one of these carries an amber **NEEDS BACKEND** flag. Rationale is
+written in plain terms on purpose — it's the argument, not just the ask.
+
+**The one v4 fact that drives F, G and H:** everything at note creation is now optional.
+The v3 screens S2·a / S2 / S2·b died; creation is a modal where every setup field
+(project · funder · opportunity — even the files) can be skipped, and whatever was
+skipped becomes a **setup gap** that Clima resolves in chat. The v4 journey (V1
+dashboard → V2 creation modal → V3 setup-gaps first-open → V4 funder-chosen →
+V5 drafting → V6 export) is the design source for all three.
 
 ## A. Run listing endpoint  ⟶ unblocks **S1 Home**
 **Plainly:** the backend can only answer "here's an exact city + project + funder +
@@ -137,6 +146,10 @@ have?*" It's a filing cabinet with no drawer view: you can retrieve a note only 
 already re-type its exact scope. The home screen is literally a list of the city's notes
 with status and context-progress — one boring endpoint (`list runs for city`) makes it
 real. Without it, S1 is either empty or faked.
+
+**v4 note:** unchanged as an ask, but its weight went up — the v4 **dashboard (V1)** is
+built directly on this listing (note cards with name, status, context-progress). It's now
+the first screen of the whole flow, not one view among several.
 
 ## B. `context_annotate`  ⟶ unblocks the confirm-or-correct promise (C3, tool screen ⑪)
 **Plainly:** the tiles promise "confirm or correct — never re-enter." The user says
@@ -156,12 +169,20 @@ resolves the architecture's own open question (bundle run-scoped vs promotable) 
 **shared** — flagging it here so it lands as the product decision it is. Payoff: a
 second note costs minutes, not another assembly.
 
-## D. ~~Auto-assembly trigger~~ — DOWNGRADED to a behavior note
-**Plainly:** on review this is ~90% frontend: `start_run` already kicks off ingestion
-and assembly, so "no assemble button" just means the UI calls `start_run` the moment the
-fourth selector is picked. The only backend sliver — signaling *re*-assembly when scope
-is edited later — is covered by event #4 (bundle delta). **Nothing new requested.**
-The S2·a flag in Figma now reads BEHAVIOR, not NEEDS BACKEND.
+**v4 note:** unchanged as an ask, but the v4 **dashboard (V1)** shows the shared-context
+strip above the note list — so the dashboard depends on both A and C together.
+
+## D. Run creation timing — REWRITTEN for v4 (the v3 behavior note is dead)
+**Plainly:** v3 said "the UI calls `start_run` the moment the fourth selector is
+picked." That flow no longer exists — there is no fourth pick, because in v4 every
+setup field is optional. Instead, the creation modal (V2) has a single **CREATE**
+action, and the run must exist the moment it's pressed: everything after CREATE is
+run-scoped, starting with uploads (`POST /concept-notes/{run_id}/uploads` — there is
+no pre-run holding area for files, and source PDFs stay ≤ 20 MB). So the sequence is
+CREATE → `start_run` with whatever scope exists (possibly none — see F) → the modal's
+upload step attaches files to that run. Assembly still starts without an assemble
+button; it just starts from CREATE, with whatever context is present, and re-runs as
+scope and files arrive (event #4 covers the re-assembly signal, as before).
 
 ## E. Applicant eligibility validation  ⟶ unblocks the C5/S2 eligibility surface
 **Plainly:** the funder profile already lists *who may apply* — eligible applicant
@@ -172,8 +193,38 @@ three field comparisons at assembly time, and the design already shows where the
 goes (the ✓/✗ list on the funder card). It's the "check you're allowed to enter before
 standing in line for an hour" gate.
 
-**Suggested order:** events #1+#2 → A (run listing) → events #3+#4 → B+C (the
-shared-context model) → E.
+## F. Optional scope at `start_run` — nullable fields, or a `concept_note_set_scope` tool
+**Plainly:** the v4 creation modal lets a user create a note having picked *nothing* —
+no project, no funder, no opportunity. But `start_run` today demands the full scope up
+front, which would force the modal to lie or block. Two acceptable shapes, pick
+whichever costs less: **(1)** make the scope fields nullable at `start_run`, or
+**(2)** keep `start_run` minimal and add a `concept_note_set_scope` tool that Clima
+calls mid-chat when the user finally names the funder or project. Either way the
+requirement is the same: **scope must be settable after the run exists.** Skipped setup
+becomes a setup gap Clima resolves in conversation — not a wall at the door. (Setting
+the funder later is exactly the V4 moment: the template arrives and the pre-template
+draft re-maps onto it.)
+
+## G. Setup-gap blocker values in the always-on agent context  ⟶ unblocks **SetupGapChatCard (V3)**
+**Plainly:** when setup was skipped, Clima has to open the conversation knowing *what's
+missing and what it blocks* — "you haven't picked a funder yet; without one there's no
+template, so I'll draft against a generic structure and re-map when you choose." The
+agent's always-on context (which already carries the workflow step) should also carry
+the setup-gap state: which of project / funder / opportunity are unset, and the blocker
+value for each (what capability is gated). Without it, Clima either ignores the gaps or
+re-derives them by tool-poking every turn. This is what SetupGapChatCard and the
+ContextPanel blocker rows render.
+
+## H. A `name` column on `concept_note_runs`  ⟶ unblocks **NoteCard on the dashboard (V1)**
+**Plainly:** in v3 a run's identity *was* its scope tuple (city + project + funder +
+opportunity). In v4 a note can exist before any of those are chosen — so the tuple can
+no longer be the display identity. Users name the note at creation (the modal's one
+always-available field) and the dashboard lists notes by name. One column on
+`concept_note_runs`, accepted at `start_run` and editable (rename) afterwards.
+
+**Suggested order:** events #1+#2 → A + H (the dashboard: listing + names) → F
+(optional scope — the creation modal) → events #3+#4 → B+C (the shared-context model)
+→ G → E.
 
 **Explicitly out (Carlos, 2026-07-28):** per-field confidence levels and sub-field source
 structure (the Porto Alegre note's `### field` + confidence pattern) — not requested;

--- a/docs/ConceptNoteBuilderBackendRequests.md
+++ b/docs/ConceptNoteBuilderBackendRequests.md
@@ -1,0 +1,180 @@
+# CNB — SSE events the UI needs
+
+**From:** Carlos (design) · **To:** Piotr (backend) · **Date:** 2026-07-24
+**Companion to:** the UI Development Spec v2 and the two fixtures in [`fixtures/`](fixtures/).
+
+The architecture emits **eleven** SSE events, and states plainly that
+`concept_note_context_bundle_ready` is the **only** user-visible event covering the whole
+context-assembly phase. That single fact is what forces most of this ask: today a user
+drops a large CAP and receives no signal until OCR, funder load, and similar-project
+matching have **all** finished — minutes later. A silent wait reads as a hang.
+
+Four event families would close the gap. They're ordered by how much they hurt to lack.
+Each is already present in the fixtures as `tier: "requested"`, so you can see the exact
+shape and where it fires.
+
+---
+
+## 1. `concept_note_upload_status` — per-upload lifecycle  ⟶ unblocks **C2 UploadCard**
+
+**Why it can't be worked around client-side.** OCR on a 180-page PDF is minutes-long. The
+client uploads bytes and then has nothing to show. The failure codes we need to
+distinguish **already exist** in the architecture's own failure table
+(`cc_ocr_failed`, `ca_markdown_ingest_failed`) — they just never reach the client.
+
+**Shape** (one event per transition, per `upload_id`):
+
+```json
+{ "event": "concept_note_upload_status",
+  "data": { "run_id": "...", "upload_id": "up_cap01", "filename": "CAP.pdf",
+            "status": "converting|processing|ready|failed",
+            "detail": "OCR — 180 pp", "pages": 180,
+            "error_code": null, "retryable": true, "http_status": null } }
+```
+
+**The failure codes must arrive distinct**, because they mean opposite things to the user:
+
+| `error_code` | What it tells the user | Retry semantics |
+|---|---|---|
+| `cc_ocr_failed` | *Your file may be bad* (image-only scan, corrupt). CC keeps the file. | Retry may enqueue another OCR attempt. |
+| `ca_markdown_ingest_failed` | *Your file is fine* — our indexing hiccuped. | Retry re-runs indexing only, not OCR. |
+| `markdown_identity_conflict` | Duplicate; the upload is immutable. | Not retryable (`http_status: 409`). |
+| (size) | Over the 20 MB source-PDF limit. | N/A — reject before upload. |
+
+Collapsing these into a generic "upload failed" is the single biggest avoidable source of
+support load in this feature.
+
+---
+
+## 2. `concept_note_workflow_step_changed` — step transitions  ⟶ unblocks **C1, S2, S3**
+
+**Why it can't be worked around.** The workflow step is injected into the *agent's*
+always-on context; it is never streamed. So the UI cannot tell `interviewing` from
+`drafting_document` from `assembling_context`, and the entire assembly phase — the part
+with the longest waits — has no signal at all. C1 (RunStatusIndicator) can currently only
+guess from other events, and can't cover assembly.
+
+**Shape:**
+
+```json
+{ "event": "concept_note_workflow_step_changed",
+  "data": { "run_id": "...", "from": "assembling_context", "to": "interviewing" } }
+```
+
+Steps, per the architecture:
+`selecting_scope → ingesting_user_files → profiling_funder → matching_examples →
+assembling_context → interviewing → drafting_document → editing_document → completed`.
+
+If a per-step event is too heavy, even a coarser `phase_changed` (scope / context /
+interview / draft / done) would let C1 stop showing an unchanging spinner.
+
+---
+
+## 3. `document_chapter_ready` — chapter marked ready  ⟶ unblocks **C8 ChapterOutlineRow**
+
+**Why it can't be worked around.** `document_mark_chapter_ready` is a **tool with no
+matching event**. So when a chapter transitions to `ready`, the outline has no reactive
+signal and can't update without polling. (Note the gate: this transition can't fire while
+a critical gap is open — the event should reflect that, so the UI and backend agree on
+when "ready" is legal.)
+
+**Shape:**
+
+```json
+{ "event": "document_chapter_ready",
+  "data": { "document_id": "...", "chapter_id": "ch_problem", "status": "ready" } }
+```
+
+Symmetry note: `document_chapter_updated` already fires for draft/edit transitions, so this
+is filling the one hole in an otherwise complete chapter-lifecycle event set.
+
+---
+
+## 4. Bundle re-assembly delta  ⟶ unblocks **C4 ContextReadinessPanel**, and C3 tiles
+
+**Why it can't be worked around.** When a file lands mid-interview and the bundle
+re-assembles, the backend emits the **same** `concept_note_context_bundle_ready` event as
+the first assembly. With no delta, the UI can't distinguish "+1 file added" from "starting
+over" — a mid-flow re-assembly looks like a reset, and the user thinks they lost work.
+
+**Option A (cheapest):** add a discriminator to the existing event —
+
+```json
+{ "event": "concept_note_context_bundle_ready",
+  "data": { "reassembly": true, "changed": ["selected_sources", "document_context"],
+            "added_source_ids": ["src_letter"] } }
+```
+
+**Option B:** a dedicated `concept_note_context_bundle_updated` carrying only the delta.
+Either works for the UI; Option A is less surface area for you.
+
+---
+
+## What we're doing until these exist
+
+The UI is being built against the two fixtures, consuming both `existing` and `requested`
+tiers. Components fall back to indeterminate/last-known states where only `existing` events
+are available (a temporary polling fallback covers the worst gaps). When these four land,
+the same components become reactive with no redesign — the fixtures are written so the
+shapes above drop straight in.
+
+**Smallest useful first step, if you want to stage it:** #1 (`upload_status`) and #2
+(`workflow_step_changed`) together remove essentially all of the "is it hung?" ambiguity,
+which is the highest-severity UX problem today.
+
+---
+
+# Tools / endpoints requested (beyond events)
+
+Added 2026-07-28 after the v3 design review. Each spot in the Figma file that depends on
+one of these carries an amber **NEEDS BACKEND** flag. Rationale is written in plain terms
+on purpose — it's the argument, not just the ask.
+
+## A. Run listing endpoint  ⟶ unblocks **S1 Home**
+**Plainly:** the backend can only answer "here's an exact city + project + funder +
+opportunity — create or resume *that* run." It cannot answer "*what notes does this city
+have?*" It's a filing cabinet with no drawer view: you can retrieve a note only if you
+already re-type its exact scope. The home screen is literally a list of the city's notes
+with status and context-progress — one boring endpoint (`list runs for city`) makes it
+real. Without it, S1 is either empty or faked.
+
+## B. `context_annotate`  ⟶ unblocks the confirm-or-correct promise (C3, tool screen ⑪)
+**Plainly:** the tiles promise "confirm or correct — never re-enter." The user says
+"population is 92,400, not 86,697." Two constraints collide: we must *use her number*,
+and we must *never edit CityCatalyst* (the city's official record, owned by another
+module). So the correction needs somewhere durable to live: a small stored fact —
+"for this note, population = 92,400, provided by the user." Run-scoped = attached to
+this note, not to CC. Without the tool, the correction only exists in the chat
+transcript: it evaporates on resume, and the export can silently revert to the wrong
+number.
+
+## C. Shared context across notes (bundle promotion)  ⟶ unblocks S1/S4 shared-context cards
+**Plainly:** a city's context (CC data + uploaded files) shouldn't be rebuilt per note.
+The design's model: one auto-saved **shared context** per city, reused by every note;
+each note keeps only its own setup (project · funder · opportunity). This deliberately
+resolves the architecture's own open question (bundle run-scoped vs promotable) toward
+**shared** — flagging it here so it lands as the product decision it is. Payoff: a
+second note costs minutes, not another assembly.
+
+## D. ~~Auto-assembly trigger~~ — DOWNGRADED to a behavior note
+**Plainly:** on review this is ~90% frontend: `start_run` already kicks off ingestion
+and assembly, so "no assemble button" just means the UI calls `start_run` the moment the
+fourth selector is picked. The only backend sliver — signaling *re*-assembly when scope
+is edited later — is covered by event #4 (bundle delta). **Nothing new requested.**
+The S2·a flag in Figma now reads BEHAVIOR, not NEEDS BACKEND.
+
+## E. Applicant eligibility validation  ⟶ unblocks the C5/S2 eligibility surface
+**Plainly:** the funder profile already lists *who may apply* — eligible applicant
+types, geography, categories. Today that data only filters **similar projects**; nothing
+ever asks "*does this city itself qualify?*" So a city can spend an hour drafting seven
+chapters and be rejected in thirty seconds by the funder's front desk. The check is
+three field comparisons at assembly time, and the design already shows where the answer
+goes (the ✓/✗ list on the funder card). It's the "check you're allowed to enter before
+standing in line for an hour" gate.
+
+**Suggested order:** events #1+#2 → A (run listing) → events #3+#4 → B+C (the
+shared-context model) → E.
+
+**Explicitly out (Carlos, 2026-07-28):** per-field confidence levels and sub-field source
+structure (the Porto Alegre note's `### field` + confidence pattern) — not requested;
+chapter-level `body_markdown` + evidence links stay as-is.

--- a/docs/ConceptNoteBuilderUIHandoff.md
+++ b/docs/ConceptNoteBuilderUIHandoff.md
@@ -1,0 +1,65 @@
+# Concept Note Builder — UI Design Handoff (v3)
+
+**Owner:** Carlos Graffi (design) · **Backend counterpart:** Piotr · **Date:** 2026-07-28 · **Status:** design complete, pending backend requests below
+
+**Design source of truth:** Figma file *"Agentic Flow - Concept Note Builder"*, page **"CNB v3 – 2026-07-27"**, sections 14–17 (sections 8–10 are the Stationary Energy reference; 11–13 are superseded). Styling source: Claude Design project *"CityCatalyst Terra UI"* (tokens + component specs, lifted from `app/src/lib/theme`). Companion artifacts (design workspace): SSE fixtures (`uc1-happy-path.sse.json`, `uc1-degraded.sse.json`) and the backend request doc (mirrored here as `ConceptNoteBuilderBackendRequests.md`).
+
+---
+
+## 1. The product in one paragraph
+
+A city picks a project, a funder and a funding opportunity; Clima (the Climate Advisor) assembles context from CityCatalyst data, the city's uploaded files and the funder profile, then drafts a funder-ready concept note through a guided interview — **never a wizard** — while the note is visible, readable and restructurable at all times. Every factual claim is source-linked; when no source exists, Clima asks instead of inventing. Export produces DOCX + PDF.
+
+## 2. Design principles (non-negotiables)
+
+1. **The workspace is ONE screen** whose regions change state — never a step sequence. All template chapters exist as visible empty rows from t=0 (the outline is the contract).
+2. **The note is text.** The Draft preview shows the full document as readable prose at every moment — empty sections as placeholders, never hidden. The preview is exactly what export renders.
+3. **Gap ≠ status.** A chapter can be EMPTY *and* carry a gap tag *and* be locked — three independent signals. Critical gaps functionally gate mark-chapter-ready and export.
+4. **Never fabricate, made visible.** Every claim links to a source, a user confirmation, or a CC snapshot. The red "no source" chip is the alarm state; Clima's grounded question always states *why* it's asking.
+5. **Export warns, never blocks.** Cities send imperfect drafts on deadlines; "Export anyway" is always available on warnings. DOCX and PDF are independent artifacts.
+6. **Users never type into the note.** Every user-sourced field is an interview answer (`You · interview`) or an upload. No "Manual entry" language anywhere.
+7. **Auto-save, no save buttons.** Every change writes a full-body revision; adding files saves automatically. A save affordance appears only inside a future bundle-edit view.
+8. **Clima green is chat-identity only.** All product actions are Terra blue, uppercase, pill; Export actions are green; danger is red. One button size everywhere (12px Poppins SemiBold, 1.25px tracking, 8/14 padding).
+
+## 3. Information architecture — screens (Figma section 15)
+
+| Screen | Purpose | Key states |
+|---|---|---|
+| **S1 · Home — Runs** | All of the city's concept notes, resumable. Shared-context strip on top. | empty / has-runs / per-card status + context-% |
+| **S2·a · Start a new note** | The selection state: SHARED CONTEXT (city) vs THIS NOTE'S SETUP (project · funder · opportunity). Assembly starts on the 4th pick — no assemble button. | 3-of-4 chosen, dropdown open, disabled until ready |
+| **S2 · Scope & context** | Selection collapsed to a summary bar; readiness panel + CC tile mosaic + funder card (with proposed eligibility check) + files/dropzone. | assembling / ready / **ready-with-gaps** (never blocks) / blocked (funder profile only) |
+| **S2·b · Thin context (UC-5)** | Same launchpad, city with almost no data. Files become the primary source; nothing hidden. | 3 MISSING tiles, interview still starts |
+| **S3 · Workspace** | Clima chat (620) + concept-note artifact (752) with **three tabs**: Draft preview (full text + SECTIONS navigator) · Structure · Context. | interviewing / drafting / gap open / mid-flow upload |
+| **S3·b · Structure tab** | Drag-reorder, remove, ADD CUSTOM CHAPTER — or ask Clima (same tools). | row lifted "Moved by Clima" |
+| **S4 · Export** | Sheet over the dimmed workspace. Preflight checklist with chapter deep-links, REVIEW FULL TEXT, independent .DOCX/.PDF cards, shared-context auto-saved card. | clean / warnings / blocking / per-format failure with persisted retry |
+
+**Navigation:** primary loop S1 → S2·a → S2 → S3 ⇄ S4 → S1. Resume/Duplicate short-circuit from S1 (Duplicate = setup pre-filled, shared context already in place). Every screen reaches Home via "← All concept notes". Full audited map: the Navigation card in section 15.
+
+## 4. Component inventory (Figma section 14 — every state drawn, frame names = intended React names)
+
+C1 RunStatusIndicator · C2 UploadCard (incl. 4 distinct failure modes) · C3 ContextTile (**Connected** badge, preview line — GHGI: total + sectors covered; CCRA: risks mapped; HIAP: ranking status — and "Open in module" redirect) · C4 ContextReadinessPanel · C5 FunderSummaryCard (+ proposed eligibility state) · C6 SimilarProjectCard (weak/empty first; no scores in v1) · C7 ConversationTurn (incl. the grounded question with WHY) · C8 ChapterOutlineRow (real enum: empty·draft·needs_review·ready·deleted; `user_locked` boolean; gap tag separate) · C9 ChapterBody (body = latest revision) · C10 CitationChip + SourcePopover (no-basis = red alarm) · C11 GapIndicator (severity is functional) · C12 DiffProposal (inline diff + REASON; v1.1) · C13 DestructiveConfirm (soft delete) · C14 ExportPreflight · C15 NotePreview + StructureTab (empty→streaming→complete; reorder; add-custom) · DECISION band (evidence-in-export A/B, unresolved).
+
+## 5. Tool → SSE → UI behavior (Figma sections 16 + 17)
+
+Thirteen moments, each as a reference card (16) and a full workspace screen (17):
+① start_run → 7 empty rows instantly · ② bundle_ready → context lands everywhere at once · ③ update_chapter → text streams into the preview · ④ link_evidence → provenance pills + source trail · ⑤ flag_gap → grounded question; row keeps EMPTY + gains gap tag · ⑥ user answer → gap resolves into citable provenance · ⑦ mark_chapter_ready → refused while critical gap open · ⑧ edit on user_locked → inline diff + REASON · ⑨ delete → gated, soft, preflight warning · ⑩ restore → full body returns · ⑪ context_annotate → run-scoped override, Context tab · ⑫ export → independent formats, persisted retry · ⑬ **mid-flow upload → "what context do you have now?"** → in-chat upload card + structured context summary by source type.
+
+Amber SSE chips throughout = events that don't exist yet (see the requests doc).
+
+## 6. Data model the design assumes
+
+- **Shared context per city** (CC data + files, auto-saved, reused by every note) + **per-note setup** (project · funder · opportunity). This resolves the architecture's bundle open question toward *shared* — deliberately.
+- **Provenance types:** upload (CAP p.x) · CC dataset · funder criterion · similar project · `You · interview`. **Out of scope by decision:** per-field confidence levels and sub-field source structure.
+- Real notes run ~20+ numbered sections with inline gaps and tables (reference: the Porto Alegre BPJP/C40 example note) — hence the SECTIONS navigator and the Structure tab.
+
+## 7. Backend requests
+
+Full detail + plain-terms rationale in `ConceptNoteBuilderBackendRequests.md`. Summary: **4 SSE events** (per-upload status · workflow step changed · chapter ready · bundle re-assembly delta) + **4 tools/endpoints** (run listing · `context_annotate` · shared-context promotion · applicant eligibility validation). Auto-assembly trigger was reviewed and **downgraded to frontend behavior** (call `start_run` on the 4th selector pick). Suggested order: events 1+2 → run listing → events 3+4 → annotate + shared context → eligibility.
+
+## 8. Open decisions
+
+1. **Evidence in export** (blocking, Carlos + Piotr): architecture says workspace-only; PRD says linked sources travel to the funder. Both export variants are drawn in section 14's DECISION band.
+2. Custom chapters in the funder document (architecture's own open question).
+3. Restore position after reorders.
+4. Citation-density collapse rule (Carlos).
+5. Real MN funder template — the 7-chapter plan everywhere is a placeholder.

--- a/docs/ConceptNoteBuilderUIHandoff.md
+++ b/docs/ConceptNoteBuilderUIHandoff.md
@@ -2,7 +2,26 @@
 
 **Owner:** Carlos Graffi (design) · **Backend counterpart:** Piotr · **Date:** 2026-07-28 · **Status:** design complete, pending backend requests below
 
-**Design source of truth:** Figma file *"Agentic Flow - Concept Note Builder"*, page **"CNB v3 – 2026-07-27"**, sections 14–17 (sections 8–10 are the Stationary Energy reference; 11–13 are superseded). Styling source: Claude Design project *"CityCatalyst Terra UI"* (tokens + component specs, lifted from `app/src/lib/theme`). Companion artifacts (design workspace): SSE fixtures (`uc1-happy-path.sse.json`, `uc1-degraded.sse.json`) and the backend request doc (mirrored here as `ConceptNoteBuilderBackendRequests.md`).
+**Design source of truth:** Figma file *"Agentic Flow - Concept Note Builder"*, page **"CNB v3 – 2026-07-27"**, sections 14–17 (sections 8–10 are the Stationary Energy reference; 11–13 are superseded) — **entry flow superseded by v4, see the update box below**. Styling source: Claude Design project *"CityCatalyst Terra UI"* (tokens + component specs, lifted from `app/src/lib/theme`). Companion artifacts (design workspace): SSE fixtures (`uc1-happy-path.sse.json`, `uc1-degraded.sse.json`) and the backend request doc (mirrored here as `ConceptNoteBuilderBackendRequests.md`).
+
+> ### v4 update — 2026-07-28 (first handoff)
+> Figma page **"CNB v4 –– First Handoff"** (sections 18 · Journey, 19 · New & changed
+> components) supersedes the **entry flow** of this doc:
+> - **Everything at note creation is optional.** Screens **S2·a, S2 and S2·b no longer
+>   exist.** Creation is a modal (V2) where every setup field — project, funder,
+>   opportunity, even files — can be skipped; whatever is skipped becomes a **setup gap**
+>   that Clima resolves in chat (V3, SetupGapChatCard). "Assembly starts on the 4th
+>   pick" is dead: the run is created on the modal's CREATE, before uploads (which are
+>   run-scoped).
+> - **The home screen is now a dashboard (V1)** — note cards by name, shared-context
+>   strip, expanded ContextPanel. Workspace drafting runs at chat 480 / artifact 900.
+> - **Backend deltas:** §D of `ConceptNoteBuilderBackendRequests.md` is rewritten and
+>   §F–H are new (optional scope at `start_run` / `concept_note_set_scope` · setup-gap
+>   blocker values in the agent context · a `name` column on `concept_note_runs`). The
+>   amber "v4 backend deltas" card in Figma section 19 carries the same list.
+> Section 3's screen table is kept as the v3 record (read S2·a/S2/S2·b rows through
+> this box); §7 is updated in place. Everything else (principles, components, tool
+> moments, data model) carries over unchanged.
 
 ---
 
@@ -54,7 +73,7 @@ Amber SSE chips throughout = events that don't exist yet (see the requests doc).
 
 ## 7. Backend requests
 
-Full detail + plain-terms rationale in `ConceptNoteBuilderBackendRequests.md`. Summary: **4 SSE events** (per-upload status · workflow step changed · chapter ready · bundle re-assembly delta) + **4 tools/endpoints** (run listing · `context_annotate` · shared-context promotion · applicant eligibility validation). Auto-assembly trigger was reviewed and **downgraded to frontend behavior** (call `start_run` on the 4th selector pick). Suggested order: events 1+2 → run listing → events 3+4 → annotate + shared context → eligibility.
+Full detail + plain-terms rationale in `ConceptNoteBuilderBackendRequests.md`. Summary: **4 SSE events** (per-upload status · workflow step changed · chapter ready · bundle re-assembly delta) + **7 tools/endpoints/schema asks** (run listing · `context_annotate` · shared-context promotion · applicant eligibility validation · optional scope at `start_run` or `concept_note_set_scope` · setup-gap blocker values in the agent context · `name` column on `concept_note_runs`). The v3 "auto-assembly = frontend behavior on the 4th pick" note is **dead** — v4 creates the run on the modal's CREATE, before run-scoped uploads (`POST /concept-notes/{run_id}/uploads`); see the rewritten §D. Suggested order: events 1+2 → run listing + name column → optional scope → events 3+4 → annotate + shared context → setup-gap context → eligibility.
 
 ## 8. Open decisions
 


### PR DESCRIPTION
## What

Design handoff for the Concept Note Builder v3 UI, plus the backend event/tool requests with plain-terms rationale.

- `docs/ConceptNoteBuilderUIHandoff.md` — the product in one paragraph, design principles, all 7 screens, component inventory (C1–C15), the 13 tool→SSE→UI behaviors, data-model assumptions (shared context + per-note setup, provenance types), open decisions.
- `docs/ConceptNoteBuilderBackendRequests.md` — 4 requested SSE events + 4 requested tools/endpoints (run listing, context_annotate, shared-context promotion, applicant eligibility validation), each with rationale; auto-assembly trigger reviewed and downgraded to frontend behavior; confidence/sub-field sourcing explicitly out of scope.

## Where the design lives

Figma *"Agentic Flow - Concept Note Builder"* → page **CNB v3 – 2026-07-27**, sections 14–17 (components / screens / tool cards / full tool screens), styled from the Claude Design "CityCatalyst Terra UI" project. Every backend-dependent element in the file carries an amber NEEDS BACKEND flag matching these docs.

## For review

- Piotr: the requests doc — especially the shared-context decision (it resolves the architecture's bundle open question toward *shared*).
- The evidence-in-export decision (architecture vs PRD) is still open and blocks C10/C14.

Draft until Carlos signs off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)