### PR TITLE
Fix "No data" state not showing for empty GHG inventories

### DIFF
--- a/app/src/backend/InventoryService.ts
+++ b/app/src/backend/InventoryService.ts
@@ -60,11 +60,11 @@ export class InventoryService {
     }
 
     // TODO [ON-2429]: Save total emissions for inventory every time activity data is modified
-    // Returns 0 when inventory values exist but all co2eq are null (e.g. notation-key-only prefill),
-    // and NULL only when no inventory values exist at all.
+    // NULL when no activity data has been recorded yet (no inventory values, or all
+    // co2eq are null, e.g. notation-key-only prefill) so the UI can show "No data"
+    // instead of a misleading 0kg.
     const rawQuery = `
-    SELECT
-      CASE WHEN COUNT(*) > 0 THEN COALESCE(SUM(co2eq), 0) ELSE NULL END AS sum
+    SELECT SUM(co2eq) AS sum
     FROM "InventoryValue"
     WHERE inventory_id = :inventoryId
   `;
@@ -75,7 +75,7 @@ export class InventoryService {
       raw: true,
     })) as unknown as { sum: number | null }[];
 
-    inventory.totalEmissions = sum != null ? Number(sum) : 0;
+    inventory.totalEmissions = sum != null ? Number(sum) : null;
     return inventory;
   }
 }

--- a/app/src/components/GHGI/inventory-result/EmissionsWidget.tsx
+++ b/app/src/components/GHGI/inventory-result/EmissionsWidget.tsx
@@ -126,7 +126,7 @@ const EmissionsWidget = ({
           Total GHG Emissions in {{ year: inventory?.year }}
         </Trans>
       ),
-      value: inventory?.totalEmissions,
+      value: inventory?.totalEmissions ?? undefined,
       icon: FiHeart,
       showProgress: false,
       isLoading: false,

--- a/app/src/components/HomePageJN/ActionCards.tsx
+++ b/app/src/components/HomePageJN/ActionCards.tsx
@@ -23,7 +23,6 @@ import {
 import { MdArrowForward } from "react-icons/md";
 import { AllProjectsIcon } from "../icons";
 import ActionCardSmall from "./ActionCardSmall";
-import { useGetUserAccessStatusQuery } from "@/services/api";
 
 export function ActionCards({
   organization,
@@ -31,20 +30,17 @@ export function ActionCards({
   t,
   city,
   ghgiCityData,
+  isCollaboratorRole,
 }: {
   t: TFunction;
   organization: OrganizationWithThemeResponse;
   lng: string;
   city?: CityWithProjectDataResponse;
   ghgiCityData?: InventoryResponse;
+  isCollaboratorRole: boolean;
 }) {
   const router = useRouter();
-  const { data: accessStatus } = useGetUserAccessStatusQuery({});
-  const isCollaborator =
-    accessStatus?.isCollaborator &&
-    !accessStatus?.isOrgOwner &&
-    !accessStatus?.isProjectAdmin;
-  const hasNoInventory = !ghgiCityData;
+  const hasNoData = !ghgiCityData || ghgiCityData.totalEmissions == null;
   return (
     <Box display="flex" gap={6} w="full">
       <Box display="flex" flexDirection="column" gap={2} w="full">
@@ -58,7 +54,7 @@ export function ActionCards({
           <GridItem
             colSpan={1}
             rowSpan={{ base: 1, md: 2 }}
-            bg={isCollaborator && hasNoInventory ? "background.neutral" : "base.light"}
+            bg={isCollaboratorRole && hasNoData ? "background.neutral" : "base.light"}
             borderRadius="lg"
             p={6}
             color="base.dark"
@@ -70,7 +66,7 @@ export function ActionCards({
             borderWidth="2px"
             borderColor="border.neutral"
           >
-            {isCollaborator && hasNoInventory ? (
+            {isCollaboratorRole && hasNoData ? (
               <Box>
                 <Text fontWeight="bold" fontSize="xl" mb={2}>
                   {t("no-inventory-title")}
@@ -104,7 +100,7 @@ export function ActionCards({
                   />
                 </Text>
               </Box>
-            ) : ghgiCityData ? (
+            ) : !hasNoData ? (
               <>
                 <Box>
                   <HStack alignItems="center">

--- a/app/src/components/HomePageJN/HomePage.tsx
+++ b/app/src/components/HomePageJN/HomePage.tsx
@@ -253,6 +253,7 @@ export default function HomePage({
                 organization={orgData}
                 city={city}
                 ghgiCityData={ghgiCityData}
+                isCollaboratorRole={isCollaboratorRole}
               />
             </VStack>
           </Box>

--- a/app/src/models/Inventory.ts
+++ b/app/src/models/Inventory.ts
@@ -12,7 +12,7 @@ export interface InventoryAttributes {
   inventoryId: string;
   inventoryName?: string;
   year?: number;
-  totalEmissions?: number;
+  totalEmissions?: number | null;
   cityId?: string;
   totalCountryEmissions?: number;
   isPublic?: boolean;
@@ -48,7 +48,7 @@ export class Inventory
   declare inventoryId: string;
   declare inventoryName?: string;
   declare year?: number;
-  declare totalEmissions?: number;
+  declare totalEmissions?: number | null;
   declare cityId?: string;
   declare totalCountryEmissions?: number;
   declare isPublic?: boolean;


### PR DESCRIPTION
## Summary

Two related bugs made the home page lie about GHG inventory status: an inventory with no real activity data showed "0kg" instead of "No data", and the action-card CTA below it picked collaborator-vs-admin messaging using the wrong signal, so some non-admin accounts saw an admin "get started" prompt instead of the "contact your administrator" empty state.

## Changes

- `InventoryService.getInventoryWithTotalEmissions`: stop coalescing a NULL emissions sum to 0. NULL now propagates whenever an inventory has no activity data (no `InventoryValue` rows, or all `co2eq` are null, e.g. notation-key-only prefill), letting the existing "No data" UI path fire correctly instead of showing a misleading 0kg.
- `models/Inventory.ts`: widen `totalEmissions` to `number | null` to match.
- `EmissionsWidget.tsx`: adjust one downstream consumer for the widened type.
- `HomePageJN/ActionCards.tsx` + `HomePage.tsx`: the action card decided collaborator-vs-admin messaging from per-city `CityUser` presence (`useGetUserAccessStatusQuery`) instead of the account's actual role. Now uses the same `isCollaboratorRole` (`userInfo.role === Roles.User`) the parent `HomePage.tsx` already computes, so the messaging is consistent with the rest of the page and correct for non-admin accounts with no city association yet.

## How to test

1. Find or seed a city with an inventory that has no real activity data (rows exist but `co2eq` is null, or zero `ActivityValue` rows).
2. Load that city's home page — the emissions stat should read "No data", not "0kg".
3. As a non-admin account with no `CityUser`/`ProjectAdmin`/`OrganizationAdmin` row, load the home page for a city with no data — the action card should show "No greenhouse gas inventory has been created yet / Contact your administrator...", not "Get started with GHG Inventory".

## Notes

Verified the emissions-sum fix directly against a seeded inventory (query returned `null` instead of `0` post-fix). `tsc --noEmit` shows only pre-existing, unrelated errors (confirmed identical on `develop`).