### PR TITLE
CC-545: Always show JN drawer, fix cities table links

### DIFF
--- a/app/src/components/Project/CitiesTable.tsx
+++ b/app/src/components/Project/CitiesTable.tsx
@@ -40,7 +40,7 @@ export default function CitiesTable({
       ]}
       selectKey="cityId"
       renderRow={(item, idx) => (
-        <Table.Row key={idx} _hover={{ bg: "background.alternativeLight" }}>
+        <Table.Row key={idx} _hover={{ bg: "border.neutral" }}>
           <Table.Cell>
             <Link
               href={`/${lng}/cities/${item.cityId}`}
@@ -73,7 +73,7 @@ export default function CitiesTable({
           </Table.Cell>
           <Table.Cell>
             <Link
-              href={`/${lng}/organization/${organizationId}/account-settings?tab=team&project=${projectId}&city=${item.cityId}`}
+              href={`/${lng}/settings?tab=team&project=${projectId}&city=${item.cityId}`}
               color="content.link"
               textDecoration="underline"
               fontFamily="body"

--- a/app/src/components/navigation-bar.tsx
+++ b/app/src/components/navigation-bar.tsx
@@ -42,9 +42,7 @@ import { Avatar } from "@/components/ui/avatar";
 
 import { Button } from "@/components/ui/button";
 import { Roles } from "@/util/types";
-import ProjectDrawer from "@/components/GHGIHomePage/ProjectDrawer";
 import { useTheme } from "next-themes";
-import { FeatureFlags, hasFeatureFlag } from "@/util/feature-flags";
 import { useOrganizationContext } from "@/hooks/organization-context-provider/use-organizational-context";
 import { Trans } from "react-i18next";
 import JNDrawer from "./HomePage/JNDrawer";
@@ -568,31 +566,17 @@ export function NavigationBar({
           </Box>
         </Box>
         {/* JN Drawer */}
-        {/* Should be shown if JN is enabled */}
-        {hasFeatureFlag(FeatureFlags.JN_ENABLED) && (
-          <JNDrawer
-            lng={activeLng}
-            currentCityId={currentCityId}
-            organizationId={
-              (organization?.organizationId ??
-                userAccessStatus?.organizationId) as string
-            }
-            isOpen={isDrawerOpen}
-            onClose={() => setIsDrawerOpen(false)}
-            onOpenChange={({ open }) => setIsDrawerOpen(open)}
-          />
-        )}
-        {/* TODO: [ON-4452] Remove project drawer and replace with JN drawer after JN is live */}
-        {/* Project Drawer */}
-        {!hasFeatureFlag(FeatureFlags.JN_ENABLED) && (
-          <ProjectDrawer
-            lng={activeLng}
-            currentInventoryId={currentInventoryId as string}
-            isOpen={isDrawerOpen}
-            onClose={() => setIsDrawerOpen(false)}
-            onOpenChange={({ open }) => setIsDrawerOpen(open)}
-          />
-        )}
+        <JNDrawer
+          lng={activeLng}
+          currentCityId={currentCityId}
+          organizationId={
+            (organization?.organizationId ??
+              userAccessStatus?.organizationId) as string
+          }
+          isOpen={isDrawerOpen}
+          onClose={() => setIsDrawerOpen(false)}
+          onOpenChange={({ open }) => setIsDrawerOpen(open)}
+        />
       </Box>
       {isFrozen && !isPublic && !isAuth && (
         <Box py={2} px={16} bg="sentiment.warningDefault" w="full" zIndex={50}>


### PR DESCRIPTION
## Summary
- Always render `JNDrawer` in the nav bar instead of gating it behind the `JN_ENABLED` flag with `ProjectDrawer` as the fallback.
- Fix the "View full list" link in the project cities table, which pointed to a nonexistent `/organization/{id}/account-settings` route; it now goes to `/settings?tab=team` with the project/city preselected via query params.
- Match the cities table row hover background to `border.neutral` (#D7D8FA) per design.

## Test plan
- [ ] Verify the JN drawer opens from the nav menu on desktop.
- [ ] From a project's cities table, click "View full list" and confirm it lands on the team tab of account settings with the right project/city preselected.
- [ ] Hover a cities table row and confirm the background matches `border.neutral`.