### PR TITLE
CC-543: Fix navbar font consistency and breadcrumb styling

### DIFF
--- a/app/src/components/GHGI/inventory-pages/add-data-steps-page.tsx
+++ b/app/src/components/GHGI/inventory-pages/add-data-steps-page.tsx
@@ -713,29 +713,24 @@ export default function AddDataSteps() {
             <Box>
               <BreadcrumbRoot
                 gap="8px"
-                fontFamily="heading"
-                fontWeight="bold"
-                letterSpacing="widest"
-                fontSize="14px"
-                textTransform="uppercase"
+                fontFamily="body"
+                fontWeight="medium"
+                fontSize="body.sm"
+                lineHeight="16"
                 separator={
                   <Icon as={MdChevronRight} color="gray.500" h="24px" />
                 }
               >
                 <BreadcrumbLink
                   href={inventoryDataBasePath}
-                  color="content.tertiary"
-                  textDecoration="none"
-                  _hover={{
-                    textDecoration: "underline",
-                    textUnderlineOffset: "4px",
-                  }}
+                  color="content.link"
+                  textDecoration="underline"
                 >
                   {t("all-sectors")}
                 </BreadcrumbLink>
 
                 <BreadcrumbCurrentLink
-                  color="content.link"
+                  color="content.secondary"
                   textDecoration="none"
                 >
                   {t(kebab(currentStep.name || ""))}

--- a/app/src/components/GHGI/inventory-pages/sub-sector-page.tsx
+++ b/app/src/components/GHGI/inventory-pages/sub-sector-page.tsx
@@ -246,41 +246,32 @@ function SubSectorPage(props: {
                 <Box>
                   <BreadcrumbRoot
                     gap="8px"
-                    fontFamily="heading"
-                    fontWeight="bold"
-                    letterSpacing="widest"
-                    fontSize="14px"
-                    textTransform="uppercase"
+                    fontFamily="body"
+                    fontWeight="medium"
+                    fontSize="body.sm"
+                    lineHeight="16"
                     separator={
                       <Icon as={MdChevronRight} color="gray.500" h="24px" />
                     }
                   >
                     <BreadcrumbLink
                       href={pathname.replace(`/${step}/${subsector}`, "")}
-                      color="content.tertiary"
-                      textDecoration="none"
-                      _hover={{
-                        textDecoration: "underline",
-                        textUnderlineOffset: "4px",
-                      }}
+                      color="content.link"
+                      textDecoration="underline"
                       truncate
                     >
                       {t("all-sectors")}
                     </BreadcrumbLink>
                     <BreadcrumbLink
                       href={pathname.replace(`/${subsector}`, "")}
-                      color="content.tertiary"
-                      textDecoration="none"
-                      _hover={{
-                        textDecoration: "underline",
-                        textUnderlineOffset: "4px",
-                      }}
+                      color="content.link"
+                      textDecoration="underline"
                       truncate
                     >
                       {t(getSectorName(step))}
                     </BreadcrumbLink>
                     <BreadcrumbCurrentLink
-                      color="content.link"
+                      color="content.secondary"
                       textDecoration="none"
                     >
                       <Text truncate lineClamp={1}>

--- a/app/src/components/navigation-bar.tsx
+++ b/app/src/components/navigation-bar.tsx
@@ -276,7 +276,12 @@ export function NavigationBar({
                         width="24"
                       />
 
-                      <Text fontSize="title.md" fontWeight="bold">
+                      <Text
+                        fontSize="title.sm"
+                        fontWeight="medium"
+                        letterSpacing="wide"
+                        lineHeight="20"
+                      >
                         {i18next.language.toUpperCase()}
                       </Text>
 
@@ -350,8 +355,10 @@ export function NavigationBar({
                           overflow="hidden"
                           textOverflow="ellipsis"
                           whiteSpace="nowrap"
-                          fontSize="title.md"
-                          fontWeight="bold"
+                          fontSize="title.sm"
+                          fontWeight="medium"
+                          letterSpacing="wide"
+                          lineHeight="20"
                         >
                           {currentOrganizationName}
                         </Text>


### PR DESCRIPTION
## Summary

Follow-up fixes from QA review feedback on the CC-543 navigation improvements: the navbar had inconsistent font sizing between elements, and the breadcrumb styling didn't match the Figma design.

## Changes

- Unify navbar label font size/weight/spacing: language selector and organization name text used `title.md`/bold with no letter-spacing or line-height, while the username text next to them already used the correct label style. Aligned all three to the same theme tokens (`title.sm`, `medium`, `wide`, `20`).
- Match breadcrumb styling to Figma: breadcrumb was rendered all-uppercase, bold, with widest letter spacing, and had the link/current colors swapped (current segment was blue, links were gray-with-hover-underline). Switched to the xs/font-medium body text style and made non-current segments underlined links while the current segment is plain secondary text.

## How to test

1. Load any page with the top navigation bar and confirm the language selector, organization name, and username all render at the same font size/weight (14px/medium) with no bold callouts.
2. Navigate to a GHGI sector/subsector data entry page and confirm the breadcrumb ("All sectors > Sector > Subsector") renders in sentence case, with non-current segments as blue underlined links and the current segment as plain gray text.

## Ticket

https://linear.app/openearth/issue/CC-543/cc-navigation-general-improvements

## Notes

The third QA item (feedback form link not respecting user's language preference) was checked and it was working, waiting for Juan's answer on ticket 