### PR TITLE
[2/3] CC-608: Add CA Concept Note run API

### DIFF
--- a/climate-advisor/.env.example
+++ b/climate-advisor/.env.example
@@ -38,6 +38,6 @@ CC_BASE_URL=http://localhost:3000
 # Complete inline JSON body limit for optional CC-produced Markdown ingest.
 # This is independent from CC's source-PDF upload limit.
 CNB_MARKDOWN_REQUEST_MAX_BYTES=20971520
-# Local reviewed-reference importer only. Points to the externally managed CNB
-# database; the Climate Advisor service does not create or migrate its tables.
+# Externally managed CNB database used by the reviewed-reference importer and
+# runtime funding-reference validation. Climate Advisor does not migrate it.
 CNB_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/cnb

--- a/climate-advisor/README.md
+++ b/climate-advisor/README.md
@@ -528,6 +528,9 @@ language, or client-side fallback behavior. The boundary is:
 
 - `OPENROUTER_API_KEY` - OpenRouter API key for LLM access
 - `CA_DATABASE_URL` - PostgreSQL connection string
+- `CNB_DATABASE_URL` - Externally managed CNB PostgreSQL database used to
+  validate supplied `funder_id` and `selected_funding_record_id` values before
+  starting a run; requests without funding references do not require it
 - `CA_PORT` - Server port (default: `8080`)
 - `CA_LOG_LEVEL` - Logging level: `info|debug` (default: `info`)
 - `CA_CORS_ORIGINS` - CORS allowed origins (default: `*`)

--- a/climate-advisor/service/app/config/settings.py
+++ b/climate-advisor/service/app/config/settings.py
@@ -431,6 +431,7 @@ class Settings(BaseModel):
 
     # Database configuration
     database_url: str | None = os.getenv("CA_DATABASE_URL")
+    cnb_database_url: str | None = os.getenv("CNB_DATABASE_URL")
     database_pool_size: Optional[int] = _parse_int(
         os.getenv("CA_DATABASE_POOL_SIZE"), 5
     )

--- a/climate-advisor/service/app/db/cnb_reference.py
+++ b/climate-advisor/service/app/db/cnb_reference.py
@@ -1,0 +1,38 @@
+"""Async session factory for the externally managed CNB reference database."""
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from app.config.settings import get_settings
+from app.db.session import _ensure_asyncpg_url
+
+
+_engine: AsyncEngine | None = None
+_session_factory: async_sessionmaker[AsyncSession] | None = None
+
+
+def _create_session_factory() -> async_sessionmaker[AsyncSession]:
+    """Create the shared CNB reference-data session factory."""
+    global _engine, _session_factory
+    if _session_factory is not None:
+        return _session_factory
+
+    database_url = get_settings().cnb_database_url
+    if not database_url:
+        raise RuntimeError("CNB_DATABASE_URL is not configured")
+
+    _engine = create_async_engine(
+        _ensure_asyncpg_url(database_url),
+        pool_pre_ping=True,
+    )
+    _session_factory = async_sessionmaker(_engine, expire_on_commit=False)
+    return _session_factory
+
+
+def get_cnb_reference_session_factory() -> async_sessionmaker[AsyncSession]:
+    """Return the shared session factory for managed funding reference data."""
+    return _session_factory or _create_session_factory()

--- a/climate-advisor/service/app/main.py
+++ b/climate-advisor/service/app/main.py
@@ -8,6 +8,7 @@ from app.routes.concept_note_city_context import (
     router as concept_note_city_context_router,
 )
 from app.routes.concept_note_markdown import router as concept_note_markdown_router
+from app.routes.concept_note_runs import router as concept_note_runs_router
 from app.routes.dev_inventory import router as dev_inventory_router
 from app.routes.health import router as health_router
 from app.routes.messages import router as messages_router
@@ -90,6 +91,7 @@ def get_app() -> FastAPI:
     app.include_router(stationary_energy_drafts_router, prefix="/v1")
     app.include_router(concept_note_markdown_router, prefix="/v1")
     app.include_router(concept_note_city_context_router, prefix="/v1")
+    app.include_router(concept_note_runs_router, prefix="/v1")
 
     # Static playground for manual testing
     static_dir = Path(__file__).resolve().parent / "static"

--- a/climate-advisor/service/app/models/concept_note_runs.py
+++ b/climate-advisor/service/app/models/concept_note_runs.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class ConceptNoteStartRequest(BaseModel):
+    """Authenticated request to create one Concept Note Builder run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    user_id: str = Field(min_length=1, max_length=255)
+    name: str = Field(min_length=1, max_length=120)
+    city_id: UUID
+    project_id: str | None = Field(default=None, min_length=1, max_length=255)
+    funder_id: UUID | None = None
+    selected_funding_record_id: UUID | None = None
+    thread_id: UUID | None = None
+    idempotency_key: UUID
+
+    @field_validator("name")
+    @classmethod
+    def normalize_name(cls, value: str) -> str:
+        """Trim the display name and reject whitespace-only values."""
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("name must not be blank")
+        return normalized
+
+    @field_validator("project_id")
+    @classmethod
+    def normalize_project_id(cls, value: str | None) -> str | None:
+        """Trim an optional external project identifier."""
+        if value is None:
+            return None
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("project_id must not be blank")
+        return normalized
+
+    @model_validator(mode="after")
+    def validate_scope_references(self) -> "ConceptNoteStartRequest":
+        """Require a funder whenever a funding opportunity is supplied."""
+        if self.selected_funding_record_id is not None and self.funder_id is None:
+            raise ValueError(
+                "funder_id is required when selected_funding_record_id is provided"
+            )
+        return self
+
+
+class ConceptNoteRunResponse(BaseModel):
+    """Persisted concept-note run returned by start and detail endpoints."""
+
+    run_id: UUID
+    thread_id: UUID | None = None
+    user_id: str
+    name: str
+    city_id: str
+    project_id: str | None = None
+    funder_id: UUID | None = None
+    selected_funding_record_id: UUID | None = None
+    status: Literal["active"]
+    workflow_step: Literal["assembling_context"]
+    next_action: Literal["load_context"] = "load_context"
+    created: bool
+    trace_id: str | None = None
+    created_at: datetime
+    updated_at: datetime

--- a/climate-advisor/service/app/routes/concept_note_runs.py
+++ b/climate-advisor/service/app/routes/concept_note_runs.py
@@ -31,12 +31,8 @@ async def start_concept_note_run(
 ) -> JSONResponse:
     """Create a concept-note run or replay an identical idempotent request."""
     service = ConceptNoteRunService(session)
-    try:
-        response = await service.start_run(payload, authorization=authorization)
-        await session.commit()
-    except Exception:
-        await session.rollback()
-        raise
+    response = await service.start_run(payload, authorization=authorization)
+    await session.commit()
 
     return JSONResponse(
         status_code=201 if response.created else 200,

--- a/climate-advisor/service/app/routes/concept_note_runs.py
+++ b/climate-advisor/service/app/routes/concept_note_runs.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Header, Query
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.models.concept_note_runs import (
+    ConceptNoteRunResponse,
+    ConceptNoteStartRequest,
+)
+from app.services.concept_note_runs import ConceptNoteRunService
+
+
+router = APIRouter()
+
+
+@router.post(
+    "/concept-notes/start",
+    status_code=201,
+    response_model=ConceptNoteRunResponse,
+    responses={200: {"model": ConceptNoteRunResponse}},
+)
+async def start_concept_note_run(
+    payload: ConceptNoteStartRequest,
+    authorization: str | None = Header(default=None),
+    session: AsyncSession = Depends(get_session),
+) -> JSONResponse:
+    """Create a concept-note run or replay an identical idempotent request."""
+    service = ConceptNoteRunService(session)
+    try:
+        response = await service.start_run(payload, authorization=authorization)
+        await session.commit()
+    except Exception:
+        await session.rollback()
+        raise
+
+    return JSONResponse(
+        status_code=201 if response.created else 200,
+        content=jsonable_encoder(response),
+    )
+
+
+@router.get(
+    "/concept-notes/{run_id}",
+    response_model=ConceptNoteRunResponse,
+)
+async def get_concept_note_run(
+    run_id: UUID,
+    user_id: str = Query(..., min_length=1),
+    authorization: str | None = Header(default=None),
+    session: AsyncSession = Depends(get_session),
+) -> ConceptNoteRunResponse:
+    """Return one concept-note run after ownership and city-access checks."""
+    service = ConceptNoteRunService(session)
+    return await service.get_run(
+        run_id=run_id,
+        requested_user_id=user_id,
+        authorization=authorization,
+    )

--- a/climate-advisor/service/app/services/citycatalyst_client.py
+++ b/climate-advisor/service/app/services/citycatalyst_client.py
@@ -768,7 +768,8 @@ class CityCatalystClient:
         if not response.is_success:
             error_text = response.text[:200] if response.text else "Unknown error"
             raise CityCatalystClientError(
-                f"Failed to fetch city {city_id}: {response.status_code} - {error_text}"
+                f"Failed to fetch city {city_id}: {response.status_code} - {error_text}",
+                status_code=response.status_code,
             )
         
         try:

--- a/climate-advisor/service/app/services/cnb/funding_references.py
+++ b/climate-advisor/service/app/services/cnb/funding_references.py
@@ -1,0 +1,108 @@
+"""Validate run funding references against the managed CNB database."""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlalchemy import Uuid, bindparam, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.db.cnb_reference import get_cnb_reference_session_factory
+
+
+logger = logging.getLogger(__name__)
+
+
+class FundingReferenceValidator(Protocol):
+    """Validate external funder and funding-record identifiers."""
+
+    async def validate(
+        self,
+        *,
+        funder_id: UUID | None,
+        selected_funding_record_id: UUID | None,
+    ) -> None:
+        """Raise when supplied identifiers are unavailable or inconsistent."""
+
+
+class PostgresFundingReferenceValidator:
+    """Read authoritative funding identifiers from managed CNB tables."""
+
+    def __init__(
+        self,
+        session_factory: async_sessionmaker[AsyncSession] | None = None,
+    ) -> None:
+        """Accept an optional session factory for tests and dependency injection."""
+        self._session_factory = session_factory
+
+    async def validate(
+        self,
+        *,
+        funder_id: UUID | None,
+        selected_funding_record_id: UUID | None,
+    ) -> None:
+        """Require supplied records to exist and share the requested funder."""
+        if funder_id is None:
+            return
+
+        try:
+            session_factory = (
+                self._session_factory or get_cnb_reference_session_factory()
+            )
+            async with session_factory() as session:
+                await self._require_funder(session, funder_id)
+                if selected_funding_record_id is not None:
+                    await self._require_funding_record(
+                        session,
+                        funder_id=funder_id,
+                        funding_record_id=selected_funding_record_id,
+                    )
+        except HTTPException:
+            raise
+        except Exception as exc:
+            logger.exception("CNB funding-reference validation failed")
+            raise HTTPException(
+                status_code=503,
+                detail="Funding reference data is unavailable",
+            ) from exc
+
+    async def _require_funder(self, session: AsyncSession, funder_id: UUID) -> None:
+        """Require one canonical funder row."""
+        result = await session.execute(
+            text(
+                "SELECT funder_id FROM funders WHERE funder_id = :funder_id"
+            ).bindparams(bindparam("funder_id", type_=Uuid(as_uuid=True))),
+            {"funder_id": funder_id},
+        )
+        if result.scalar_one_or_none() is None:
+            raise HTTPException(status_code=422, detail="Unknown funder_id")
+
+    async def _require_funding_record(
+        self,
+        session: AsyncSession,
+        *,
+        funder_id: UUID,
+        funding_record_id: UUID,
+    ) -> None:
+        """Require one funding record owned by the supplied funder."""
+        result = await session.execute(
+            text(
+                "SELECT funder_id FROM funding_records "
+                "WHERE funding_record_id = :funding_record_id"
+            ).bindparams(bindparam("funding_record_id", type_=Uuid(as_uuid=True))),
+            {"funding_record_id": funding_record_id},
+        )
+        record_funder_id = result.scalar_one_or_none()
+        if record_funder_id is None:
+            raise HTTPException(
+                status_code=422,
+                detail="Unknown selected_funding_record_id",
+            )
+        if UUID(str(record_funder_id)) != funder_id:
+            raise HTTPException(
+                status_code=422,
+                detail="selected_funding_record_id does not belong to funder_id",
+            )

--- a/climate-advisor/service/app/services/concept_note_runs.py
+++ b/climate-advisor/service/app/services/concept_note_runs.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.middleware.request_context import get_request_id
+from app.models.concept_note_runs import (
+    ConceptNoteRunResponse,
+    ConceptNoteStartRequest,
+)
+from app.models.db.concept_note import ConceptNoteRun
+from app.services.citycatalyst_client import (
+    CityCatalystClient,
+    CityCatalystClientError,
+)
+from app.persistence.concept_notes.runs import ConceptNoteRunRepository
+
+
+class ConceptNoteRunService:
+    """Authorize, create, replay, and read Concept Note Builder runs."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        cc_client: CityCatalystClient | None = None,
+    ) -> None:
+        """Initialize the service with persistence and CityCatalyst clients."""
+        self.repository = ConceptNoteRunRepository(session)
+        self.cc_client = cc_client or CityCatalystClient()
+
+    async def start_run(
+        self,
+        payload: ConceptNoteStartRequest,
+        *,
+        authorization: str | None,
+    ) -> ConceptNoteRunResponse:
+        """Create or replay a run after validating user and city access."""
+        token = _require_bearer_token(authorization)
+        await self._authorize_scope(
+            token=token,
+            requested_user_id=payload.user_id,
+            city_id=payload.city_id,
+        )
+        if payload.thread_id is not None and not (
+            await self.repository.thread_belongs_to_user(
+                thread_id=payload.thread_id,
+                user_id=payload.user_id,
+            )
+        ):
+            raise HTTPException(status_code=404, detail="Chat thread not found")
+
+        fingerprint = _request_fingerprint(payload)
+        run, created = await self.repository.create_or_get(
+            user_id=payload.user_id,
+            name=payload.name,
+            city_id=str(payload.city_id),
+            project_id=payload.project_id,
+            funder_id=payload.funder_id,
+            selected_funding_record_id=payload.selected_funding_record_id,
+            thread_id=payload.thread_id,
+            idempotency_key=payload.idempotency_key,
+            request_fingerprint=fingerprint,
+            trace_id=get_request_id() or None,
+        )
+        _require_matching_fingerprint(run, fingerprint)
+        return _to_response(run, created=created)
+
+    async def get_run(
+        self,
+        *,
+        run_id: UUID,
+        requested_user_id: str,
+        authorization: str | None,
+    ) -> ConceptNoteRunResponse:
+        """Return an owned run after revalidating current city access."""
+        token = _require_bearer_token(authorization)
+        canonical_user_id = await self._canonical_user_id(token)
+        if canonical_user_id != requested_user_id:
+            raise HTTPException(
+                status_code=403,
+                detail="Request user does not match authenticated token",
+            )
+
+        run = await self.repository.get_for_user(
+            run_id=run_id,
+            user_id=canonical_user_id,
+        )
+        if run is None:
+            raise HTTPException(status_code=404, detail="Concept Note run not found")
+
+        await self._validate_city_access(
+            token=token,
+            user_id=canonical_user_id,
+            city_id=UUID(run.city_id),
+        )
+        return _to_response(run, created=False)
+
+    async def _authorize_scope(
+        self,
+        *,
+        token: str,
+        requested_user_id: str,
+        city_id: UUID,
+    ) -> None:
+        """Validate token identity and CityCatalyst city access."""
+        canonical_user_id = await self._canonical_user_id(token)
+        if canonical_user_id != requested_user_id:
+            raise HTTPException(
+                status_code=403,
+                detail="Request user does not match authenticated token",
+            )
+        await self._validate_city_access(
+            token=token,
+            user_id=canonical_user_id,
+            city_id=city_id,
+        )
+
+    async def _canonical_user_id(self, token: str) -> str:
+        """Resolve a bearer token to its canonical CityCatalyst user."""
+        try:
+            return await self.cc_client.validate_user_identity(token)
+        except CityCatalystClientError as exc:
+            raise _citycatalyst_http_exception(exc) from exc
+
+    async def _validate_city_access(
+        self,
+        *,
+        token: str,
+        user_id: str,
+        city_id: UUID,
+    ) -> None:
+        """Require current CityCatalyst access to the requested city."""
+        try:
+            await self.cc_client.get_city(
+                city_id=str(city_id),
+                token=token,
+                user_id=user_id,
+            )
+        except CityCatalystClientError as exc:
+            raise _citycatalyst_http_exception(exc) from exc
+
+
+def _require_bearer_token(authorization: str | None) -> str:
+    """Extract a non-empty bearer token from an Authorization header."""
+    if authorization is None:
+        raise HTTPException(
+            status_code=401,
+            detail="CityCatalyst access token is required",
+        )
+    scheme, separator, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not separator or not token.strip():
+        raise HTTPException(
+            status_code=401,
+            detail="Authorization header must use Bearer token",
+        )
+    return token.strip()
+
+
+def _request_fingerprint(payload: ConceptNoteStartRequest) -> str:
+    """Hash the immutable normalized creation payload for replay validation."""
+    fingerprint_payload = payload.model_dump(
+        mode="json",
+        exclude={"idempotency_key"},
+    )
+    encoded = json.dumps(
+        fingerprint_payload,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _require_matching_fingerprint(
+    run: ConceptNoteRun,
+    request_fingerprint: str,
+) -> None:
+    """Reject reuse of an idempotency key for different creation data."""
+    if run.request_fingerprint != request_fingerprint:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "idempotency_key_reused",
+                "message": "Idempotency key was already used for another request",
+            },
+        )
+
+
+def _citycatalyst_http_exception(
+    exc: CityCatalystClientError,
+) -> HTTPException:
+    """Map CityCatalyst integration failures to stable public HTTP statuses."""
+    if exc.status_code in {401, 403, 404}:
+        return HTTPException(
+            status_code=exc.status_code,
+            detail="CityCatalyst authorization failed",
+        )
+    return HTTPException(
+        status_code=503,
+        detail="CityCatalyst authorization is unavailable",
+    )
+
+
+def _to_response(
+    run: ConceptNoteRun,
+    *,
+    created: bool,
+) -> ConceptNoteRunResponse:
+    """Serialize one persisted run into the public API contract."""
+    return ConceptNoteRunResponse(
+        run_id=run.run_id,
+        thread_id=run.thread_id,
+        user_id=run.user_id,
+        name=run.name,
+        city_id=run.city_id,
+        project_id=run.project_id,
+        funder_id=run.funder_id,
+        selected_funding_record_id=run.selected_funding_record_id,
+        status="active",
+        workflow_step="assembling_context",
+        created=created,
+        trace_id=run.trace_id,
+        created_at=run.created_at,
+        updated_at=run.updated_at,
+    )

--- a/climate-advisor/service/app/services/concept_note_runs.py
+++ b/climate-advisor/service/app/services/concept_note_runs.py
@@ -17,6 +17,10 @@ from app.services.citycatalyst_client import (
     CityCatalystClient,
     CityCatalystClientError,
 )
+from app.services.cnb.funding_references import (
+    FundingReferenceValidator,
+    PostgresFundingReferenceValidator,
+)
 from app.persistence.concept_notes.runs import ConceptNoteRunRepository
 
 
@@ -28,10 +32,14 @@ class ConceptNoteRunService:
         session: AsyncSession,
         *,
         cc_client: CityCatalystClient | None = None,
+        funding_reference_validator: FundingReferenceValidator | None = None,
     ) -> None:
         """Initialize the service with persistence and CityCatalyst clients."""
         self.repository = ConceptNoteRunRepository(session)
         self.cc_client = cc_client or CityCatalystClient()
+        self.funding_reference_validator = (
+            funding_reference_validator or PostgresFundingReferenceValidator()
+        )
 
     async def start_run(
         self,
@@ -53,6 +61,10 @@ class ConceptNoteRunService:
             )
         ):
             raise HTTPException(status_code=404, detail="Chat thread not found")
+        await self.funding_reference_validator.validate(
+            funder_id=payload.funder_id,
+            selected_funding_record_id=payload.selected_funding_record_id,
+        )
 
         fingerprint = _request_fingerprint(payload)
         run, created = await self.repository.create_or_get(

--- a/climate-advisor/service/tests/test_concept_note_runs.py
+++ b/climate-advisor/service/tests/test_concept_note_runs.py
@@ -1,10 +1,194 @@
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
+import pytest
+from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
+from app.models.concept_note_runs import ConceptNoteStartRequest
+from app.models.db.concept_note import ConceptNoteRun
 from app.models.db.thread import Thread
 from app.persistence.concept_notes.runs import ConceptNoteRunRepository
+from app.services.citycatalyst_client import (
+    CityCatalystClient,
+    CityCatalystClientError,
+)
+from app.services.cnb.funding_references import FundingReferenceValidator
+from app.services.concept_note_runs import (
+    ConceptNoteRunService,
+    _request_fingerprint,
+)
+
+
+def _start_request(*, user_id: str = "owner-1") -> ConceptNoteStartRequest:
+    """Build a valid run-start request for service tests."""
+    return ConceptNoteStartRequest(
+        user_id=user_id,
+        name="Resilient neighborhoods",
+        city_id=uuid4(),
+        idempotency_key=uuid4(),
+    )
+
+
+def _persisted_run(
+    payload: ConceptNoteStartRequest,
+    *,
+    request_fingerprint: str,
+) -> ConceptNoteRun:
+    """Build the persisted run shape returned by the repository."""
+    now = datetime.now(timezone.utc)
+    return ConceptNoteRun(
+        run_id=uuid4(),
+        thread_id=payload.thread_id,
+        user_id=payload.user_id,
+        name=payload.name,
+        city_id=str(payload.city_id),
+        project_id=payload.project_id,
+        funder_id=payload.funder_id,
+        selected_funding_record_id=payload.selected_funding_record_id,
+        status="active",
+        workflow_step="assembling_context",
+        context_summary={},
+        permission_summary={},
+        trace_id=None,
+        idempotency_key=payload.idempotency_key,
+        request_fingerprint=request_fingerprint,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _run_service(
+    *,
+    canonical_user_id: str = "owner-1",
+) -> tuple[ConceptNoteRunService, AsyncMock, AsyncMock, AsyncMock]:
+    """Create a run service with isolated repository and integration mocks."""
+    session = AsyncMock(spec=AsyncSession)
+    cc_client = AsyncMock(spec=CityCatalystClient)
+    cc_client.validate_user_identity.return_value = canonical_user_id
+    cc_client.get_city.return_value = {}
+    funding_validator = AsyncMock(spec=FundingReferenceValidator)
+    repository = AsyncMock(spec=ConceptNoteRunRepository)
+
+    service = ConceptNoteRunService(
+        session,
+        cc_client=cc_client,
+        funding_reference_validator=funding_validator,
+    )
+    service.repository = repository
+    return service, repository, cc_client, funding_validator
+
+
+async def test_start_run_creates_after_scope_and_reference_validation() -> None:
+    """Create a run only after validating identity, city, and funding scope."""
+    payload = _start_request()
+    service, repository, cc_client, funding_validator = _run_service()
+    repository.create_or_get.return_value = (
+        _persisted_run(
+            payload,
+            request_fingerprint=_request_fingerprint(payload),
+        ),
+        True,
+    )
+
+    response = await service.start_run(payload, authorization="Bearer token")
+
+    assert response.created is True
+    assert response.user_id == payload.user_id
+    cc_client.validate_user_identity.assert_awaited_once_with("token")
+    cc_client.get_city.assert_awaited_once_with(
+        city_id=str(payload.city_id),
+        token="token",
+        user_id=payload.user_id,
+    )
+    funding_validator.validate.assert_awaited_once_with(
+        funder_id=None,
+        selected_funding_record_id=None,
+    )
+
+
+async def test_start_run_rejects_reused_key_with_different_fingerprint() -> None:
+    """Return 409 when an idempotency key is replayed with changed inputs."""
+    payload = _start_request()
+    service, repository, _, _ = _run_service()
+    repository.create_or_get.return_value = (
+        _persisted_run(payload, request_fingerprint="different-request"),
+        False,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.start_run(payload, authorization="Bearer token")
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["code"] == "idempotency_key_reused"
+
+
+async def test_get_run_rejects_authenticated_user_mismatch() -> None:
+    """Return 403 before reading storage for a mismatched token subject."""
+    service, repository, _, _ = _run_service(canonical_user_id="other-user")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.get_run(
+            run_id=uuid4(),
+            requested_user_id="owner-1",
+            authorization="Bearer token",
+        )
+
+    assert exc_info.value.status_code == 403
+    repository.get_for_user.assert_not_awaited()
+
+
+async def test_get_run_hides_missing_or_unowned_run() -> None:
+    """Return the same 404 for a missing run or one owned by another user."""
+    service, repository, cc_client, _ = _run_service()
+    repository.get_for_user.return_value = None
+    run_id = uuid4()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.get_run(
+            run_id=run_id,
+            requested_user_id="owner-1",
+            authorization="Bearer token",
+        )
+
+    assert exc_info.value.status_code == 404
+    repository.get_for_user.assert_awaited_once_with(
+        run_id=run_id,
+        user_id="owner-1",
+    )
+    cc_client.get_city.assert_not_awaited()
+
+
+async def test_get_run_revalidates_city_access_owned_by_citycatalyst() -> None:
+    """Reject a stored run when current CityCatalyst city access is revoked."""
+    payload = _start_request()
+    run = _persisted_run(
+        payload,
+        request_fingerprint=_request_fingerprint(payload),
+    )
+    service, repository, cc_client, _ = _run_service()
+    repository.get_for_user.return_value = run
+    cc_client.get_city.side_effect = CityCatalystClientError(
+        "City access revoked",
+        status_code=403,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.get_run(
+            run_id=run.run_id,
+            requested_user_id=payload.user_id,
+            authorization="Bearer token",
+        )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "CityCatalyst authorization failed"
+    cc_client.get_city.assert_awaited_once_with(
+        city_id=str(payload.city_id),
+        token="token",
+        user_id=payload.user_id,
+    )
 
 
 async def test_thread_ownership_rejects_missing_and_wrong_user_threads() -> None:

--- a/climate-advisor/service/tests/test_concept_note_runs.py
+++ b/climate-advisor/service/tests/test_concept_note_runs.py
@@ -1,0 +1,45 @@
+from uuid import uuid4
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models.db.thread import Thread
+from app.persistence.concept_notes.runs import ConceptNoteRunRepository
+
+
+async def test_thread_ownership_rejects_missing_and_wrong_user_threads() -> None:
+    """Require both an existing thread and its matching user without a run FK."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    session_factory: async_sessionmaker[AsyncSession] = async_sessionmaker(
+        engine,
+        expire_on_commit=False,
+    )
+    owned_thread_id = uuid4()
+
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(Thread.__table__.create)
+
+        async with session_factory() as session:
+            session.add(Thread(thread_id=owned_thread_id, user_id="owner-1"))
+            await session.commit()
+            repository = ConceptNoteRunRepository(session)
+
+            assert await repository.thread_belongs_to_user(
+                thread_id=owned_thread_id,
+                user_id="owner-1",
+            )
+            assert not await repository.thread_belongs_to_user(
+                thread_id=owned_thread_id,
+                user_id="other-user",
+            )
+            assert not await repository.thread_belongs_to_user(
+                thread_id=uuid4(),
+                user_id="owner-1",
+            )
+    finally:
+        await engine.dispose()

--- a/climate-advisor/service/tests/test_funding_references.py
+++ b/climate-advisor/service/tests/test_funding_references.py
@@ -1,0 +1,155 @@
+from collections.abc import AsyncIterator
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import Uuid, bindparam, text
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.services.cnb.funding_references import PostgresFundingReferenceValidator
+
+
+@pytest.fixture
+async def reference_session_factory() -> AsyncIterator[
+    async_sessionmaker[AsyncSession]
+]:
+    """Provide managed-reference table shapes through in-memory SQLite."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as connection:
+        await connection.execute(
+            text("CREATE TABLE funders (funder_id TEXT PRIMARY KEY)")
+        )
+        await connection.execute(
+            text(
+                "CREATE TABLE funding_records ("
+                "funding_record_id TEXT PRIMARY KEY, funder_id TEXT NOT NULL)"
+            )
+        )
+
+    try:
+        yield async_sessionmaker(engine, expire_on_commit=False)
+    finally:
+        await engine.dispose()
+
+
+async def _insert_references(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    funder_id: UUID,
+    funding_record_id: UUID | None = None,
+) -> None:
+    """Insert one funder and an optional owned funding record."""
+    async with session_factory() as session:
+        await session.execute(
+            text("INSERT INTO funders (funder_id) VALUES (:funder_id)").bindparams(
+                bindparam("funder_id", type_=Uuid(as_uuid=True))
+            ),
+            {"funder_id": funder_id},
+        )
+        if funding_record_id is not None:
+            await session.execute(
+                text(
+                    "INSERT INTO funding_records (funding_record_id, funder_id) "
+                    "VALUES (:funding_record_id, :funder_id)"
+                ).bindparams(
+                    bindparam("funding_record_id", type_=Uuid(as_uuid=True)),
+                    bindparam("funder_id", type_=Uuid(as_uuid=True)),
+                ),
+                {
+                    "funding_record_id": funding_record_id,
+                    "funder_id": funder_id,
+                },
+            )
+        await session.commit()
+
+
+async def test_validator_accepts_known_funder_and_owned_record(
+    reference_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    funder_id = uuid4()
+    funding_record_id = uuid4()
+    await _insert_references(
+        reference_session_factory,
+        funder_id=funder_id,
+        funding_record_id=funding_record_id,
+    )
+
+    validator = PostgresFundingReferenceValidator(reference_session_factory)
+    await validator.validate(
+        funder_id=funder_id,
+        selected_funding_record_id=funding_record_id,
+    )
+
+
+async def test_validator_rejects_unknown_funder(
+    reference_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    validator = PostgresFundingReferenceValidator(reference_session_factory)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await validator.validate(
+            funder_id=uuid4(),
+            selected_funding_record_id=None,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "Unknown funder_id"
+
+
+async def test_validator_rejects_unknown_funding_record(
+    reference_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    funder_id = uuid4()
+    await _insert_references(
+        reference_session_factory,
+        funder_id=funder_id,
+    )
+    validator = PostgresFundingReferenceValidator(reference_session_factory)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await validator.validate(
+            funder_id=funder_id,
+            selected_funding_record_id=uuid4(),
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "Unknown selected_funding_record_id"
+
+
+async def test_validator_rejects_record_owned_by_another_funder(
+    reference_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    requested_funder_id = uuid4()
+    record_funder_id = uuid4()
+    funding_record_id = uuid4()
+    await _insert_references(
+        reference_session_factory,
+        funder_id=requested_funder_id,
+    )
+    await _insert_references(
+        reference_session_factory,
+        funder_id=record_funder_id,
+        funding_record_id=funding_record_id,
+    )
+    validator = PostgresFundingReferenceValidator(reference_session_factory)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await validator.validate(
+            funder_id=requested_funder_id,
+            selected_funding_record_id=funding_record_id,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert (
+        exc_info.value.detail
+        == "selected_funding_record_id does not belong to funder_id"
+    )


### PR DESCRIPTION
## Stack

1. #2925 — CA persistence foundation
2. **#2930 — CA run API** (this PR)
3. #2931 — CityCatalyst proxy and cross-service documentation

## Summary

- add the Climate Advisor request and response contracts for Concept Note runs
- add authenticated start and read routes with idempotent run creation
- register the routes and connect the service to CityCatalyst authorization

## Scope

Climate Advisor API and service only. CityCatalyst proxy routes are intentionally delivered in layer 3.

## Validation

- imported the Climate Advisor app and verified `/v1/concept-notes/start` and `/v1/concept-notes/{run_id}` are registered
- `33 passed` for the existing Concept Note city-context and Markdown-ingest suites
- `git diff --check`