### PR TITLE
[1/2] CC-609: Persist CNB upload Markdown pointers

### DIFF
--- a/climate-advisor/.env.example
+++ b/climate-advisor/.env.example
@@ -35,7 +35,7 @@ CA_DATABASE_ECHO=false
 # CityCatalyst Integration
 CC_API_KEY=your-cc-service-api-key-here
 CC_BASE_URL=http://localhost:3000
-# Complete inline JSON body limit for optional CC-produced Markdown ingest.
+# Maximum CC-owned Markdown artifact size CA will verify through authenticated CC.
 # This is independent from CC's source-PDF upload limit.
 CNB_MARKDOWN_REQUEST_MAX_BYTES=20971520
 # Externally managed CNB database used by the reviewed-reference importer and

--- a/climate-advisor/README.md
+++ b/climate-advisor/README.md
@@ -539,9 +539,9 @@ language, or client-side fallback behavior. The boundary is:
 - `CC_BASE_URL` - CityCatalyst base URL for inventory API and token refresh
 - `CC_API_KEY` - Service credential used when CA asks CC to validate the
   CC-issued user bearer token
-- `CNB_MARKDOWN_REQUEST_MAX_BYTES` - Complete JSON request-body limit for the
-  optional CC-to-CA Markdown ingest endpoint (default `20971520`; this is an
-  operational body guard, not a source-PDF or page-count acceptance limit)
+- `CNB_MARKDOWN_REQUEST_MAX_BYTES` - Maximum Markdown artifact size CA will
+  accept while verifying a CC-owned result (default `20971520`; independent
+  from the source-PDF and page-count limits)
 - `MLFLOW_ENABLED` - Enables best-effort MLflow logging when set to `true`
 - `MLFLOW_TRACKING_URI` - Shared MLflow backend URL, normally
   `https://mlflow-dev.openearth.dev`
@@ -563,17 +563,16 @@ language, or client-side fallback behavior. The boundary is:
 
 ### CC-produced Concept Note Markdown baseline
 
-`POST /v1/concept-notes/{run_id}/uploads/{upload_id}/markdown` validates the
-CC-issued user token through CC before consuming the request, streams the body
-up to `CNB_MARKDOWN_REQUEST_MAX_BYTES`, recomputes SHA-256, verifies contiguous
-page markers and their positive metadata count without imposing a page-count
-limit, and delegates atomic run/upload registration to a repository
-interface. The production repository validates run ownership, preserves the
-immutable upload-to-run binding and Markdown digest, and stores the received
-artifact in `concept_note_uploads` through `CA_DATABASE_URL`. Repeating the same
-upload and digest is idempotent; changing its run or digest returns `409`. CA
-owns no OCR queue, Mistral dependency, S3 object, or S3 permission. An
-unavailable or unmigrated workflow database returns `503
+`POST /v1/concept-notes/{run_id}/uploads` creates or replays the authoritative
+pre-conversion upload row. After CC OCR completes,
+`POST /v1/concept-notes/{run_id}/uploads/{upload_id}/markdown` receives only a
+stable S3 key, SHA-256, page count, filename, and label. CA fetches the artifact
+through CC's authenticated internal Markdown route, checks the returned
+identity, recomputes SHA-256, verifies page markers, and then stores the pointer
+as ready in `concept_note_uploads` through `CA_DATABASE_URL`. Identical create
+and delivery requests are idempotent; changing upload or Markdown identity
+returns `409`. CA owns no OCR queue, Mistral dependency, bucket credential, or
+presigned URL. An unavailable or unmigrated workflow database returns `503
 cnb_storage_unavailable`.
 
 ### Concept Note run foundation

--- a/climate-advisor/README.md
+++ b/climate-advisor/README.md
@@ -576,6 +576,13 @@ Markdown identity returns `409`. CA owns no OCR queue, Mistral dependency,
 bucket credential, or presigned URL. An unavailable or unmigrated workflow
 database returns `503 cnb_storage_unavailable`.
 
+CC uses the intentionally separate service-to-service route
+`GET /v1/concept-note-uploads/{upload_id}/delivery-context` with
+`X-CC-Service-Key` to recover the run and user scope for an opaque upload ID.
+Rejected service-key requests emit a `WARNING` audit log with the upload ID but
+never the supplied credential. Deployments should alert on repeated warnings or
+`401 invalid_service_key` responses for this route.
+
 ### Concept Note run foundation
 
 `POST /v1/concept-notes/start` validates a CC-issued bearer token, verifies that

--- a/climate-advisor/README.md
+++ b/climate-advisor/README.md
@@ -566,14 +566,15 @@ language, or client-side fallback behavior. The boundary is:
 `POST /v1/concept-notes/{run_id}/uploads` creates or replays the authoritative
 pre-conversion upload row. After CC OCR completes,
 `POST /v1/concept-notes/{run_id}/uploads/{upload_id}/markdown` receives only a
-stable S3 key, SHA-256, page count, filename, and label. CA fetches the artifact
-through CC's authenticated internal Markdown route, checks the returned
-identity, recomputes SHA-256, verifies page markers, and then stores the pointer
-as ready in `concept_note_uploads` through `CA_DATABASE_URL`. Identical create
-and delivery requests are idempotent; changing upload or Markdown identity
-returns `409`. CA owns no OCR queue, Mistral dependency, bucket credential, or
-presigned URL. An unavailable or unmigrated workflow database returns `503
-cnb_storage_unavailable`.
+stable S3 key, SHA-256, page count, filename, and label. CA rejects control JSON
+larger than 16 KiB before parsing, then streams the artifact through CC's
+authenticated internal Markdown route up to `CNB_MARKDOWN_REQUEST_MAX_BYTES`,
+checks the returned identity, recomputes SHA-256, verifies page markers, and
+stores the pointer as ready in `concept_note_uploads` through `CA_DATABASE_URL`.
+Identical create and delivery requests are idempotent; changing upload or
+Markdown identity returns `409`. CA owns no OCR queue, Mistral dependency,
+bucket credential, or presigned URL. An unavailable or unmigrated workflow
+database returns `503 cnb_storage_unavailable`.
 
 ### Concept Note run foundation
 

--- a/climate-advisor/service/app/models/concept_note_markdown.py
+++ b/climate-advisor/service/app/models/concept_note_markdown.py
@@ -1,15 +1,29 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ConceptNoteUploadCreateRequest(BaseModel):
+    """Register an immutable upload identity before CC conversion begins."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    upload_id: UUID
+    user_id: str = Field(min_length=1, max_length=255)
+    filename: str = Field(min_length=1, max_length=255)
+    source_label: str | None = Field(default=None, max_length=255)
 
 
 class ConceptNoteMarkdownRequest(BaseModel):
-    """Completed CC-produced Markdown and immutable artifact metadata."""
+    """Completed CC-owned Markdown object and immutable result metadata."""
 
-    markdown: str = Field(min_length=1)
+    model_config = ConfigDict(extra="forbid")
+
+    markdown_s3_key: str = Field(min_length=1, max_length=1024)
     filename: str = Field(min_length=1, max_length=255)
     source_label: str | None = Field(default=None, max_length=255)
     page_count: int = Field(ge=1)
@@ -17,7 +31,37 @@ class ConceptNoteMarkdownRequest(BaseModel):
 
 
 class ConceptNoteMarkdownResponse(BaseModel):
-    """Acknowledgement returned after durable repository registration."""
+    """Lifecycle response returned for one run-scoped upload."""
 
     upload_id: UUID
-    status: Literal["processing"] = "processing"
+    status: Literal["queued", "processing", "ready", "failed"]
+
+
+class ConceptNoteUploadStatusResponse(ConceptNoteMarkdownResponse):
+    """Safe persisted metadata returned to the CC browser-facing proxy."""
+
+    run_id: UUID
+    filename: str
+    source_label: str | None = None
+    page_count: int | None = None
+    error_code: str | None = None
+    received_at: datetime
+    completed_at: datetime | None = None
+
+
+class ConceptNoteUploadFailureRequest(BaseModel):
+    """Record a stable CC upload, OCR, or delivery failure."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    error_code: str = Field(min_length=1, max_length=64)
+
+
+class ConceptNoteUploadDeliveryContext(BaseModel):
+    """Metadata CC needs to deliver a terminal OCR outcome."""
+
+    upload_id: UUID
+    run_id: UUID
+    user_id: str
+    filename: str
+    source_label: str | None = None

--- a/climate-advisor/service/app/models/db/concept_note.py
+++ b/climate-advisor/service/app/models/db/concept_note.py
@@ -11,7 +11,6 @@ from sqlalchemy import (
     Index,
     Integer,
     String,
-    Text,
     UniqueConstraint,
     func,
 )
@@ -157,7 +156,7 @@ class ConceptNoteContextBundle(Base):
 
 
 class ConceptNoteUpload(Base):
-    """Durable Markdown handoff associated with a concept-note run."""
+    """Durable CNB upload metadata and CC-owned Markdown pointer."""
 
     __tablename__ = "concept_note_uploads"
 
@@ -179,14 +178,20 @@ class ConceptNoteUpload(Base):
         String(255),
         nullable=True,
     )
-    markdown_text: Mapped[str] = mapped_column(Text, nullable=False)
-    markdown_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
-    page_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    markdown_s3_key: Mapped[str | None] = mapped_column(
+        String(1024),
+        nullable=True,
+    )
+    markdown_sha256: Mapped[str | None] = mapped_column(
+        String(64),
+        nullable=True,
+    )
+    page_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
     ingest_status: Mapped[str] = mapped_column(
         String(64),
         nullable=False,
-        default="processing",
-        server_default="processing",
+        default="queued",
+        server_default="queued",
     )
     ingest_error_code: Mapped[str | None] = mapped_column(
         String(64),

--- a/climate-advisor/service/app/persistence/concept_notes/markdown.py
+++ b/climate-advisor/service/app/persistence/concept_notes/markdown.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import func, select
@@ -9,7 +11,10 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.db.session import get_session_factory
-from app.models.concept_note_markdown import ConceptNoteMarkdownRequest
+from app.models.concept_note_markdown import (
+    ConceptNoteMarkdownRequest,
+    ConceptNoteUploadCreateRequest,
+)
 from app.models.db.concept_note import ConceptNoteRun, ConceptNoteUpload
 
 
@@ -32,12 +37,50 @@ class ConceptNoteStorageUnavailable(ConceptNoteMarkdownRepositoryError):
         super().__init__(
             "cnb_storage_unavailable",
             503,
-            "Concept Note Markdown storage is unavailable",
+            "Concept Note upload storage is unavailable",
         )
 
 
+@dataclass(frozen=True)
+class ConceptNoteUploadSnapshot:
+    """Detached upload state safe to return outside a database session."""
+
+    upload_id: UUID
+    run_id: UUID
+    user_id: str
+    filename: str
+    source_label: str | None
+    markdown_s3_key: str | None
+    markdown_sha256: str | None
+    page_count: int | None
+    status: str
+    error_code: str | None
+    received_at: datetime
+    completed_at: datetime | None
+
+
 class ConceptNoteMarkdownRepository(ABC):
-    """Atomic registration boundary for received Concept Note Markdown."""
+    """Atomic persistence boundary for run-scoped CNB uploads."""
+
+    @abstractmethod
+    async def create_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        payload: ConceptNoteUploadCreateRequest,
+    ) -> ConceptNoteUploadSnapshot:
+        """Create or replay an immutable pre-conversion upload row."""
+
+    @abstractmethod
+    async def get_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        """Return an owned upload bound to the requested run."""
 
     @abstractmethod
     async def register_markdown(
@@ -47,13 +90,60 @@ class ConceptNoteMarkdownRepository(ABC):
         run_id: UUID,
         upload_id: UUID,
         payload: ConceptNoteMarkdownRequest,
-    ) -> None:
-        """Validate ownership/binding/idempotency and durably register Markdown."""
+    ) -> ConceptNoteUploadSnapshot:
+        """Register the immutable CC S3 pointer and mark the upload ready."""
+
+    @abstractmethod
+    async def mark_failed(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+        error_code: str,
+    ) -> ConceptNoteUploadSnapshot:
+        """Persist a terminal upload or OCR failure."""
+
+    @abstractmethod
+    async def retry_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        """Return a failed upload to the queued lifecycle."""
+
+    @abstractmethod
+    async def get_delivery_context(
+        self,
+        *,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        """Return source metadata for authenticated CC delivery."""
 
 
 class UnavailableConceptNoteMarkdownRepository(ConceptNoteMarkdownRepository):
     """Safe fallback when the workflow database cannot be configured."""
 
+    async def create_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        payload: ConceptNoteUploadCreateRequest,
+    ) -> ConceptNoteUploadSnapshot:
+        raise ConceptNoteStorageUnavailable()
+
+    async def get_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        raise ConceptNoteStorageUnavailable()
+
     async def register_markdown(
         self,
         *,
@@ -61,74 +151,82 @@ class UnavailableConceptNoteMarkdownRepository(ConceptNoteMarkdownRepository):
         run_id: UUID,
         upload_id: UUID,
         payload: ConceptNoteMarkdownRequest,
-    ) -> None:
-        """Reject registration when durable workflow storage is unavailable."""
+    ) -> ConceptNoteUploadSnapshot:
+        raise ConceptNoteStorageUnavailable()
+
+    async def mark_failed(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+        error_code: str,
+    ) -> ConceptNoteUploadSnapshot:
+        raise ConceptNoteStorageUnavailable()
+
+    async def retry_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        raise ConceptNoteStorageUnavailable()
+
+    async def get_delivery_context(
+        self,
+        *,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
         raise ConceptNoteStorageUnavailable()
 
 
 class SqlAlchemyConceptNoteMarkdownRepository(ConceptNoteMarkdownRepository):
-    """Persist validated Markdown in the Climate Advisor workflow database."""
+    """Persist CNB upload lifecycle state in the CA workflow database."""
 
     def __init__(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """Store the session factory used for atomic registration."""
         self._session_factory = session_factory
 
-    async def register_markdown(
+    async def create_upload(
         self,
         *,
         user_id: str,
         run_id: UUID,
-        upload_id: UUID,
-        payload: ConceptNoteMarkdownRequest,
-    ) -> None:
-        """Validate run ownership and idempotently persist one Markdown handoff."""
+        payload: ConceptNoteUploadCreateRequest,
+    ) -> ConceptNoteUploadSnapshot:
+        """Create or idempotently replay one pre-conversion upload."""
         try:
             async with self._session_factory() as session, session.begin():
-                run = await session.scalar(
-                    select(ConceptNoteRun)
-                    .where(ConceptNoteRun.run_id == run_id)
-                    .with_for_update()
+                await _require_owned_run(
+                    session=session,
+                    user_id=user_id,
+                    run_id=run_id,
                 )
-                if run is None:
-                    raise ConceptNoteMarkdownRepositoryError(
-                        "concept_note_run_not_found",
-                        404,
-                        "Concept Note run was not found",
-                    )
-                if run.user_id != user_id:
-                    raise ConceptNoteMarkdownRepositoryError(
-                        "concept_note_run_forbidden",
-                        403,
-                        "Concept Note run belongs to another user",
-                    )
-
                 existing = await session.get(
                     ConceptNoteUpload,
-                    upload_id,
+                    payload.upload_id,
                     with_for_update=True,
                 )
                 if existing is not None:
-                    _validate_existing_upload(
+                    _validate_upload_identity(
                         existing=existing,
                         run_id=run_id,
-                        markdown_sha256=payload.sha256,
+                        user_id=user_id,
+                        filename=payload.filename,
+                        source_label=payload.source_label,
                     )
-                    return
+                    return _snapshot(existing)
 
                 upload = ConceptNoteUpload(
-                    upload_id=upload_id,
+                    upload_id=payload.upload_id,
                     run_id=run_id,
                     uploaded_by_user_id=user_id,
                     filename=payload.filename,
                     source_label=payload.source_label,
-                    markdown_text=payload.markdown,
-                    markdown_sha256=payload.sha256,
-                    page_count=payload.page_count,
-                    ingest_status="processing",
-                    ingest_started_at=func.now(),
+                    ingest_status="queued",
                 )
                 try:
                     async with session.begin_nested():
@@ -137,45 +235,369 @@ class SqlAlchemyConceptNoteMarkdownRepository(ConceptNoteMarkdownRepository):
                 except IntegrityError:
                     existing = await session.get(
                         ConceptNoteUpload,
-                        upload_id,
+                        payload.upload_id,
                         with_for_update=True,
                     )
                     if existing is None:
                         raise
-                    _validate_existing_upload(
+                    _validate_upload_identity(
                         existing=existing,
                         run_id=run_id,
-                        markdown_sha256=payload.sha256,
+                        user_id=user_id,
+                        filename=payload.filename,
+                        source_label=payload.source_label,
                     )
+                    return _snapshot(existing)
+
+                await session.refresh(upload)
+                return _snapshot(upload)
         except ConceptNoteMarkdownRepositoryError:
             raise
         except (OSError, SQLAlchemyError) as exc:
-            logger.exception(
-                "Failed to persist Concept Note Markdown",
-                extra={"run_id": str(run_id), "upload_id": str(upload_id)},
+            _raise_storage_unavailable(
+                exc,
+                message="Failed to create Concept Note upload",
+                run_id=run_id,
+                upload_id=payload.upload_id,
             )
-            raise ConceptNoteStorageUnavailable() from exc
+
+    async def get_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        """Return one owned upload."""
+        try:
+            async with self._session_factory() as session:
+                await _require_owned_run(
+                    session=session,
+                    user_id=user_id,
+                    run_id=run_id,
+                )
+                upload = await session.get(ConceptNoteUpload, upload_id)
+                _require_upload_binding(
+                    upload=upload,
+                    run_id=run_id,
+                    user_id=user_id,
+                )
+                return _snapshot(upload)
+        except ConceptNoteMarkdownRepositoryError:
+            raise
+        except (OSError, SQLAlchemyError) as exc:
+            _raise_storage_unavailable(
+                exc,
+                message="Failed to load Concept Note upload",
+                run_id=run_id,
+                upload_id=upload_id,
+            )
+
+    async def register_markdown(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+        payload: ConceptNoteMarkdownRequest,
+    ) -> ConceptNoteUploadSnapshot:
+        """Persist one immutable CC Markdown pointer and mark it ready."""
+        try:
+            async with self._session_factory() as session, session.begin():
+                await _require_owned_run(
+                    session=session,
+                    user_id=user_id,
+                    run_id=run_id,
+                )
+                upload = await session.get(
+                    ConceptNoteUpload,
+                    upload_id,
+                    with_for_update=True,
+                )
+                _require_upload_binding(
+                    upload=upload,
+                    run_id=run_id,
+                    user_id=user_id,
+                )
+                _validate_upload_identity(
+                    existing=upload,
+                    run_id=run_id,
+                    user_id=user_id,
+                    filename=payload.filename,
+                    source_label=payload.source_label,
+                )
+                if upload.markdown_sha256 is not None:
+                    _validate_existing_markdown(
+                        existing=upload,
+                        markdown_s3_key=payload.markdown_s3_key,
+                        markdown_sha256=payload.sha256,
+                        page_count=payload.page_count,
+                    )
+                    return _snapshot(upload)
+
+                upload.markdown_s3_key = payload.markdown_s3_key
+                upload.markdown_sha256 = payload.sha256
+                upload.page_count = payload.page_count
+                upload.ingest_status = "ready"
+                upload.ingest_error_code = None
+                upload.ingest_started_at = upload.ingest_started_at or func.now()
+                upload.ingest_completed_at = func.now()
+                await session.flush()
+                await session.refresh(upload)
+                return _snapshot(upload)
+        except ConceptNoteMarkdownRepositoryError:
+            raise
+        except (OSError, SQLAlchemyError) as exc:
+            _raise_storage_unavailable(
+                exc,
+                message="Failed to persist Concept Note Markdown pointer",
+                run_id=run_id,
+                upload_id=upload_id,
+            )
+
+    async def mark_failed(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+        error_code: str,
+    ) -> ConceptNoteUploadSnapshot:
+        """Mark a non-ready upload failed without deleting its identity."""
+        try:
+            async with self._session_factory() as session, session.begin():
+                await _require_owned_run(
+                    session=session,
+                    user_id=user_id,
+                    run_id=run_id,
+                )
+                upload = await session.get(
+                    ConceptNoteUpload,
+                    upload_id,
+                    with_for_update=True,
+                )
+                _require_upload_binding(
+                    upload=upload,
+                    run_id=run_id,
+                    user_id=user_id,
+                )
+                if upload.ingest_status == "ready":
+                    raise ConceptNoteMarkdownRepositoryError(
+                        "upload_already_ready",
+                        409,
+                        "A ready upload cannot be marked failed",
+                    )
+                upload.ingest_status = "failed"
+                upload.ingest_error_code = error_code
+                upload.ingest_completed_at = func.now()
+                await session.flush()
+                await session.refresh(upload)
+                return _snapshot(upload)
+        except ConceptNoteMarkdownRepositoryError:
+            raise
+        except (OSError, SQLAlchemyError) as exc:
+            _raise_storage_unavailable(
+                exc,
+                message="Failed to mark Concept Note upload failed",
+                run_id=run_id,
+                upload_id=upload_id,
+            )
+
+    async def retry_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        """Return a failed upload to queued state."""
+        try:
+            async with self._session_factory() as session, session.begin():
+                await _require_owned_run(
+                    session=session,
+                    user_id=user_id,
+                    run_id=run_id,
+                )
+                upload = await session.get(
+                    ConceptNoteUpload,
+                    upload_id,
+                    with_for_update=True,
+                )
+                _require_upload_binding(
+                    upload=upload,
+                    run_id=run_id,
+                    user_id=user_id,
+                )
+                if upload.ingest_status == "ready":
+                    raise ConceptNoteMarkdownRepositoryError(
+                        "upload_not_retryable",
+                        409,
+                        "A ready upload cannot be retried",
+                    )
+                upload.ingest_status = "queued"
+                upload.ingest_error_code = None
+                upload.ingest_completed_at = None
+                await session.flush()
+                await session.refresh(upload)
+                return _snapshot(upload)
+        except ConceptNoteMarkdownRepositoryError:
+            raise
+        except (OSError, SQLAlchemyError) as exc:
+            _raise_storage_unavailable(
+                exc,
+                message="Failed to retry Concept Note upload",
+                run_id=run_id,
+                upload_id=upload_id,
+            )
+
+    async def get_delivery_context(
+        self,
+        *,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        """Return upload metadata to an authenticated CC service request."""
+        try:
+            async with self._session_factory() as session:
+                upload = await session.get(ConceptNoteUpload, upload_id)
+                if upload is None:
+                    raise ConceptNoteMarkdownRepositoryError(
+                        "concept_note_upload_not_found",
+                        404,
+                        "Concept Note upload was not found",
+                    )
+                return _snapshot(upload)
+        except ConceptNoteMarkdownRepositoryError:
+            raise
+        except (OSError, SQLAlchemyError) as exc:
+            _raise_storage_unavailable(
+                exc,
+                message="Failed to load Concept Note delivery context",
+                upload_id=upload_id,
+            )
 
 
-def _validate_existing_upload(
+async def _require_owned_run(
     *,
-    existing: ConceptNoteUpload,
+    session: AsyncSession,
+    user_id: str,
     run_id: UUID,
-    markdown_sha256: str,
+) -> ConceptNoteRun:
+    run = await session.scalar(
+        select(ConceptNoteRun).where(ConceptNoteRun.run_id == run_id).with_for_update()
+    )
+    if run is None:
+        raise ConceptNoteMarkdownRepositoryError(
+            "concept_note_run_not_found",
+            404,
+            "Concept Note run was not found",
+        )
+    if run.user_id != user_id:
+        raise ConceptNoteMarkdownRepositoryError(
+            "concept_note_run_forbidden",
+            403,
+            "Concept Note run belongs to another user",
+        )
+    return run
+
+
+def _require_upload_binding(
+    *,
+    upload: ConceptNoteUpload | None,
+    run_id: UUID,
+    user_id: str,
 ) -> None:
-    """Enforce immutable upload-to-run binding and Markdown identity."""
-    if existing.run_id != run_id:
+    if upload is None:
+        raise ConceptNoteMarkdownRepositoryError(
+            "concept_note_upload_not_found",
+            404,
+            "Concept Note upload was not found",
+        )
+    if upload.run_id != run_id:
         raise ConceptNoteMarkdownRepositoryError(
             "upload_run_binding_conflict",
             409,
-            "Upload is already associated with another Concept Note run",
+            "Upload is associated with another Concept Note run",
         )
-    if existing.markdown_sha256 != markdown_sha256:
+    if upload.uploaded_by_user_id != user_id:
+        raise ConceptNoteMarkdownRepositoryError(
+            "concept_note_upload_forbidden",
+            403,
+            "Concept Note upload belongs to another user",
+        )
+
+
+def _validate_upload_identity(
+    *,
+    existing: ConceptNoteUpload,
+    run_id: UUID,
+    user_id: str,
+    filename: str,
+    source_label: str | None,
+) -> None:
+    _require_upload_binding(
+        upload=existing,
+        run_id=run_id,
+        user_id=user_id,
+    )
+    if existing.filename != filename or existing.source_label != source_label:
+        raise ConceptNoteMarkdownRepositoryError(
+            "upload_identity_conflict",
+            409,
+            "Upload metadata cannot change",
+        )
+
+
+def _validate_existing_markdown(
+    *,
+    existing: ConceptNoteUpload,
+    markdown_s3_key: str,
+    markdown_sha256: str,
+    page_count: int,
+) -> None:
+    if (
+        existing.markdown_s3_key != markdown_s3_key
+        or existing.markdown_sha256 != markdown_sha256
+        or existing.page_count != page_count
+    ):
         raise ConceptNoteMarkdownRepositoryError(
             "markdown_identity_conflict",
             409,
-            "Upload Markdown digest cannot change",
+            "Upload Markdown identity cannot change",
         )
+
+
+def _snapshot(upload: ConceptNoteUpload) -> ConceptNoteUploadSnapshot:
+    return ConceptNoteUploadSnapshot(
+        upload_id=upload.upload_id,
+        run_id=upload.run_id,
+        user_id=upload.uploaded_by_user_id,
+        filename=upload.filename,
+        source_label=upload.source_label,
+        markdown_s3_key=upload.markdown_s3_key,
+        markdown_sha256=upload.markdown_sha256,
+        page_count=upload.page_count,
+        status=upload.ingest_status,
+        error_code=upload.ingest_error_code,
+        received_at=upload.received_at,
+        completed_at=upload.ingest_completed_at,
+    )
+
+
+def _raise_storage_unavailable(
+    exc: Exception,
+    *,
+    message: str,
+    run_id: UUID | None = None,
+    upload_id: UUID | None = None,
+) -> None:
+    logger.exception(
+        message,
+        extra={
+            "run_id": str(run_id) if run_id else None,
+            "upload_id": str(upload_id) if upload_id else None,
+        },
+    )
+    raise ConceptNoteStorageUnavailable() from exc
 
 
 def get_concept_note_markdown_repository() -> ConceptNoteMarkdownRepository:

--- a/climate-advisor/service/app/routes/concept_note_markdown.py
+++ b/climate-advisor/service/app/routes/concept_note_markdown.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import logging
 import re
 from collections.abc import AsyncIterator
 from typing import Any
@@ -33,6 +34,7 @@ from app.services.citycatalyst_client import (
 )
 
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 PAGE_MARKER = re.compile(r"<!-- page: (\d+) -->")
 JSON_REQUEST_MAX_BYTES = 16 * 1024
@@ -372,10 +374,17 @@ async def get_concept_note_delivery_context(
     ),
 ) -> JSONResponse | ConceptNoteUploadDeliveryContext:
     """Return delivery metadata to CC after reverse service authentication."""
+    # Authenticate the reverse service without recording its credential.
     expected_key = get_settings().cc_api_key or ""
     supplied_key = request.headers.get("X-CC-Service-Key", "")
     if not expected_key or not hmac.compare_digest(expected_key, supplied_key):
+        logger.warning(
+            "Rejected CC delivery-context request for upload_id=%s",
+            upload_id,
+        )
         return problem(401, "invalid_service_key", "CC service authentication failed")
+
+    # Return only the delivery metadata associated with the opaque upload ID.
     try:
         snapshot = await repository.get_delivery_context(upload_id=upload_id)
     except ConceptNoteMarkdownRepositoryError as exc:

--- a/climate-advisor/service/app/routes/concept_note_markdown.py
+++ b/climate-advisor/service/app/routes/concept_note_markdown.py
@@ -35,6 +35,7 @@ from app.services.citycatalyst_client import (
 
 router = APIRouter()
 PAGE_MARKER = re.compile(r"<!-- page: (\d+) -->")
+JSON_REQUEST_MAX_BYTES = 16 * 1024
 
 
 async def get_citycatalyst_client() -> AsyncIterator[CityCatalystClient]:
@@ -83,15 +84,45 @@ async def read_json_model(
     request: Request,
     model_type: type[Any],
 ) -> Any | JSONResponse:
-    """Parse one strict Pydantic JSON request after authentication."""
-    if "application/json" not in request.headers.get("Content-Type", ""):
+    """Read a bounded JSON body and parse one strict Pydantic model."""
+    content_type = request.headers.get("Content-Type", "")
+    if content_type.split(";", 1)[0].strip().lower() != "application/json":
         return problem(
             415,
             "unsupported_media_type",
             "Content-Type must be application/json",
         )
+
+    # Reject a trustworthy declared size before allocating the request body.
+    content_length = request.headers.get("Content-Length")
+    if content_length:
+        try:
+            declared_size = int(content_length)
+        except ValueError:
+            return problem(400, "invalid_content_length", "Content-Length is invalid")
+        if declared_size < 0:
+            return problem(400, "invalid_content_length", "Content-Length is invalid")
+        if declared_size > JSON_REQUEST_MAX_BYTES:
+            return problem(
+                413,
+                "upload_request_too_large",
+                "JSON request exceeds the allowed maximum",
+            )
+
+    # Apply the same bound while consuming chunked or misdeclared requests.
+    body = bytearray()
+    async for chunk in request.stream():
+        if len(body) + len(chunk) > JSON_REQUEST_MAX_BYTES:
+            return problem(
+                413,
+                "upload_request_too_large",
+                "JSON request exceeds the allowed maximum",
+            )
+        body.extend(chunk)
+
+    # Parse only the authenticated, bounded payload.
     try:
-        return model_type.model_validate(await request.json())
+        return model_type.model_validate_json(body)
     except (ValidationError, ValueError):
         return problem(422, "invalid_upload_payload", "Upload payload is invalid")
 
@@ -236,7 +267,7 @@ async def ingest_concept_note_markdown(
             token=authorization,
         )
     except CityCatalystClientError as exc:
-        status_code = 413 if exc.status_code == 413 else 503
+        status_code = exc.status_code if exc.status_code in (409, 413, 422) else 503
         return problem(
             status_code,
             "cc_markdown_verification_failed",

--- a/climate-advisor/service/app/routes/concept_note_markdown.py
+++ b/climate-advisor/service/app/routes/concept_note_markdown.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import re
 from collections.abc import AsyncIterator
+from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Request, status
@@ -13,15 +15,21 @@ from app.config import get_settings
 from app.models.concept_note_markdown import (
     ConceptNoteMarkdownRequest,
     ConceptNoteMarkdownResponse,
+    ConceptNoteUploadCreateRequest,
+    ConceptNoteUploadDeliveryContext,
+    ConceptNoteUploadFailureRequest,
+    ConceptNoteUploadStatusResponse,
 )
 from app.persistence.concept_notes.markdown import (
     ConceptNoteMarkdownRepository,
     ConceptNoteMarkdownRepositoryError,
+    ConceptNoteUploadSnapshot,
     get_concept_note_markdown_repository,
 )
 from app.services.citycatalyst_client import (
     CityCatalystClient,
     CityCatalystClientError,
+    ConceptNoteMarkdownArtifact,
 )
 
 
@@ -30,7 +38,7 @@ PAGE_MARKER = re.compile(r"<!-- page: (\d+) -->")
 
 
 async def get_citycatalyst_client() -> AsyncIterator[CityCatalystClient]:
-    """Provide and close the CC client used for opaque bearer validation."""
+    """Provide and close the CC client used for identity and artifact checks."""
     client = CityCatalystClient()
     try:
         yield client
@@ -39,7 +47,7 @@ async def get_citycatalyst_client() -> AsyncIterator[CityCatalystClient]:
 
 
 def problem(status_code: int, code: str, message: str) -> JSONResponse:
-    """Return a stable machine-readable Markdown-ingest error."""
+    """Return a stable machine-readable CNB upload error."""
     return JSONResponse(
         status_code=status_code,
         content={"code": code, "detail": message, "status": status_code},
@@ -47,40 +55,156 @@ def problem(status_code: int, code: str, message: str) -> JSONResponse:
     )
 
 
-async def read_limited_body(request: Request, max_bytes: int) -> bytes | None:
-    """Stream a request body, returning ``None`` once the byte limit is exceeded."""
-    body = bytearray()
-    async for chunk in request.stream():
-        if len(body) + len(chunk) > max_bytes:
-            return None
-        body.extend(chunk)
-    return bytes(body)
+async def authenticate_user(
+    request: Request,
+    cc_client: CityCatalystClient,
+) -> tuple[str | None, JSONResponse | None]:
+    """Resolve the canonical CC user before any stateful repository action."""
+    authorization = request.headers.get("Authorization", "")
+    if not authorization.startswith("Bearer ") or not authorization[7:].strip():
+        return None, problem(401, "invalid_bearer_token", "Bearer token is required")
+    try:
+        user_id = await cc_client.validate_user_identity(authorization[7:].strip())
+    except CityCatalystClientError as exc:
+        status_code = 401 if exc.status_code in (401, 403) else 503
+        code = (
+            "invalid_bearer_token" if status_code == 401 else "cc_identity_unavailable"
+        )
+        message = (
+            "Bearer token is invalid or expired"
+            if status_code == 401
+            else "Identity service is temporarily unavailable"
+        )
+        return None, problem(status_code, code, message)
+    return user_id, None
 
 
-def validate_markdown(payload: ConceptNoteMarkdownRequest) -> str | None:
-    """Validate digest, page markers, page count, and non-empty content."""
-    # Validate the immutable artifact identity.
-    digest = hashlib.sha256(payload.markdown.encode("utf-8")).hexdigest()
+async def read_json_model(
+    request: Request,
+    model_type: type[Any],
+) -> Any | JSONResponse:
+    """Parse one strict Pydantic JSON request after authentication."""
+    if "application/json" not in request.headers.get("Content-Type", ""):
+        return problem(
+            415,
+            "unsupported_media_type",
+            "Content-Type must be application/json",
+        )
+    try:
+        return model_type.model_validate(await request.json())
+    except (ValidationError, ValueError):
+        return problem(422, "invalid_upload_payload", "Upload payload is invalid")
+
+
+def validate_markdown_artifact(
+    artifact: ConceptNoteMarkdownArtifact,
+    payload: ConceptNoteMarkdownRequest,
+) -> str | None:
+    """Validate the fetched artifact and immutable pointer identity."""
+    if (
+        artifact.markdown_s3_key != payload.markdown_s3_key
+        or artifact.sha256 != payload.sha256
+        or artifact.page_count != payload.page_count
+    ):
+        return "markdown_identity_conflict"
+
+    digest = hashlib.sha256(artifact.markdown.encode("utf-8")).hexdigest()
     if digest != payload.sha256:
         return "markdown_digest_mismatch"
-
-    # Validate ordered page markers without allocating an expected page range.
-    if not payload.markdown.lstrip().startswith("<!-- page: 1 -->"):
+    if not artifact.markdown.lstrip().startswith("<!-- page: 1 -->"):
         return "invalid_markdown_pages"
+
     marker_count = 0
     for marker_count, match in enumerate(
-        PAGE_MARKER.finditer(payload.markdown), start=1
+        PAGE_MARKER.finditer(artifact.markdown), start=1
     ):
         if int(match.group(1)) != marker_count:
             return "invalid_markdown_pages"
     if marker_count != payload.page_count:
         return "invalid_markdown_pages"
-
-    # Require content beyond the page separators.
-    content = PAGE_MARKER.sub("", payload.markdown)
-    if not content.strip():
+    if not PAGE_MARKER.sub("", artifact.markdown).strip():
         return "empty_markdown"
     return None
+
+
+def status_response(
+    snapshot: ConceptNoteUploadSnapshot,
+) -> ConceptNoteUploadStatusResponse:
+    """Map persistence state to the safe CC-facing upload contract."""
+    return ConceptNoteUploadStatusResponse(
+        upload_id=snapshot.upload_id,
+        run_id=snapshot.run_id,
+        status=snapshot.status,
+        filename=snapshot.filename,
+        source_label=snapshot.source_label,
+        page_count=snapshot.page_count,
+        error_code=snapshot.error_code,
+        received_at=snapshot.received_at,
+        completed_at=snapshot.completed_at,
+    )
+
+
+@router.post(
+    "/concept-notes/{run_id}/uploads",
+    response_model=ConceptNoteMarkdownResponse,
+)
+async def create_concept_note_upload(
+    run_id: UUID,
+    request: Request,
+    repository: ConceptNoteMarkdownRepository = Depends(
+        get_concept_note_markdown_repository
+    ),
+    cc_client: CityCatalystClient = Depends(get_citycatalyst_client),
+) -> JSONResponse | ConceptNoteMarkdownResponse:
+    """Create or replay the authoritative pre-conversion upload row."""
+    user_id, auth_error = await authenticate_user(request, cc_client)
+    if auth_error:
+        return auth_error
+    payload = await read_json_model(request, ConceptNoteUploadCreateRequest)
+    if isinstance(payload, JSONResponse):
+        return payload
+    if payload.user_id != user_id:
+        return problem(403, "concept_note_upload_forbidden", "User identity mismatch")
+    try:
+        snapshot = await repository.create_upload(
+            user_id=user_id,
+            run_id=run_id,
+            payload=payload,
+        )
+    except ConceptNoteMarkdownRepositoryError as exc:
+        return problem(exc.status_code, exc.code, str(exc))
+    return ConceptNoteMarkdownResponse(
+        upload_id=snapshot.upload_id,
+        status=snapshot.status,
+    )
+
+
+@router.get(
+    "/concept-notes/{run_id}/uploads/{upload_id}",
+    response_model=ConceptNoteUploadStatusResponse,
+)
+async def get_concept_note_upload(
+    run_id: UUID,
+    upload_id: UUID,
+    request: Request,
+    repository: ConceptNoteMarkdownRepository = Depends(
+        get_concept_note_markdown_repository
+    ),
+    cc_client: CityCatalystClient = Depends(get_citycatalyst_client),
+) -> JSONResponse | ConceptNoteUploadStatusResponse:
+    """Return safe lifecycle metadata for one owned upload."""
+    user_id, auth_error = await authenticate_user(request, cc_client)
+    if auth_error:
+        return auth_error
+    try:
+        snapshot = await repository.get_upload(
+            user_id=user_id,
+            run_id=run_id,
+            upload_id=upload_id,
+        )
+    except ConceptNoteMarkdownRepositoryError as exc:
+        return problem(exc.status_code, exc.code, str(exc))
+    return status_response(snapshot)
 
 
 @router.post(
@@ -97,76 +221,138 @@ async def ingest_concept_note_markdown(
     ),
     cc_client: CityCatalystClient = Depends(get_citycatalyst_client),
 ) -> JSONResponse | ConceptNoteMarkdownResponse:
-    """Validate and atomically register CC-produced Markdown for a CNB run."""
-    authorization = request.headers.get("Authorization", "")
-    if not authorization.startswith("Bearer ") or not authorization[7:].strip():
-        return problem(401, "invalid_bearer_token", "Bearer token is required")
-    if "application/json" not in request.headers.get("Content-Type", ""):
-        return problem(
-            415,
-            "unsupported_media_type",
-            "Content-Type must be application/json",
-        )
+    """Verify the CC object, then persist its immutable pointer as ready."""
+    user_id, auth_error = await authenticate_user(request, cc_client)
+    if auth_error:
+        return auth_error
+    payload = await read_json_model(request, ConceptNoteMarkdownRequest)
+    if isinstance(payload, JSONResponse):
+        return payload
 
-    settings = get_settings()
-    max_bytes = settings.cnb_markdown_request_max_bytes
-    content_length = request.headers.get("Content-Length")
-    if content_length:
-        try:
-            declared_size = int(content_length)
-        except ValueError:
-            return problem(400, "invalid_content_length", "Content-Length is invalid")
-        if declared_size < 0:
-            return problem(400, "invalid_content_length", "Content-Length is invalid")
-        if declared_size > max_bytes:
-            return problem(
-                413,
-                "markdown_request_too_large",
-                "JSON request exceeds the configured maximum",
-            )
-
-    # Authenticate before consuming, parsing, or hashing the request body.
+    authorization = request.headers["Authorization"][7:].strip()
     try:
-        user_id = await cc_client.validate_user_identity(authorization[7:].strip())
+        artifact = await cc_client.get_concept_note_markdown(
+            upload_id=str(upload_id),
+            token=authorization,
+        )
     except CityCatalystClientError as exc:
-        status_code = 401 if exc.status_code in (401, 403) else 503
-        code = (
-            "invalid_bearer_token" if status_code == 401 else "cc_identity_unavailable"
-        )
-        message = (
-            "Bearer token is invalid or expired"
-            if status_code == 401
-            else "Identity service is temporarily unavailable"
-        )
-        return problem(status_code, code, message)
-
-    # Enforce the limit while consuming bodies without a trustworthy size header.
-    body = await read_limited_body(request, max_bytes)
-    if body is None:
+        status_code = 413 if exc.status_code == 413 else 503
         return problem(
-            413,
-            "markdown_request_too_large",
-            "JSON request exceeds the configured maximum",
+            status_code,
+            "cc_markdown_verification_failed",
+            "CC Markdown artifact could not be verified",
         )
-    try:
-        payload = ConceptNoteMarkdownRequest.model_validate_json(body)
-    except ValidationError:
-        return problem(422, "invalid_markdown_payload", "Markdown payload is invalid")
 
-    validation_error = validate_markdown(payload)
+    validation_error = validate_markdown_artifact(artifact, payload)
     if validation_error:
-        return problem(422, validation_error, "Markdown validation failed")
+        status_code = 409 if validation_error == "markdown_identity_conflict" else 422
+        return problem(status_code, validation_error, "Markdown verification failed")
 
     try:
-        await repository.register_markdown(
+        snapshot = await repository.register_markdown(
             user_id=user_id,
             run_id=run_id,
             upload_id=upload_id,
             payload=payload,
         )
     except ConceptNoteMarkdownRepositoryError as exc:
-        return problem(
-            exc.status_code, exc.code, "Unable to register markdown at this time"
-        )
+        return problem(exc.status_code, exc.code, str(exc))
+    return ConceptNoteMarkdownResponse(
+        upload_id=snapshot.upload_id,
+        status=snapshot.status,
+    )
 
-    return ConceptNoteMarkdownResponse(upload_id=upload_id)
+
+@router.post(
+    "/concept-notes/{run_id}/uploads/{upload_id}/failed",
+    response_model=ConceptNoteMarkdownResponse,
+)
+async def mark_concept_note_upload_failed(
+    run_id: UUID,
+    upload_id: UUID,
+    request: Request,
+    repository: ConceptNoteMarkdownRepository = Depends(
+        get_concept_note_markdown_repository
+    ),
+    cc_client: CityCatalystClient = Depends(get_citycatalyst_client),
+) -> JSONResponse | ConceptNoteMarkdownResponse:
+    """Persist a stable upload or OCR failure code."""
+    user_id, auth_error = await authenticate_user(request, cc_client)
+    if auth_error:
+        return auth_error
+    payload = await read_json_model(request, ConceptNoteUploadFailureRequest)
+    if isinstance(payload, JSONResponse):
+        return payload
+    try:
+        snapshot = await repository.mark_failed(
+            user_id=user_id,
+            run_id=run_id,
+            upload_id=upload_id,
+            error_code=payload.error_code,
+        )
+    except ConceptNoteMarkdownRepositoryError as exc:
+        return problem(exc.status_code, exc.code, str(exc))
+    return ConceptNoteMarkdownResponse(
+        upload_id=snapshot.upload_id,
+        status=snapshot.status,
+    )
+
+
+@router.post(
+    "/concept-notes/{run_id}/uploads/{upload_id}/retry",
+    response_model=ConceptNoteMarkdownResponse,
+)
+async def retry_concept_note_upload(
+    run_id: UUID,
+    upload_id: UUID,
+    request: Request,
+    repository: ConceptNoteMarkdownRepository = Depends(
+        get_concept_note_markdown_repository
+    ),
+    cc_client: CityCatalystClient = Depends(get_citycatalyst_client),
+) -> JSONResponse | ConceptNoteMarkdownResponse:
+    """Return a failed authoritative upload row to queued state."""
+    user_id, auth_error = await authenticate_user(request, cc_client)
+    if auth_error:
+        return auth_error
+    try:
+        snapshot = await repository.retry_upload(
+            user_id=user_id,
+            run_id=run_id,
+            upload_id=upload_id,
+        )
+    except ConceptNoteMarkdownRepositoryError as exc:
+        return problem(exc.status_code, exc.code, str(exc))
+    return ConceptNoteMarkdownResponse(
+        upload_id=snapshot.upload_id,
+        status=snapshot.status,
+    )
+
+
+@router.get(
+    "/concept-note-uploads/{upload_id}/delivery-context",
+    response_model=ConceptNoteUploadDeliveryContext,
+)
+async def get_concept_note_delivery_context(
+    upload_id: UUID,
+    request: Request,
+    repository: ConceptNoteMarkdownRepository = Depends(
+        get_concept_note_markdown_repository
+    ),
+) -> JSONResponse | ConceptNoteUploadDeliveryContext:
+    """Return delivery metadata to CC after reverse service authentication."""
+    expected_key = get_settings().cc_api_key or ""
+    supplied_key = request.headers.get("X-CC-Service-Key", "")
+    if not expected_key or not hmac.compare_digest(expected_key, supplied_key):
+        return problem(401, "invalid_service_key", "CC service authentication failed")
+    try:
+        snapshot = await repository.get_delivery_context(upload_id=upload_id)
+    except ConceptNoteMarkdownRepositoryError as exc:
+        return problem(exc.status_code, exc.code, str(exc))
+    return ConceptNoteUploadDeliveryContext(
+        upload_id=snapshot.upload_id,
+        run_id=snapshot.run_id,
+        user_id=snapshot.user_id,
+        filename=snapshot.filename,
+        source_label=snapshot.source_label,
+    )

--- a/climate-advisor/service/app/services/citycatalyst_client.py
+++ b/climate-advisor/service/app/services/citycatalyst_client.py
@@ -11,9 +11,8 @@ This module provides an HTTP client for secure communication with CityCatalyst:
 
 from __future__ import annotations
 
-import asyncio
 import logging
-from datetime import datetime, timezone
+from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple
 
 import httpx
@@ -21,17 +20,25 @@ import httpx
 from app.config import get_settings
 from app.utils.token_manager import (
     is_token_expired,
-    redact_token,
-    get_token_expiry,
-    create_token_context,
     parse_jwt_claims,
 )
 
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class ConceptNoteMarkdownArtifact:
+    """Verified metadata and bytes returned by the CC Markdown read boundary."""
+
+    markdown: str
+    markdown_s3_key: str
+    sha256: str
+    page_count: int
+
+
 class TokenRefreshError(Exception):
     """Raised when token refresh fails."""
+
     pass
 
 
@@ -51,15 +58,20 @@ class CityCatalystClientError(Exception):
 
 class CityCatalystClient:
     """HTTP client for CityCatalyst integration.
-    
+
     Handles JWT token lifecycle:
     - Validates token expiry before use
     - Automatically refreshes expired tokens
     - Makes authenticated requests to CC inventory APIs
     - Gracefully handles auth failures
     """
-    
-    def __init__(self, base_url: Optional[str] = None, api_key: Optional[str] = None, timeout: int = 30):
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        timeout: int = 30,
+    ):
         """Initialize CityCatalyst client.
 
         Args:
@@ -76,67 +88,62 @@ class CityCatalystClient:
         self.datasource_timeout = max(self.timeout, 90)
         self._client: Optional[httpx.AsyncClient] = None
         self.last_refreshed_token: Optional[str] = None
-        
+
         if not self.base_url:
             logger.warning(
                 "CityCatalyst base URL not configured. "
                 "Set CC_BASE_URL environment variable for token refresh and inventory access."
             )
-    
+
     async def _get_client(self) -> httpx.AsyncClient:
         """Get or create async HTTP client."""
         if self._client is None:
             self._client = httpx.AsyncClient(timeout=self.timeout)
         return self._client
-    
+
     async def close(self) -> None:
         """Close HTTP client connection."""
         if self._client:
             await self._client.aclose()
             self._client = None
-    
+
     async def __aenter__(self):
         """Async context manager entry."""
         return self
-    
+
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Async context manager exit."""
         await self.close()
-    
+
     async def refresh_token(
         self,
         user_id: str,
     ) -> Tuple[str, int]:
         """Refresh an expired token using CA service API key.
-        
+
         Args:
             user_id: User ID for token scoping
-        
+
         Returns:
             Tuple of (fresh_jwt_token, expires_in_seconds)
-        
+
         Raises:
             TokenRefreshError: If token refresh fails
         """
         if not self.base_url:
-            raise TokenRefreshError(
-                "CC_BASE_URL not configured. Cannot refresh token."
-            )
-        
+            raise TokenRefreshError("CC_BASE_URL not configured. Cannot refresh token.")
+
         if not self.api_key:
             raise TokenRefreshError(
                 "CC_API_KEY not configured. Cannot authenticate with CityCatalyst."
             )
-        
+
         url = f"{self.base_url}/api/v1/internal/ca/user-token"
         payload = {
             "user_id": user_id,
         }
-        headers = {
-            "X-CA-Service-Key": self.api_key,
-            "Content-Type": "application/json"
-        }
-        
+        headers = {"X-CA-Service-Key": self.api_key, "Content-Type": "application/json"}
+
         try:
             client = await self._get_client()
             logger.debug(
@@ -145,9 +152,11 @@ class CityCatalystClient:
             )
 
             # Allow redirects for compatibility
-            response = await client.post(url, json=payload, headers=headers, follow_redirects=True)
+            response = await client.post(
+                url, json=payload, headers=headers, follow_redirects=True
+            )
             response.raise_for_status()
-            
+
             data = response.json()
             fresh_token, expires_in, claims = self._validate_refresh_response(
                 data=data,
@@ -166,14 +175,16 @@ class CityCatalystClient:
                 audience or "unknown",
             )
             return fresh_token, expires_in
-            
+
         except httpx.HTTPStatusError as e:
             logger.error(
                 "Token refresh failed with status %d: %s",
                 e.response.status_code,
                 e.response.text[:200],
             )
-            raise TokenRefreshError(f"Token refresh failed: HTTP {e.response.status_code}") from e
+            raise TokenRefreshError(
+                f"Token refresh failed: HTTP {e.response.status_code}"
+            ) from e
         except TokenRefreshError:
             raise
         except Exception as e:
@@ -207,7 +218,9 @@ class CityCatalystClient:
         claims = parse_jwt_claims(fresh_token)
         if isinstance(claims, dict):
             if claims.get("sub") != user_id:
-                raise TokenRefreshError("Refreshed token subject does not match requested user")
+                raise TokenRefreshError(
+                    "Refreshed token subject does not match requested user"
+                )
             if claims.get("iss") != "climate-advisor-service":
                 raise TokenRefreshError("Invalid token issuer in refresh response")
             if not self._audience_matches(claims.get("aud")):
@@ -230,7 +243,7 @@ class CityCatalystClient:
                 for value in audience
             )
         return False
-    
+
     async def get_with_auto_refresh(
         self,
         url: str,
@@ -242,17 +255,17 @@ class CityCatalystClient:
         request_timeout: Optional[float] = None,
     ) -> httpx.Response:
         """Make GET request with automatic token refresh on 401.
-        
+
         Args:
             url: Full URL to request
             token: Bearer token
             user_id: User ID (for token refresh context)
             thread_id: Thread ID (for token refresh context)
             auto_refresh: Automatically refresh token on 401
-        
+
         Returns:
             Response object
-        
+
         Raises:
             CityCatalystClientError: If request fails
         """
@@ -264,12 +277,12 @@ class CityCatalystClient:
             except TokenRefreshError as e:
                 logger.warning("Preemptive token refresh failed: %s", e)
                 # Continue with expired token - let server reject it
-        
+
         try:
             client = await self._get_client()
             headers = self._auth_headers(token)
             timeout_value = request_timeout or self.timeout
-            
+
             logger.debug("Making GET request to %s (timeout=%s)", url, timeout_value)
             response = await client.get(
                 url,
@@ -277,7 +290,7 @@ class CityCatalystClient:
                 follow_redirects=True,
                 timeout=timeout_value,
             )
-            
+
             # Handle 401 Unauthorized - try to refresh
             if response.status_code == 401 and auto_refresh:
                 logger.debug("Got 401, attempting token refresh")
@@ -293,13 +306,13 @@ class CityCatalystClient:
                 except TokenRefreshError as e:
                     logger.error("Failed to refresh token: %s", e)
                     raise CityCatalystClientError(f"Authentication failed: {e}") from e
-            
+
             return response
-            
+
         except Exception as e:
             logger.error("Request failed: %s", e)
             raise CityCatalystClientError(f"Request failed: {e}") from e
-    
+
     async def post_with_auto_refresh(
         self,
         url: str,
@@ -312,7 +325,7 @@ class CityCatalystClient:
         request_timeout: Optional[float] = None,
     ) -> httpx.Response:
         """Make POST request with automatic token refresh on 401.
-        
+
         Args:
             url: Full URL to request
             token: Bearer token
@@ -320,10 +333,10 @@ class CityCatalystClient:
             thread_id: Thread ID (for token refresh context)
             json_data: JSON payload
             auto_refresh: Automatically refresh token on 401
-        
+
         Returns:
             Response object
-        
+
         Raises:
             CityCatalystClientError: If request fails
         """
@@ -334,12 +347,12 @@ class CityCatalystClient:
                 token, _ = await self.refresh_token(user_id)
             except TokenRefreshError as e:
                 logger.warning("Preemptive token refresh failed: %s", e)
-        
+
         try:
             client = await self._get_client()
             headers = self._auth_headers(token)
             timeout_value = request_timeout or self.timeout
-            
+
             logger.debug("Making POST request to %s (timeout=%s)", url, timeout_value)
             response = await client.post(
                 url,
@@ -348,7 +361,7 @@ class CityCatalystClient:
                 follow_redirects=True,
                 timeout=timeout_value,
             )
-            
+
             # Handle 401 Unauthorized - try to refresh
             if response.status_code == 401 and auto_refresh:
                 logger.debug("Got 401, attempting token refresh")
@@ -365,19 +378,19 @@ class CityCatalystClient:
                 except TokenRefreshError as e:
                     logger.error("Failed to refresh token: %s", e)
                     raise CityCatalystClientError(f"Authentication failed: {e}") from e
-            
+
             return response
-            
+
         except Exception as e:
             logger.error("Request failed: %s", e)
             raise CityCatalystClientError(f"Request failed: {e}") from e
-    
+
     def _auth_headers(self, token: str) -> Dict[str, str]:
         """Build authorization headers for requests.
-        
+
         Args:
             token: Bearer token
-        
+
         Returns:
             Headers dictionary with service authentication
         """
@@ -437,6 +450,74 @@ class CityCatalystClient:
                 status_code=503,
             )
         return user_id
+
+    async def get_concept_note_markdown(
+        self,
+        *,
+        upload_id: str,
+        token: str,
+    ) -> ConceptNoteMarkdownArtifact:
+        """Read a completed CNB Markdown artifact through authenticated CC."""
+        if not self.base_url:
+            raise CityCatalystClientError(
+                "CC_BASE_URL not configured",
+                status_code=503,
+            )
+
+        client = await self._get_client()
+        try:
+            response = await client.get(
+                (
+                    f"{self.base_url}/api/v1/internal/ca/"
+                    f"concept-note-uploads/{upload_id}/markdown"
+                ),
+                headers=self._internal_headers(token),
+                follow_redirects=True,
+                timeout=self.datasource_timeout,
+            )
+        except httpx.HTTPError as exc:
+            raise CityCatalystClientError(
+                "CC Markdown verification is unavailable",
+                status_code=503,
+            ) from exc
+
+        if not response.is_success:
+            raise CityCatalystClientError(
+                "CC Markdown artifact could not be verified",
+                status_code=response.status_code,
+            )
+
+        settings = get_settings()
+        if len(response.content) > settings.cnb_markdown_request_max_bytes:
+            raise CityCatalystClientError(
+                "CC Markdown artifact exceeds the configured maximum",
+                status_code=413,
+            )
+
+        markdown_s3_key = response.headers.get("X-Markdown-S3-Key")
+        sha256 = response.headers.get("X-Markdown-SHA256")
+        page_count_header = response.headers.get("X-Page-Count")
+        try:
+            page_count = int(page_count_header or "")
+            markdown = response.content.decode("utf-8")
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise CityCatalystClientError(
+                "CC Markdown artifact metadata is invalid",
+                status_code=502,
+            ) from exc
+
+        if not markdown_s3_key or not sha256 or len(sha256) != 64 or page_count < 1:
+            raise CityCatalystClientError(
+                "CC Markdown artifact metadata is invalid",
+                status_code=502,
+            )
+
+        return ConceptNoteMarkdownArtifact(
+            markdown=markdown,
+            markdown_s3_key=markdown_s3_key,
+            sha256=sha256,
+            page_count=page_count,
+        )
 
     async def post_internal_capability(
         self,
@@ -532,9 +613,13 @@ class CityCatalystClient:
         if isinstance(data, list):
             capabilities = data
         else:
-            capabilities = data.get("capabilities") or data.get("allowed_capabilities") or data
+            capabilities = (
+                data.get("capabilities") or data.get("allowed_capabilities") or data
+            )
         if isinstance(capabilities, dict):
-            capabilities = capabilities.get("capabilities") or capabilities.get("ids") or []
+            capabilities = (
+                capabilities.get("capabilities") or capabilities.get("ids") or []
+            )
         if not isinstance(capabilities, list):
             raise CityCatalystClientError("Invalid allowed capabilities response")
 
@@ -643,9 +728,9 @@ class CityCatalystClient:
             json_data=request_payload,
             token=token,
         )
-    
+
     # Convenience methods for common CC API operations
-    
+
     async def get_inventory(
         self,
         inventory_id: str,
@@ -653,21 +738,21 @@ class CityCatalystClient:
         user_id: str,
     ) -> Dict[str, Any]:
         """Fetch inventory data from CityCatalyst.
-        
+
         Args:
             inventory_id: Inventory UUID
             token: User access token
             user_id: User ID for token refresh context
-            
+
         Returns:
             Inventory data dictionary
-            
+
         Raises:
             CityCatalystClientError: If API call fails
         """
         if not self.base_url:
             raise CityCatalystClientError("CC_BASE_URL not configured")
-        
+
         url = f"{self.base_url}/api/v1/inventory/{inventory_id}"
         response = await self.get_with_auto_refresh(
             url=url,
@@ -675,17 +760,19 @@ class CityCatalystClient:
             user_id=user_id,
             thread_id="",  # Not used in new refresh method
         )
-        
+
         if not response.is_success:
             error_text = response.text[:200] if response.text else "Unknown error"
             raise CityCatalystClientError(
                 f"Failed to fetch inventory {inventory_id}: {response.status_code} - {error_text}"
             )
-        
+
         try:
             return response.json()
         except Exception as e:
-            raise CityCatalystClientError(f"Failed to parse inventory response: {e}") from e
+            raise CityCatalystClientError(
+                f"Failed to parse inventory response: {e}"
+            ) from e
 
     async def get_user_inventories(
         self,
@@ -734,7 +821,7 @@ class CityCatalystClient:
             raise CityCatalystClientError(
                 f"Failed to parse user inventories response: {e}"
             ) from e
-    
+
     async def get_city(
         self,
         city_id: str,
@@ -742,21 +829,21 @@ class CityCatalystClient:
         user_id: str,
     ) -> Dict[str, Any]:
         """Fetch city data from CityCatalyst.
-        
+
         Args:
             city_id: City UUID
             token: User access token
             user_id: User ID for token refresh context
-            
+
         Returns:
             City data dictionary
-            
+
         Raises:
             CityCatalystClientError: If API call fails
         """
         if not self.base_url:
             raise CityCatalystClientError("CC_BASE_URL not configured")
-        
+
         url = f"{self.base_url}/api/v1/city/{city_id}"
         response = await self.get_with_auto_refresh(
             url=url,
@@ -764,14 +851,14 @@ class CityCatalystClient:
             user_id=user_id,
             thread_id="",  # Not used in new refresh method
         )
-        
+
         if not response.is_success:
             error_text = response.text[:200] if response.text else "Unknown error"
             raise CityCatalystClientError(
                 f"Failed to fetch city {city_id}: {response.status_code} - {error_text}",
                 status_code=response.status_code,
             )
-        
+
         try:
             return response.json()
         except Exception as e:
@@ -817,4 +904,6 @@ class CityCatalystClient:
         try:
             return response.json()
         except Exception as e:
-            raise CityCatalystClientError(f"Failed to parse data sources response: {e}") from e
+            raise CityCatalystClientError(
+                f"Failed to parse data sources response: {e}"
+            ) from e

--- a/climate-advisor/service/app/services/citycatalyst_client.py
+++ b/climate-advisor/service/app/services/citycatalyst_client.py
@@ -466,7 +466,8 @@ class CityCatalystClient:
 
         client = await self._get_client()
         try:
-            response = await client.get(
+            async with client.stream(
+                "GET",
                 (
                     f"{self.base_url}/api/v1/internal/ca/"
                     f"concept-note-uploads/{upload_id}/markdown"
@@ -474,32 +475,58 @@ class CityCatalystClient:
                 headers=self._internal_headers(token),
                 follow_redirects=True,
                 timeout=self.datasource_timeout,
-            )
+            ) as response:
+                if not response.is_success:
+                    raise CityCatalystClientError(
+                        "CC Markdown artifact could not be verified",
+                        status_code=response.status_code,
+                    )
+
+                # Reject a trustworthy declared size before consuming the body.
+                settings = get_settings()
+                max_bytes = settings.cnb_markdown_request_max_bytes
+                content_length = response.headers.get("Content-Length")
+                if content_length:
+                    try:
+                        declared_size = int(content_length)
+                    except ValueError as exc:
+                        raise CityCatalystClientError(
+                            "CC Markdown artifact metadata is invalid",
+                            status_code=502,
+                        ) from exc
+                    if declared_size < 0:
+                        raise CityCatalystClientError(
+                            "CC Markdown artifact metadata is invalid",
+                            status_code=502,
+                        )
+                    if declared_size > max_bytes:
+                        raise CityCatalystClientError(
+                            "CC Markdown artifact exceeds the configured maximum",
+                            status_code=413,
+                        )
+
+                # Bound streamed and decompressed bytes even without a size header.
+                markdown_bytes = bytearray()
+                async for chunk in response.aiter_bytes():
+                    if len(markdown_bytes) + len(chunk) > max_bytes:
+                        raise CityCatalystClientError(
+                            "CC Markdown artifact exceeds the configured maximum",
+                            status_code=413,
+                        )
+                    markdown_bytes.extend(chunk)
+
+                # Capture immutable identity metadata before closing the response.
+                markdown_s3_key = response.headers.get("X-Markdown-S3-Key")
+                sha256 = response.headers.get("X-Markdown-SHA256")
+                page_count_header = response.headers.get("X-Page-Count")
         except httpx.HTTPError as exc:
             raise CityCatalystClientError(
                 "CC Markdown verification is unavailable",
                 status_code=503,
             ) from exc
-
-        if not response.is_success:
-            raise CityCatalystClientError(
-                "CC Markdown artifact could not be verified",
-                status_code=response.status_code,
-            )
-
-        settings = get_settings()
-        if len(response.content) > settings.cnb_markdown_request_max_bytes:
-            raise CityCatalystClientError(
-                "CC Markdown artifact exceeds the configured maximum",
-                status_code=413,
-            )
-
-        markdown_s3_key = response.headers.get("X-Markdown-S3-Key")
-        sha256 = response.headers.get("X-Markdown-SHA256")
-        page_count_header = response.headers.get("X-Page-Count")
         try:
             page_count = int(page_count_header or "")
-            markdown = response.content.decode("utf-8")
+            markdown = markdown_bytes.decode("utf-8")
         except (UnicodeDecodeError, ValueError) as exc:
             raise CityCatalystClientError(
                 "CC Markdown artifact metadata is invalid",

--- a/climate-advisor/service/migrations/versions/20260730_120000_concept_note_upload_pointers.py
+++ b/climate-advisor/service/migrations/versions/20260730_120000_concept_note_upload_pointers.py
@@ -44,7 +44,11 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Restore the legacy inline-Markdown schema shape."""
+    """Restore the legacy schema with placeholders, not recovered Markdown.
+
+    Empty Markdown and a zero hash only satisfy the legacy NOT NULL constraints;
+    they cannot recover inline content discarded by the upgrade.
+    """
     op.add_column(
         "concept_note_uploads",
         sa.Column("markdown_text", sa.Text(), nullable=True),

--- a/climate-advisor/service/migrations/versions/20260730_120000_concept_note_upload_pointers.py
+++ b/climate-advisor/service/migrations/versions/20260730_120000_concept_note_upload_pointers.py
@@ -1,0 +1,90 @@
+"""Store Concept Note Markdown by CC S3 pointer.
+
+Revision ID: 20260730_120000
+Revises: 20260729_120000
+Create Date: 2026-07-30 12:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260730_120000"
+down_revision = "20260729_120000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Allow pre-conversion uploads and replace inline Markdown with an S3 key."""
+    op.add_column(
+        "concept_note_uploads",
+        sa.Column("markdown_s3_key", sa.String(length=1024), nullable=True),
+    )
+    op.alter_column(
+        "concept_note_uploads",
+        "markdown_sha256",
+        existing_type=sa.String(length=64),
+        nullable=True,
+    )
+    op.alter_column(
+        "concept_note_uploads",
+        "page_count",
+        existing_type=sa.Integer(),
+        nullable=True,
+    )
+    op.alter_column(
+        "concept_note_uploads",
+        "ingest_status",
+        existing_type=sa.String(length=64),
+        server_default="queued",
+        existing_nullable=False,
+    )
+    op.drop_column("concept_note_uploads", "markdown_text")
+
+
+def downgrade() -> None:
+    """Restore the legacy inline-Markdown schema shape."""
+    op.add_column(
+        "concept_note_uploads",
+        sa.Column("markdown_text", sa.Text(), nullable=True),
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE concept_note_uploads
+            SET markdown_text = COALESCE(markdown_text, ''),
+                markdown_sha256 = COALESCE(
+                    markdown_sha256,
+                    repeat('0', 64)
+                ),
+                page_count = COALESCE(page_count, 1)
+            """
+        )
+    )
+    op.alter_column(
+        "concept_note_uploads",
+        "markdown_text",
+        existing_type=sa.Text(),
+        nullable=False,
+    )
+    op.alter_column(
+        "concept_note_uploads",
+        "ingest_status",
+        existing_type=sa.String(length=64),
+        server_default="processing",
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "concept_note_uploads",
+        "page_count",
+        existing_type=sa.Integer(),
+        nullable=False,
+    )
+    op.alter_column(
+        "concept_note_uploads",
+        "markdown_sha256",
+        existing_type=sa.String(length=64),
+        nullable=False,
+    )
+    op.drop_column("concept_note_uploads", "markdown_s3_key")

--- a/climate-advisor/service/tests/test_concept_note_markdown_client.py
+++ b/climate-advisor/service/tests/test_concept_note_markdown_client.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from app.services.citycatalyst_client import (
+    CityCatalystClient,
+    CityCatalystClientError,
+)
+
+
+class TrackingStream(httpx.AsyncByteStream):
+    """Yield controlled chunks and record how far the client consumed them."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self.chunks = chunks
+        self.chunks_read = 0
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self.chunks:
+            self.chunks_read += 1
+            yield chunk
+
+    async def aclose(self) -> None:
+        """Satisfy the HTTPX streaming response contract."""
+
+
+def settings(max_bytes: int) -> SimpleNamespace:
+    """Return the CityCatalyst settings used by these focused client tests."""
+    return SimpleNamespace(
+        cc_base_url=None,
+        cc_api_key=None,
+        cnb_markdown_request_max_bytes=max_bytes,
+    )
+
+
+@pytest.mark.asyncio
+async def test_markdown_client_streams_and_parses_a_bounded_artifact() -> None:
+    markdown = b"<!-- page: 1 -->\n# Plan"
+    digest = hashlib.sha256(markdown).hexdigest()
+    stream = TrackingStream([markdown[:10], markdown[10:]])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "Bearer user-token"
+        assert request.headers["X-Service-Key"] == "service-key"
+        return httpx.Response(
+            200,
+            headers={
+                "Content-Length": str(len(markdown)),
+                "X-Markdown-S3-Key": "results/upload/combined.md",
+                "X-Markdown-SHA256": digest,
+                "X-Page-Count": "1",
+            },
+            stream=stream,
+        )
+
+    with patch(
+        "app.services.citycatalyst_client.get_settings",
+        return_value=settings(len(markdown)),
+    ):
+        client = CityCatalystClient(
+            base_url="https://cc.example",
+            api_key="service-key",
+        )
+        client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        try:
+            artifact = await client.get_concept_note_markdown(
+                upload_id="upload-id",
+                token="user-token",
+            )
+        finally:
+            await client.close()
+
+    assert artifact.markdown == markdown.decode()
+    assert artifact.markdown_s3_key == "results/upload/combined.md"
+    assert artifact.sha256 == digest
+    assert artifact.page_count == 1
+    assert stream.chunks_read == 2
+
+
+@pytest.mark.asyncio
+async def test_markdown_client_rejects_declared_oversize_before_streaming() -> None:
+    stream = TrackingStream([b"never consumed"])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"Content-Length": "6"},
+            stream=stream,
+        )
+
+    with patch(
+        "app.services.citycatalyst_client.get_settings",
+        return_value=settings(5),
+    ):
+        client = CityCatalystClient(base_url="https://cc.example")
+        client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        try:
+            with pytest.raises(CityCatalystClientError) as error:
+                await client.get_concept_note_markdown(
+                    upload_id="upload-id",
+                    token="user-token",
+                )
+        finally:
+            await client.close()
+
+    assert error.value.status_code == 413
+    assert stream.chunks_read == 0
+
+
+@pytest.mark.asyncio
+async def test_markdown_client_stops_an_undeclared_oversize_stream() -> None:
+    stream = TrackingStream([b"1234", b"5678", b"not consumed"])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=stream)
+
+    with patch(
+        "app.services.citycatalyst_client.get_settings",
+        return_value=settings(5),
+    ):
+        client = CityCatalystClient(base_url="https://cc.example")
+        client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        try:
+            with pytest.raises(CityCatalystClientError) as error:
+                await client.get_concept_note_markdown(
+                    upload_id="upload-id",
+                    token="user-token",
+                )
+        finally:
+            await client.close()
+
+    assert error.value.status_code == 413
+    assert stream.chunks_read == 2

--- a/climate-advisor/service/tests/test_concept_note_markdown_ingest.py
+++ b/climate-advisor/service/tests/test_concept_note_markdown_ingest.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Iterable
+from dataclasses import replace
+from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
 import pytest
@@ -9,43 +10,62 @@ from fastapi.testclient import TestClient
 
 from app.config import get_settings
 from app.main import get_app
-from app.models.concept_note_markdown import ConceptNoteMarkdownRequest
+from app.models.concept_note_markdown import (
+    ConceptNoteMarkdownRequest,
+    ConceptNoteUploadCreateRequest,
+)
 from app.persistence.concept_notes.markdown import (
     ConceptNoteMarkdownRepository,
     ConceptNoteMarkdownRepositoryError,
+    ConceptNoteUploadSnapshot,
     get_concept_note_markdown_repository,
 )
 from app.routes.concept_note_markdown import get_citycatalyst_client
-from app.services.citycatalyst_client import CityCatalystClientError
+from app.services.citycatalyst_client import (
+    CityCatalystClientError,
+    ConceptNoteMarkdownArtifact,
+)
 
 
-class FakeIdentityClient:
-    """Resolve test tokens without sharing a CC signing secret."""
+MARKDOWN = "<!-- page: 1 -->\n# Plan"
+SHA256 = hashlib.sha256(MARKDOWN.encode()).hexdigest()
+S3_KEY = "pdf-ocr/results/concept_note_upload/upload/1/combined_markdown.md"
+
+
+class FakeCityCatalystClient:
+    """Resolve opaque identities and serve a controlled CC Markdown artifact."""
+
+    def __init__(self) -> None:
+        self.artifact = ConceptNoteMarkdownArtifact(
+            markdown=MARKDOWN,
+            markdown_s3_key=S3_KEY,
+            sha256=SHA256,
+            page_count=1,
+        )
 
     async def validate_user_identity(self, token: str) -> str:
-        """Return the canonical subject or reject an invalid token."""
         if token == "invalid":
             raise CityCatalystClientError("invalid", status_code=401)
         return token
 
+    async def get_concept_note_markdown(
+        self,
+        *,
+        upload_id: str,
+        token: str,
+    ) -> ConceptNoteMarkdownArtifact:
+        return self.artifact
+
 
 class FakeMarkdownRepository(ConceptNoteMarkdownRepository):
-    """Atomic in-memory implementation used only for API contract tests."""
+    """In-memory implementation of the authoritative upload lifecycle."""
 
     def __init__(self, run_id: UUID, owner_id: str) -> None:
         self.run_id = run_id
         self.owner_id = owner_id
-        self.uploads: dict[UUID, tuple[UUID, str]] = {}
+        self.uploads: dict[UUID, ConceptNoteUploadSnapshot] = {}
 
-    async def register_markdown(
-        self,
-        *,
-        user_id: str,
-        run_id: UUID,
-        upload_id: UUID,
-        payload: ConceptNoteMarkdownRequest,
-    ) -> None:
-        """Enforce run ownership, upload binding, and digest idempotency atomically."""
+    def authorize(self, user_id: str, run_id: UUID) -> None:
         if run_id != self.run_id:
             raise ConceptNoteMarkdownRepositoryError(
                 "concept_note_run_not_found", 404, "Run not found"
@@ -54,197 +74,287 @@ class FakeMarkdownRepository(ConceptNoteMarkdownRepository):
             raise ConceptNoteMarkdownRepositoryError(
                 "concept_note_run_forbidden", 403, "Run owner does not match"
             )
-        existing = self.uploads.get(upload_id)
-        if existing and existing[0] != run_id:
+
+    async def create_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        payload: ConceptNoteUploadCreateRequest,
+    ) -> ConceptNoteUploadSnapshot:
+        self.authorize(user_id, run_id)
+        existing = self.uploads.get(payload.upload_id)
+        if existing:
+            if (
+                existing.filename != payload.filename
+                or existing.source_label != payload.source_label
+            ):
+                raise ConceptNoteMarkdownRepositoryError(
+                    "upload_identity_conflict", 409, "Upload changed"
+                )
+            return existing
+        snapshot = ConceptNoteUploadSnapshot(
+            upload_id=payload.upload_id,
+            run_id=run_id,
+            user_id=user_id,
+            filename=payload.filename,
+            source_label=payload.source_label,
+            markdown_s3_key=None,
+            markdown_sha256=None,
+            page_count=None,
+            status="queued",
+            error_code=None,
+            received_at=datetime.now(timezone.utc),
+            completed_at=None,
+        )
+        self.uploads[payload.upload_id] = snapshot
+        return snapshot
+
+    async def get_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        self.authorize(user_id, run_id)
+        try:
+            return self.uploads[upload_id]
+        except KeyError as exc:
             raise ConceptNoteMarkdownRepositoryError(
-                "upload_run_binding_conflict", 409, "Upload belongs to another run"
-            )
-        if existing and existing[1] != payload.sha256:
+                "concept_note_upload_not_found", 404, "Upload not found"
+            ) from exc
+
+    async def register_markdown(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+        payload: ConceptNoteMarkdownRequest,
+    ) -> ConceptNoteUploadSnapshot:
+        current = await self.get_upload(
+            user_id=user_id,
+            run_id=run_id,
+            upload_id=upload_id,
+        )
+        if current.markdown_sha256:
+            if (
+                current.markdown_s3_key != payload.markdown_s3_key
+                or current.markdown_sha256 != payload.sha256
+            ):
+                raise ConceptNoteMarkdownRepositoryError(
+                    "markdown_identity_conflict", 409, "Markdown changed"
+                )
+            return current
+        updated = replace(
+            current,
+            markdown_s3_key=payload.markdown_s3_key,
+            markdown_sha256=payload.sha256,
+            page_count=payload.page_count,
+            status="ready",
+            completed_at=datetime.now(timezone.utc),
+        )
+        self.uploads[upload_id] = updated
+        return updated
+
+    async def mark_failed(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+        error_code: str,
+    ) -> ConceptNoteUploadSnapshot:
+        current = await self.get_upload(
+            user_id=user_id,
+            run_id=run_id,
+            upload_id=upload_id,
+        )
+        updated = replace(current, status="failed", error_code=error_code)
+        self.uploads[upload_id] = updated
+        return updated
+
+    async def retry_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        current = await self.get_upload(
+            user_id=user_id,
+            run_id=run_id,
+            upload_id=upload_id,
+        )
+        if current.status == "ready":
             raise ConceptNoteMarkdownRepositoryError(
-                "markdown_identity_conflict", 409, "Upload digest cannot change"
+                "upload_not_retryable", 409, "Ready upload"
             )
-        self.uploads[upload_id] = (run_id, payload.sha256)
+        updated = replace(current, status="queued", error_code=None)
+        self.uploads[upload_id] = updated
+        return updated
+
+    async def get_delivery_context(
+        self,
+        *,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        try:
+            return self.uploads[upload_id]
+        except KeyError as exc:
+            raise ConceptNoteMarkdownRepositoryError(
+                "concept_note_upload_not_found", 404, "Upload not found"
+            ) from exc
 
 
-def payload(
-    markdown: str = "<!-- page: 1 -->\n# Plan", page_count: int = 1
-) -> dict[str, object]:
-    """Build a valid request with a digest over the exact UTF-8 Markdown."""
+def create_payload(upload_id: UUID) -> dict[str, object]:
     return {
-        "markdown": markdown,
+        "upload_id": str(upload_id),
+        "user_id": "owner-user",
         "filename": "plan.pdf",
         "source_label": "Climate Action Plan",
-        "page_count": page_count,
-        "sha256": hashlib.sha256(markdown.encode()).hexdigest(),
     }
+
+
+def pointer_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "markdown_s3_key": S3_KEY,
+        "filename": "plan.pdf",
+        "source_label": "Climate Action Plan",
+        "page_count": 1,
+        "sha256": SHA256,
+    }
+    payload.update(overrides)
+    return payload
 
 
 @pytest.fixture
 def ingest_client():
-    """Provide a client and fake atomic repository for each contract test."""
     run_id = uuid4()
     repository = FakeMarkdownRepository(run_id, "owner-user")
+    cc_client = FakeCityCatalystClient()
     app = get_app()
-    app.dependency_overrides[get_citycatalyst_client] = FakeIdentityClient
+    app.dependency_overrides[get_citycatalyst_client] = lambda: cc_client
     app.dependency_overrides[get_concept_note_markdown_repository] = lambda: repository
+    settings = get_settings()
+    original_key = settings.cc_api_key
+    settings.cc_api_key = "service-key"
     with TestClient(app) as client:
-        yield client, repository, run_id
+        yield client, repository, cc_client, run_id
+    settings.cc_api_key = original_key
     app.dependency_overrides.clear()
 
 
-def post(
-    client: TestClient, run_id: UUID, upload_id: UUID, body: dict, token="owner-user"
-):
-    """Post one Markdown artifact with the requested identity token."""
+def auth(token: str = "owner-user") -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def create_upload(client: TestClient, run_id: UUID, upload_id: UUID):
     return client.post(
-        f"/v1/concept-notes/{run_id}/uploads/{upload_id}/markdown",
-        json=body,
-        headers={"Authorization": f"Bearer {token}"} if token else {},
+        f"/v1/concept-notes/{run_id}/uploads",
+        json=create_payload(upload_id),
+        headers=auth(),
     )
 
 
-def post_stream(
-    client: TestClient,
-    run_id: UUID,
-    upload_id: UUID,
-    chunks: Iterable[bytes],
-    token: str = "owner-user",
-):
-    """Post a lazily consumed JSON byte stream without a Content-Length header."""
-    return client.post(
-        f"/v1/concept-notes/{run_id}/uploads/{upload_id}/markdown",
-        content=chunks,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-        },
-    )
-
-
-def test_missing_and_invalid_bearer_token(ingest_client) -> None:
-    client, _, run_id = ingest_client
-    assert post(client, run_id, uuid4(), payload(), token="").status_code == 401
-    assert post(client, run_id, uuid4(), payload(), token="invalid").status_code == 401
-
-
-def test_invalid_bearer_is_rejected_before_stream_consumption(ingest_client) -> None:
-    client, _, run_id = ingest_client
-    consumed_chunks: list[bytes] = []
-
-    def body_chunks() -> Iterable[bytes]:
-        chunk = b"untrusted request body"
-        consumed_chunks.append(chunk)
-        yield chunk
-
-    response = post_stream(
-        client, run_id, uuid4(), body_chunks(), token="invalid"
-    )
-
-    assert response.status_code == 401
-    assert consumed_chunks == []
-
-
-def test_owner_missing_run_and_upload_binding(ingest_client) -> None:
-    client, repository, run_id = ingest_client
-    assert post(client, uuid4(), uuid4(), payload()).status_code == 404
-    assert (
-        post(client, run_id, uuid4(), payload(), token="other-user").status_code == 403
-    )
+def test_create_requires_auth_and_run_owner(ingest_client) -> None:
+    client, _, _, run_id = ingest_client
     upload_id = uuid4()
-    repository.uploads[upload_id] = (uuid4(), payload()["sha256"])
-    response = post(client, run_id, upload_id, payload())
+    assert (
+        client.post(
+            f"/v1/concept-notes/{run_id}/uploads",
+            json=create_payload(upload_id),
+        ).status_code
+        == 401
+    )
+    assert (
+        client.post(
+            f"/v1/concept-notes/{run_id}/uploads",
+            json=create_payload(upload_id),
+            headers=auth("other-user"),
+        ).status_code
+        == 403
+    )
+
+
+def test_create_is_idempotent_and_metadata_is_immutable(ingest_client) -> None:
+    client, _, _, run_id = ingest_client
+    upload_id = uuid4()
+    assert create_upload(client, run_id, upload_id).status_code == 200
+    assert create_upload(client, run_id, upload_id).status_code == 200
+    changed = create_payload(upload_id)
+    changed["filename"] = "changed.pdf"
+    response = client.post(
+        f"/v1/concept-notes/{run_id}/uploads",
+        json=changed,
+        headers=auth(),
+    )
     assert response.status_code == 409
-    assert response.json()["code"] == "upload_run_binding_conflict"
+    assert response.json()["code"] == "upload_identity_conflict"
 
 
-def test_digest_validation_idempotency_and_identity_conflict(ingest_client) -> None:
-    client, _, run_id = ingest_client
+def test_pointer_delivery_verifies_cc_then_persists_ready(ingest_client) -> None:
+    client, repository, _, run_id = ingest_client
     upload_id = uuid4()
-    invalid = payload()
-    invalid["sha256"] = "0" * 64
-    assert (
-        post(client, run_id, upload_id, invalid).json()["code"]
-        == "markdown_digest_mismatch"
-    )
+    create_upload(client, run_id, upload_id)
+    path = f"/v1/concept-notes/{run_id}/uploads/{upload_id}/markdown"
 
-    first = post(client, run_id, upload_id, payload())
-    second = post(client, run_id, upload_id, payload())
+    first = client.post(path, json=pointer_payload(), headers=auth())
+    second = client.post(path, json=pointer_payload(), headers=auth())
+
     assert first.status_code == second.status_code == 202
-
-    changed = payload("<!-- page: 1 -->\n# Changed")
-    conflict = post(client, run_id, upload_id, changed)
-    assert conflict.status_code == 409
-    assert conflict.json()["code"] == "markdown_identity_conflict"
+    assert first.json() == {"upload_id": str(upload_id), "status": "ready"}
+    assert repository.uploads[upload_id].markdown_s3_key == S3_KEY
+    assert repository.uploads[upload_id].status == "ready"
 
 
-def test_page_and_body_size_validation(ingest_client) -> None:
-    client, _, run_id = ingest_client
-    invalid_pages = payload("<!-- page: 2 -->\n# Plan")
-    assert (
-        post(client, run_id, uuid4(), invalid_pages).json()["code"]
-        == "invalid_markdown_pages"
+def test_pointer_or_fetched_bytes_conflict_is_rejected(ingest_client) -> None:
+    client, _, cc_client, run_id = ingest_client
+    upload_id = uuid4()
+    create_upload(client, run_id, upload_id)
+    path = f"/v1/concept-notes/{run_id}/uploads/{upload_id}/markdown"
+
+    response = client.post(
+        path,
+        json=pointer_payload(markdown_s3_key="different/key.md"),
+        headers=auth(),
     )
-    mismatched_count = payload()
-    mismatched_count["page_count"] = 2
-    assert (
-        post(client, run_id, uuid4(), mismatched_count).json()["code"]
-        == "invalid_markdown_pages"
+    assert response.status_code == 409
+    assert response.json()["code"] == "markdown_identity_conflict"
+
+    cc_client.artifact = replace(cc_client.artifact, markdown="# Tampered")
+    response = client.post(path, json=pointer_payload(), headers=auth())
+    assert response.status_code == 422
+    assert response.json()["code"] == "markdown_digest_mismatch"
+
+
+def test_failure_status_and_retry_lifecycle(ingest_client) -> None:
+    client, _, _, run_id = ingest_client
+    upload_id = uuid4()
+    create_upload(client, run_id, upload_id)
+    base = f"/v1/concept-notes/{run_id}/uploads/{upload_id}"
+
+    failed = client.post(
+        f"{base}/failed",
+        json={"error_code": "mistral_unavailable"},
+        headers=auth(),
     )
-
-    settings = get_settings()
-    original_limit = settings.cnb_markdown_request_max_bytes
-    settings.cnb_markdown_request_max_bytes = 32
-    try:
-        response = post(client, run_id, uuid4(), payload())
-        assert response.status_code == 413
-        assert response.json()["code"] == "markdown_request_too_large"
-    finally:
-        settings.cnb_markdown_request_max_bytes = original_limit
+    assert failed.json()["status"] == "failed"
+    status_response = client.get(base, headers=auth())
+    assert status_response.json()["error_code"] == "mistral_unavailable"
+    retried = client.post(f"{base}/retry", headers=auth())
+    assert retried.json()["status"] == "queued"
 
 
-def test_page_count_has_no_acceptance_cap(ingest_client) -> None:
-    client, _, run_id = ingest_client
-    page_count = 1_001
-    markdown = "\n".join(
-        f"<!-- page: {page_number} -->\nPage {page_number}"
-        for page_number in range(1, page_count + 1)
-    )
+def test_delivery_context_requires_reverse_service_key(ingest_client) -> None:
+    client, _, _, run_id = ingest_client
+    upload_id = uuid4()
+    create_upload(client, run_id, upload_id)
+    path = f"/v1/concept-note-uploads/{upload_id}/delivery-context"
 
-    response = post(
-        client,
-        run_id,
-        uuid4(),
-        payload(markdown=markdown, page_count=page_count),
-    )
-
-    assert response.status_code == 202
-
-
-def test_chunked_body_without_content_length_is_bounded(ingest_client) -> None:
-    client, _, run_id = ingest_client
-    settings = get_settings()
-    original_limit = settings.cnb_markdown_request_max_bytes
-    settings.cnb_markdown_request_max_bytes = 8
-    try:
-        response = post_stream(
-            client,
-            run_id,
-            uuid4(),
-            iter((b"12345", b"67890")),
-        )
-    finally:
-        settings.cnb_markdown_request_max_bytes = original_limit
-
-    assert "Content-Length" not in response.request.headers
-    assert response.status_code == 413
-    assert response.json()["code"] == "markdown_request_too_large"
-
-
-def test_unavailable_production_repository_returns_503() -> None:
-    app = get_app()
-    app.dependency_overrides[get_citycatalyst_client] = FakeIdentityClient
-    with TestClient(app) as client:
-        response = post(client, uuid4(), uuid4(), payload())
-    app.dependency_overrides.clear()
-    assert response.status_code == 503
-    assert response.json()["code"] == "cnb_storage_unavailable"
+    assert client.get(path).status_code == 401
+    response = client.get(path, headers={"X-CC-Service-Key": "service-key"})
+    assert response.status_code == 200
+    assert response.json()["run_id"] == str(run_id)
+    assert response.json()["user_id"] == "owner-user"

--- a/climate-advisor/service/tests/test_concept_note_markdown_ingest.py
+++ b/climate-advisor/service/tests/test_concept_note_markdown_ingest.py
@@ -20,7 +20,10 @@ from app.persistence.concept_notes.markdown import (
     ConceptNoteUploadSnapshot,
     get_concept_note_markdown_repository,
 )
-from app.routes.concept_note_markdown import get_citycatalyst_client
+from app.routes.concept_note_markdown import (
+    JSON_REQUEST_MAX_BYTES,
+    get_citycatalyst_client,
+)
 from app.services.citycatalyst_client import (
     CityCatalystClientError,
     ConceptNoteMarkdownArtifact,
@@ -42,6 +45,7 @@ class FakeCityCatalystClient:
             sha256=SHA256,
             page_count=1,
         )
+        self.markdown_error: CityCatalystClientError | None = None
 
     async def validate_user_identity(self, token: str) -> str:
         if token == "invalid":
@@ -54,6 +58,8 @@ class FakeCityCatalystClient:
         upload_id: str,
         token: str,
     ) -> ConceptNoteMarkdownArtifact:
+        if self.markdown_error:
+            raise self.markdown_error
         return self.artifact
 
 
@@ -294,6 +300,45 @@ def test_create_is_idempotent_and_metadata_is_immutable(ingest_client) -> None:
     assert response.json()["code"] == "upload_identity_conflict"
 
 
+def test_json_body_limit_applies_without_content_length(ingest_client) -> None:
+    client, _, _, run_id = ingest_client
+    body = iter(
+        [
+            b'{"padding":"',
+            b"a" * JSON_REQUEST_MAX_BYTES,
+            b'"}',
+        ]
+    )
+
+    response = client.post(
+        f"/v1/concept-notes/{run_id}/uploads",
+        content=body,
+        headers={**auth(), "Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 413
+    assert response.json()["code"] == "upload_request_too_large"
+
+
+def test_json_body_limit_rejects_declared_oversize_before_reading(
+    ingest_client,
+) -> None:
+    client, _, _, run_id = ingest_client
+
+    response = client.post(
+        f"/v1/concept-notes/{run_id}/uploads",
+        content=b"{}",
+        headers={
+            **auth(),
+            "Content-Type": "application/json",
+            "Content-Length": str(JSON_REQUEST_MAX_BYTES + 1),
+        },
+    )
+
+    assert response.status_code == 413
+    assert response.json()["code"] == "upload_request_too_large"
+
+
 def test_pointer_delivery_verifies_cc_then_persists_ready(ingest_client) -> None:
     client, repository, _, run_id = ingest_client
     upload_id = uuid4()
@@ -327,6 +372,25 @@ def test_pointer_or_fetched_bytes_conflict_is_rejected(ingest_client) -> None:
     response = client.post(path, json=pointer_payload(), headers=auth())
     assert response.status_code == 422
     assert response.json()["code"] == "markdown_digest_mismatch"
+
+
+def test_terminal_cc_verification_error_is_not_made_retryable(ingest_client) -> None:
+    client, _, cc_client, run_id = ingest_client
+    upload_id = uuid4()
+    create_upload(client, run_id, upload_id)
+    cc_client.markdown_error = CityCatalystClientError(
+        "Stored Markdown failed its integrity check",
+        status_code=409,
+    )
+
+    response = client.post(
+        f"/v1/concept-notes/{run_id}/uploads/{upload_id}/markdown",
+        json=pointer_payload(),
+        headers=auth(),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["code"] == "cc_markdown_verification_failed"
 
 
 def test_failure_status_and_retry_lifecycle(ingest_client) -> None:

--- a/climate-advisor/service/tests/test_concept_note_markdown_ingest.py
+++ b/climate-advisor/service/tests/test_concept_note_markdown_ingest.py
@@ -422,3 +422,22 @@ def test_delivery_context_requires_reverse_service_key(ingest_client) -> None:
     assert response.status_code == 200
     assert response.json()["run_id"] == str(run_id)
     assert response.json()["user_id"] == "owner-user"
+
+
+def test_delivery_context_audits_rejected_key_without_logging_credential(
+    ingest_client,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client, _, _, run_id = ingest_client
+    upload_id = uuid4()
+    create_upload(client, run_id, upload_id)
+    supplied_key = "unexpected-service-key"
+    path = f"/v1/concept-note-uploads/{upload_id}/delivery-context"
+
+    with caplog.at_level("WARNING", logger="app.routes.concept_note_markdown"):
+        response = client.get(path, headers={"X-CC-Service-Key": supplied_key})
+
+    assert response.status_code == 401
+    assert response.json()["code"] == "invalid_service_key"
+    assert str(upload_id) in caplog.text
+    assert supplied_key not in caplog.text

--- a/climate-advisor/service/tests/test_concept_note_upload_pointer_migration.py
+++ b/climate-advisor/service/tests/test_concept_note_upload_pointer_migration.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import Mock
+
+
+def load_migration() -> ModuleType:
+    path = (
+        Path(__file__).parents[1]
+        / "migrations"
+        / "versions"
+        / "20260730_120000_concept_note_upload_pointers.py"
+    )
+    spec = importlib.util.spec_from_file_location("cnb_pointer_migration", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_upgrade_replaces_inline_markdown_with_nullable_pointer() -> None:
+    migration = load_migration()
+    operations = Mock()
+    migration.op = operations
+
+    migration.upgrade()
+
+    added_column = operations.add_column.call_args.args[1]
+    assert added_column.name == "markdown_s3_key"
+    assert added_column.nullable is True
+    nullable_columns = {
+        call.args[1]
+        for call in operations.alter_column.call_args_list
+        if call.kwargs.get("nullable") is True
+    }
+    assert nullable_columns == {"markdown_sha256", "page_count"}
+    operations.drop_column.assert_called_once_with(
+        "concept_note_uploads", "markdown_text"
+    )
+
+
+def test_downgrade_restores_parent_schema_shape() -> None:
+    migration = load_migration()
+    operations = Mock()
+    migration.op = operations
+
+    migration.downgrade()
+
+    altered = {
+        call.args[1]: call.kwargs for call in operations.alter_column.call_args_list
+    }
+    assert altered["markdown_text"]["nullable"] is False
+    assert altered["markdown_sha256"]["nullable"] is False
+    assert altered["page_count"]["nullable"] is False
+    operations.execute.assert_called_once()
+    operations.drop_column.assert_called_once_with(
+        "concept_note_uploads", "markdown_s3_key"
+    )

--- a/climate-advisor/service/tests/test_concept_note_upload_repository.py
+++ b/climate-advisor/service/tests/test_concept_note_upload_repository.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.db import Base
+from app.models.concept_note_markdown import (
+    ConceptNoteMarkdownRequest,
+    ConceptNoteUploadCreateRequest,
+)
+from app.models.db.concept_note import ConceptNoteRun, ConceptNoteUpload
+from app.persistence.concept_notes.markdown import (
+    ConceptNoteMarkdownRepositoryError,
+    SqlAlchemyConceptNoteMarkdownRepository,
+)
+
+
+@pytest.mark.asyncio
+async def test_repository_persists_nullable_then_immutable_pointer(
+    tmp_path,
+) -> None:
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{(tmp_path / 'cnb.db').as_posix()}"
+    )
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(
+                lambda sync_connection: Base.metadata.create_all(
+                    sync_connection,
+                    tables=[
+                        ConceptNoteRun.__table__,
+                        ConceptNoteUpload.__table__,
+                    ],
+                )
+            )
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        run_id = uuid4()
+        upload_id = uuid4()
+        async with session_factory() as session, session.begin():
+            session.add(
+                ConceptNoteRun(
+                    run_id=run_id,
+                    user_id="owner-user",
+                    name="Test run",
+                    city_id=str(uuid4()),
+                    idempotency_key=uuid4(),
+                    request_fingerprint="a" * 64,
+                    context_summary={},
+                    permission_summary={},
+                )
+            )
+
+        repository = SqlAlchemyConceptNoteMarkdownRepository(session_factory)
+        created = await repository.create_upload(
+            user_id="owner-user",
+            run_id=run_id,
+            payload=ConceptNoteUploadCreateRequest(
+                upload_id=upload_id,
+                user_id="owner-user",
+                filename="plan.pdf",
+                source_label="Plan",
+            ),
+        )
+        assert created.status == "queued"
+        assert created.markdown_s3_key is None
+        assert created.markdown_sha256 is None
+        assert created.page_count is None
+
+        pointer = ConceptNoteMarkdownRequest(
+            markdown_s3_key="pdf-ocr/results/result.md",
+            filename="plan.pdf",
+            source_label="Plan",
+            page_count=3,
+            sha256="b" * 64,
+        )
+        ready = await repository.register_markdown(
+            user_id="owner-user",
+            run_id=run_id,
+            upload_id=upload_id,
+            payload=pointer,
+        )
+        replayed = await repository.register_markdown(
+            user_id="owner-user",
+            run_id=run_id,
+            upload_id=upload_id,
+            payload=pointer,
+        )
+        assert ready.status == replayed.status == "ready"
+        assert ready.markdown_s3_key == pointer.markdown_s3_key
+
+        with pytest.raises(ConceptNoteMarkdownRepositoryError) as conflict:
+            await repository.register_markdown(
+                user_id="owner-user",
+                run_id=run_id,
+                upload_id=upload_id,
+                payload=pointer.model_copy(
+                    update={"markdown_s3_key": "different/result.md"}
+                ),
+            )
+        assert conflict.value.code == "markdown_identity_conflict"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Stack

1. **#2937 — Climate Advisor upload persistence** (this PR)
2. #2938 — CityCatalyst PDF OCR integration
## Summary

- add the follow-up Climate Advisor migration for nullable pre-conversion uploads
- replace inline Markdown persistence with a durable `markdown_s3_key`
- add authoritative upload creation, lifecycle, failure, retry, and pointer-delivery contracts
- make identical delivery idempotent and reject changed Markdown identity
- add the authenticated CityCatalyst Markdown verification client

## Scope

Climate Advisor backend only. This PR contains 11 `climate-advisor` files and no CityCatalyst or frontend changes. It is based on the unchanged CC-608 top branch.

## Validation

- `9 passed` across the focused Concept Note upload and migration pytest suites
- fatal Ruff checks passed
- `git diff --check` passed
- exact-content preservation verified against the original CC-609 head

## Recovery

The original combined CC-609 head is preserved at `codex/CC-609-pre-ca-cc-split-backup-06ba57b` (`06ba57ba541b7c1f94a9764e555e323b3603c11d`).