### PR TITLE
[2/2] CC-609: Connect CNB uploads to PDF OCR

### DIFF
--- a/app/scripts/build-swagger-doc.ts
+++ b/app/scripts/build-swagger-doc.ts
@@ -101,6 +101,15 @@ function generateOpenAPISpec() {
             description: "Waste composition operations",
           },
           {
+            name: "concept-notes",
+            description: "Concept Note Builder run and upload operations",
+          },
+          {
+            name: "concept-notes-internal",
+            description:
+              "Authenticated CityCatalyst and Climate Advisor integration contracts",
+          },
+          {
             name: "cron",
             description: "Cron job operations",
           },

--- a/app/src/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/retry/route.ts
+++ b/app/src/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/retry/route.ts
@@ -1,0 +1,66 @@
+import createHttpError from "http-errors";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import {
+  loadConceptNoteRunCity,
+  loadConceptNoteUpload,
+  updateConceptNoteUpload,
+} from "@/backend/ConceptNoteUploadService";
+import {
+  getConceptNotePdfOcrJob,
+  retryConceptNotePdfOcr,
+} from "@/backend/PdfOcrService";
+import { PermissionService } from "@/backend/permissions/PermissionService";
+import { apiHandler } from "@/util/api";
+
+const paramsSchema = z.object({
+  runId: z.string().uuid(),
+  uploadId: z.string().uuid(),
+});
+
+export const POST = apiHandler(async (req, { session, params }) => {
+  if (!session?.user?.id) {
+    throw new createHttpError.Unauthorized("Authentication required");
+  }
+  const { runId, uploadId } = paramsSchema.parse(params);
+  const userId = session.user.id;
+  const currentRequestId = req.headers.get("x-request-id")?.trim() || undefined;
+  const cityId = await loadConceptNoteRunCity({
+    runId,
+    userId,
+    requestId: currentRequestId,
+  });
+  await PermissionService.canAccessCity(session, cityId, {
+    includeResource: false,
+  });
+  const upload = await loadConceptNoteUpload({
+    runId,
+    uploadId,
+    userId,
+    requestId: currentRequestId,
+  });
+  const job = await getConceptNotePdfOcrJob(uploadId);
+  if (!job) {
+    throw new createHttpError.Conflict("PDF conversion job is unavailable");
+  }
+  if (upload.status === "ready" || job.deliveryStatus === "delivered") {
+    throw new createHttpError.Conflict("A completed upload cannot be retried");
+  }
+
+  await updateConceptNoteUpload({
+    runId,
+    uploadId,
+    userId,
+    action: "retry",
+    requestId: currentRequestId,
+  });
+  const retryKind = await retryConceptNotePdfOcr(job);
+  return NextResponse.json(
+    {
+      upload_id: uploadId,
+      status: retryKind === "delivery" ? "processing" : "queued",
+    },
+    { status: 202 },
+  );
+});

--- a/app/src/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/retry/route.ts
+++ b/app/src/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/retry/route.ts
@@ -27,9 +27,9 @@
  *           application/json:
  *             schema:
  *               type: object
- *               required: [upload_id, status, stage]
+ *               required: [uploadId, status, stage]
  *               properties:
- *                 upload_id:
+ *                 uploadId:
  *                   type: string
  *                   format: uuid
  *                 status:
@@ -38,7 +38,7 @@
  *                 stage:
  *                   type: string
  *                   enum: [ocr, delivery]
- *                 retry_kind:
+ *                 retryKind:
  *                   type: string
  *                   enum: [ocr, delivery]
  *       401:
@@ -123,10 +123,10 @@ export const POST = apiHandler(async (req, { session, params }) => {
     (currentState.stage === "complete" ? "delivery" : currentState.stage);
   return NextResponse.json(
     {
-      upload_id: uploadId,
+      uploadId,
       status,
       stage,
-      ...(acceptedKind ? { retry_kind: acceptedKind } : {}),
+      ...(acceptedKind ? { retryKind: acceptedKind } : {}),
     },
     { status: 202 },
   );

--- a/app/src/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/retry/route.ts
+++ b/app/src/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/retry/route.ts
@@ -1,3 +1,55 @@
+/**
+ * @swagger
+ * /api/v1/concept-notes/{runId}/uploads/{uploadId}/retry:
+ *   post:
+ *     operationId: retryConceptNoteUpload
+ *     summary: Retry failed Concept Note OCR or Markdown-pointer delivery
+ *     description: Failed OCR reruns conversion; delivery retry reuses successful OCR without calling Mistral again.
+ *     tags:
+ *       - concept-notes
+ *     parameters:
+ *       - in: path
+ *         name: runId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: path
+ *         name: uploadId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       202:
+ *         description: Retry accepted or an identical retry is already in progress
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required: [upload_id, status, stage]
+ *               properties:
+ *                 upload_id:
+ *                   type: string
+ *                   format: uuid
+ *                 status:
+ *                   type: string
+ *                   enum: [queued, processing]
+ *                 stage:
+ *                   type: string
+ *                   enum: [ocr, delivery]
+ *                 retry_kind:
+ *                   type: string
+ *                   enum: [ocr, delivery]
+ *       401:
+ *         description: Authentication required
+ *       403:
+ *         description: City or run access denied
+ *       404:
+ *         description: Run or upload not found
+ *       409:
+ *         description: The upload has completed or its CC OCR job is unavailable
+ */
 import createHttpError from "http-errors";
 import { NextResponse } from "next/server";
 import { z } from "zod";
@@ -9,6 +61,7 @@ import {
 } from "@/backend/ConceptNoteUploadService";
 import {
   getConceptNotePdfOcrJob,
+  normalizeConceptNotePdfOcrStatus,
   retryConceptNotePdfOcr,
 } from "@/backend/PdfOcrService";
 import { PermissionService } from "@/backend/permissions/PermissionService";
@@ -44,7 +97,8 @@ export const POST = apiHandler(async (req, { session, params }) => {
   if (!job) {
     throw new createHttpError.Conflict("PDF conversion job is unavailable");
   }
-  if (upload.status === "ready" || job.deliveryStatus === "delivered") {
+  const currentState = normalizeConceptNotePdfOcrStatus(job);
+  if (upload.status === "ready" || currentState.status === "ready") {
     throw new createHttpError.Conflict("A completed upload cannot be retried");
   }
 
@@ -56,10 +110,23 @@ export const POST = apiHandler(async (req, { session, params }) => {
     requestId: currentRequestId,
   });
   const retryKind = await retryConceptNotePdfOcr(job);
+  const acceptedKind =
+    retryKind === "noop" ? currentState.retryKind : retryKind;
+  const status =
+    retryKind === "ocr"
+      ? "queued"
+      : retryKind === "delivery"
+        ? "processing"
+        : currentState.status;
+  const stage =
+    acceptedKind ||
+    (currentState.stage === "complete" ? "delivery" : currentState.stage);
   return NextResponse.json(
     {
       upload_id: uploadId,
-      status: retryKind === "delivery" ? "processing" : "queued",
+      status,
+      stage,
+      ...(acceptedKind ? { retry_kind: acceptedKind } : {}),
     },
     { status: 202 },
   );

--- a/app/src/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/route.ts
+++ b/app/src/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/route.ts
@@ -1,0 +1,62 @@
+import createHttpError from "http-errors";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import {
+  loadConceptNoteRunCity,
+  loadConceptNoteUpload,
+} from "@/backend/ConceptNoteUploadService";
+import {
+  getConceptNotePdfOcrJob,
+  normalizeConceptNotePdfOcrStatus,
+} from "@/backend/PdfOcrService";
+import { PermissionService } from "@/backend/permissions/PermissionService";
+import { apiHandler } from "@/util/api";
+
+const paramsSchema = z.object({
+  runId: z.string().uuid(),
+  uploadId: z.string().uuid(),
+});
+
+export const GET = apiHandler(async (req, { session, params }) => {
+  if (!session?.user?.id) {
+    throw new createHttpError.Unauthorized("Authentication required");
+  }
+  const { runId, uploadId } = paramsSchema.parse(params);
+  const userId = session.user.id;
+  const currentRequestId = req.headers.get("x-request-id")?.trim() || undefined;
+  const cityId = await loadConceptNoteRunCity({
+    runId,
+    userId,
+    requestId: currentRequestId,
+  });
+  await PermissionService.canAccessCity(session, cityId, {
+    includeResource: false,
+  });
+  const upload = await loadConceptNoteUpload({
+    runId,
+    uploadId,
+    userId,
+    requestId: currentRequestId,
+  });
+  const job = await getConceptNotePdfOcrJob(uploadId);
+  const workerState = job ? normalizeConceptNotePdfOcrStatus(job) : null;
+  const status =
+    upload.status === "ready" ? "ready" : workerState?.status || upload.status;
+  const errorCode =
+    status === "failed"
+      ? workerState?.errorCode || upload.error_code || undefined
+      : undefined;
+
+  return NextResponse.json({
+    upload_id: upload.upload_id,
+    run_id: upload.run_id,
+    status,
+    filename: upload.filename,
+    source_label: upload.source_label || null,
+    page_count: upload.page_count || null,
+    ...(errorCode ? { error_code: errorCode } : {}),
+    received_at: upload.received_at,
+    completed_at: upload.completed_at || null,
+  });
+});

--- a/app/src/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/route.ts
+++ b/app/src/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/route.ts
@@ -28,18 +28,18 @@
  *             schema:
  *               type: object
  *               required:
- *                 - upload_id
- *                 - run_id
+ *                 - uploadId
+ *                 - runId
  *                 - status
  *                 - stage
- *                 - can_retry
+ *                 - canRetry
  *                 - filename
- *                 - received_at
+ *                 - receivedAt
  *               properties:
- *                 upload_id:
+ *                 uploadId:
  *                   type: string
  *                   format: uuid
- *                 run_id:
+ *                 runId:
  *                   type: string
  *                   format: uuid
  *                 status:
@@ -48,25 +48,25 @@
  *                 stage:
  *                   type: string
  *                   enum: [upload, ocr, delivery, complete]
- *                 can_retry:
+ *                 canRetry:
  *                   type: boolean
- *                 retry_kind:
+ *                 retryKind:
  *                   type: string
  *                   enum: [ocr, delivery]
  *                 filename:
  *                   type: string
- *                 source_label:
+ *                 sourceLabel:
  *                   type: string
  *                   nullable: true
- *                 page_count:
+ *                 pageCount:
  *                   type: integer
  *                   nullable: true
- *                 error_code:
+ *                 errorCode:
  *                   type: string
- *                 received_at:
+ *                 receivedAt:
  *                   type: string
  *                   format: date-time
- *                 completed_at:
+ *                 completedAt:
  *                   type: string
  *                   format: date-time
  *                   nullable: true
@@ -127,21 +127,21 @@ export const GET = apiHandler(async (req, { session, params }) => {
   const retryKind = canRetry ? workerState?.retryKind : undefined;
   const errorCode =
     status === "failed"
-      ? workerState?.errorCode || upload.error_code || undefined
+      ? workerState?.errorCode || upload.errorCode || undefined
       : undefined;
 
   return NextResponse.json({
-    upload_id: upload.upload_id,
-    run_id: upload.run_id,
+    uploadId: upload.uploadId,
+    runId: upload.runId,
     status,
     stage,
-    can_retry: canRetry,
-    ...(retryKind ? { retry_kind: retryKind } : {}),
+    canRetry,
+    ...(retryKind ? { retryKind } : {}),
     filename: upload.filename,
-    source_label: upload.source_label || null,
-    page_count: upload.page_count || null,
-    ...(errorCode ? { error_code: errorCode } : {}),
-    received_at: upload.received_at,
-    completed_at: upload.completed_at || null,
+    sourceLabel: upload.sourceLabel || null,
+    pageCount: upload.pageCount || null,
+    ...(errorCode ? { errorCode } : {}),
+    receivedAt: upload.receivedAt,
+    completedAt: upload.completedAt || null,
   });
 });

--- a/app/src/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/route.ts
+++ b/app/src/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/route.ts
@@ -1,3 +1,82 @@
+/**
+ * @swagger
+ * /api/v1/concept-notes/{runId}/uploads/{uploadId}:
+ *   get:
+ *     operationId: getConceptNoteUploadStatus
+ *     summary: Get the authorized lifecycle status of a Concept Note PDF upload
+ *     description: Reports whether failure occurred during upload registration, OCR, or pointer delivery and whether retry is supported.
+ *     tags:
+ *       - concept-notes
+ *     parameters:
+ *       - in: path
+ *         name: runId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: path
+ *         name: uploadId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Upload lifecycle status
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required:
+ *                 - upload_id
+ *                 - run_id
+ *                 - status
+ *                 - stage
+ *                 - can_retry
+ *                 - filename
+ *                 - received_at
+ *               properties:
+ *                 upload_id:
+ *                   type: string
+ *                   format: uuid
+ *                 run_id:
+ *                   type: string
+ *                   format: uuid
+ *                 status:
+ *                   type: string
+ *                   enum: [queued, processing, ready, failed]
+ *                 stage:
+ *                   type: string
+ *                   enum: [upload, ocr, delivery, complete]
+ *                 can_retry:
+ *                   type: boolean
+ *                 retry_kind:
+ *                   type: string
+ *                   enum: [ocr, delivery]
+ *                 filename:
+ *                   type: string
+ *                 source_label:
+ *                   type: string
+ *                   nullable: true
+ *                 page_count:
+ *                   type: integer
+ *                   nullable: true
+ *                 error_code:
+ *                   type: string
+ *                 received_at:
+ *                   type: string
+ *                   format: date-time
+ *                 completed_at:
+ *                   type: string
+ *                   format: date-time
+ *                   nullable: true
+ *       401:
+ *         description: Authentication required
+ *       403:
+ *         description: City or run access denied
+ *       404:
+ *         description: Run or upload not found
+ */
 import createHttpError from "http-errors";
 import { NextResponse } from "next/server";
 import { z } from "zod";
@@ -41,8 +120,11 @@ export const GET = apiHandler(async (req, { session, params }) => {
   });
   const job = await getConceptNotePdfOcrJob(uploadId);
   const workerState = job ? normalizeConceptNotePdfOcrStatus(job) : null;
-  const status =
-    upload.status === "ready" ? "ready" : workerState?.status || upload.status;
+  const completed = upload.status === "ready";
+  const status = completed ? "ready" : workerState?.status || upload.status;
+  const stage = completed ? "complete" : workerState?.stage || "upload";
+  const canRetry = status === "failed" && Boolean(workerState?.canRetry);
+  const retryKind = canRetry ? workerState?.retryKind : undefined;
   const errorCode =
     status === "failed"
       ? workerState?.errorCode || upload.error_code || undefined
@@ -52,6 +134,9 @@ export const GET = apiHandler(async (req, { session, params }) => {
     upload_id: upload.upload_id,
     run_id: upload.run_id,
     status,
+    stage,
+    can_retry: canRetry,
+    ...(retryKind ? { retry_kind: retryKind } : {}),
     filename: upload.filename,
     source_label: upload.source_label || null,
     page_count: upload.page_count || null,

--- a/app/src/app/api/v1/concept-notes/[runId]/uploads/route.ts
+++ b/app/src/app/api/v1/concept-notes/[runId]/uploads/route.ts
@@ -1,7 +1,81 @@
-import { randomUUID } from "node:crypto";
+/**
+ * @swagger
+ * /api/v1/concept-notes/{runId}/uploads:
+ *   post:
+ *     operationId: createConceptNoteUpload
+ *     summary: Register and queue an authorized Concept Note PDF upload
+ *     description: Identical run, user, filename, label, and PDF bytes replay the same upload identity.
+ *     tags:
+ *       - concept-notes
+ *     parameters:
+ *       - in: path
+ *         name: runId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             required: [file]
+ *             properties:
+ *               file:
+ *                 type: string
+ *                 format: binary
+ *               source_label:
+ *                 type: string
+ *                 maxLength: 255
+ *                 nullable: true
+ *     responses:
+ *       200:
+ *         description: Identical upload already completed
+ *       202:
+ *         description: Upload registered and conversion queued, processing, or replayed
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required: [upload_id, status, stage, can_retry]
+ *               properties:
+ *                 upload_id:
+ *                   type: string
+ *                   format: uuid
+ *                 status:
+ *                   type: string
+ *                   enum: [queued, processing, ready, failed]
+ *                 stage:
+ *                   type: string
+ *                   enum: [ocr, delivery, complete]
+ *                 can_retry:
+ *                   type: boolean
+ *                 retry_kind:
+ *                   type: string
+ *                   enum: [ocr, delivery]
+ *       400:
+ *         description: Invalid multipart request
+ *       401:
+ *         description: Authentication required
+ *       403:
+ *         description: City or run access denied
+ *       413:
+ *         description: PDF exceeds the 20 MiB limit
+ *       415:
+ *         description: Only PDF uploads are accepted
+ *       422:
+ *         description: Invalid filename, label, empty file, or PDF signature
+ *       502:
+ *         description: Climate Advisor returned an invalid upload identity
+ *       503:
+ *         description: Source storage or OCR queueing is unavailable
+ */
+import { createHash } from "node:crypto";
 
 import createHttpError from "http-errors";
 import { NextResponse } from "next/server";
+import { v5 as uuidv5 } from "uuid";
 import { z } from "zod";
 
 import {
@@ -12,6 +86,8 @@ import InventoryFileStorageService from "@/backend/InventoryFileStorageService";
 import {
   conceptNotePdfSourceKey,
   enqueueConceptNotePdfOcr,
+  getConceptNotePdfOcrJob,
+  normalizeConceptNotePdfOcrStatus,
 } from "@/backend/PdfOcrService";
 import {
   callConceptNoteApi,
@@ -29,6 +105,27 @@ const createResponseSchema = z.object({
 
 function requestId(req: Request): string | undefined {
   return req.headers.get("x-request-id")?.trim() || undefined;
+}
+
+function conceptNoteUploadId(args: {
+  runId: string;
+  userId: string;
+  filename: string;
+  sourceLabel: string | null;
+  fileBuffer: Buffer;
+}): string {
+  const contentSha256 = createHash("sha256")
+    .update(args.fileBuffer)
+    .digest("hex");
+  const identity = JSON.stringify([
+    "citycatalyst-concept-note-upload-v1",
+    args.runId,
+    args.userId,
+    args.filename,
+    args.sourceLabel,
+    contentSha256,
+  ]);
+  return uuidv5(identity, uuidv5.URL);
 }
 
 export const POST = apiHandler(async (req, { session, params }) => {
@@ -94,7 +191,13 @@ export const POST = apiHandler(async (req, { session, params }) => {
     throw new createHttpError.UnprocessableEntity("Source label is too long");
   }
 
-  const uploadId = randomUUID();
+  const uploadId = conceptNoteUploadId({
+    runId,
+    userId,
+    filename,
+    sourceLabel,
+    fileBuffer,
+  });
   const createResponse = await callConceptNoteApi({
     path: `/v1/concept-notes/${runId}/uploads`,
     userId,
@@ -126,8 +229,33 @@ export const POST = apiHandler(async (req, { session, params }) => {
     );
   }
 
+  const existingJob = await getConceptNotePdfOcrJob(uploadId);
+  if (existingJob) {
+    const state = normalizeConceptNotePdfOcrStatus(existingJob);
+    if (created.data.status === "failed" && state.status !== "failed") {
+      await updateConceptNoteUpload({
+        runId,
+        uploadId,
+        userId,
+        action: "retry",
+        requestId: currentRequestId,
+      });
+    }
+    return NextResponse.json(
+      {
+        upload_id: uploadId,
+        status: state.status,
+        stage: state.stage,
+        can_retry: state.canRetry,
+        ...(state.retryKind ? { retry_kind: state.retryKind } : {}),
+      },
+      { status: state.status === "ready" ? 200 : 202 },
+    );
+  }
+
   const sourceKey = conceptNotePdfSourceKey(uploadId);
   let failureCode = "source_storage_failed";
+  let job: Awaited<ReturnType<typeof enqueueConceptNotePdfOcr>>;
   try {
     await InventoryFileStorageService.putFile(
       sourceKey,
@@ -135,9 +263,8 @@ export const POST = apiHandler(async (req, { session, params }) => {
       "application/pdf",
     );
     failureCode = "ocr_enqueue_failed";
-    await enqueueConceptNotePdfOcr(uploadId);
+    job = await enqueueConceptNotePdfOcr(uploadId);
   } catch {
-    await InventoryFileStorageService.deleteFile(sourceKey).catch(() => {});
     await updateConceptNoteUpload({
       runId,
       uploadId,
@@ -151,8 +278,26 @@ export const POST = apiHandler(async (req, { session, params }) => {
     );
   }
 
+  if (created.data.status === "failed") {
+    await updateConceptNoteUpload({
+      runId,
+      uploadId,
+      userId,
+      action: "retry",
+      requestId: currentRequestId,
+    });
+  }
+
+  const state = normalizeConceptNotePdfOcrStatus(job);
+
   return NextResponse.json(
-    { upload_id: uploadId, status: "queued" },
+    {
+      upload_id: uploadId,
+      status: state.status,
+      stage: state.stage,
+      can_retry: state.canRetry,
+      ...(state.retryKind ? { retry_kind: state.retryKind } : {}),
+    },
     { status: 202 },
   );
 });

--- a/app/src/app/api/v1/concept-notes/[runId]/uploads/route.ts
+++ b/app/src/app/api/v1/concept-notes/[runId]/uploads/route.ts
@@ -1,0 +1,158 @@
+import { randomUUID } from "node:crypto";
+
+import createHttpError from "http-errors";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import {
+  loadConceptNoteRunCity,
+  updateConceptNoteUpload,
+} from "@/backend/ConceptNoteUploadService";
+import InventoryFileStorageService from "@/backend/InventoryFileStorageService";
+import {
+  conceptNotePdfSourceKey,
+  enqueueConceptNotePdfOcr,
+} from "@/backend/PdfOcrService";
+import {
+  callConceptNoteApi,
+  readConceptNoteApiPayload,
+} from "@/backend/concept-notes";
+import { INVENTORY_IMPORT_MAX_FILE_SIZE_BYTES } from "@/backend/inventory-import-file-limits";
+import { PermissionService } from "@/backend/permissions/PermissionService";
+import { apiHandler } from "@/util/api";
+
+const paramsSchema = z.object({ runId: z.string().uuid() });
+const createResponseSchema = z.object({
+  upload_id: z.string().uuid(),
+  status: z.enum(["queued", "processing", "ready", "failed"]),
+});
+
+function requestId(req: Request): string | undefined {
+  return req.headers.get("x-request-id")?.trim() || undefined;
+}
+
+export const POST = apiHandler(async (req, { session, params }) => {
+  if (!session?.user?.id) {
+    throw new createHttpError.Unauthorized("Authentication required");
+  }
+  const { runId } = paramsSchema.parse(params);
+  const userId = session.user.id;
+  const currentRequestId = requestId(req);
+
+  // Authenticate the run and city before consuming the multipart file body.
+  const cityId = await loadConceptNoteRunCity({
+    runId,
+    userId,
+    requestId: currentRequestId,
+  });
+  await PermissionService.canAccessCity(session, cityId, {
+    includeResource: false,
+  });
+
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch {
+    throw new createHttpError.BadRequest("Invalid multipart upload");
+  }
+  const fileEntry = formData.get("file");
+  if (!(fileEntry instanceof File)) {
+    throw new createHttpError.BadRequest("A PDF file is required");
+  }
+  const filename = fileEntry.name.trim();
+  if (!filename || filename.length > 255) {
+    throw new createHttpError.UnprocessableEntity("Invalid PDF filename");
+  }
+  if (
+    fileEntry.type !== "application/pdf" ||
+    !filename.toLowerCase().endsWith(".pdf")
+  ) {
+    throw new createHttpError.UnsupportedMediaType(
+      "Only application/pdf uploads are accepted",
+    );
+  }
+  if (fileEntry.size === 0) {
+    throw new createHttpError.UnprocessableEntity("PDF file is empty");
+  }
+  if (fileEntry.size > INVENTORY_IMPORT_MAX_FILE_SIZE_BYTES) {
+    throw new createHttpError.PayloadTooLarge(
+      "PDF exceeds the 20 MiB upload limit",
+    );
+  }
+  const fileBuffer = Buffer.from(await fileEntry.arrayBuffer());
+  if (fileBuffer.subarray(0, 5).toString("ascii") !== "%PDF-") {
+    throw new createHttpError.UnprocessableEntity(
+      "Uploaded file does not have a valid PDF signature",
+    );
+  }
+  const sourceLabelEntry = formData.get("source_label");
+  const sourceLabel =
+    typeof sourceLabelEntry === "string" && sourceLabelEntry.trim()
+      ? sourceLabelEntry.trim()
+      : null;
+  if (sourceLabel && sourceLabel.length > 255) {
+    throw new createHttpError.UnprocessableEntity("Source label is too long");
+  }
+
+  const uploadId = randomUUID();
+  const createResponse = await callConceptNoteApi({
+    path: `/v1/concept-notes/${runId}/uploads`,
+    userId,
+    method: "POST",
+    requestId: currentRequestId,
+    body: {
+      upload_id: uploadId,
+      user_id: userId,
+      filename,
+      source_label: sourceLabel,
+    },
+  });
+  const createPayload = await readConceptNoteApiPayload(createResponse);
+  if (!createResponse.ok) {
+    return NextResponse.json(createPayload, { status: createResponse.status });
+  }
+  const created = createResponseSchema.safeParse(createPayload);
+  if (!created.success || created.data.upload_id !== uploadId) {
+    await updateConceptNoteUpload({
+      runId,
+      uploadId,
+      userId,
+      action: "failed",
+      requestId: currentRequestId,
+      body: { error_code: "ca_upload_response_invalid" },
+    }).catch(() => {});
+    throw new createHttpError.BadGateway(
+      "Climate Advisor returned an invalid upload identity",
+    );
+  }
+
+  const sourceKey = conceptNotePdfSourceKey(uploadId);
+  let failureCode = "source_storage_failed";
+  try {
+    await InventoryFileStorageService.putFile(
+      sourceKey,
+      fileBuffer,
+      "application/pdf",
+    );
+    failureCode = "ocr_enqueue_failed";
+    await enqueueConceptNotePdfOcr(uploadId);
+  } catch {
+    await InventoryFileStorageService.deleteFile(sourceKey).catch(() => {});
+    await updateConceptNoteUpload({
+      runId,
+      uploadId,
+      userId,
+      action: "failed",
+      requestId: currentRequestId,
+      body: { error_code: failureCode },
+    }).catch(() => {});
+    throw new createHttpError.ServiceUnavailable(
+      "PDF conversion could not be queued",
+    );
+  }
+
+  return NextResponse.json(
+    { upload_id: uploadId, status: "queued" },
+    { status: 202 },
+  );
+});

--- a/app/src/app/api/v1/concept-notes/[runId]/uploads/route.ts
+++ b/app/src/app/api/v1/concept-notes/[runId]/uploads/route.ts
@@ -4,7 +4,7 @@
  *   post:
  *     operationId: createConceptNoteUpload
  *     summary: Register and queue an authorized Concept Note PDF upload
- *     description: Identical run, user, filename, label, and PDF bytes replay the same upload identity.
+ *     description: Each accepted request receives a new UUID v4 upload identity before conversion is queued.
  *     tags:
  *       - concept-notes
  *     parameters:
@@ -25,22 +25,20 @@
  *               file:
  *                 type: string
  *                 format: binary
- *               source_label:
+ *               sourceLabel:
  *                 type: string
  *                 maxLength: 255
  *                 nullable: true
  *     responses:
- *       200:
- *         description: Identical upload already completed
  *       202:
- *         description: Upload registered and conversion queued, processing, or replayed
+ *         description: Upload registered and conversion queued
  *         content:
  *           application/json:
  *             schema:
  *               type: object
- *               required: [upload_id, status, stage, can_retry]
+ *               required: [uploadId, status, stage, canRetry]
  *               properties:
- *                 upload_id:
+ *                 uploadId:
  *                   type: string
  *                   format: uuid
  *                 status:
@@ -49,9 +47,9 @@
  *                 stage:
  *                   type: string
  *                   enum: [ocr, delivery, complete]
- *                 can_retry:
+ *                 canRetry:
  *                   type: boolean
- *                 retry_kind:
+ *                 retryKind:
  *                   type: string
  *                   enum: [ocr, delivery]
  *       400:
@@ -71,11 +69,10 @@
  *       503:
  *         description: Source storage or OCR queueing is unavailable
  */
-import { createHash } from "node:crypto";
+import { randomUUID } from "node:crypto";
 
 import createHttpError from "http-errors";
 import { NextResponse } from "next/server";
-import { v5 as uuidv5 } from "uuid";
 import { z } from "zod";
 
 import {
@@ -86,7 +83,6 @@ import InventoryFileStorageService from "@/backend/InventoryFileStorageService";
 import {
   conceptNotePdfSourceKey,
   enqueueConceptNotePdfOcr,
-  getConceptNotePdfOcrJob,
   normalizeConceptNotePdfOcrStatus,
 } from "@/backend/PdfOcrService";
 import {
@@ -98,34 +94,18 @@ import { PermissionService } from "@/backend/permissions/PermissionService";
 import { apiHandler } from "@/util/api";
 
 const paramsSchema = z.object({ runId: z.string().uuid() });
-const createResponseSchema = z.object({
-  upload_id: z.string().uuid(),
-  status: z.enum(["queued", "processing", "ready", "failed"]),
-});
+const createResponseWireSchema = z
+  .object({
+    upload_id: z.string().uuid(),
+    status: z.enum(["queued", "processing", "ready", "failed"]),
+  })
+  .transform((payload) => ({
+    uploadId: payload.upload_id,
+    status: payload.status,
+  }));
 
 function requestId(req: Request): string | undefined {
   return req.headers.get("x-request-id")?.trim() || undefined;
-}
-
-function conceptNoteUploadId(args: {
-  runId: string;
-  userId: string;
-  filename: string;
-  sourceLabel: string | null;
-  fileBuffer: Buffer;
-}): string {
-  const contentSha256 = createHash("sha256")
-    .update(args.fileBuffer)
-    .digest("hex");
-  const identity = JSON.stringify([
-    "citycatalyst-concept-note-upload-v1",
-    args.runId,
-    args.userId,
-    args.filename,
-    args.sourceLabel,
-    contentSha256,
-  ]);
-  return uuidv5(identity, uuidv5.URL);
 }
 
 export const POST = apiHandler(async (req, { session, params }) => {
@@ -182,7 +162,7 @@ export const POST = apiHandler(async (req, { session, params }) => {
       "Uploaded file does not have a valid PDF signature",
     );
   }
-  const sourceLabelEntry = formData.get("source_label");
+  const sourceLabelEntry = formData.get("sourceLabel");
   const sourceLabel =
     typeof sourceLabelEntry === "string" && sourceLabelEntry.trim()
       ? sourceLabelEntry.trim()
@@ -191,13 +171,7 @@ export const POST = apiHandler(async (req, { session, params }) => {
     throw new createHttpError.UnprocessableEntity("Source label is too long");
   }
 
-  const uploadId = conceptNoteUploadId({
-    runId,
-    userId,
-    filename,
-    sourceLabel,
-    fileBuffer,
-  });
+  const uploadId = randomUUID();
   const createResponse = await callConceptNoteApi({
     path: `/v1/concept-notes/${runId}/uploads`,
     userId,
@@ -214,42 +188,18 @@ export const POST = apiHandler(async (req, { session, params }) => {
   if (!createResponse.ok) {
     return NextResponse.json(createPayload, { status: createResponse.status });
   }
-  const created = createResponseSchema.safeParse(createPayload);
-  if (!created.success || created.data.upload_id !== uploadId) {
+  const created = createResponseWireSchema.safeParse(createPayload);
+  if (!created.success || created.data.uploadId !== uploadId) {
     await updateConceptNoteUpload({
       runId,
       uploadId,
       userId,
       action: "failed",
       requestId: currentRequestId,
-      body: { error_code: "ca_upload_response_invalid" },
+      errorCode: "ca_upload_response_invalid",
     }).catch(() => {});
     throw new createHttpError.BadGateway(
       "Climate Advisor returned an invalid upload identity",
-    );
-  }
-
-  const existingJob = await getConceptNotePdfOcrJob(uploadId);
-  if (existingJob) {
-    const state = normalizeConceptNotePdfOcrStatus(existingJob);
-    if (created.data.status === "failed" && state.status !== "failed") {
-      await updateConceptNoteUpload({
-        runId,
-        uploadId,
-        userId,
-        action: "retry",
-        requestId: currentRequestId,
-      });
-    }
-    return NextResponse.json(
-      {
-        upload_id: uploadId,
-        status: state.status,
-        stage: state.stage,
-        can_retry: state.canRetry,
-        ...(state.retryKind ? { retry_kind: state.retryKind } : {}),
-      },
-      { status: state.status === "ready" ? 200 : 202 },
     );
   }
 
@@ -271,32 +221,22 @@ export const POST = apiHandler(async (req, { session, params }) => {
       userId,
       action: "failed",
       requestId: currentRequestId,
-      body: { error_code: failureCode },
+      errorCode: failureCode,
     }).catch(() => {});
     throw new createHttpError.ServiceUnavailable(
       "PDF conversion could not be queued",
     );
   }
 
-  if (created.data.status === "failed") {
-    await updateConceptNoteUpload({
-      runId,
-      uploadId,
-      userId,
-      action: "retry",
-      requestId: currentRequestId,
-    });
-  }
-
   const state = normalizeConceptNotePdfOcrStatus(job);
 
   return NextResponse.json(
     {
-      upload_id: uploadId,
+      uploadId,
       status: state.status,
       stage: state.stage,
-      can_retry: state.canRetry,
-      ...(state.retryKind ? { retry_kind: state.retryKind } : {}),
+      canRetry: state.canRetry,
+      ...(state.retryKind ? { retryKind: state.retryKind } : {}),
     },
     { status: 202 },
   );

--- a/app/src/app/api/v1/internal/ca/concept-note-uploads/[uploadId]/markdown/route.ts
+++ b/app/src/app/api/v1/internal/ca/concept-note-uploads/[uploadId]/markdown/route.ts
@@ -1,3 +1,44 @@
+/**
+ * @swagger
+ * /api/v1/internal/ca/concept-note-uploads/{uploadId}/markdown:
+ *   get:
+ *     operationId: getConceptNoteUploadMarkdown
+ *     summary: Read verified CC-owned Markdown for Climate Advisor
+ *     description: Requires Climate Advisor service authentication plus the CC-issued user bearer token. CA never receives S3 credentials or a signed URL.
+ *     tags:
+ *       - concept-notes-internal
+ *     parameters:
+ *       - in: path
+ *         name: uploadId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Verified Markdown bytes streamed by CityCatalyst
+ *         headers:
+ *           X-Markdown-S3-Key:
+ *             description: Stable CC S3 object key used as pointer identity, not an access credential
+ *             schema:
+ *               type: string
+ *           X-Markdown-SHA256:
+ *             schema:
+ *               type: string
+ *           X-Page-Count:
+ *             schema:
+ *               type: integer
+ *         content:
+ *           text/markdown:
+ *             schema:
+ *               type: string
+ *       401:
+ *         description: Climate Advisor service or user authentication is missing
+ *       404:
+ *         description: Completed Markdown was not found
+ *       409:
+ *         description: Stored Markdown failed its SHA-256 integrity check
+ */
 import { createHash } from "node:crypto";
 
 import createHttpError from "http-errors";

--- a/app/src/app/api/v1/internal/ca/concept-note-uploads/[uploadId]/markdown/route.ts
+++ b/app/src/app/api/v1/internal/ca/concept-note-uploads/[uploadId]/markdown/route.ts
@@ -1,0 +1,53 @@
+import { createHash } from "node:crypto";
+
+import createHttpError from "http-errors";
+import { z } from "zod";
+
+import { requireClimateAdvisorServiceRequest } from "@/backend/agentic/ghgi/stationary-energy/auth";
+import InventoryFileStorageService from "@/backend/InventoryFileStorageService";
+import { getConceptNotePdfOcrJob } from "@/backend/PdfOcrService";
+import { apiHandler } from "@/util/api";
+
+const paramsSchema = z.object({ uploadId: z.string().uuid() });
+
+export const GET = apiHandler(async (req, { session, params }) => {
+  requireClimateAdvisorServiceRequest(req);
+  if (!session?.user?.id) {
+    throw new createHttpError.Unauthorized("Authentication required");
+  }
+  const { uploadId } = paramsSchema.parse(params);
+  const job = await getConceptNotePdfOcrJob(uploadId);
+  if (
+    !job ||
+    job.status !== "succeeded" ||
+    !job.resultS3Key ||
+    !job.resultSha256 ||
+    !job.pageCount
+  ) {
+    throw new createHttpError.NotFound(
+      "Completed Concept Note Markdown was not found",
+    );
+  }
+
+  const markdown = await InventoryFileStorageService.getFileBuffer(
+    job.resultS3Key,
+  );
+  const digest = createHash("sha256").update(markdown).digest("hex");
+  if (digest !== job.resultSha256) {
+    throw new createHttpError.Conflict(
+      "Stored Concept Note Markdown failed its integrity check",
+    );
+  }
+
+  return new Response(markdown.toString("utf8"), {
+    status: 200,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Content-Length": String(markdown.byteLength),
+      "X-Markdown-S3-Key": job.resultS3Key,
+      "X-Markdown-SHA256": job.resultSha256,
+      "X-Page-Count": String(job.pageCount),
+      "Cache-Control": "private, no-store",
+    },
+  });
+});

--- a/app/src/backend/ConceptNoteUploadService.ts
+++ b/app/src/backend/ConceptNoteUploadService.ts
@@ -1,0 +1,96 @@
+import createHttpError from "http-errors";
+import { z } from "zod";
+
+import {
+  callConceptNoteApi,
+  readConceptNoteApiPayload,
+} from "@/backend/concept-notes";
+
+const runSchema = z.object({
+  city_id: z.string().uuid(),
+});
+
+export const conceptNoteUploadSchema = z.object({
+  upload_id: z.string().uuid(),
+  run_id: z.string().uuid(),
+  status: z.enum(["queued", "processing", "ready", "failed"]),
+  filename: z.string(),
+  source_label: z.string().nullable().optional(),
+  page_count: z.number().int().positive().nullable().optional(),
+  error_code: z.string().nullable().optional(),
+  received_at: z.string(),
+  completed_at: z.string().nullable().optional(),
+});
+
+function upstreamError(status: number, payload: unknown): Error {
+  const detail =
+    payload &&
+    typeof payload === "object" &&
+    typeof (payload as Record<string, unknown>).detail === "string"
+      ? (payload as Record<string, string>).detail
+      : "Climate Advisor rejected the Concept Note request";
+  return createHttpError(status, detail, { expose: status < 500 });
+}
+
+export async function loadConceptNoteRunCity(args: {
+  runId: string;
+  userId: string;
+  requestId?: string;
+}): Promise<string> {
+  const response = await callConceptNoteApi({
+    path: `/v1/concept-notes/${args.runId}`,
+    userId: args.userId,
+    requestId: args.requestId,
+    searchParams: { user_id: args.userId },
+  });
+  const payload = await readConceptNoteApiPayload(response);
+  if (!response.ok) throw upstreamError(response.status, payload);
+  const parsed = runSchema.safeParse(payload);
+  if (!parsed.success) {
+    throw new createHttpError.BadGateway(
+      "Climate Advisor returned an invalid concept-note run",
+    );
+  }
+  return parsed.data.city_id;
+}
+
+export async function loadConceptNoteUpload(args: {
+  runId: string;
+  uploadId: string;
+  userId: string;
+  requestId?: string;
+}) {
+  const response = await callConceptNoteApi({
+    path: `/v1/concept-notes/${args.runId}/uploads/${args.uploadId}`,
+    userId: args.userId,
+    requestId: args.requestId,
+  });
+  const payload = await readConceptNoteApiPayload(response);
+  if (!response.ok) throw upstreamError(response.status, payload);
+  const parsed = conceptNoteUploadSchema.safeParse(payload);
+  if (!parsed.success) {
+    throw new createHttpError.BadGateway(
+      "Climate Advisor returned invalid Concept Note upload state",
+    );
+  }
+  return parsed.data;
+}
+
+export async function updateConceptNoteUpload(args: {
+  runId: string;
+  uploadId: string;
+  userId: string;
+  action: "failed" | "retry";
+  requestId?: string;
+  body?: Record<string, unknown>;
+}): Promise<void> {
+  const response = await callConceptNoteApi({
+    path: `/v1/concept-notes/${args.runId}/uploads/${args.uploadId}/${args.action}`,
+    userId: args.userId,
+    method: "POST",
+    requestId: args.requestId,
+    body: args.body,
+  });
+  const payload = await readConceptNoteApiPayload(response);
+  if (!response.ok) throw upstreamError(response.status, payload);
+}

--- a/app/src/backend/ConceptNoteUploadService.ts
+++ b/app/src/backend/ConceptNoteUploadService.ts
@@ -6,21 +6,49 @@ import {
   readConceptNoteApiPayload,
 } from "@/backend/concept-notes";
 
-const runSchema = z.object({
-  city_id: z.string().uuid(),
-});
+const runWireSchema = z
+  .object({
+    city_id: z.string().uuid(),
+  })
+  .transform((run) => ({ cityId: run.city_id }));
 
 export const conceptNoteUploadSchema = z.object({
-  upload_id: z.string().uuid(),
-  run_id: z.string().uuid(),
+  uploadId: z.string().uuid(),
+  runId: z.string().uuid(),
   status: z.enum(["queued", "processing", "ready", "failed"]),
   filename: z.string(),
-  source_label: z.string().nullable().optional(),
-  page_count: z.number().int().positive().nullable().optional(),
-  error_code: z.string().nullable().optional(),
-  received_at: z.string(),
-  completed_at: z.string().nullable().optional(),
+  sourceLabel: z.string().nullable().optional(),
+  pageCount: z.number().int().positive().nullable().optional(),
+  errorCode: z.string().nullable().optional(),
+  receivedAt: z.string(),
+  completedAt: z.string().nullable().optional(),
 });
+
+const conceptNoteUploadWireSchema = z
+  .object({
+    upload_id: z.string().uuid(),
+    run_id: z.string().uuid(),
+    status: z.enum(["queued", "processing", "ready", "failed"]),
+    filename: z.string(),
+    source_label: z.string().nullable().optional(),
+    page_count: z.number().int().positive().nullable().optional(),
+    error_code: z.string().nullable().optional(),
+    received_at: z.string(),
+    completed_at: z.string().nullable().optional(),
+  })
+  .transform((upload) =>
+    conceptNoteUploadSchema.parse({
+      uploadId: upload.upload_id,
+      runId: upload.run_id,
+      status: upload.status,
+      filename: upload.filename,
+      sourceLabel: upload.source_label,
+      pageCount: upload.page_count,
+      errorCode: upload.error_code,
+      receivedAt: upload.received_at,
+      completedAt: upload.completed_at,
+    }),
+  );
 
 function upstreamError(status: number, payload: unknown): Error {
   const detail =
@@ -45,13 +73,13 @@ export async function loadConceptNoteRunCity(args: {
   });
   const payload = await readConceptNoteApiPayload(response);
   if (!response.ok) throw upstreamError(response.status, payload);
-  const parsed = runSchema.safeParse(payload);
+  const parsed = runWireSchema.safeParse(payload);
   if (!parsed.success) {
     throw new createHttpError.BadGateway(
       "Climate Advisor returned an invalid concept-note run",
     );
   }
-  return parsed.data.city_id;
+  return parsed.data.cityId;
 }
 
 export async function loadConceptNoteUpload(args: {
@@ -67,7 +95,7 @@ export async function loadConceptNoteUpload(args: {
   });
   const payload = await readConceptNoteApiPayload(response);
   if (!response.ok) throw upstreamError(response.status, payload);
-  const parsed = conceptNoteUploadSchema.safeParse(payload);
+  const parsed = conceptNoteUploadWireSchema.safeParse(payload);
   if (!parsed.success) {
     throw new createHttpError.BadGateway(
       "Climate Advisor returned invalid Concept Note upload state",
@@ -82,14 +110,14 @@ export async function updateConceptNoteUpload(args: {
   userId: string;
   action: "failed" | "retry";
   requestId?: string;
-  body?: Record<string, unknown>;
+  errorCode?: string;
 }): Promise<void> {
   const response = await callConceptNoteApi({
     path: `/v1/concept-notes/${args.runId}/uploads/${args.uploadId}/${args.action}`,
     userId: args.userId,
     method: "POST",
     requestId: args.requestId,
-    body: args.body,
+    body: args.errorCode ? { error_code: args.errorCode } : undefined,
   });
   const payload = await readConceptNoteApiPayload(response);
   if (!response.ok) throw upstreamError(response.status, payload);

--- a/app/src/backend/InventoryFileStorageService.ts
+++ b/app/src/backend/InventoryFileStorageService.ts
@@ -56,6 +56,24 @@ async function bodyToBuffer(body: unknown): Promise<Buffer> {
  *   AWS_FILE_UPLOAD_REGION        — AWS region (default: us-east-1)
  */
 export default class InventoryFileStorageService {
+  /** Store a file at an already-authorized deterministic object key. */
+  static async putFile(
+    s3Key: string,
+    buffer: Buffer,
+    contentType: string,
+  ): Promise<void> {
+    assertConfigured();
+    await getS3Client().send(
+      new PutObjectCommand({
+        Bucket: BUCKET!,
+        Key: s3Key,
+        Body: buffer,
+        ContentType: contentType,
+        ServerSideEncryption: "AES256",
+      }),
+    );
+  }
+
   /**
    * Upload a file buffer to S3 and return the object key.
    */
@@ -159,15 +177,10 @@ export default class InventoryFileStorageService {
   }
 
   static async putTextFile(s3Key: string, text: string): Promise<void> {
-    assertConfigured();
-    await getS3Client().send(
-      new PutObjectCommand({
-        Bucket: BUCKET!,
-        Key: s3Key,
-        Body: Buffer.from(text, "utf8"),
-        ContentType: "text/markdown; charset=utf-8",
-        ServerSideEncryption: "AES256",
-      }),
+    await this.putFile(
+      s3Key,
+      Buffer.from(text, "utf8"),
+      "text/markdown; charset=utf-8",
     );
   }
 

--- a/app/src/backend/PdfOcrDeliveryService.ts
+++ b/app/src/backend/PdfOcrDeliveryService.ts
@@ -1,7 +1,7 @@
 import { Op } from "sequelize";
+
 import { db } from "@/models";
 import type { PdfOcrJob } from "@/models/PdfOcrJob";
-import InventoryFileStorageService from "@/backend/InventoryFileStorageService";
 import { issueClimateAdvisorUserToken } from "@/backend/chat/climate-advisor";
 import {
   joinServiceUrl,
@@ -33,55 +33,30 @@ export class PdfOcrDeliveryError extends Error {
 }
 
 export function serializeMarkdownDeliveryPayload(
-  markdown: string,
   job: PdfOcrJob,
   source: PdfOcrDeliverySource,
 ): string {
-  if (!job.resultSha256 || !job.pageCount) {
+  if (!job.resultS3Key || !job.resultSha256 || !job.pageCount) {
     throw new PdfOcrDeliveryError(
       "ocr_result_incomplete",
       false,
       "OCR result metadata is incomplete",
     );
   }
-  const body = JSON.stringify({
-    markdown,
+  return JSON.stringify({
+    markdown_s3_key: job.resultS3Key,
     filename: source.filename,
     source_label: source.sourceLabel || null,
     page_count: job.pageCount,
     sha256: job.resultSha256,
   });
-  if (
-    Buffer.byteLength(body, "utf8") >
-    getPdfOcrConfig().caMarkdownRequestMaxBytes
-  ) {
-    throw new PdfOcrDeliveryError(
-      "ca_markdown_request_too_large",
-      false,
-      "Climate Advisor Markdown request exceeds the configured maximum",
-    );
-  }
-  return body;
 }
 
-export async function deliverPdfOcrJob(
-  job: PdfOcrJob,
+async function issueDeliveryToken(
   source: PdfOcrDeliverySource,
-): Promise<void> {
-  if (job.status !== "succeeded" || !job.resultS3Key) {
-    throw new PdfOcrDeliveryError(
-      "ocr_result_unavailable",
-      false,
-      "OCR result is not available for delivery",
-    );
-  }
-  const markdown = await InventoryFileStorageService.getTextFile(
-    job.resultS3Key,
-  );
-  const body = serializeMarkdownDeliveryPayload(markdown, job, source);
-  let token: Awaited<ReturnType<typeof issueClimateAdvisorUserToken>>;
+): Promise<Awaited<ReturnType<typeof issueClimateAdvisorUserToken>>> {
   try {
-    token = await issueClimateAdvisorUserToken({ userId: source.userId });
+    return await issueClimateAdvisorUserToken({ userId: source.userId });
   } catch {
     throw new PdfOcrDeliveryError(
       "ca_token_unavailable",
@@ -89,12 +64,20 @@ export async function deliverPdfOcrJob(
       "CC could not issue the Climate Advisor user token",
     );
   }
+}
+
+async function postClimateAdvisorDelivery(
+  source: PdfOcrDeliverySource,
+  suffix: "markdown" | "failed",
+  body: string,
+): Promise<void> {
+  const token = await issueDeliveryToken(source);
   let response: Response;
   try {
     response = await fetch(
       joinServiceUrl(
         requireServiceEnv("CA_BASE_URL"),
-        `/v1/concept-notes/${source.runId}/uploads/${source.uploadId}/markdown`,
+        `/v1/concept-notes/${source.runId}/uploads/${source.uploadId}/${suffix}`,
       ),
       {
         method: "POST",
@@ -122,9 +105,35 @@ export async function deliverPdfOcrJob(
           ? "ca_delivery_transient_error"
           : "ca_delivery_rejected",
       retryable,
-      `Climate Advisor rejected Markdown with status ${response.status}`,
+      `Climate Advisor rejected delivery with status ${response.status}`,
     );
   }
+}
+
+export async function deliverPdfOcrJob(
+  job: PdfOcrJob,
+  source: PdfOcrDeliverySource,
+): Promise<void> {
+  if (job.status === "failed") {
+    await postClimateAdvisorDelivery(
+      source,
+      "failed",
+      JSON.stringify({ error_code: job.errorCode || "pdf_ocr_failed" }),
+    );
+    return;
+  }
+  if (job.status !== "succeeded") {
+    throw new PdfOcrDeliveryError(
+      "ocr_result_unavailable",
+      false,
+      "OCR result is not available for delivery",
+    );
+  }
+  await postClimateAdvisorDelivery(
+    source,
+    "markdown",
+    serializeMarkdownDeliveryPayload(job, source),
+  );
 }
 
 async function recordDeliveryFailure(
@@ -147,13 +156,13 @@ async function recordDeliveryFailure(
   });
 }
 
-/** Process due optional deliveries. Inventory jobs never enter this query. */
+/** Process due terminal OCR outcomes without ever repeating successful OCR. */
 export async function processPdfOcrDeliveries(
   resolveSource: PdfOcrDeliveryResolver,
 ): Promise<number> {
   const jobs = await db.models.PdfOcrJob.findAll({
     where: {
-      status: "succeeded",
+      status: { [Op.in]: ["succeeded", "failed"] },
       deliveryTarget: "climate_advisor",
       [Op.or]: [
         { deliveryStatus: "delivering" },
@@ -170,20 +179,16 @@ export async function processPdfOcrDeliveries(
     limit: 2,
   });
   for (const job of jobs) {
-    const source = await resolveSource(job);
-    if (!source) {
-      await recordDeliveryFailure(
-        job,
-        new PdfOcrDeliveryError(
+    try {
+      const source = await resolveSource(job);
+      if (!source) {
+        throw new PdfOcrDeliveryError(
           "delivery_source_unavailable",
           false,
           "Delivery source metadata is unavailable",
-        ),
-      );
-      continue;
-    }
-    await job.update({ deliveryStatus: "delivering" });
-    try {
+        );
+      }
+      await job.update({ deliveryStatus: "delivering" });
       await deliverPdfOcrJob(job, source);
       await job.update({
         deliveryStatus: "delivered",
@@ -201,6 +206,64 @@ export async function processPdfOcrDeliveries(
   return jobs.length;
 }
 
-/** Inventory-first baseline: future source types register their resolver here. */
-export const resolvePdfOcrDeliverySource: PdfOcrDeliveryResolver = async () =>
-  null;
+export const resolvePdfOcrDeliverySource: PdfOcrDeliveryResolver = async (
+  job,
+) => {
+  if (job.sourceType !== "concept_note_upload") return null;
+  let response: Response;
+  try {
+    response = await fetch(
+      joinServiceUrl(
+        requireServiceEnv("CA_BASE_URL"),
+        `/v1/concept-note-uploads/${job.sourceId}/delivery-context`,
+      ),
+      {
+        headers: {
+          "X-CC-Service-Key": requireServiceEnv("CC_SERVICE_API_KEY"),
+        },
+        signal: AbortSignal.timeout(getPdfOcrConfig().caDeliveryTimeoutMs),
+      },
+    );
+  } catch {
+    throw new PdfOcrDeliveryError(
+      "delivery_source_network_error",
+      true,
+      "Climate Advisor delivery context is unavailable",
+    );
+  }
+  if (!response.ok) {
+    throw new PdfOcrDeliveryError(
+      "delivery_source_unavailable",
+      response.status === 429 || response.status >= 500,
+      `Climate Advisor rejected delivery context with status ${response.status}`,
+    );
+  }
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new PdfOcrDeliveryError(
+      "delivery_source_invalid",
+      false,
+      "Climate Advisor returned invalid delivery context",
+    );
+  }
+  if (!payload || typeof payload !== "object") return null;
+  const source = payload as Record<string, unknown>;
+  if (
+    source.upload_id !== job.sourceId ||
+    typeof source.run_id !== "string" ||
+    typeof source.user_id !== "string" ||
+    typeof source.filename !== "string"
+  ) {
+    return null;
+  }
+  return {
+    uploadId: source.upload_id,
+    runId: source.run_id,
+    userId: source.user_id,
+    filename: source.filename,
+    sourceLabel:
+      typeof source.source_label === "string" ? source.source_label : null,
+  };
+};

--- a/app/src/backend/PdfOcrService.ts
+++ b/app/src/backend/PdfOcrService.ts
@@ -615,24 +615,39 @@ export async function getConceptNotePdfOcrJob(
 
 export function normalizeConceptNotePdfOcrStatus(job: PdfOcrJob): {
   status: "queued" | "processing" | "ready" | "failed";
+  stage: "ocr" | "delivery" | "complete";
+  canRetry: boolean;
+  retryKind?: "ocr" | "delivery";
   errorCode?: string;
 } {
-  if (job.status === "queued") return { status: "queued" };
-  if (job.status === "running") return { status: "processing" };
+  if (job.status === "queued") {
+    return { status: "queued", stage: "ocr", canRetry: false };
+  }
+  if (job.status === "running") {
+    return { status: "processing", stage: "ocr", canRetry: false };
+  }
   if (job.status === "failed") {
     return {
       status: "failed",
+      stage: "ocr",
+      canRetry: true,
+      retryKind: "ocr",
       ...(job.errorCode ? { errorCode: job.errorCode } : {}),
     };
   }
-  if (job.deliveryStatus === "delivered") return { status: "ready" };
+  if (job.deliveryStatus === "delivered") {
+    return { status: "ready", stage: "complete", canRetry: false };
+  }
   if (job.deliveryStatus === "failed") {
     return {
       status: "failed",
+      stage: "delivery",
+      canRetry: true,
+      retryKind: "delivery",
       ...(job.deliveryErrorCode ? { errorCode: job.deliveryErrorCode } : {}),
     };
   }
-  return { status: "processing" };
+  return { status: "processing", stage: "delivery", canRetry: false };
 }
 
 export async function retryConceptNotePdfOcr(

--- a/app/src/backend/PdfOcrService.ts
+++ b/app/src/backend/PdfOcrService.ts
@@ -19,7 +19,12 @@ import { extractInventoryRowsFromDocument } from "@/backend/InventoryExtractionS
 import { ImportStatusEnum } from "@/util/enums";
 import { logger } from "@/services/logger";
 
-const SOURCE_TYPE = "inventory_import" as const;
+const INVENTORY_SOURCE_TYPE = "inventory_import" as const;
+const CONCEPT_NOTE_SOURCE_TYPE = "concept_note_upload" as const;
+
+export function conceptNotePdfSourceKey(uploadId: string): string {
+  return `pdf-ocr/sources/${CONCEPT_NOTE_SOURCE_TYPE}/${uploadId}/source.pdf`;
+}
 
 class PdfSourceError extends Error {
   constructor(
@@ -40,9 +45,12 @@ export async function enqueueInventoryPdfOcr(
   importedFile: ImportedInventoryFile,
 ): Promise<PdfOcrJob> {
   const [job] = await db.models.PdfOcrJob.findOrCreate({
-    where: { sourceType: SOURCE_TYPE, sourceId: importedFile.id },
+    where: {
+      sourceType: INVENTORY_SOURCE_TYPE,
+      sourceId: importedFile.id,
+    },
     defaults: {
-      sourceType: SOURCE_TYPE,
+      sourceType: INVENTORY_SOURCE_TYPE,
       sourceId: importedFile.id,
       status: "queued",
       attemptCount: 0,
@@ -54,6 +62,28 @@ export async function enqueueInventoryPdfOcr(
     importStatus: ImportStatusEnum.EXTRACTING,
     errorLog: null,
     lastUpdated: new Date(),
+  });
+  return job;
+}
+
+export async function enqueueConceptNotePdfOcr(
+  uploadId: string,
+): Promise<PdfOcrJob> {
+  const [job] = await db.models.PdfOcrJob.findOrCreate({
+    where: {
+      sourceType: CONCEPT_NOTE_SOURCE_TYPE,
+      sourceId: uploadId,
+    },
+    defaults: {
+      sourceType: CONCEPT_NOTE_SOURCE_TYPE,
+      sourceId: uploadId,
+      status: "queued",
+      attemptCount: 0,
+      runAfter: new Date(),
+      deliveryTarget: "climate_advisor",
+      deliveryStatus: "pending",
+      deliveryAttemptCount: 0,
+    },
   });
   return job;
 }
@@ -121,7 +151,7 @@ export async function claimInventoryExtractionJobs(
     // status is user-visible workflow state, not an atomic worker claim.
     const jobs = await db.models.PdfOcrJob.findAll({
       where: {
-        sourceType: SOURCE_TYPE,
+        sourceType: INVENTORY_SOURCE_TYPE,
         sourceId: {
           // Filter import eligibility before LIMIT so unrelated unfinished
           // imports cannot hide later OCR results that are ready to extract.
@@ -185,21 +215,14 @@ async function heartbeat(
 }
 
 async function validateSource(
-  importedFile: ImportedInventoryFile,
+  s3Key: string,
+  knownSize?: number,
 ): Promise<void> {
   const config = getPdfOcrConfig();
-  if (!importedFile.s3Key) {
-    throw new PdfSourceError(
-      "pdf_s3_required",
-      "PDF source is not stored in S3",
-    );
-  }
-  if (Number(importedFile.fileSize) > config.maxSourcePdfBytes) {
+  if (knownSize !== undefined && knownSize > config.maxSourcePdfBytes) {
     throw new PdfSourceError("pdf_too_large", "PDF exceeds the OCR size limit");
   }
-  const metadata = await InventoryFileStorageService.getFileMetadata(
-    importedFile.s3Key,
-  );
+  const metadata = await InventoryFileStorageService.getFileMetadata(s3Key);
   if (Number(metadata.ContentLength || 0) > config.maxSourcePdfBytes) {
     throw new PdfSourceError("pdf_too_large", "PDF exceeds the OCR size limit");
   }
@@ -209,10 +232,7 @@ async function validateSource(
       "PDF source has an invalid content type",
     );
   }
-  const prefix = await InventoryFileStorageService.getFilePrefix(
-    importedFile.s3Key,
-    5,
-  );
+  const prefix = await InventoryFileStorageService.getFilePrefix(s3Key, 5);
   if (prefix.toString("ascii") !== "%PDF-") {
     throw new PdfSourceError(
       "invalid_pdf_source",
@@ -221,20 +241,34 @@ async function validateSource(
   }
 }
 
-async function persistOcrResult(job: PdfOcrJob, owner: string): Promise<void> {
+async function resolvePdfSource(job: PdfOcrJob): Promise<{
+  s3Key: string;
+  knownSize?: number;
+}> {
+  if (job.sourceType === CONCEPT_NOTE_SOURCE_TYPE) {
+    return { s3Key: conceptNotePdfSourceKey(job.sourceId) };
+  }
   const importedFile = await db.models.ImportedInventoryFile.findByPk(
     job.sourceId,
   );
-  if (!importedFile || importedFile.fileType !== "pdf") {
+  if (!importedFile || importedFile.fileType !== "pdf" || !importedFile.s3Key) {
     throw new PdfSourceError(
       "invalid_pdf_source",
       "PDF source no longer exists",
     );
   }
-  await validateSource(importedFile);
+  return {
+    s3Key: importedFile.s3Key,
+    knownSize: Number(importedFile.fileSize),
+  };
+}
+
+async function persistOcrResult(job: PdfOcrJob, owner: string): Promise<void> {
+  const source = await resolvePdfSource(job);
+  await validateSource(source.s3Key, source.knownSize);
   const config = getPdfOcrConfig();
   const documentUrl = await InventoryFileStorageService.createSignedDownloadUrl(
-    importedFile.s3Key!,
+    source.s3Key,
     config.presignedUrlSeconds,
   );
   const result = await convertPdfUrlToMarkdown(documentUrl);
@@ -310,7 +344,7 @@ async function failOrRetry(
       },
     },
   );
-  if (!shouldRetry && job.sourceType === SOURCE_TYPE) {
+  if (!shouldRetry && job.sourceType === INVENTORY_SOURCE_TYPE) {
     await db.models.ImportedInventoryFile.update(
       {
         importStatus: ImportStatusEnum.FAILED,
@@ -505,7 +539,6 @@ export async function processPdfOcrJobs() {
   const expiredAt = new Date();
   const exhausted = await db.models.PdfOcrJob.findAll({
     where: {
-      sourceType: SOURCE_TYPE,
       status: "running",
       attemptCount: { [Op.gte]: config.maxAttempts },
       leaseExpiresAt: { [Op.lt]: expiredAt },
@@ -522,14 +555,16 @@ export async function processPdfOcrJobs() {
       leaseExpiresAt: null,
       heartbeatAt: null,
     });
-    await db.models.ImportedInventoryFile.update(
-      {
-        importStatus: ImportStatusEnum.FAILED,
-        errorLog: "attempts_exhausted",
-        lastUpdated: expiredAt,
-      },
-      { where: { id: job.sourceId } },
-    );
+    if (job.sourceType === INVENTORY_SOURCE_TYPE) {
+      await db.models.ImportedInventoryFile.update(
+        {
+          importStatus: ImportStatusEnum.FAILED,
+          errorLog: "attempts_exhausted",
+          lastUpdated: expiredAt,
+        },
+        { where: { id: job.sourceId } },
+      );
+    }
   }
 
   const owner = `pdf-ocr-${randomUUID()}`;
@@ -555,7 +590,7 @@ export async function getInventoryPdfOcrStatus(
   importStatus?: ImportStatusEnum,
 ) {
   const job = await db.models.PdfOcrJob.findOne({
-    where: { sourceType: SOURCE_TYPE, sourceId },
+    where: { sourceType: INVENTORY_SOURCE_TYPE, sourceId },
   });
   if (!job) return null;
   const canRetry =
@@ -565,4 +600,72 @@ export async function getInventoryPdfOcrStatus(
     ...(job.errorCode ? { errorCode: job.errorCode } : {}),
     canRetry,
   };
+}
+
+export async function getConceptNotePdfOcrJob(
+  uploadId: string,
+): Promise<PdfOcrJob | null> {
+  return db.models.PdfOcrJob.findOne({
+    where: {
+      sourceType: CONCEPT_NOTE_SOURCE_TYPE,
+      sourceId: uploadId,
+    },
+  });
+}
+
+export function normalizeConceptNotePdfOcrStatus(job: PdfOcrJob): {
+  status: "queued" | "processing" | "ready" | "failed";
+  errorCode?: string;
+} {
+  if (job.status === "queued") return { status: "queued" };
+  if (job.status === "running") return { status: "processing" };
+  if (job.status === "failed") {
+    return {
+      status: "failed",
+      ...(job.errorCode ? { errorCode: job.errorCode } : {}),
+    };
+  }
+  if (job.deliveryStatus === "delivered") return { status: "ready" };
+  if (job.deliveryStatus === "failed") {
+    return {
+      status: "failed",
+      ...(job.deliveryErrorCode ? { errorCode: job.deliveryErrorCode } : {}),
+    };
+  }
+  return { status: "processing" };
+}
+
+export async function retryConceptNotePdfOcr(
+  job: PdfOcrJob,
+): Promise<"ocr" | "delivery" | "noop"> {
+  if (job.status === "failed") {
+    await job.update({
+      status: "queued",
+      attemptCount: 0,
+      runAfter: new Date(),
+      completedAt: null,
+      errorCode: null,
+      errorMessage: null,
+      leaseOwner: null,
+      leaseExpiresAt: null,
+      heartbeatAt: null,
+      deliveryStatus: "pending",
+      deliveryAttemptCount: 0,
+      deliveryRunAfter: null,
+      deliveredAt: null,
+      deliveryErrorCode: null,
+      deliveryErrorMessage: null,
+    });
+    return "ocr";
+  }
+  if (job.status === "succeeded" && job.deliveryStatus !== "delivered") {
+    await job.update({
+      deliveryStatus: "pending",
+      deliveryRunAfter: new Date(),
+      deliveryErrorCode: null,
+      deliveryErrorMessage: null,
+    });
+    return "delivery";
+  }
+  return "noop";
 }

--- a/app/tests/concept-note-markdown-read.jest.ts
+++ b/app/tests/concept-note-markdown-read.jest.ts
@@ -1,0 +1,84 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import { createHash } from "node:crypto";
+
+const requireServiceRequest = jest.fn();
+const getJob = jest.fn<() => Promise<Record<string, unknown> | null>>();
+const getFileBuffer = jest.fn<() => Promise<Buffer>>();
+
+jest.unstable_mockModule(
+  "@/backend/agentic/ghgi/stationary-energy/auth",
+  () => ({
+    requireClimateAdvisorServiceRequest: requireServiceRequest,
+  }),
+);
+jest.unstable_mockModule("@/backend/PdfOcrService", () => ({
+  getConceptNotePdfOcrJob: getJob,
+}));
+jest.unstable_mockModule("@/backend/InventoryFileStorageService", () => ({
+  default: { getFileBuffer },
+}));
+jest.unstable_mockModule("@/util/api", () => ({
+  apiHandler: (handler: unknown) => handler,
+}));
+
+let readHandler: typeof import("@/app/api/v1/internal/ca/concept-note-uploads/[uploadId]/markdown/route").GET;
+const uploadId = "22222222-2222-4222-8222-222222222222";
+const markdown = Buffer.from("<!-- page: 1 -->\n# Plan", "utf8");
+const sha256 = createHash("sha256").update(markdown).digest("hex");
+
+beforeAll(async () => {
+  ({ GET: readHandler } = await import(
+    "@/app/api/v1/internal/ca/concept-note-uploads/[uploadId]/markdown/route"
+  ));
+});
+
+describe("authenticated Concept Note Markdown read", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getJob.mockResolvedValue({
+      status: "succeeded",
+      resultS3Key: "result.md",
+      resultSha256: sha256,
+      pageCount: 1,
+    });
+    getFileBuffer.mockResolvedValue(markdown);
+  });
+
+  it("streams only a successful artifact with immutable metadata headers", async () => {
+    const request = new Request("http://localhost");
+    const response = await readHandler(request, {
+      session: { user: { id: "owner-user" } },
+      params: { uploadId },
+    });
+
+    expect(requireServiceRequest).toHaveBeenCalledWith(request);
+    expect(response.headers.get("X-Markdown-S3-Key")).toBe("result.md");
+    expect(response.headers.get("X-Markdown-SHA256")).toBe(sha256);
+    expect(response.headers.get("X-Page-Count")).toBe("1");
+    expect(await response.text()).toContain("# Plan");
+  });
+
+  it("rejects missing user auth and a changed stored digest", async () => {
+    await expect(
+      readHandler(new Request("http://localhost"), {
+        session: null,
+        params: { uploadId },
+      }),
+    ).rejects.toMatchObject({ statusCode: 401 });
+
+    getFileBuffer.mockResolvedValue(Buffer.from("tampered"));
+    await expect(
+      readHandler(new Request("http://localhost"), {
+        session: { user: { id: "owner-user" } },
+        params: { uploadId },
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+});

--- a/app/tests/concept-note-upload-service.jest.ts
+++ b/app/tests/concept-note-upload-service.jest.ts
@@ -1,0 +1,97 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+const runId = "11111111-1111-4111-8111-111111111111";
+const uploadId = "22222222-2222-4222-8222-222222222222";
+const callConceptNoteApi = jest.fn<() => Promise<Response>>();
+
+jest.unstable_mockModule("@/backend/concept-notes", () => ({
+  callConceptNoteApi,
+  readConceptNoteApiPayload: (response: Response) => response.json(),
+}));
+
+let loadConceptNoteRunCity: typeof import("@/backend/ConceptNoteUploadService").loadConceptNoteRunCity;
+let loadConceptNoteUpload: typeof import("@/backend/ConceptNoteUploadService").loadConceptNoteUpload;
+let updateConceptNoteUpload: typeof import("@/backend/ConceptNoteUploadService").updateConceptNoteUpload;
+
+beforeAll(async () => {
+  ({ loadConceptNoteRunCity, loadConceptNoteUpload, updateConceptNoteUpload } =
+    await import("@/backend/ConceptNoteUploadService"));
+});
+
+describe("Concept Note upload Climate Advisor adapter", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("maps the snake_case CA run response before returning the city ID", async () => {
+    const cityId = "33333333-3333-4333-8333-333333333333";
+    callConceptNoteApi.mockResolvedValueOnce(
+      Response.json({ city_id: cityId }),
+    );
+
+    await expect(
+      loadConceptNoteRunCity({ runId, userId: "owner-user" }),
+    ).resolves.toBe(cityId);
+  });
+
+  it("maps the snake_case CA response to a camelCase service object", async () => {
+    callConceptNoteApi.mockResolvedValueOnce(
+      Response.json({
+        upload_id: uploadId,
+        run_id: runId,
+        status: "ready",
+        filename: "plan.pdf",
+        source_label: "Climate plan",
+        page_count: 3,
+        error_code: null,
+        received_at: "2026-07-31T10:00:00Z",
+        completed_at: "2026-07-31T10:01:00Z",
+      }),
+    );
+
+    await expect(
+      loadConceptNoteUpload({
+        runId,
+        uploadId,
+        userId: "owner-user",
+      }),
+    ).resolves.toEqual({
+      uploadId,
+      runId,
+      status: "ready",
+      filename: "plan.pdf",
+      sourceLabel: "Climate plan",
+      pageCount: 3,
+      errorCode: null,
+      receivedAt: "2026-07-31T10:00:00Z",
+      completedAt: "2026-07-31T10:01:00Z",
+    });
+  });
+
+  it("maps the camelCase error code to the snake_case CA request body", async () => {
+    callConceptNoteApi.mockResolvedValueOnce(
+      Response.json({ status: "failed" }),
+    );
+
+    await updateConceptNoteUpload({
+      runId,
+      uploadId,
+      userId: "owner-user",
+      action: "failed",
+      errorCode: "ocr_enqueue_failed",
+    });
+
+    expect(callConceptNoteApi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: { error_code: "ocr_enqueue_failed" },
+      }),
+    );
+  });
+});

--- a/app/tests/concept-note-upload-status-retry.jest.ts
+++ b/app/tests/concept-note-upload-status-retry.jest.ts
@@ -79,12 +79,10 @@ const context = {
 };
 
 beforeAll(async () => {
-  ({ GET: statusHandler } = await import(
-    "@/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/route"
-  ));
-  ({ POST: retryHandler } = await import(
-    "@/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/retry/route"
-  ));
+  ({ GET: statusHandler } =
+    await import("@/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/route"));
+  ({ POST: retryHandler } =
+    await import("@/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/retry/route"));
 });
 
 describe("Concept Note upload status and retry routes", () => {
@@ -93,15 +91,15 @@ describe("Concept Note upload status and retry routes", () => {
     loadRunCity.mockResolvedValue(cityId);
     canAccessCity.mockResolvedValue(undefined);
     loadUpload.mockResolvedValue({
-      upload_id: uploadId,
-      run_id: runId,
+      uploadId,
+      runId,
       status: "failed",
       filename: "plan.pdf",
-      source_label: "Climate plan",
-      page_count: null,
-      error_code: "mistral_unavailable",
-      received_at: "2026-07-31T10:00:00Z",
-      completed_at: "2026-07-31T10:01:00Z",
+      sourceLabel: "Climate plan",
+      pageCount: null,
+      errorCode: "mistral_unavailable",
+      receivedAt: "2026-07-31T10:00:00Z",
+      completedAt: "2026-07-31T10:01:00Z",
     });
     getJob.mockResolvedValue({
       status: "failed",
@@ -122,20 +120,20 @@ describe("Concept Note upload status and retry routes", () => {
       expect.objectContaining({
         status: "failed",
         stage: "ocr",
-        can_retry: true,
-        retry_kind: "ocr",
-        error_code: "mistral_unavailable",
+        canRetry: true,
+        retryKind: "ocr",
+        errorCode: "mistral_unavailable",
       }),
     );
   });
 
   it("pinpoints a pointer-delivery failure without rerunning OCR", async () => {
     loadUpload.mockResolvedValueOnce({
-      upload_id: uploadId,
-      run_id: runId,
+      uploadId,
+      runId,
       status: "processing",
       filename: "plan.pdf",
-      received_at: "2026-07-31T10:00:00Z",
+      receivedAt: "2026-07-31T10:00:00Z",
     });
     getJob.mockResolvedValueOnce({
       status: "succeeded",
@@ -152,9 +150,9 @@ describe("Concept Note upload status and retry routes", () => {
       expect.objectContaining({
         status: "failed",
         stage: "delivery",
-        can_retry: true,
-        retry_kind: "delivery",
-        error_code: "ca_delivery_rejected",
+        canRetry: true,
+        retryKind: "delivery",
+        errorCode: "ca_delivery_rejected",
       }),
     );
   });
@@ -162,12 +160,12 @@ describe("Concept Note upload status and retry routes", () => {
   it("marks pre-queue upload failures as non-retryable through the OCR endpoint", async () => {
     getJob.mockResolvedValueOnce(null);
     loadUpload.mockResolvedValueOnce({
-      upload_id: uploadId,
-      run_id: runId,
+      uploadId,
+      runId,
       status: "failed",
       filename: "plan.pdf",
-      error_code: "source_storage_failed",
-      received_at: "2026-07-31T10:00:00Z",
+      errorCode: "source_storage_failed",
+      receivedAt: "2026-07-31T10:00:00Z",
     });
 
     const response = await statusHandler(
@@ -180,11 +178,11 @@ describe("Concept Note upload status and retry routes", () => {
       expect.objectContaining({
         status: "failed",
         stage: "upload",
-        can_retry: false,
-        error_code: "source_storage_failed",
+        canRetry: false,
+        errorCode: "source_storage_failed",
       }),
     );
-    expect(payload).not.toHaveProperty("retry_kind");
+    expect(payload).not.toHaveProperty("retryKind");
   });
 
   it("allows OCR retry after the terminal failure was delivered to CA", async () => {
@@ -195,10 +193,10 @@ describe("Concept Note upload status and retry routes", () => {
 
     expect(response.status).toBe(202);
     expect(await response.json()).toEqual({
-      upload_id: uploadId,
+      uploadId,
       status: "queued",
       stage: "ocr",
-      retry_kind: "ocr",
+      retryKind: "ocr",
     });
     expect(updateUpload).toHaveBeenCalledWith(
       expect.objectContaining({ action: "retry", uploadId }),
@@ -213,11 +211,11 @@ describe("Concept Note upload status and retry routes", () => {
 
   it("keeps delivery retry separate from successful OCR", async () => {
     loadUpload.mockResolvedValueOnce({
-      upload_id: uploadId,
-      run_id: runId,
+      uploadId,
+      runId,
       status: "failed",
       filename: "plan.pdf",
-      received_at: "2026-07-31T10:00:00Z",
+      receivedAt: "2026-07-31T10:00:00Z",
     });
     getJob.mockResolvedValueOnce({
       status: "succeeded",
@@ -232,20 +230,20 @@ describe("Concept Note upload status and retry routes", () => {
     );
 
     expect(await response.json()).toEqual({
-      upload_id: uploadId,
+      uploadId,
       status: "processing",
       stage: "delivery",
-      retry_kind: "delivery",
+      retryKind: "delivery",
     });
   });
 
   it("still rejects an upload whose successful OCR was delivered", async () => {
     loadUpload.mockResolvedValueOnce({
-      upload_id: uploadId,
-      run_id: runId,
+      uploadId,
+      runId,
       status: "ready",
       filename: "plan.pdf",
-      received_at: "2026-07-31T10:00:00Z",
+      receivedAt: "2026-07-31T10:00:00Z",
     });
     getJob.mockResolvedValueOnce({
       status: "succeeded",

--- a/app/tests/concept-note-upload-status-retry.jest.ts
+++ b/app/tests/concept-note-upload-status-retry.jest.ts
@@ -1,0 +1,261 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+const runId = "11111111-1111-4111-8111-111111111111";
+const uploadId = "22222222-2222-4222-8222-222222222222";
+const cityId = "33333333-3333-4333-8333-333333333333";
+
+const loadRunCity = jest.fn<() => Promise<string>>();
+const loadUpload = jest.fn<() => Promise<Record<string, unknown>>>();
+const updateUpload = jest.fn<() => Promise<void>>();
+const getJob = jest.fn<() => Promise<Record<string, unknown> | null>>();
+const retryOcr = jest.fn<() => Promise<"ocr" | "delivery" | "noop">>();
+const canAccessCity = jest.fn<() => Promise<void>>();
+
+function normalizeStatus(job: Record<string, unknown>) {
+  if (job.status === "queued") {
+    return { status: "queued", stage: "ocr", canRetry: false } as const;
+  }
+  if (job.status === "running") {
+    return { status: "processing", stage: "ocr", canRetry: false } as const;
+  }
+  if (job.status === "failed") {
+    return {
+      status: "failed",
+      stage: "ocr",
+      canRetry: true,
+      retryKind: "ocr",
+      ...(typeof job.errorCode === "string"
+        ? { errorCode: job.errorCode }
+        : {}),
+    } as const;
+  }
+  if (job.deliveryStatus === "delivered") {
+    return { status: "ready", stage: "complete", canRetry: false } as const;
+  }
+  if (job.deliveryStatus === "failed") {
+    return {
+      status: "failed",
+      stage: "delivery",
+      canRetry: true,
+      retryKind: "delivery",
+      ...(typeof job.deliveryErrorCode === "string"
+        ? { errorCode: job.deliveryErrorCode }
+        : {}),
+    } as const;
+  }
+  return { status: "processing", stage: "delivery", canRetry: false } as const;
+}
+
+jest.unstable_mockModule("@/backend/ConceptNoteUploadService", () => ({
+  loadConceptNoteRunCity: loadRunCity,
+  loadConceptNoteUpload: loadUpload,
+  updateConceptNoteUpload: updateUpload,
+}));
+jest.unstable_mockModule("@/backend/PdfOcrService", () => ({
+  getConceptNotePdfOcrJob: getJob,
+  normalizeConceptNotePdfOcrStatus: normalizeStatus,
+  retryConceptNotePdfOcr: retryOcr,
+}));
+jest.unstable_mockModule("@/backend/permissions/PermissionService", () => ({
+  PermissionService: { canAccessCity },
+}));
+jest.unstable_mockModule("@/util/api", () => ({
+  apiHandler: (handler: unknown) => handler,
+}));
+
+let statusHandler: typeof import("@/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/route").GET;
+let retryHandler: typeof import("@/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/retry/route").POST;
+
+const context = {
+  session: { user: { id: "owner-user" } },
+  params: { runId, uploadId },
+};
+
+beforeAll(async () => {
+  ({ GET: statusHandler } = await import(
+    "@/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/route"
+  ));
+  ({ POST: retryHandler } = await import(
+    "@/app/api/v1/concept-notes/[runId]/uploads/[uploadId]/retry/route"
+  ));
+});
+
+describe("Concept Note upload status and retry routes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    loadRunCity.mockResolvedValue(cityId);
+    canAccessCity.mockResolvedValue(undefined);
+    loadUpload.mockResolvedValue({
+      upload_id: uploadId,
+      run_id: runId,
+      status: "failed",
+      filename: "plan.pdf",
+      source_label: "Climate plan",
+      page_count: null,
+      error_code: "mistral_unavailable",
+      received_at: "2026-07-31T10:00:00Z",
+      completed_at: "2026-07-31T10:01:00Z",
+    });
+    getJob.mockResolvedValue({
+      status: "failed",
+      deliveryStatus: "delivered",
+      errorCode: "mistral_unavailable",
+    });
+    updateUpload.mockResolvedValue(undefined);
+    retryOcr.mockResolvedValue("ocr");
+  });
+
+  it("pinpoints a delivered terminal OCR failure as OCR-retryable", async () => {
+    const response = await statusHandler(
+      new Request("http://localhost"),
+      context,
+    );
+
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        stage: "ocr",
+        can_retry: true,
+        retry_kind: "ocr",
+        error_code: "mistral_unavailable",
+      }),
+    );
+  });
+
+  it("pinpoints a pointer-delivery failure without rerunning OCR", async () => {
+    loadUpload.mockResolvedValueOnce({
+      upload_id: uploadId,
+      run_id: runId,
+      status: "processing",
+      filename: "plan.pdf",
+      received_at: "2026-07-31T10:00:00Z",
+    });
+    getJob.mockResolvedValueOnce({
+      status: "succeeded",
+      deliveryStatus: "failed",
+      deliveryErrorCode: "ca_delivery_rejected",
+    });
+
+    const response = await statusHandler(
+      new Request("http://localhost"),
+      context,
+    );
+
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        stage: "delivery",
+        can_retry: true,
+        retry_kind: "delivery",
+        error_code: "ca_delivery_rejected",
+      }),
+    );
+  });
+
+  it("marks pre-queue upload failures as non-retryable through the OCR endpoint", async () => {
+    getJob.mockResolvedValueOnce(null);
+    loadUpload.mockResolvedValueOnce({
+      upload_id: uploadId,
+      run_id: runId,
+      status: "failed",
+      filename: "plan.pdf",
+      error_code: "source_storage_failed",
+      received_at: "2026-07-31T10:00:00Z",
+    });
+
+    const response = await statusHandler(
+      new Request("http://localhost"),
+      context,
+    );
+    const payload = await response.json();
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        stage: "upload",
+        can_retry: false,
+        error_code: "source_storage_failed",
+      }),
+    );
+    expect(payload).not.toHaveProperty("retry_kind");
+  });
+
+  it("allows OCR retry after the terminal failure was delivered to CA", async () => {
+    const response = await retryHandler(
+      new Request("http://localhost"),
+      context,
+    );
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({
+      upload_id: uploadId,
+      status: "queued",
+      stage: "ocr",
+      retry_kind: "ocr",
+    });
+    expect(updateUpload).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "retry", uploadId }),
+    );
+    expect(retryOcr).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "failed",
+        deliveryStatus: "delivered",
+      }),
+    );
+  });
+
+  it("keeps delivery retry separate from successful OCR", async () => {
+    loadUpload.mockResolvedValueOnce({
+      upload_id: uploadId,
+      run_id: runId,
+      status: "failed",
+      filename: "plan.pdf",
+      received_at: "2026-07-31T10:00:00Z",
+    });
+    getJob.mockResolvedValueOnce({
+      status: "succeeded",
+      deliveryStatus: "failed",
+      deliveryErrorCode: "ca_delivery_rejected",
+    });
+    retryOcr.mockResolvedValueOnce("delivery");
+
+    const response = await retryHandler(
+      new Request("http://localhost"),
+      context,
+    );
+
+    expect(await response.json()).toEqual({
+      upload_id: uploadId,
+      status: "processing",
+      stage: "delivery",
+      retry_kind: "delivery",
+    });
+  });
+
+  it("still rejects an upload whose successful OCR was delivered", async () => {
+    loadUpload.mockResolvedValueOnce({
+      upload_id: uploadId,
+      run_id: runId,
+      status: "ready",
+      filename: "plan.pdf",
+      received_at: "2026-07-31T10:00:00Z",
+    });
+    getJob.mockResolvedValueOnce({
+      status: "succeeded",
+      deliveryStatus: "delivered",
+    });
+
+    await expect(
+      retryHandler(new Request("http://localhost"), context),
+    ).rejects.toMatchObject({ statusCode: 409 });
+    expect(updateUpload).not.toHaveBeenCalled();
+    expect(retryOcr).not.toHaveBeenCalled();
+  });
+});

--- a/app/tests/concept-note-upload.jest.ts
+++ b/app/tests/concept-note-upload.jest.ts
@@ -11,23 +11,36 @@ const runId = "11111111-1111-4111-8111-111111111111";
 const loadRunCity = jest.fn<() => Promise<string>>();
 const updateUpload = jest.fn<() => Promise<void>>();
 const putFile = jest.fn<() => Promise<void>>();
-const deleteFile = jest.fn<() => Promise<void>>();
-const enqueue = jest.fn<() => Promise<Record<string, never>>>();
+const enqueue =
+  jest.fn<(uploadId: string) => Promise<Record<string, unknown>>>();
+const getJob =
+  jest.fn<(uploadId: string) => Promise<Record<string, unknown> | null>>();
+const normalizeStatus = jest.fn<
+  (job: Record<string, unknown>) => {
+    status: "queued" | "processing" | "ready" | "failed";
+    stage: "ocr" | "delivery" | "complete";
+    canRetry: boolean;
+    retryKind?: "ocr" | "delivery";
+  }
+>();
 const callConceptNoteApi =
   jest.fn<(request: { body?: { upload_id?: string } }) => Promise<Response>>();
 const canAccessCity = jest.fn<() => Promise<void>>();
+const jobs = new Map<string, Record<string, unknown>>();
 
 jest.unstable_mockModule("@/backend/ConceptNoteUploadService", () => ({
   loadConceptNoteRunCity: loadRunCity,
   updateConceptNoteUpload: updateUpload,
 }));
 jest.unstable_mockModule("@/backend/InventoryFileStorageService", () => ({
-  default: { putFile, deleteFile },
+  default: { putFile },
 }));
 jest.unstable_mockModule("@/backend/PdfOcrService", () => ({
   conceptNotePdfSourceKey: (id: string) =>
     `pdf-ocr/sources/concept_note_upload/${id}/source.pdf`,
   enqueueConceptNotePdfOcr: enqueue,
+  getConceptNotePdfOcrJob: getJob,
+  normalizeConceptNotePdfOcrStatus: normalizeStatus,
 }));
 jest.unstable_mockModule("@/backend/concept-notes", () => ({
   callConceptNoteApi,
@@ -83,9 +96,20 @@ describe("Concept Note PDF upload route", () => {
       }),
     );
     putFile.mockResolvedValue(undefined);
-    enqueue.mockResolvedValue({});
+    jobs.clear();
+    getJob.mockImplementation(async (uploadId) => jobs.get(uploadId) || null);
+    enqueue.mockImplementation(async (uploadId) => {
+      const job = { status: "queued", deliveryStatus: "pending" };
+      jobs.set(uploadId, job);
+      return job;
+    });
+    normalizeStatus.mockImplementation((job) => {
+      if (job.status === "succeeded" && job.deliveryStatus === "delivered") {
+        return { status: "ready", stage: "complete", canRetry: false };
+      }
+      return { status: "queued", stage: "ocr", canRetry: false };
+    });
     updateUpload.mockResolvedValue(undefined);
-    deleteFile.mockResolvedValue(undefined);
   });
 
   it("authorizes the run and city before consuming multipart bytes", async () => {
@@ -115,6 +139,7 @@ describe("Concept Note PDF upload route", () => {
     expect(response.status).toBe(202);
     const payload = await response.json();
     expect(payload.status).toBe("queued");
+    expect(payload.stage).toBe("ocr");
     expect(callConceptNoteApi).toHaveBeenCalledWith(
       expect.objectContaining({
         path: `/v1/concept-notes/${runId}/uploads`,
@@ -128,6 +153,42 @@ describe("Concept Note PDF upload route", () => {
       "application/pdf",
     );
     expect(enqueue).toHaveBeenCalledWith(payload.upload_id);
+  });
+
+  it("replays identical bytes and metadata with one stable upload identity", async () => {
+    const first = await uploadHandler(
+      requestWithFile("%PDF-1.7\nidentical"),
+      context,
+    );
+    const second = await uploadHandler(
+      requestWithFile("%PDF-1.7\nidentical"),
+      context,
+    );
+
+    const firstPayload = await first.json();
+    const secondPayload = await second.json();
+    expect(secondPayload.upload_id).toBe(firstPayload.upload_id);
+    expect(callConceptNoteApi.mock.calls[0][0].body?.upload_id).toBe(
+      callConceptNoteApi.mock.calls[1][0].body?.upload_id,
+    );
+    expect(putFile).toHaveBeenCalledTimes(1);
+    expect(enqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a different upload identity when the PDF bytes change", async () => {
+    const first = await uploadHandler(
+      requestWithFile("%PDF-1.7\nfirst"),
+      context,
+    );
+    const second = await uploadHandler(
+      requestWithFile("%PDF-1.7\nsecond"),
+      context,
+    );
+
+    expect((await second.json()).upload_id).not.toBe(
+      (await first.json()).upload_id,
+    );
+    expect(enqueue).toHaveBeenCalledTimes(2);
   });
 
   it("rejects MIME, empty, and signature failures before CA registration", async () => {
@@ -160,14 +221,13 @@ describe("Concept Note PDF upload route", () => {
     expect(enqueue).not.toHaveBeenCalled();
   });
 
-  it("removes a newly stored source and marks CA failed when enqueueing fails", async () => {
+  it("retains the deterministic source and marks CA failed when enqueueing fails", async () => {
     enqueue.mockRejectedValueOnce(new Error("database unavailable"));
 
     await expect(
       uploadHandler(requestWithFile("%PDF-1.7\ncontent"), context),
     ).rejects.toMatchObject({ statusCode: 503 });
 
-    expect(deleteFile).toHaveBeenCalledTimes(1);
     expect(updateUpload).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "failed",

--- a/app/tests/concept-note-upload.jest.ts
+++ b/app/tests/concept-note-upload.jest.ts
@@ -1,0 +1,178 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+const runId = "11111111-1111-4111-8111-111111111111";
+const loadRunCity = jest.fn<() => Promise<string>>();
+const updateUpload = jest.fn<() => Promise<void>>();
+const putFile = jest.fn<() => Promise<void>>();
+const deleteFile = jest.fn<() => Promise<void>>();
+const enqueue = jest.fn<() => Promise<Record<string, never>>>();
+const callConceptNoteApi =
+  jest.fn<(request: { body?: { upload_id?: string } }) => Promise<Response>>();
+const canAccessCity = jest.fn<() => Promise<void>>();
+
+jest.unstable_mockModule("@/backend/ConceptNoteUploadService", () => ({
+  loadConceptNoteRunCity: loadRunCity,
+  updateConceptNoteUpload: updateUpload,
+}));
+jest.unstable_mockModule("@/backend/InventoryFileStorageService", () => ({
+  default: { putFile, deleteFile },
+}));
+jest.unstable_mockModule("@/backend/PdfOcrService", () => ({
+  conceptNotePdfSourceKey: (id: string) =>
+    `pdf-ocr/sources/concept_note_upload/${id}/source.pdf`,
+  enqueueConceptNotePdfOcr: enqueue,
+}));
+jest.unstable_mockModule("@/backend/concept-notes", () => ({
+  callConceptNoteApi,
+  readConceptNoteApiPayload: (response: Response) => response.json(),
+}));
+jest.unstable_mockModule("@/backend/permissions/PermissionService", () => ({
+  PermissionService: { canAccessCity },
+}));
+jest.unstable_mockModule("@/util/api", () => ({
+  apiHandler: (handler: unknown) => handler,
+}));
+
+let uploadHandler: typeof import("@/app/api/v1/concept-notes/[runId]/uploads/route").POST;
+
+beforeAll(async () => {
+  ({ POST: uploadHandler } = await import(
+    "@/app/api/v1/concept-notes/[runId]/uploads/route"
+  ));
+});
+
+function requestWithFile(
+  bytes: string,
+  options: { name?: string; type?: string } = {},
+): Request {
+  const form = new FormData();
+  form.set(
+    "file",
+    new File([bytes], options.name || "plan.pdf", {
+      type: options.type || "application/pdf",
+    }),
+  );
+  form.set("source_label", "Climate plan");
+  return new Request(`http://localhost/api/v1/concept-notes/${runId}/uploads`, {
+    method: "POST",
+    body: form,
+  });
+}
+
+const context = {
+  session: { user: { id: "owner-user" } },
+  params: { runId },
+};
+
+describe("Concept Note PDF upload route", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    loadRunCity.mockResolvedValue("33333333-3333-4333-8333-333333333333");
+    canAccessCity.mockResolvedValue(undefined);
+    callConceptNoteApi.mockImplementation(async (request) =>
+      Response.json({
+        upload_id: request.body?.upload_id,
+        status: "queued",
+      }),
+    );
+    putFile.mockResolvedValue(undefined);
+    enqueue.mockResolvedValue({});
+    updateUpload.mockResolvedValue(undefined);
+    deleteFile.mockResolvedValue(undefined);
+  });
+
+  it("authorizes the run and city before consuming multipart bytes", async () => {
+    loadRunCity.mockRejectedValueOnce(
+      Object.assign(new Error("forbidden"), {
+        statusCode: 403,
+      }),
+    );
+    const formData = jest.fn<() => Promise<FormData>>();
+    const request = {
+      headers: new Headers(),
+      formData,
+    } as unknown as Request;
+
+    await expect(uploadHandler(request, context)).rejects.toMatchObject({
+      statusCode: 403,
+    });
+    expect(formData).not.toHaveBeenCalled();
+  });
+
+  it("registers CA first, stores a deterministic source, and queues one job", async () => {
+    const response = await uploadHandler(
+      requestWithFile("%PDF-1.7\ncontent"),
+      context,
+    );
+
+    expect(response.status).toBe(202);
+    const payload = await response.json();
+    expect(payload.status).toBe("queued");
+    expect(callConceptNoteApi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: `/v1/concept-notes/${runId}/uploads`,
+        method: "POST",
+        body: expect.objectContaining({ upload_id: payload.upload_id }),
+      }),
+    );
+    expect(putFile).toHaveBeenCalledWith(
+      `pdf-ocr/sources/concept_note_upload/${payload.upload_id}/source.pdf`,
+      expect.any(Buffer),
+      "application/pdf",
+    );
+    expect(enqueue).toHaveBeenCalledWith(payload.upload_id);
+  });
+
+  it("rejects MIME, empty, and signature failures before CA registration", async () => {
+    await expect(
+      uploadHandler(
+        requestWithFile("%PDF-1.7", { type: "text/plain" }),
+        context,
+      ),
+    ).rejects.toMatchObject({ statusCode: 415 });
+    await expect(
+      uploadHandler(requestWithFile(""), context),
+    ).rejects.toMatchObject({ statusCode: 422 });
+    await expect(
+      uploadHandler(requestWithFile("not a pdf"), context),
+    ).rejects.toMatchObject({ statusCode: 422 });
+    expect(callConceptNoteApi).not.toHaveBeenCalled();
+  });
+
+  it("does not store or queue when CA row creation fails", async () => {
+    callConceptNoteApi.mockResolvedValueOnce(
+      Response.json({ code: "run_not_found" }, { status: 404 }),
+    );
+    const response = await uploadHandler(
+      requestWithFile("%PDF-1.7\ncontent"),
+      context,
+    );
+
+    expect(response.status).toBe(404);
+    expect(putFile).not.toHaveBeenCalled();
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it("removes a newly stored source and marks CA failed when enqueueing fails", async () => {
+    enqueue.mockRejectedValueOnce(new Error("database unavailable"));
+
+    await expect(
+      uploadHandler(requestWithFile("%PDF-1.7\ncontent"), context),
+    ).rejects.toMatchObject({ statusCode: 503 });
+
+    expect(deleteFile).toHaveBeenCalledTimes(1);
+    expect(updateUpload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "failed",
+        body: { error_code: "ocr_enqueue_failed" },
+      }),
+    );
+  });
+});

--- a/app/tests/concept-note-upload.jest.ts
+++ b/app/tests/concept-note-upload.jest.ts
@@ -13,8 +13,6 @@ const updateUpload = jest.fn<() => Promise<void>>();
 const putFile = jest.fn<() => Promise<void>>();
 const enqueue =
   jest.fn<(uploadId: string) => Promise<Record<string, unknown>>>();
-const getJob =
-  jest.fn<(uploadId: string) => Promise<Record<string, unknown> | null>>();
 const normalizeStatus = jest.fn<
   (job: Record<string, unknown>) => {
     status: "queued" | "processing" | "ready" | "failed";
@@ -26,7 +24,6 @@ const normalizeStatus = jest.fn<
 const callConceptNoteApi =
   jest.fn<(request: { body?: { upload_id?: string } }) => Promise<Response>>();
 const canAccessCity = jest.fn<() => Promise<void>>();
-const jobs = new Map<string, Record<string, unknown>>();
 
 jest.unstable_mockModule("@/backend/ConceptNoteUploadService", () => ({
   loadConceptNoteRunCity: loadRunCity,
@@ -39,7 +36,6 @@ jest.unstable_mockModule("@/backend/PdfOcrService", () => ({
   conceptNotePdfSourceKey: (id: string) =>
     `pdf-ocr/sources/concept_note_upload/${id}/source.pdf`,
   enqueueConceptNotePdfOcr: enqueue,
-  getConceptNotePdfOcrJob: getJob,
   normalizeConceptNotePdfOcrStatus: normalizeStatus,
 }));
 jest.unstable_mockModule("@/backend/concept-notes", () => ({
@@ -56,9 +52,8 @@ jest.unstable_mockModule("@/util/api", () => ({
 let uploadHandler: typeof import("@/app/api/v1/concept-notes/[runId]/uploads/route").POST;
 
 beforeAll(async () => {
-  ({ POST: uploadHandler } = await import(
-    "@/app/api/v1/concept-notes/[runId]/uploads/route"
-  ));
+  ({ POST: uploadHandler } =
+    await import("@/app/api/v1/concept-notes/[runId]/uploads/route"));
 });
 
 function requestWithFile(
@@ -72,7 +67,7 @@ function requestWithFile(
       type: options.type || "application/pdf",
     }),
   );
-  form.set("source_label", "Climate plan");
+  form.set("sourceLabel", "Climate plan");
   return new Request(`http://localhost/api/v1/concept-notes/${runId}/uploads`, {
     method: "POST",
     body: form,
@@ -96,13 +91,7 @@ describe("Concept Note PDF upload route", () => {
       }),
     );
     putFile.mockResolvedValue(undefined);
-    jobs.clear();
-    getJob.mockImplementation(async (uploadId) => jobs.get(uploadId) || null);
-    enqueue.mockImplementation(async (uploadId) => {
-      const job = { status: "queued", deliveryStatus: "pending" };
-      jobs.set(uploadId, job);
-      return job;
-    });
+    enqueue.mockResolvedValue({ status: "queued", deliveryStatus: "pending" });
     normalizeStatus.mockImplementation((job) => {
       if (job.status === "succeeded" && job.deliveryStatus === "delivered") {
         return { status: "ready", stage: "complete", canRetry: false };
@@ -130,7 +119,7 @@ describe("Concept Note PDF upload route", () => {
     expect(formData).not.toHaveBeenCalled();
   });
 
-  it("registers CA first, stores a deterministic source, and queues one job", async () => {
+  it("registers CA first, stores the source, and queues one UUID v4 job", async () => {
     const response = await uploadHandler(
       requestWithFile("%PDF-1.7\ncontent"),
       context,
@@ -138,24 +127,31 @@ describe("Concept Note PDF upload route", () => {
 
     expect(response.status).toBe(202);
     const payload = await response.json();
-    expect(payload.status).toBe("queued");
-    expect(payload.stage).toBe("ocr");
+    expect(payload).toEqual({
+      uploadId: expect.any(String),
+      status: "queued",
+      stage: "ocr",
+      canRetry: false,
+    });
+    expect(payload.uploadId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
     expect(callConceptNoteApi).toHaveBeenCalledWith(
       expect.objectContaining({
         path: `/v1/concept-notes/${runId}/uploads`,
         method: "POST",
-        body: expect.objectContaining({ upload_id: payload.upload_id }),
+        body: expect.objectContaining({ upload_id: payload.uploadId }),
       }),
     );
     expect(putFile).toHaveBeenCalledWith(
-      `pdf-ocr/sources/concept_note_upload/${payload.upload_id}/source.pdf`,
+      `pdf-ocr/sources/concept_note_upload/${payload.uploadId}/source.pdf`,
       expect.any(Buffer),
       "application/pdf",
     );
-    expect(enqueue).toHaveBeenCalledWith(payload.upload_id);
+    expect(enqueue).toHaveBeenCalledWith(payload.uploadId);
   });
 
-  it("replays identical bytes and metadata with one stable upload identity", async () => {
+  it("assigns a fresh identity to repeated initial uploads", async () => {
     const first = await uploadHandler(
       requestWithFile("%PDF-1.7\nidentical"),
       context,
@@ -167,27 +163,11 @@ describe("Concept Note PDF upload route", () => {
 
     const firstPayload = await first.json();
     const secondPayload = await second.json();
-    expect(secondPayload.upload_id).toBe(firstPayload.upload_id);
-    expect(callConceptNoteApi.mock.calls[0][0].body?.upload_id).toBe(
+    expect(secondPayload.uploadId).not.toBe(firstPayload.uploadId);
+    expect(callConceptNoteApi.mock.calls[0][0].body?.upload_id).not.toBe(
       callConceptNoteApi.mock.calls[1][0].body?.upload_id,
     );
-    expect(putFile).toHaveBeenCalledTimes(1);
-    expect(enqueue).toHaveBeenCalledTimes(1);
-  });
-
-  it("uses a different upload identity when the PDF bytes change", async () => {
-    const first = await uploadHandler(
-      requestWithFile("%PDF-1.7\nfirst"),
-      context,
-    );
-    const second = await uploadHandler(
-      requestWithFile("%PDF-1.7\nsecond"),
-      context,
-    );
-
-    expect((await second.json()).upload_id).not.toBe(
-      (await first.json()).upload_id,
-    );
+    expect(putFile).toHaveBeenCalledTimes(2);
     expect(enqueue).toHaveBeenCalledTimes(2);
   });
 
@@ -221,7 +201,7 @@ describe("Concept Note PDF upload route", () => {
     expect(enqueue).not.toHaveBeenCalled();
   });
 
-  it("retains the deterministic source and marks CA failed when enqueueing fails", async () => {
+  it("retains the stored source and marks CA failed when enqueueing fails", async () => {
     enqueue.mockRejectedValueOnce(new Error("database unavailable"));
 
     await expect(
@@ -231,7 +211,7 @@ describe("Concept Note PDF upload route", () => {
     expect(updateUpload).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "failed",
-        body: { error_code: "ocr_enqueue_failed" },
+        errorCode: "ocr_enqueue_failed",
       }),
     );
   });

--- a/app/tests/pdf-ocr-delivery.jest.ts
+++ b/app/tests/pdf-ocr-delivery.jest.ts
@@ -8,14 +8,10 @@ import {
 } from "@jest/globals";
 import type { PdfOcrJob } from "@/models/PdfOcrJob";
 
-const getTextFile = jest.fn<() => Promise<string>>();
 const issueToken = jest.fn<() => Promise<{ access_token: string }>>();
 
 jest.unstable_mockModule("@/models", () => ({
   db: { models: { PdfOcrJob: { findAll: jest.fn() } } },
-}));
-jest.unstable_mockModule("@/backend/InventoryFileStorageService", () => ({
-  default: { getTextFile },
 }));
 jest.unstable_mockModule("@/backend/chat/climate-advisor", () => ({
   issueClimateAdvisorUserToken: issueToken,
@@ -26,6 +22,7 @@ jest.unstable_mockModule("@/services/logger", () => ({
 
 let deliverPdfOcrJob: typeof import("@/backend/PdfOcrDeliveryService").deliverPdfOcrJob;
 let serializeMarkdownDeliveryPayload: typeof import("@/backend/PdfOcrDeliveryService").serializeMarkdownDeliveryPayload;
+let resolvePdfOcrDeliverySource: typeof import("@/backend/PdfOcrDeliveryService").resolvePdfOcrDeliverySource;
 
 const job = {
   status: "succeeded",
@@ -42,9 +39,11 @@ const source = {
 };
 
 beforeAll(async () => {
-  ({ deliverPdfOcrJob, serializeMarkdownDeliveryPayload } = await import(
-    "@/backend/PdfOcrDeliveryService"
-  ));
+  ({
+    deliverPdfOcrJob,
+    serializeMarkdownDeliveryPayload,
+    resolvePdfOcrDeliverySource,
+  } = await import("@/backend/PdfOcrDeliveryService"));
 });
 
 describe("PDF OCR delivery", () => {
@@ -52,31 +51,22 @@ describe("PDF OCR delivery", () => {
     jest.restoreAllMocks();
     jest.clearAllMocks();
     delete process.env.CA_BASE_URL;
+    delete process.env.CC_SERVICE_API_KEY;
   });
 
-  it("serializes the documented payload and rejects requests over 20 MiB", () => {
-    const body = JSON.parse(
-      serializeMarkdownDeliveryPayload("<!-- page: 1 -->\n# Plan", job, source),
-    );
+  it("serializes only the durable pointer and immutable metadata", () => {
+    const body = JSON.parse(serializeMarkdownDeliveryPayload(job, source));
     expect(body).toEqual({
-      markdown: "<!-- page: 1 -->\n# Plan",
+      markdown_s3_key: "result.md",
       filename: "plan.pdf",
       source_label: "Plan",
       page_count: 1,
       sha256: "a".repeat(64),
     });
-    expect(() =>
-      serializeMarkdownDeliveryPayload(
-        "x".repeat(20 * 1024 * 1024),
-        job,
-        source,
-      ),
-    ).toThrow("exceeds the configured maximum");
   });
 
   it("accepts idempotent 202 responses without changing OCR state", async () => {
     process.env.CA_BASE_URL = "http://climate-advisor";
-    getTextFile.mockResolvedValue("<!-- page: 1 -->\n# Plan");
     issueToken.mockResolvedValue({ access_token: "token" });
     const fetchMock = jest
       .spyOn(global, "fetch")
@@ -97,7 +87,6 @@ describe("PDF OCR delivery", () => {
     "classifies CA status %s independently",
     async (status, retryable, code) => {
       process.env.CA_BASE_URL = "http://climate-advisor";
-      getTextFile.mockResolvedValue("<!-- page: 1 -->\n# Plan");
       issueToken.mockResolvedValue({ access_token: "token" });
       jest
         .spyOn(global, "fetch")
@@ -108,4 +97,55 @@ describe("PDF OCR delivery", () => {
       });
     },
   );
+
+  it("delivers a terminal OCR failure without requiring Markdown", async () => {
+    process.env.CA_BASE_URL = "http://climate-advisor";
+    issueToken.mockResolvedValue({ access_token: "token" });
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response("", { status: 200 }));
+    await deliverPdfOcrJob(
+      {
+        ...job,
+        status: "failed",
+        errorCode: "mistral_unavailable",
+        resultS3Key: null,
+      } as PdfOcrJob,
+      source,
+    );
+    expect(fetchMock.mock.calls[0][0]).toContain(
+      `/concept-notes/${source.runId}/uploads/${source.uploadId}/failed`,
+    );
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toEqual({
+      error_code: "mistral_unavailable",
+    });
+  });
+
+  it("resolves delivery metadata through reverse service authentication", async () => {
+    process.env.CA_BASE_URL = "http://climate-advisor";
+    process.env.CC_SERVICE_API_KEY = "shared-key";
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue(
+      Response.json({
+        upload_id: source.uploadId,
+        run_id: source.runId,
+        user_id: source.userId,
+        filename: source.filename,
+        source_label: source.sourceLabel,
+      }),
+    );
+
+    await expect(
+      resolvePdfOcrDeliverySource({
+        ...job,
+        sourceType: "concept_note_upload",
+        sourceId: source.uploadId,
+      } as PdfOcrJob),
+    ).resolves.toEqual(source);
+    expect(fetchMock.mock.calls[0][0]).toContain(
+      `/concept-note-uploads/${source.uploadId}/delivery-context`,
+    );
+    expect(fetchMock.mock.calls[0][1]?.headers).toEqual({
+      "X-CC-Service-Key": "shared-key",
+    });
+  });
 });

--- a/app/tests/pdf-ocr-queue.jest.ts
+++ b/app/tests/pdf-ocr-queue.jest.ts
@@ -61,6 +61,7 @@ let enqueueInventoryPdfOcr: typeof import("@/backend/PdfOcrService").enqueueInve
 let enqueueConceptNotePdfOcr: typeof import("@/backend/PdfOcrService").enqueueConceptNotePdfOcr;
 let conceptNotePdfSourceKey: typeof import("@/backend/PdfOcrService").conceptNotePdfSourceKey;
 let retryConceptNotePdfOcr: typeof import("@/backend/PdfOcrService").retryConceptNotePdfOcr;
+let normalizeConceptNotePdfOcrStatus: typeof import("@/backend/PdfOcrService").normalizeConceptNotePdfOcrStatus;
 let claimPdfOcrJobs: typeof import("@/backend/PdfOcrService").claimPdfOcrJobs;
 let claimInventoryExtractionJobs: typeof import("@/backend/PdfOcrService").claimInventoryExtractionJobs;
 let getInventoryPdfOcrStatus: typeof import("@/backend/PdfOcrService").getInventoryPdfOcrStatus;
@@ -72,6 +73,7 @@ beforeAll(async () => {
     enqueueConceptNotePdfOcr,
     conceptNotePdfSourceKey,
     retryConceptNotePdfOcr,
+    normalizeConceptNotePdfOcrStatus,
     claimPdfOcrJobs,
     claimInventoryExtractionJobs,
     getInventoryPdfOcrStatus,
@@ -154,6 +156,36 @@ describe("PdfOcrJob queue", () => {
     );
     expect(update.mock.calls[0][0]).not.toHaveProperty("status");
     expect(update.mock.calls[0][0]).not.toHaveProperty("attemptCount");
+  });
+
+  it("distinguishes retryable OCR failure from retryable delivery failure", () => {
+    expect(
+      normalizeConceptNotePdfOcrStatus({
+        status: "failed",
+        deliveryStatus: "delivered",
+        errorCode: "mistral_unavailable",
+      } as never),
+    ).toEqual({
+      status: "failed",
+      stage: "ocr",
+      canRetry: true,
+      retryKind: "ocr",
+      errorCode: "mistral_unavailable",
+    });
+
+    expect(
+      normalizeConceptNotePdfOcrStatus({
+        status: "succeeded",
+        deliveryStatus: "failed",
+        deliveryErrorCode: "ca_delivery_rejected",
+      } as never),
+    ).toEqual({
+      status: "failed",
+      stage: "delivery",
+      canRetry: true,
+      retryKind: "delivery",
+      errorCode: "ca_delivery_rejected",
+    });
   });
 
   it("claims at most two due jobs atomically with SKIP LOCKED and leases", async () => {

--- a/app/tests/pdf-ocr-queue.jest.ts
+++ b/app/tests/pdf-ocr-queue.jest.ts
@@ -58,6 +58,9 @@ jest.unstable_mockModule("@/services/logger", () => ({
 }));
 
 let enqueueInventoryPdfOcr: typeof import("@/backend/PdfOcrService").enqueueInventoryPdfOcr;
+let enqueueConceptNotePdfOcr: typeof import("@/backend/PdfOcrService").enqueueConceptNotePdfOcr;
+let conceptNotePdfSourceKey: typeof import("@/backend/PdfOcrService").conceptNotePdfSourceKey;
+let retryConceptNotePdfOcr: typeof import("@/backend/PdfOcrService").retryConceptNotePdfOcr;
 let claimPdfOcrJobs: typeof import("@/backend/PdfOcrService").claimPdfOcrJobs;
 let claimInventoryExtractionJobs: typeof import("@/backend/PdfOcrService").claimInventoryExtractionJobs;
 let getInventoryPdfOcrStatus: typeof import("@/backend/PdfOcrService").getInventoryPdfOcrStatus;
@@ -66,6 +69,9 @@ let extractInventoryRowsFromStoredMarkdown: typeof import("@/backend/PdfOcrServi
 beforeAll(async () => {
   ({
     enqueueInventoryPdfOcr,
+    enqueueConceptNotePdfOcr,
+    conceptNotePdfSourceKey,
+    retryConceptNotePdfOcr,
     claimPdfOcrJobs,
     claimInventoryExtractionJobs,
     getInventoryPdfOcrStatus,
@@ -101,6 +107,53 @@ describe("PdfOcrJob queue", () => {
     expect(importedFile.update).toHaveBeenCalledWith(
       expect.objectContaining({ importStatus: "extracting" }),
     );
+  });
+
+  it("uses the upload identity for one CA-delivered CNB OCR job", async () => {
+    const uploadId = "22222222-2222-4222-8222-222222222222";
+    const job = { status: "queued" };
+    findOrCreate.mockResolvedValue([job, false]);
+
+    await expect(enqueueConceptNotePdfOcr(uploadId)).resolves.toBe(job);
+
+    expect(findOrCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          sourceType: "concept_note_upload",
+          sourceId: uploadId,
+        },
+        defaults: expect.objectContaining({
+          deliveryTarget: "climate_advisor",
+          deliveryStatus: "pending",
+        }),
+      }),
+    );
+    expect(conceptNotePdfSourceKey(uploadId)).toBe(
+      `pdf-ocr/sources/concept_note_upload/${uploadId}/source.pdf`,
+    );
+  });
+
+  it("retries pointer delivery without resetting successful OCR", async () => {
+    const update = jest
+      .fn<(values: Record<string, unknown>) => Promise<void>>()
+      .mockResolvedValue(undefined);
+    const job = {
+      status: "succeeded",
+      attemptCount: 2,
+      deliveryStatus: "failed",
+      update,
+    } as unknown as Parameters<typeof retryConceptNotePdfOcr>[0];
+
+    await expect(retryConceptNotePdfOcr(job)).resolves.toBe("delivery");
+
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deliveryStatus: "pending",
+        deliveryErrorCode: null,
+      }),
+    );
+    expect(update.mock.calls[0][0]).not.toHaveProperty("status");
+    expect(update.mock.calls[0][0]).not.toHaveProperty("attemptCount");
   });
 
   it("claims at most two due jobs atomically with SKIP LOCKED and leases", async () => {

--- a/climate-advisor/.env.example
+++ b/climate-advisor/.env.example
@@ -35,7 +35,7 @@ CA_DATABASE_ECHO=false
 # CityCatalyst Integration
 CC_API_KEY=your-cc-service-api-key-here
 CC_BASE_URL=http://localhost:3000
-# Complete inline JSON body limit for optional CC-produced Markdown ingest.
+# Maximum CC-owned Markdown artifact size CA will verify through authenticated CC.
 # This is independent from CC's source-PDF upload limit.
 CNB_MARKDOWN_REQUEST_MAX_BYTES=20971520
 # Externally managed CNB database used by the reviewed-reference importer and

--- a/climate-advisor/README.md
+++ b/climate-advisor/README.md
@@ -539,9 +539,9 @@ language, or client-side fallback behavior. The boundary is:
 - `CC_BASE_URL` - CityCatalyst base URL for inventory API and token refresh
 - `CC_API_KEY` - Service credential used when CA asks CC to validate the
   CC-issued user bearer token
-- `CNB_MARKDOWN_REQUEST_MAX_BYTES` - Complete JSON request-body limit for the
-  optional CC-to-CA Markdown ingest endpoint (default `20971520`; this is an
-  operational body guard, not a source-PDF or page-count acceptance limit)
+- `CNB_MARKDOWN_REQUEST_MAX_BYTES` - Maximum Markdown artifact size CA will
+  accept while verifying a CC-owned result (default `20971520`; independent
+  from the source-PDF and page-count limits)
 - `MLFLOW_ENABLED` - Enables best-effort MLflow logging when set to `true`
 - `MLFLOW_TRACKING_URI` - Shared MLflow backend URL, normally
   `https://mlflow-dev.openearth.dev`
@@ -563,17 +563,16 @@ language, or client-side fallback behavior. The boundary is:
 
 ### CC-produced Concept Note Markdown baseline
 
-`POST /v1/concept-notes/{run_id}/uploads/{upload_id}/markdown` validates the
-CC-issued user token through CC before consuming the request, streams the body
-up to `CNB_MARKDOWN_REQUEST_MAX_BYTES`, recomputes SHA-256, verifies contiguous
-page markers and their positive metadata count without imposing a page-count
-limit, and delegates atomic run/upload registration to a repository
-interface. The production repository validates run ownership, preserves the
-immutable upload-to-run binding and Markdown digest, and stores the received
-artifact in `concept_note_uploads` through `CA_DATABASE_URL`. Repeating the same
-upload and digest is idempotent; changing its run or digest returns `409`. CA
-owns no OCR queue, Mistral dependency, S3 object, or S3 permission. An
-unavailable or unmigrated workflow database returns `503
+`POST /v1/concept-notes/{run_id}/uploads` creates or replays the authoritative
+pre-conversion upload row. After CC OCR completes,
+`POST /v1/concept-notes/{run_id}/uploads/{upload_id}/markdown` receives only a
+stable S3 key, SHA-256, page count, filename, and label. CA fetches the artifact
+through CC's authenticated internal Markdown route, checks the returned
+identity, recomputes SHA-256, verifies page markers, and then stores the pointer
+as ready in `concept_note_uploads` through `CA_DATABASE_URL`. Identical create
+and delivery requests are idempotent; changing upload or Markdown identity
+returns `409`. CA owns no OCR queue, Mistral dependency, bucket credential, or
+presigned URL. An unavailable or unmigrated workflow database returns `503
 cnb_storage_unavailable`.
 
 ### Concept Note run foundation

--- a/climate-advisor/README.md
+++ b/climate-advisor/README.md
@@ -576,6 +576,13 @@ Markdown identity returns `409`. CA owns no OCR queue, Mistral dependency,
 bucket credential, or presigned URL. An unavailable or unmigrated workflow
 database returns `503 cnb_storage_unavailable`.
 
+CC uses the intentionally separate service-to-service route
+`GET /v1/concept-note-uploads/{upload_id}/delivery-context` with
+`X-CC-Service-Key` to recover the run and user scope for an opaque upload ID.
+Rejected service-key requests emit a `WARNING` audit log with the upload ID but
+never the supplied credential. Deployments should alert on repeated warnings or
+`401 invalid_service_key` responses for this route.
+
 ### Concept Note run foundation
 
 `POST /v1/concept-notes/start` validates a CC-issued bearer token, verifies that

--- a/climate-advisor/README.md
+++ b/climate-advisor/README.md
@@ -566,14 +566,15 @@ language, or client-side fallback behavior. The boundary is:
 `POST /v1/concept-notes/{run_id}/uploads` creates or replays the authoritative
 pre-conversion upload row. After CC OCR completes,
 `POST /v1/concept-notes/{run_id}/uploads/{upload_id}/markdown` receives only a
-stable S3 key, SHA-256, page count, filename, and label. CA fetches the artifact
-through CC's authenticated internal Markdown route, checks the returned
-identity, recomputes SHA-256, verifies page markers, and then stores the pointer
-as ready in `concept_note_uploads` through `CA_DATABASE_URL`. Identical create
-and delivery requests are idempotent; changing upload or Markdown identity
-returns `409`. CA owns no OCR queue, Mistral dependency, bucket credential, or
-presigned URL. An unavailable or unmigrated workflow database returns `503
-cnb_storage_unavailable`.
+stable S3 key, SHA-256, page count, filename, and label. CA rejects control JSON
+larger than 16 KiB before parsing, then streams the artifact through CC's
+authenticated internal Markdown route up to `CNB_MARKDOWN_REQUEST_MAX_BYTES`,
+checks the returned identity, recomputes SHA-256, verifies page markers, and
+stores the pointer as ready in `concept_note_uploads` through `CA_DATABASE_URL`.
+Identical create and delivery requests are idempotent; changing upload or
+Markdown identity returns `409`. CA owns no OCR queue, Mistral dependency,
+bucket credential, or presigned URL. An unavailable or unmigrated workflow
+database returns `503 cnb_storage_unavailable`.
 
 ### Concept Note run foundation
 

--- a/climate-advisor/service/app/models/concept_note_markdown.py
+++ b/climate-advisor/service/app/models/concept_note_markdown.py
@@ -1,15 +1,29 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ConceptNoteUploadCreateRequest(BaseModel):
+    """Register an immutable upload identity before CC conversion begins."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    upload_id: UUID
+    user_id: str = Field(min_length=1, max_length=255)
+    filename: str = Field(min_length=1, max_length=255)
+    source_label: str | None = Field(default=None, max_length=255)
 
 
 class ConceptNoteMarkdownRequest(BaseModel):
-    """Completed CC-produced Markdown and immutable artifact metadata."""
+    """Completed CC-owned Markdown object and immutable result metadata."""
 
-    markdown: str = Field(min_length=1)
+    model_config = ConfigDict(extra="forbid")
+
+    markdown_s3_key: str = Field(min_length=1, max_length=1024)
     filename: str = Field(min_length=1, max_length=255)
     source_label: str | None = Field(default=None, max_length=255)
     page_count: int = Field(ge=1)
@@ -17,7 +31,37 @@ class ConceptNoteMarkdownRequest(BaseModel):
 
 
 class ConceptNoteMarkdownResponse(BaseModel):
-    """Acknowledgement returned after durable repository registration."""
+    """Lifecycle response returned for one run-scoped upload."""
 
     upload_id: UUID
-    status: Literal["processing"] = "processing"
+    status: Literal["queued", "processing", "ready", "failed"]
+
+
+class ConceptNoteUploadStatusResponse(ConceptNoteMarkdownResponse):
+    """Safe persisted metadata returned to the CC browser-facing proxy."""
+
+    run_id: UUID
+    filename: str
+    source_label: str | None = None
+    page_count: int | None = None
+    error_code: str | None = None
+    received_at: datetime
+    completed_at: datetime | None = None
+
+
+class ConceptNoteUploadFailureRequest(BaseModel):
+    """Record a stable CC upload, OCR, or delivery failure."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    error_code: str = Field(min_length=1, max_length=64)
+
+
+class ConceptNoteUploadDeliveryContext(BaseModel):
+    """Metadata CC needs to deliver a terminal OCR outcome."""
+
+    upload_id: UUID
+    run_id: UUID
+    user_id: str
+    filename: str
+    source_label: str | None = None

--- a/climate-advisor/service/app/models/db/concept_note.py
+++ b/climate-advisor/service/app/models/db/concept_note.py
@@ -11,7 +11,6 @@ from sqlalchemy import (
     Index,
     Integer,
     String,
-    Text,
     UniqueConstraint,
     func,
 )
@@ -157,7 +156,7 @@ class ConceptNoteContextBundle(Base):
 
 
 class ConceptNoteUpload(Base):
-    """Durable Markdown handoff associated with a concept-note run."""
+    """Durable CNB upload metadata and CC-owned Markdown pointer."""
 
     __tablename__ = "concept_note_uploads"
 
@@ -179,14 +178,20 @@ class ConceptNoteUpload(Base):
         String(255),
         nullable=True,
     )
-    markdown_text: Mapped[str] = mapped_column(Text, nullable=False)
-    markdown_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
-    page_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    markdown_s3_key: Mapped[str | None] = mapped_column(
+        String(1024),
+        nullable=True,
+    )
+    markdown_sha256: Mapped[str | None] = mapped_column(
+        String(64),
+        nullable=True,
+    )
+    page_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
     ingest_status: Mapped[str] = mapped_column(
         String(64),
         nullable=False,
-        default="processing",
-        server_default="processing",
+        default="queued",
+        server_default="queued",
     )
     ingest_error_code: Mapped[str | None] = mapped_column(
         String(64),

--- a/climate-advisor/service/app/persistence/concept_notes/markdown.py
+++ b/climate-advisor/service/app/persistence/concept_notes/markdown.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import func, select
@@ -9,7 +11,10 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.db.session import get_session_factory
-from app.models.concept_note_markdown import ConceptNoteMarkdownRequest
+from app.models.concept_note_markdown import (
+    ConceptNoteMarkdownRequest,
+    ConceptNoteUploadCreateRequest,
+)
 from app.models.db.concept_note import ConceptNoteRun, ConceptNoteUpload
 
 
@@ -32,12 +37,50 @@ class ConceptNoteStorageUnavailable(ConceptNoteMarkdownRepositoryError):
         super().__init__(
             "cnb_storage_unavailable",
             503,
-            "Concept Note Markdown storage is unavailable",
+            "Concept Note upload storage is unavailable",
         )
 
 
+@dataclass(frozen=True)
+class ConceptNoteUploadSnapshot:
+    """Detached upload state safe to return outside a database session."""
+
+    upload_id: UUID
+    run_id: UUID
+    user_id: str
+    filename: str
+    source_label: str | None
+    markdown_s3_key: str | None
+    markdown_sha256: str | None
+    page_count: int | None
+    status: str
+    error_code: str | None
+    received_at: datetime
+    completed_at: datetime | None
+
+
 class ConceptNoteMarkdownRepository(ABC):
-    """Atomic registration boundary for received Concept Note Markdown."""
+    """Atomic persistence boundary for run-scoped CNB uploads."""
+
+    @abstractmethod
+    async def create_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        payload: ConceptNoteUploadCreateRequest,
+    ) -> ConceptNoteUploadSnapshot:
+        """Create or replay an immutable pre-conversion upload row."""
+
+    @abstractmethod
+    async def get_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        """Return an owned upload bound to the requested run."""
 
     @abstractmethod
     async def register_markdown(
@@ -47,13 +90,60 @@ class ConceptNoteMarkdownRepository(ABC):
         run_id: UUID,
         upload_id: UUID,
         payload: ConceptNoteMarkdownRequest,
-    ) -> None:
-        """Validate ownership/binding/idempotency and durably register Markdown."""
+    ) -> ConceptNoteUploadSnapshot:
+        """Register the immutable CC S3 pointer and mark the upload ready."""
+
+    @abstractmethod
+    async def mark_failed(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+        error_code: str,
+    ) -> ConceptNoteUploadSnapshot:
+        """Persist a terminal upload or OCR failure."""
+
+    @abstractmethod
+    async def retry_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        """Return a failed upload to the queued lifecycle."""
+
+    @abstractmethod
+    async def get_delivery_context(
+        self,
+        *,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        """Return source metadata for authenticated CC delivery."""
 
 
 class UnavailableConceptNoteMarkdownRepository(ConceptNoteMarkdownRepository):
     """Safe fallback when the workflow database cannot be configured."""
 
+    async def create_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        payload: ConceptNoteUploadCreateRequest,
+    ) -> ConceptNoteUploadSnapshot:
+        raise ConceptNoteStorageUnavailable()
+
+    async def get_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        raise ConceptNoteStorageUnavailable()
+
     async def register_markdown(
         self,
         *,
@@ -61,74 +151,82 @@ class UnavailableConceptNoteMarkdownRepository(ConceptNoteMarkdownRepository):
         run_id: UUID,
         upload_id: UUID,
         payload: ConceptNoteMarkdownRequest,
-    ) -> None:
-        """Reject registration when durable workflow storage is unavailable."""
+    ) -> ConceptNoteUploadSnapshot:
+        raise ConceptNoteStorageUnavailable()
+
+    async def mark_failed(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+        error_code: str,
+    ) -> ConceptNoteUploadSnapshot:
+        raise ConceptNoteStorageUnavailable()
+
+    async def retry_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        raise ConceptNoteStorageUnavailable()
+
+    async def get_delivery_context(
+        self,
+        *,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
         raise ConceptNoteStorageUnavailable()
 
 
 class SqlAlchemyConceptNoteMarkdownRepository(ConceptNoteMarkdownRepository):
-    """Persist validated Markdown in the Climate Advisor workflow database."""
+    """Persist CNB upload lifecycle state in the CA workflow database."""
 
     def __init__(
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """Store the session factory used for atomic registration."""
         self._session_factory = session_factory
 
-    async def register_markdown(
+    async def create_upload(
         self,
         *,
         user_id: str,
         run_id: UUID,
-        upload_id: UUID,
-        payload: ConceptNoteMarkdownRequest,
-    ) -> None:
-        """Validate run ownership and idempotently persist one Markdown handoff."""
+        payload: ConceptNoteUploadCreateRequest,
+    ) -> ConceptNoteUploadSnapshot:
+        """Create or idempotently replay one pre-conversion upload."""
         try:
             async with self._session_factory() as session, session.begin():
-                run = await session.scalar(
-                    select(ConceptNoteRun)
-                    .where(ConceptNoteRun.run_id == run_id)
-                    .with_for_update()
+                await _require_owned_run(
+                    session=session,
+                    user_id=user_id,
+                    run_id=run_id,
                 )
-                if run is None:
-                    raise ConceptNoteMarkdownRepositoryError(
-                        "concept_note_run_not_found",
-                        404,
-                        "Concept Note run was not found",
-                    )
-                if run.user_id != user_id:
-                    raise ConceptNoteMarkdownRepositoryError(
-                        "concept_note_run_forbidden",
-                        403,
-                        "Concept Note run belongs to another user",
-                    )
-
                 existing = await session.get(
                     ConceptNoteUpload,
-                    upload_id,
+                    payload.upload_id,
                     with_for_update=True,
                 )
                 if existing is not None:
-                    _validate_existing_upload(
+                    _validate_upload_identity(
                         existing=existing,
                         run_id=run_id,
-                        markdown_sha256=payload.sha256,
+                        user_id=user_id,
+                        filename=payload.filename,
+                        source_label=payload.source_label,
                     )
-                    return
+                    return _snapshot(existing)
 
                 upload = ConceptNoteUpload(
-                    upload_id=upload_id,
+                    upload_id=payload.upload_id,
                     run_id=run_id,
                     uploaded_by_user_id=user_id,
                     filename=payload.filename,
                     source_label=payload.source_label,
-                    markdown_text=payload.markdown,
-                    markdown_sha256=payload.sha256,
-                    page_count=payload.page_count,
-                    ingest_status="processing",
-                    ingest_started_at=func.now(),
+                    ingest_status="queued",
                 )
                 try:
                     async with session.begin_nested():
@@ -137,45 +235,369 @@ class SqlAlchemyConceptNoteMarkdownRepository(ConceptNoteMarkdownRepository):
                 except IntegrityError:
                     existing = await session.get(
                         ConceptNoteUpload,
-                        upload_id,
+                        payload.upload_id,
                         with_for_update=True,
                     )
                     if existing is None:
                         raise
-                    _validate_existing_upload(
+                    _validate_upload_identity(
                         existing=existing,
                         run_id=run_id,
-                        markdown_sha256=payload.sha256,
+                        user_id=user_id,
+                        filename=payload.filename,
+                        source_label=payload.source_label,
                     )
+                    return _snapshot(existing)
+
+                await session.refresh(upload)
+                return _snapshot(upload)
         except ConceptNoteMarkdownRepositoryError:
             raise
         except (OSError, SQLAlchemyError) as exc:
-            logger.exception(
-                "Failed to persist Concept Note Markdown",
-                extra={"run_id": str(run_id), "upload_id": str(upload_id)},
+            _raise_storage_unavailable(
+                exc,
+                message="Failed to create Concept Note upload",
+                run_id=run_id,
+                upload_id=payload.upload_id,
             )
-            raise ConceptNoteStorageUnavailable() from exc
+
+    async def get_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        """Return one owned upload."""
+        try:
+            async with self._session_factory() as session:
+                await _require_owned_run(
+                    session=session,
+                    user_id=user_id,
+                    run_id=run_id,
+                )
+                upload = await session.get(ConceptNoteUpload, upload_id)
+                _require_upload_binding(
+                    upload=upload,
+                    run_id=run_id,
+                    user_id=user_id,
+                )
+                return _snapshot(upload)
+        except ConceptNoteMarkdownRepositoryError:
+            raise
+        except (OSError, SQLAlchemyError) as exc:
+            _raise_storage_unavailable(
+                exc,
+                message="Failed to load Concept Note upload",
+                run_id=run_id,
+                upload_id=upload_id,
+            )
+
+    async def register_markdown(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+        payload: ConceptNoteMarkdownRequest,
+    ) -> ConceptNoteUploadSnapshot:
+        """Persist one immutable CC Markdown pointer and mark it ready."""
+        try:
+            async with self._session_factory() as session, session.begin():
+                await _require_owned_run(
+                    session=session,
+                    user_id=user_id,
+                    run_id=run_id,
+                )
+                upload = await session.get(
+                    ConceptNoteUpload,
+                    upload_id,
+                    with_for_update=True,
+                )
+                _require_upload_binding(
+                    upload=upload,
+                    run_id=run_id,
+                    user_id=user_id,
+                )
+                _validate_upload_identity(
+                    existing=upload,
+                    run_id=run_id,
+                    user_id=user_id,
+                    filename=payload.filename,
+                    source_label=payload.source_label,
+                )
+                if upload.markdown_sha256 is not None:
+                    _validate_existing_markdown(
+                        existing=upload,
+                        markdown_s3_key=payload.markdown_s3_key,
+                        markdown_sha256=payload.sha256,
+                        page_count=payload.page_count,
+                    )
+                    return _snapshot(upload)
+
+                upload.markdown_s3_key = payload.markdown_s3_key
+                upload.markdown_sha256 = payload.sha256
+                upload.page_count = payload.page_count
+                upload.ingest_status = "ready"
+                upload.ingest_error_code = None
+                upload.ingest_started_at = upload.ingest_started_at or func.now()
+                upload.ingest_completed_at = func.now()
+                await session.flush()
+                await session.refresh(upload)
+                return _snapshot(upload)
+        except ConceptNoteMarkdownRepositoryError:
+            raise
+        except (OSError, SQLAlchemyError) as exc:
+            _raise_storage_unavailable(
+                exc,
+                message="Failed to persist Concept Note Markdown pointer",
+                run_id=run_id,
+                upload_id=upload_id,
+            )
+
+    async def mark_failed(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+        error_code: str,
+    ) -> ConceptNoteUploadSnapshot:
+        """Mark a non-ready upload failed without deleting its identity."""
+        try:
+            async with self._session_factory() as session, session.begin():
+                await _require_owned_run(
+                    session=session,
+                    user_id=user_id,
+                    run_id=run_id,
+                )
+                upload = await session.get(
+                    ConceptNoteUpload,
+                    upload_id,
+                    with_for_update=True,
+                )
+                _require_upload_binding(
+                    upload=upload,
+                    run_id=run_id,
+                    user_id=user_id,
+                )
+                if upload.ingest_status == "ready":
+                    raise ConceptNoteMarkdownRepositoryError(
+                        "upload_already_ready",
+                        409,
+                        "A ready upload cannot be marked failed",
+                    )
+                upload.ingest_status = "failed"
+                upload.ingest_error_code = error_code
+                upload.ingest_completed_at = func.now()
+                await session.flush()
+                await session.refresh(upload)
+                return _snapshot(upload)
+        except ConceptNoteMarkdownRepositoryError:
+            raise
+        except (OSError, SQLAlchemyError) as exc:
+            _raise_storage_unavailable(
+                exc,
+                message="Failed to mark Concept Note upload failed",
+                run_id=run_id,
+                upload_id=upload_id,
+            )
+
+    async def retry_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        """Return a failed upload to queued state."""
+        try:
+            async with self._session_factory() as session, session.begin():
+                await _require_owned_run(
+                    session=session,
+                    user_id=user_id,
+                    run_id=run_id,
+                )
+                upload = await session.get(
+                    ConceptNoteUpload,
+                    upload_id,
+                    with_for_update=True,
+                )
+                _require_upload_binding(
+                    upload=upload,
+                    run_id=run_id,
+                    user_id=user_id,
+                )
+                if upload.ingest_status == "ready":
+                    raise ConceptNoteMarkdownRepositoryError(
+                        "upload_not_retryable",
+                        409,
+                        "A ready upload cannot be retried",
+                    )
+                upload.ingest_status = "queued"
+                upload.ingest_error_code = None
+                upload.ingest_completed_at = None
+                await session.flush()
+                await session.refresh(upload)
+                return _snapshot(upload)
+        except ConceptNoteMarkdownRepositoryError:
+            raise
+        except (OSError, SQLAlchemyError) as exc:
+            _raise_storage_unavailable(
+                exc,
+                message="Failed to retry Concept Note upload",
+                run_id=run_id,
+                upload_id=upload_id,
+            )
+
+    async def get_delivery_context(
+        self,
+        *,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        """Return upload metadata to an authenticated CC service request."""
+        try:
+            async with self._session_factory() as session:
+                upload = await session.get(ConceptNoteUpload, upload_id)
+                if upload is None:
+                    raise ConceptNoteMarkdownRepositoryError(
+                        "concept_note_upload_not_found",
+                        404,
+                        "Concept Note upload was not found",
+                    )
+                return _snapshot(upload)
+        except ConceptNoteMarkdownRepositoryError:
+            raise
+        except (OSError, SQLAlchemyError) as exc:
+            _raise_storage_unavailable(
+                exc,
+                message="Failed to load Concept Note delivery context",
+                upload_id=upload_id,
+            )
 
 
-def _validate_existing_upload(
+async def _require_owned_run(
     *,
-    existing: ConceptNoteUpload,
+    session: AsyncSession,
+    user_id: str,
     run_id: UUID,
-    markdown_sha256: str,
+) -> ConceptNoteRun:
+    run = await session.scalar(
+        select(ConceptNoteRun).where(ConceptNoteRun.run_id == run_id).with_for_update()
+    )
+    if run is None:
+        raise ConceptNoteMarkdownRepositoryError(
+            "concept_note_run_not_found",
+            404,
+            "Concept Note run was not found",
+        )
+    if run.user_id != user_id:
+        raise ConceptNoteMarkdownRepositoryError(
+            "concept_note_run_forbidden",
+            403,
+            "Concept Note run belongs to another user",
+        )
+    return run
+
+
+def _require_upload_binding(
+    *,
+    upload: ConceptNoteUpload | None,
+    run_id: UUID,
+    user_id: str,
 ) -> None:
-    """Enforce immutable upload-to-run binding and Markdown identity."""
-    if existing.run_id != run_id:
+    if upload is None:
+        raise ConceptNoteMarkdownRepositoryError(
+            "concept_note_upload_not_found",
+            404,
+            "Concept Note upload was not found",
+        )
+    if upload.run_id != run_id:
         raise ConceptNoteMarkdownRepositoryError(
             "upload_run_binding_conflict",
             409,
-            "Upload is already associated with another Concept Note run",
+            "Upload is associated with another Concept Note run",
         )
-    if existing.markdown_sha256 != markdown_sha256:
+    if upload.uploaded_by_user_id != user_id:
+        raise ConceptNoteMarkdownRepositoryError(
+            "concept_note_upload_forbidden",
+            403,
+            "Concept Note upload belongs to another user",
+        )
+
+
+def _validate_upload_identity(
+    *,
+    existing: ConceptNoteUpload,
+    run_id: UUID,
+    user_id: str,
+    filename: str,
+    source_label: str | None,
+) -> None:
+    _require_upload_binding(
+        upload=existing,
+        run_id=run_id,
+        user_id=user_id,
+    )
+    if existing.filename != filename or existing.source_label != source_label:
+        raise ConceptNoteMarkdownRepositoryError(
+            "upload_identity_conflict",
+            409,
+            "Upload metadata cannot change",
+        )
+
+
+def _validate_existing_markdown(
+    *,
+    existing: ConceptNoteUpload,
+    markdown_s3_key: str,
+    markdown_sha256: str,
+    page_count: int,
+) -> None:
+    if (
+        existing.markdown_s3_key != markdown_s3_key
+        or existing.markdown_sha256 != markdown_sha256
+        or existing.page_count != page_count
+    ):
         raise ConceptNoteMarkdownRepositoryError(
             "markdown_identity_conflict",
             409,
-            "Upload Markdown digest cannot change",
+            "Upload Markdown identity cannot change",
         )
+
+
+def _snapshot(upload: ConceptNoteUpload) -> ConceptNoteUploadSnapshot:
+    return ConceptNoteUploadSnapshot(
+        upload_id=upload.upload_id,
+        run_id=upload.run_id,
+        user_id=upload.uploaded_by_user_id,
+        filename=upload.filename,
+        source_label=upload.source_label,
+        markdown_s3_key=upload.markdown_s3_key,
+        markdown_sha256=upload.markdown_sha256,
+        page_count=upload.page_count,
+        status=upload.ingest_status,
+        error_code=upload.ingest_error_code,
+        received_at=upload.received_at,
+        completed_at=upload.ingest_completed_at,
+    )
+
+
+def _raise_storage_unavailable(
+    exc: Exception,
+    *,
+    message: str,
+    run_id: UUID | None = None,
+    upload_id: UUID | None = None,
+) -> None:
+    logger.exception(
+        message,
+        extra={
+            "run_id": str(run_id) if run_id else None,
+            "upload_id": str(upload_id) if upload_id else None,
+        },
+    )
+    raise ConceptNoteStorageUnavailable() from exc
 
 
 def get_concept_note_markdown_repository() -> ConceptNoteMarkdownRepository:

--- a/climate-advisor/service/app/routes/concept_note_markdown.py
+++ b/climate-advisor/service/app/routes/concept_note_markdown.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import logging
 import re
 from collections.abc import AsyncIterator
 from typing import Any
@@ -33,6 +34,7 @@ from app.services.citycatalyst_client import (
 )
 
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 PAGE_MARKER = re.compile(r"<!-- page: (\d+) -->")
 JSON_REQUEST_MAX_BYTES = 16 * 1024
@@ -372,10 +374,17 @@ async def get_concept_note_delivery_context(
     ),
 ) -> JSONResponse | ConceptNoteUploadDeliveryContext:
     """Return delivery metadata to CC after reverse service authentication."""
+    # Authenticate the reverse service without recording its credential.
     expected_key = get_settings().cc_api_key or ""
     supplied_key = request.headers.get("X-CC-Service-Key", "")
     if not expected_key or not hmac.compare_digest(expected_key, supplied_key):
+        logger.warning(
+            "Rejected CC delivery-context request for upload_id=%s",
+            upload_id,
+        )
         return problem(401, "invalid_service_key", "CC service authentication failed")
+
+    # Return only the delivery metadata associated with the opaque upload ID.
     try:
         snapshot = await repository.get_delivery_context(upload_id=upload_id)
     except ConceptNoteMarkdownRepositoryError as exc:

--- a/climate-advisor/service/app/routes/concept_note_markdown.py
+++ b/climate-advisor/service/app/routes/concept_note_markdown.py
@@ -35,6 +35,7 @@ from app.services.citycatalyst_client import (
 
 router = APIRouter()
 PAGE_MARKER = re.compile(r"<!-- page: (\d+) -->")
+JSON_REQUEST_MAX_BYTES = 16 * 1024
 
 
 async def get_citycatalyst_client() -> AsyncIterator[CityCatalystClient]:
@@ -83,15 +84,45 @@ async def read_json_model(
     request: Request,
     model_type: type[Any],
 ) -> Any | JSONResponse:
-    """Parse one strict Pydantic JSON request after authentication."""
-    if "application/json" not in request.headers.get("Content-Type", ""):
+    """Read a bounded JSON body and parse one strict Pydantic model."""
+    content_type = request.headers.get("Content-Type", "")
+    if content_type.split(";", 1)[0].strip().lower() != "application/json":
         return problem(
             415,
             "unsupported_media_type",
             "Content-Type must be application/json",
         )
+
+    # Reject a trustworthy declared size before allocating the request body.
+    content_length = request.headers.get("Content-Length")
+    if content_length:
+        try:
+            declared_size = int(content_length)
+        except ValueError:
+            return problem(400, "invalid_content_length", "Content-Length is invalid")
+        if declared_size < 0:
+            return problem(400, "invalid_content_length", "Content-Length is invalid")
+        if declared_size > JSON_REQUEST_MAX_BYTES:
+            return problem(
+                413,
+                "upload_request_too_large",
+                "JSON request exceeds the allowed maximum",
+            )
+
+    # Apply the same bound while consuming chunked or misdeclared requests.
+    body = bytearray()
+    async for chunk in request.stream():
+        if len(body) + len(chunk) > JSON_REQUEST_MAX_BYTES:
+            return problem(
+                413,
+                "upload_request_too_large",
+                "JSON request exceeds the allowed maximum",
+            )
+        body.extend(chunk)
+
+    # Parse only the authenticated, bounded payload.
     try:
-        return model_type.model_validate(await request.json())
+        return model_type.model_validate_json(body)
     except (ValidationError, ValueError):
         return problem(422, "invalid_upload_payload", "Upload payload is invalid")
 
@@ -236,7 +267,7 @@ async def ingest_concept_note_markdown(
             token=authorization,
         )
     except CityCatalystClientError as exc:
-        status_code = 413 if exc.status_code == 413 else 503
+        status_code = exc.status_code if exc.status_code in (409, 413, 422) else 503
         return problem(
             status_code,
             "cc_markdown_verification_failed",

--- a/climate-advisor/service/app/routes/concept_note_markdown.py
+++ b/climate-advisor/service/app/routes/concept_note_markdown.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import re
 from collections.abc import AsyncIterator
+from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Request, status
@@ -13,15 +15,21 @@ from app.config import get_settings
 from app.models.concept_note_markdown import (
     ConceptNoteMarkdownRequest,
     ConceptNoteMarkdownResponse,
+    ConceptNoteUploadCreateRequest,
+    ConceptNoteUploadDeliveryContext,
+    ConceptNoteUploadFailureRequest,
+    ConceptNoteUploadStatusResponse,
 )
 from app.persistence.concept_notes.markdown import (
     ConceptNoteMarkdownRepository,
     ConceptNoteMarkdownRepositoryError,
+    ConceptNoteUploadSnapshot,
     get_concept_note_markdown_repository,
 )
 from app.services.citycatalyst_client import (
     CityCatalystClient,
     CityCatalystClientError,
+    ConceptNoteMarkdownArtifact,
 )
 
 
@@ -30,7 +38,7 @@ PAGE_MARKER = re.compile(r"<!-- page: (\d+) -->")
 
 
 async def get_citycatalyst_client() -> AsyncIterator[CityCatalystClient]:
-    """Provide and close the CC client used for opaque bearer validation."""
+    """Provide and close the CC client used for identity and artifact checks."""
     client = CityCatalystClient()
     try:
         yield client
@@ -39,7 +47,7 @@ async def get_citycatalyst_client() -> AsyncIterator[CityCatalystClient]:
 
 
 def problem(status_code: int, code: str, message: str) -> JSONResponse:
-    """Return a stable machine-readable Markdown-ingest error."""
+    """Return a stable machine-readable CNB upload error."""
     return JSONResponse(
         status_code=status_code,
         content={"code": code, "detail": message, "status": status_code},
@@ -47,40 +55,156 @@ def problem(status_code: int, code: str, message: str) -> JSONResponse:
     )
 
 
-async def read_limited_body(request: Request, max_bytes: int) -> bytes | None:
-    """Stream a request body, returning ``None`` once the byte limit is exceeded."""
-    body = bytearray()
-    async for chunk in request.stream():
-        if len(body) + len(chunk) > max_bytes:
-            return None
-        body.extend(chunk)
-    return bytes(body)
+async def authenticate_user(
+    request: Request,
+    cc_client: CityCatalystClient,
+) -> tuple[str | None, JSONResponse | None]:
+    """Resolve the canonical CC user before any stateful repository action."""
+    authorization = request.headers.get("Authorization", "")
+    if not authorization.startswith("Bearer ") or not authorization[7:].strip():
+        return None, problem(401, "invalid_bearer_token", "Bearer token is required")
+    try:
+        user_id = await cc_client.validate_user_identity(authorization[7:].strip())
+    except CityCatalystClientError as exc:
+        status_code = 401 if exc.status_code in (401, 403) else 503
+        code = (
+            "invalid_bearer_token" if status_code == 401 else "cc_identity_unavailable"
+        )
+        message = (
+            "Bearer token is invalid or expired"
+            if status_code == 401
+            else "Identity service is temporarily unavailable"
+        )
+        return None, problem(status_code, code, message)
+    return user_id, None
 
 
-def validate_markdown(payload: ConceptNoteMarkdownRequest) -> str | None:
-    """Validate digest, page markers, page count, and non-empty content."""
-    # Validate the immutable artifact identity.
-    digest = hashlib.sha256(payload.markdown.encode("utf-8")).hexdigest()
+async def read_json_model(
+    request: Request,
+    model_type: type[Any],
+) -> Any | JSONResponse:
+    """Parse one strict Pydantic JSON request after authentication."""
+    if "application/json" not in request.headers.get("Content-Type", ""):
+        return problem(
+            415,
+            "unsupported_media_type",
+            "Content-Type must be application/json",
+        )
+    try:
+        return model_type.model_validate(await request.json())
+    except (ValidationError, ValueError):
+        return problem(422, "invalid_upload_payload", "Upload payload is invalid")
+
+
+def validate_markdown_artifact(
+    artifact: ConceptNoteMarkdownArtifact,
+    payload: ConceptNoteMarkdownRequest,
+) -> str | None:
+    """Validate the fetched artifact and immutable pointer identity."""
+    if (
+        artifact.markdown_s3_key != payload.markdown_s3_key
+        or artifact.sha256 != payload.sha256
+        or artifact.page_count != payload.page_count
+    ):
+        return "markdown_identity_conflict"
+
+    digest = hashlib.sha256(artifact.markdown.encode("utf-8")).hexdigest()
     if digest != payload.sha256:
         return "markdown_digest_mismatch"
-
-    # Validate ordered page markers without allocating an expected page range.
-    if not payload.markdown.lstrip().startswith("<!-- page: 1 -->"):
+    if not artifact.markdown.lstrip().startswith("<!-- page: 1 -->"):
         return "invalid_markdown_pages"
+
     marker_count = 0
     for marker_count, match in enumerate(
-        PAGE_MARKER.finditer(payload.markdown), start=1
+        PAGE_MARKER.finditer(artifact.markdown), start=1
     ):
         if int(match.group(1)) != marker_count:
             return "invalid_markdown_pages"
     if marker_count != payload.page_count:
         return "invalid_markdown_pages"
-
-    # Require content beyond the page separators.
-    content = PAGE_MARKER.sub("", payload.markdown)
-    if not content.strip():
+    if not PAGE_MARKER.sub("", artifact.markdown).strip():
         return "empty_markdown"
     return None
+
+
+def status_response(
+    snapshot: ConceptNoteUploadSnapshot,
+) -> ConceptNoteUploadStatusResponse:
+    """Map persistence state to the safe CC-facing upload contract."""
+    return ConceptNoteUploadStatusResponse(
+        upload_id=snapshot.upload_id,
+        run_id=snapshot.run_id,
+        status=snapshot.status,
+        filename=snapshot.filename,
+        source_label=snapshot.source_label,
+        page_count=snapshot.page_count,
+        error_code=snapshot.error_code,
+        received_at=snapshot.received_at,
+        completed_at=snapshot.completed_at,
+    )
+
+
+@router.post(
+    "/concept-notes/{run_id}/uploads",
+    response_model=ConceptNoteMarkdownResponse,
+)
+async def create_concept_note_upload(
+    run_id: UUID,
+    request: Request,
+    repository: ConceptNoteMarkdownRepository = Depends(
+        get_concept_note_markdown_repository
+    ),
+    cc_client: CityCatalystClient = Depends(get_citycatalyst_client),
+) -> JSONResponse | ConceptNoteMarkdownResponse:
+    """Create or replay the authoritative pre-conversion upload row."""
+    user_id, auth_error = await authenticate_user(request, cc_client)
+    if auth_error:
+        return auth_error
+    payload = await read_json_model(request, ConceptNoteUploadCreateRequest)
+    if isinstance(payload, JSONResponse):
+        return payload
+    if payload.user_id != user_id:
+        return problem(403, "concept_note_upload_forbidden", "User identity mismatch")
+    try:
+        snapshot = await repository.create_upload(
+            user_id=user_id,
+            run_id=run_id,
+            payload=payload,
+        )
+    except ConceptNoteMarkdownRepositoryError as exc:
+        return problem(exc.status_code, exc.code, str(exc))
+    return ConceptNoteMarkdownResponse(
+        upload_id=snapshot.upload_id,
+        status=snapshot.status,
+    )
+
+
+@router.get(
+    "/concept-notes/{run_id}/uploads/{upload_id}",
+    response_model=ConceptNoteUploadStatusResponse,
+)
+async def get_concept_note_upload(
+    run_id: UUID,
+    upload_id: UUID,
+    request: Request,
+    repository: ConceptNoteMarkdownRepository = Depends(
+        get_concept_note_markdown_repository
+    ),
+    cc_client: CityCatalystClient = Depends(get_citycatalyst_client),
+) -> JSONResponse | ConceptNoteUploadStatusResponse:
+    """Return safe lifecycle metadata for one owned upload."""
+    user_id, auth_error = await authenticate_user(request, cc_client)
+    if auth_error:
+        return auth_error
+    try:
+        snapshot = await repository.get_upload(
+            user_id=user_id,
+            run_id=run_id,
+            upload_id=upload_id,
+        )
+    except ConceptNoteMarkdownRepositoryError as exc:
+        return problem(exc.status_code, exc.code, str(exc))
+    return status_response(snapshot)
 
 
 @router.post(
@@ -97,76 +221,138 @@ async def ingest_concept_note_markdown(
     ),
     cc_client: CityCatalystClient = Depends(get_citycatalyst_client),
 ) -> JSONResponse | ConceptNoteMarkdownResponse:
-    """Validate and atomically register CC-produced Markdown for a CNB run."""
-    authorization = request.headers.get("Authorization", "")
-    if not authorization.startswith("Bearer ") or not authorization[7:].strip():
-        return problem(401, "invalid_bearer_token", "Bearer token is required")
-    if "application/json" not in request.headers.get("Content-Type", ""):
-        return problem(
-            415,
-            "unsupported_media_type",
-            "Content-Type must be application/json",
-        )
+    """Verify the CC object, then persist its immutable pointer as ready."""
+    user_id, auth_error = await authenticate_user(request, cc_client)
+    if auth_error:
+        return auth_error
+    payload = await read_json_model(request, ConceptNoteMarkdownRequest)
+    if isinstance(payload, JSONResponse):
+        return payload
 
-    settings = get_settings()
-    max_bytes = settings.cnb_markdown_request_max_bytes
-    content_length = request.headers.get("Content-Length")
-    if content_length:
-        try:
-            declared_size = int(content_length)
-        except ValueError:
-            return problem(400, "invalid_content_length", "Content-Length is invalid")
-        if declared_size < 0:
-            return problem(400, "invalid_content_length", "Content-Length is invalid")
-        if declared_size > max_bytes:
-            return problem(
-                413,
-                "markdown_request_too_large",
-                "JSON request exceeds the configured maximum",
-            )
-
-    # Authenticate before consuming, parsing, or hashing the request body.
+    authorization = request.headers["Authorization"][7:].strip()
     try:
-        user_id = await cc_client.validate_user_identity(authorization[7:].strip())
+        artifact = await cc_client.get_concept_note_markdown(
+            upload_id=str(upload_id),
+            token=authorization,
+        )
     except CityCatalystClientError as exc:
-        status_code = 401 if exc.status_code in (401, 403) else 503
-        code = (
-            "invalid_bearer_token" if status_code == 401 else "cc_identity_unavailable"
-        )
-        message = (
-            "Bearer token is invalid or expired"
-            if status_code == 401
-            else "Identity service is temporarily unavailable"
-        )
-        return problem(status_code, code, message)
-
-    # Enforce the limit while consuming bodies without a trustworthy size header.
-    body = await read_limited_body(request, max_bytes)
-    if body is None:
+        status_code = 413 if exc.status_code == 413 else 503
         return problem(
-            413,
-            "markdown_request_too_large",
-            "JSON request exceeds the configured maximum",
+            status_code,
+            "cc_markdown_verification_failed",
+            "CC Markdown artifact could not be verified",
         )
-    try:
-        payload = ConceptNoteMarkdownRequest.model_validate_json(body)
-    except ValidationError:
-        return problem(422, "invalid_markdown_payload", "Markdown payload is invalid")
 
-    validation_error = validate_markdown(payload)
+    validation_error = validate_markdown_artifact(artifact, payload)
     if validation_error:
-        return problem(422, validation_error, "Markdown validation failed")
+        status_code = 409 if validation_error == "markdown_identity_conflict" else 422
+        return problem(status_code, validation_error, "Markdown verification failed")
 
     try:
-        await repository.register_markdown(
+        snapshot = await repository.register_markdown(
             user_id=user_id,
             run_id=run_id,
             upload_id=upload_id,
             payload=payload,
         )
     except ConceptNoteMarkdownRepositoryError as exc:
-        return problem(
-            exc.status_code, exc.code, "Unable to register markdown at this time"
-        )
+        return problem(exc.status_code, exc.code, str(exc))
+    return ConceptNoteMarkdownResponse(
+        upload_id=snapshot.upload_id,
+        status=snapshot.status,
+    )
 
-    return ConceptNoteMarkdownResponse(upload_id=upload_id)
+
+@router.post(
+    "/concept-notes/{run_id}/uploads/{upload_id}/failed",
+    response_model=ConceptNoteMarkdownResponse,
+)
+async def mark_concept_note_upload_failed(
+    run_id: UUID,
+    upload_id: UUID,
+    request: Request,
+    repository: ConceptNoteMarkdownRepository = Depends(
+        get_concept_note_markdown_repository
+    ),
+    cc_client: CityCatalystClient = Depends(get_citycatalyst_client),
+) -> JSONResponse | ConceptNoteMarkdownResponse:
+    """Persist a stable upload or OCR failure code."""
+    user_id, auth_error = await authenticate_user(request, cc_client)
+    if auth_error:
+        return auth_error
+    payload = await read_json_model(request, ConceptNoteUploadFailureRequest)
+    if isinstance(payload, JSONResponse):
+        return payload
+    try:
+        snapshot = await repository.mark_failed(
+            user_id=user_id,
+            run_id=run_id,
+            upload_id=upload_id,
+            error_code=payload.error_code,
+        )
+    except ConceptNoteMarkdownRepositoryError as exc:
+        return problem(exc.status_code, exc.code, str(exc))
+    return ConceptNoteMarkdownResponse(
+        upload_id=snapshot.upload_id,
+        status=snapshot.status,
+    )
+
+
+@router.post(
+    "/concept-notes/{run_id}/uploads/{upload_id}/retry",
+    response_model=ConceptNoteMarkdownResponse,
+)
+async def retry_concept_note_upload(
+    run_id: UUID,
+    upload_id: UUID,
+    request: Request,
+    repository: ConceptNoteMarkdownRepository = Depends(
+        get_concept_note_markdown_repository
+    ),
+    cc_client: CityCatalystClient = Depends(get_citycatalyst_client),
+) -> JSONResponse | ConceptNoteMarkdownResponse:
+    """Return a failed authoritative upload row to queued state."""
+    user_id, auth_error = await authenticate_user(request, cc_client)
+    if auth_error:
+        return auth_error
+    try:
+        snapshot = await repository.retry_upload(
+            user_id=user_id,
+            run_id=run_id,
+            upload_id=upload_id,
+        )
+    except ConceptNoteMarkdownRepositoryError as exc:
+        return problem(exc.status_code, exc.code, str(exc))
+    return ConceptNoteMarkdownResponse(
+        upload_id=snapshot.upload_id,
+        status=snapshot.status,
+    )
+
+
+@router.get(
+    "/concept-note-uploads/{upload_id}/delivery-context",
+    response_model=ConceptNoteUploadDeliveryContext,
+)
+async def get_concept_note_delivery_context(
+    upload_id: UUID,
+    request: Request,
+    repository: ConceptNoteMarkdownRepository = Depends(
+        get_concept_note_markdown_repository
+    ),
+) -> JSONResponse | ConceptNoteUploadDeliveryContext:
+    """Return delivery metadata to CC after reverse service authentication."""
+    expected_key = get_settings().cc_api_key or ""
+    supplied_key = request.headers.get("X-CC-Service-Key", "")
+    if not expected_key or not hmac.compare_digest(expected_key, supplied_key):
+        return problem(401, "invalid_service_key", "CC service authentication failed")
+    try:
+        snapshot = await repository.get_delivery_context(upload_id=upload_id)
+    except ConceptNoteMarkdownRepositoryError as exc:
+        return problem(exc.status_code, exc.code, str(exc))
+    return ConceptNoteUploadDeliveryContext(
+        upload_id=snapshot.upload_id,
+        run_id=snapshot.run_id,
+        user_id=snapshot.user_id,
+        filename=snapshot.filename,
+        source_label=snapshot.source_label,
+    )

--- a/climate-advisor/service/app/services/citycatalyst_client.py
+++ b/climate-advisor/service/app/services/citycatalyst_client.py
@@ -11,9 +11,8 @@ This module provides an HTTP client for secure communication with CityCatalyst:
 
 from __future__ import annotations
 
-import asyncio
 import logging
-from datetime import datetime, timezone
+from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple
 
 import httpx
@@ -21,17 +20,25 @@ import httpx
 from app.config import get_settings
 from app.utils.token_manager import (
     is_token_expired,
-    redact_token,
-    get_token_expiry,
-    create_token_context,
     parse_jwt_claims,
 )
 
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class ConceptNoteMarkdownArtifact:
+    """Verified metadata and bytes returned by the CC Markdown read boundary."""
+
+    markdown: str
+    markdown_s3_key: str
+    sha256: str
+    page_count: int
+
+
 class TokenRefreshError(Exception):
     """Raised when token refresh fails."""
+
     pass
 
 
@@ -51,15 +58,20 @@ class CityCatalystClientError(Exception):
 
 class CityCatalystClient:
     """HTTP client for CityCatalyst integration.
-    
+
     Handles JWT token lifecycle:
     - Validates token expiry before use
     - Automatically refreshes expired tokens
     - Makes authenticated requests to CC inventory APIs
     - Gracefully handles auth failures
     """
-    
-    def __init__(self, base_url: Optional[str] = None, api_key: Optional[str] = None, timeout: int = 30):
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        timeout: int = 30,
+    ):
         """Initialize CityCatalyst client.
 
         Args:
@@ -76,67 +88,62 @@ class CityCatalystClient:
         self.datasource_timeout = max(self.timeout, 90)
         self._client: Optional[httpx.AsyncClient] = None
         self.last_refreshed_token: Optional[str] = None
-        
+
         if not self.base_url:
             logger.warning(
                 "CityCatalyst base URL not configured. "
                 "Set CC_BASE_URL environment variable for token refresh and inventory access."
             )
-    
+
     async def _get_client(self) -> httpx.AsyncClient:
         """Get or create async HTTP client."""
         if self._client is None:
             self._client = httpx.AsyncClient(timeout=self.timeout)
         return self._client
-    
+
     async def close(self) -> None:
         """Close HTTP client connection."""
         if self._client:
             await self._client.aclose()
             self._client = None
-    
+
     async def __aenter__(self):
         """Async context manager entry."""
         return self
-    
+
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Async context manager exit."""
         await self.close()
-    
+
     async def refresh_token(
         self,
         user_id: str,
     ) -> Tuple[str, int]:
         """Refresh an expired token using CA service API key.
-        
+
         Args:
             user_id: User ID for token scoping
-        
+
         Returns:
             Tuple of (fresh_jwt_token, expires_in_seconds)
-        
+
         Raises:
             TokenRefreshError: If token refresh fails
         """
         if not self.base_url:
-            raise TokenRefreshError(
-                "CC_BASE_URL not configured. Cannot refresh token."
-            )
-        
+            raise TokenRefreshError("CC_BASE_URL not configured. Cannot refresh token.")
+
         if not self.api_key:
             raise TokenRefreshError(
                 "CC_API_KEY not configured. Cannot authenticate with CityCatalyst."
             )
-        
+
         url = f"{self.base_url}/api/v1/internal/ca/user-token"
         payload = {
             "user_id": user_id,
         }
-        headers = {
-            "X-CA-Service-Key": self.api_key,
-            "Content-Type": "application/json"
-        }
-        
+        headers = {"X-CA-Service-Key": self.api_key, "Content-Type": "application/json"}
+
         try:
             client = await self._get_client()
             logger.debug(
@@ -145,9 +152,11 @@ class CityCatalystClient:
             )
 
             # Allow redirects for compatibility
-            response = await client.post(url, json=payload, headers=headers, follow_redirects=True)
+            response = await client.post(
+                url, json=payload, headers=headers, follow_redirects=True
+            )
             response.raise_for_status()
-            
+
             data = response.json()
             fresh_token, expires_in, claims = self._validate_refresh_response(
                 data=data,
@@ -166,14 +175,16 @@ class CityCatalystClient:
                 audience or "unknown",
             )
             return fresh_token, expires_in
-            
+
         except httpx.HTTPStatusError as e:
             logger.error(
                 "Token refresh failed with status %d: %s",
                 e.response.status_code,
                 e.response.text[:200],
             )
-            raise TokenRefreshError(f"Token refresh failed: HTTP {e.response.status_code}") from e
+            raise TokenRefreshError(
+                f"Token refresh failed: HTTP {e.response.status_code}"
+            ) from e
         except TokenRefreshError:
             raise
         except Exception as e:
@@ -207,7 +218,9 @@ class CityCatalystClient:
         claims = parse_jwt_claims(fresh_token)
         if isinstance(claims, dict):
             if claims.get("sub") != user_id:
-                raise TokenRefreshError("Refreshed token subject does not match requested user")
+                raise TokenRefreshError(
+                    "Refreshed token subject does not match requested user"
+                )
             if claims.get("iss") != "climate-advisor-service":
                 raise TokenRefreshError("Invalid token issuer in refresh response")
             if not self._audience_matches(claims.get("aud")):
@@ -230,7 +243,7 @@ class CityCatalystClient:
                 for value in audience
             )
         return False
-    
+
     async def get_with_auto_refresh(
         self,
         url: str,
@@ -242,17 +255,17 @@ class CityCatalystClient:
         request_timeout: Optional[float] = None,
     ) -> httpx.Response:
         """Make GET request with automatic token refresh on 401.
-        
+
         Args:
             url: Full URL to request
             token: Bearer token
             user_id: User ID (for token refresh context)
             thread_id: Thread ID (for token refresh context)
             auto_refresh: Automatically refresh token on 401
-        
+
         Returns:
             Response object
-        
+
         Raises:
             CityCatalystClientError: If request fails
         """
@@ -264,12 +277,12 @@ class CityCatalystClient:
             except TokenRefreshError as e:
                 logger.warning("Preemptive token refresh failed: %s", e)
                 # Continue with expired token - let server reject it
-        
+
         try:
             client = await self._get_client()
             headers = self._auth_headers(token)
             timeout_value = request_timeout or self.timeout
-            
+
             logger.debug("Making GET request to %s (timeout=%s)", url, timeout_value)
             response = await client.get(
                 url,
@@ -277,7 +290,7 @@ class CityCatalystClient:
                 follow_redirects=True,
                 timeout=timeout_value,
             )
-            
+
             # Handle 401 Unauthorized - try to refresh
             if response.status_code == 401 and auto_refresh:
                 logger.debug("Got 401, attempting token refresh")
@@ -293,13 +306,13 @@ class CityCatalystClient:
                 except TokenRefreshError as e:
                     logger.error("Failed to refresh token: %s", e)
                     raise CityCatalystClientError(f"Authentication failed: {e}") from e
-            
+
             return response
-            
+
         except Exception as e:
             logger.error("Request failed: %s", e)
             raise CityCatalystClientError(f"Request failed: {e}") from e
-    
+
     async def post_with_auto_refresh(
         self,
         url: str,
@@ -312,7 +325,7 @@ class CityCatalystClient:
         request_timeout: Optional[float] = None,
     ) -> httpx.Response:
         """Make POST request with automatic token refresh on 401.
-        
+
         Args:
             url: Full URL to request
             token: Bearer token
@@ -320,10 +333,10 @@ class CityCatalystClient:
             thread_id: Thread ID (for token refresh context)
             json_data: JSON payload
             auto_refresh: Automatically refresh token on 401
-        
+
         Returns:
             Response object
-        
+
         Raises:
             CityCatalystClientError: If request fails
         """
@@ -334,12 +347,12 @@ class CityCatalystClient:
                 token, _ = await self.refresh_token(user_id)
             except TokenRefreshError as e:
                 logger.warning("Preemptive token refresh failed: %s", e)
-        
+
         try:
             client = await self._get_client()
             headers = self._auth_headers(token)
             timeout_value = request_timeout or self.timeout
-            
+
             logger.debug("Making POST request to %s (timeout=%s)", url, timeout_value)
             response = await client.post(
                 url,
@@ -348,7 +361,7 @@ class CityCatalystClient:
                 follow_redirects=True,
                 timeout=timeout_value,
             )
-            
+
             # Handle 401 Unauthorized - try to refresh
             if response.status_code == 401 and auto_refresh:
                 logger.debug("Got 401, attempting token refresh")
@@ -365,19 +378,19 @@ class CityCatalystClient:
                 except TokenRefreshError as e:
                     logger.error("Failed to refresh token: %s", e)
                     raise CityCatalystClientError(f"Authentication failed: {e}") from e
-            
+
             return response
-            
+
         except Exception as e:
             logger.error("Request failed: %s", e)
             raise CityCatalystClientError(f"Request failed: {e}") from e
-    
+
     def _auth_headers(self, token: str) -> Dict[str, str]:
         """Build authorization headers for requests.
-        
+
         Args:
             token: Bearer token
-        
+
         Returns:
             Headers dictionary with service authentication
         """
@@ -437,6 +450,74 @@ class CityCatalystClient:
                 status_code=503,
             )
         return user_id
+
+    async def get_concept_note_markdown(
+        self,
+        *,
+        upload_id: str,
+        token: str,
+    ) -> ConceptNoteMarkdownArtifact:
+        """Read a completed CNB Markdown artifact through authenticated CC."""
+        if not self.base_url:
+            raise CityCatalystClientError(
+                "CC_BASE_URL not configured",
+                status_code=503,
+            )
+
+        client = await self._get_client()
+        try:
+            response = await client.get(
+                (
+                    f"{self.base_url}/api/v1/internal/ca/"
+                    f"concept-note-uploads/{upload_id}/markdown"
+                ),
+                headers=self._internal_headers(token),
+                follow_redirects=True,
+                timeout=self.datasource_timeout,
+            )
+        except httpx.HTTPError as exc:
+            raise CityCatalystClientError(
+                "CC Markdown verification is unavailable",
+                status_code=503,
+            ) from exc
+
+        if not response.is_success:
+            raise CityCatalystClientError(
+                "CC Markdown artifact could not be verified",
+                status_code=response.status_code,
+            )
+
+        settings = get_settings()
+        if len(response.content) > settings.cnb_markdown_request_max_bytes:
+            raise CityCatalystClientError(
+                "CC Markdown artifact exceeds the configured maximum",
+                status_code=413,
+            )
+
+        markdown_s3_key = response.headers.get("X-Markdown-S3-Key")
+        sha256 = response.headers.get("X-Markdown-SHA256")
+        page_count_header = response.headers.get("X-Page-Count")
+        try:
+            page_count = int(page_count_header or "")
+            markdown = response.content.decode("utf-8")
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise CityCatalystClientError(
+                "CC Markdown artifact metadata is invalid",
+                status_code=502,
+            ) from exc
+
+        if not markdown_s3_key or not sha256 or len(sha256) != 64 or page_count < 1:
+            raise CityCatalystClientError(
+                "CC Markdown artifact metadata is invalid",
+                status_code=502,
+            )
+
+        return ConceptNoteMarkdownArtifact(
+            markdown=markdown,
+            markdown_s3_key=markdown_s3_key,
+            sha256=sha256,
+            page_count=page_count,
+        )
 
     async def post_internal_capability(
         self,
@@ -532,9 +613,13 @@ class CityCatalystClient:
         if isinstance(data, list):
             capabilities = data
         else:
-            capabilities = data.get("capabilities") or data.get("allowed_capabilities") or data
+            capabilities = (
+                data.get("capabilities") or data.get("allowed_capabilities") or data
+            )
         if isinstance(capabilities, dict):
-            capabilities = capabilities.get("capabilities") or capabilities.get("ids") or []
+            capabilities = (
+                capabilities.get("capabilities") or capabilities.get("ids") or []
+            )
         if not isinstance(capabilities, list):
             raise CityCatalystClientError("Invalid allowed capabilities response")
 
@@ -643,9 +728,9 @@ class CityCatalystClient:
             json_data=request_payload,
             token=token,
         )
-    
+
     # Convenience methods for common CC API operations
-    
+
     async def get_inventory(
         self,
         inventory_id: str,
@@ -653,21 +738,21 @@ class CityCatalystClient:
         user_id: str,
     ) -> Dict[str, Any]:
         """Fetch inventory data from CityCatalyst.
-        
+
         Args:
             inventory_id: Inventory UUID
             token: User access token
             user_id: User ID for token refresh context
-            
+
         Returns:
             Inventory data dictionary
-            
+
         Raises:
             CityCatalystClientError: If API call fails
         """
         if not self.base_url:
             raise CityCatalystClientError("CC_BASE_URL not configured")
-        
+
         url = f"{self.base_url}/api/v1/inventory/{inventory_id}"
         response = await self.get_with_auto_refresh(
             url=url,
@@ -675,17 +760,19 @@ class CityCatalystClient:
             user_id=user_id,
             thread_id="",  # Not used in new refresh method
         )
-        
+
         if not response.is_success:
             error_text = response.text[:200] if response.text else "Unknown error"
             raise CityCatalystClientError(
                 f"Failed to fetch inventory {inventory_id}: {response.status_code} - {error_text}"
             )
-        
+
         try:
             return response.json()
         except Exception as e:
-            raise CityCatalystClientError(f"Failed to parse inventory response: {e}") from e
+            raise CityCatalystClientError(
+                f"Failed to parse inventory response: {e}"
+            ) from e
 
     async def get_user_inventories(
         self,
@@ -734,7 +821,7 @@ class CityCatalystClient:
             raise CityCatalystClientError(
                 f"Failed to parse user inventories response: {e}"
             ) from e
-    
+
     async def get_city(
         self,
         city_id: str,
@@ -742,21 +829,21 @@ class CityCatalystClient:
         user_id: str,
     ) -> Dict[str, Any]:
         """Fetch city data from CityCatalyst.
-        
+
         Args:
             city_id: City UUID
             token: User access token
             user_id: User ID for token refresh context
-            
+
         Returns:
             City data dictionary
-            
+
         Raises:
             CityCatalystClientError: If API call fails
         """
         if not self.base_url:
             raise CityCatalystClientError("CC_BASE_URL not configured")
-        
+
         url = f"{self.base_url}/api/v1/city/{city_id}"
         response = await self.get_with_auto_refresh(
             url=url,
@@ -764,14 +851,14 @@ class CityCatalystClient:
             user_id=user_id,
             thread_id="",  # Not used in new refresh method
         )
-        
+
         if not response.is_success:
             error_text = response.text[:200] if response.text else "Unknown error"
             raise CityCatalystClientError(
                 f"Failed to fetch city {city_id}: {response.status_code} - {error_text}",
                 status_code=response.status_code,
             )
-        
+
         try:
             return response.json()
         except Exception as e:
@@ -817,4 +904,6 @@ class CityCatalystClient:
         try:
             return response.json()
         except Exception as e:
-            raise CityCatalystClientError(f"Failed to parse data sources response: {e}") from e
+            raise CityCatalystClientError(
+                f"Failed to parse data sources response: {e}"
+            ) from e

--- a/climate-advisor/service/app/services/citycatalyst_client.py
+++ b/climate-advisor/service/app/services/citycatalyst_client.py
@@ -466,7 +466,8 @@ class CityCatalystClient:
 
         client = await self._get_client()
         try:
-            response = await client.get(
+            async with client.stream(
+                "GET",
                 (
                     f"{self.base_url}/api/v1/internal/ca/"
                     f"concept-note-uploads/{upload_id}/markdown"
@@ -474,32 +475,58 @@ class CityCatalystClient:
                 headers=self._internal_headers(token),
                 follow_redirects=True,
                 timeout=self.datasource_timeout,
-            )
+            ) as response:
+                if not response.is_success:
+                    raise CityCatalystClientError(
+                        "CC Markdown artifact could not be verified",
+                        status_code=response.status_code,
+                    )
+
+                # Reject a trustworthy declared size before consuming the body.
+                settings = get_settings()
+                max_bytes = settings.cnb_markdown_request_max_bytes
+                content_length = response.headers.get("Content-Length")
+                if content_length:
+                    try:
+                        declared_size = int(content_length)
+                    except ValueError as exc:
+                        raise CityCatalystClientError(
+                            "CC Markdown artifact metadata is invalid",
+                            status_code=502,
+                        ) from exc
+                    if declared_size < 0:
+                        raise CityCatalystClientError(
+                            "CC Markdown artifact metadata is invalid",
+                            status_code=502,
+                        )
+                    if declared_size > max_bytes:
+                        raise CityCatalystClientError(
+                            "CC Markdown artifact exceeds the configured maximum",
+                            status_code=413,
+                        )
+
+                # Bound streamed and decompressed bytes even without a size header.
+                markdown_bytes = bytearray()
+                async for chunk in response.aiter_bytes():
+                    if len(markdown_bytes) + len(chunk) > max_bytes:
+                        raise CityCatalystClientError(
+                            "CC Markdown artifact exceeds the configured maximum",
+                            status_code=413,
+                        )
+                    markdown_bytes.extend(chunk)
+
+                # Capture immutable identity metadata before closing the response.
+                markdown_s3_key = response.headers.get("X-Markdown-S3-Key")
+                sha256 = response.headers.get("X-Markdown-SHA256")
+                page_count_header = response.headers.get("X-Page-Count")
         except httpx.HTTPError as exc:
             raise CityCatalystClientError(
                 "CC Markdown verification is unavailable",
                 status_code=503,
             ) from exc
-
-        if not response.is_success:
-            raise CityCatalystClientError(
-                "CC Markdown artifact could not be verified",
-                status_code=response.status_code,
-            )
-
-        settings = get_settings()
-        if len(response.content) > settings.cnb_markdown_request_max_bytes:
-            raise CityCatalystClientError(
-                "CC Markdown artifact exceeds the configured maximum",
-                status_code=413,
-            )
-
-        markdown_s3_key = response.headers.get("X-Markdown-S3-Key")
-        sha256 = response.headers.get("X-Markdown-SHA256")
-        page_count_header = response.headers.get("X-Page-Count")
         try:
             page_count = int(page_count_header or "")
-            markdown = response.content.decode("utf-8")
+            markdown = markdown_bytes.decode("utf-8")
         except (UnicodeDecodeError, ValueError) as exc:
             raise CityCatalystClientError(
                 "CC Markdown artifact metadata is invalid",

--- a/climate-advisor/service/migrations/versions/20260730_120000_concept_note_upload_pointers.py
+++ b/climate-advisor/service/migrations/versions/20260730_120000_concept_note_upload_pointers.py
@@ -44,7 +44,11 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Restore the legacy inline-Markdown schema shape."""
+    """Restore the legacy schema with placeholders, not recovered Markdown.
+
+    Empty Markdown and a zero hash only satisfy the legacy NOT NULL constraints;
+    they cannot recover inline content discarded by the upgrade.
+    """
     op.add_column(
         "concept_note_uploads",
         sa.Column("markdown_text", sa.Text(), nullable=True),

--- a/climate-advisor/service/migrations/versions/20260730_120000_concept_note_upload_pointers.py
+++ b/climate-advisor/service/migrations/versions/20260730_120000_concept_note_upload_pointers.py
@@ -1,0 +1,90 @@
+"""Store Concept Note Markdown by CC S3 pointer.
+
+Revision ID: 20260730_120000
+Revises: 20260729_120000
+Create Date: 2026-07-30 12:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260730_120000"
+down_revision = "20260729_120000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Allow pre-conversion uploads and replace inline Markdown with an S3 key."""
+    op.add_column(
+        "concept_note_uploads",
+        sa.Column("markdown_s3_key", sa.String(length=1024), nullable=True),
+    )
+    op.alter_column(
+        "concept_note_uploads",
+        "markdown_sha256",
+        existing_type=sa.String(length=64),
+        nullable=True,
+    )
+    op.alter_column(
+        "concept_note_uploads",
+        "page_count",
+        existing_type=sa.Integer(),
+        nullable=True,
+    )
+    op.alter_column(
+        "concept_note_uploads",
+        "ingest_status",
+        existing_type=sa.String(length=64),
+        server_default="queued",
+        existing_nullable=False,
+    )
+    op.drop_column("concept_note_uploads", "markdown_text")
+
+
+def downgrade() -> None:
+    """Restore the legacy inline-Markdown schema shape."""
+    op.add_column(
+        "concept_note_uploads",
+        sa.Column("markdown_text", sa.Text(), nullable=True),
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE concept_note_uploads
+            SET markdown_text = COALESCE(markdown_text, ''),
+                markdown_sha256 = COALESCE(
+                    markdown_sha256,
+                    repeat('0', 64)
+                ),
+                page_count = COALESCE(page_count, 1)
+            """
+        )
+    )
+    op.alter_column(
+        "concept_note_uploads",
+        "markdown_text",
+        existing_type=sa.Text(),
+        nullable=False,
+    )
+    op.alter_column(
+        "concept_note_uploads",
+        "ingest_status",
+        existing_type=sa.String(length=64),
+        server_default="processing",
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "concept_note_uploads",
+        "page_count",
+        existing_type=sa.Integer(),
+        nullable=False,
+    )
+    op.alter_column(
+        "concept_note_uploads",
+        "markdown_sha256",
+        existing_type=sa.String(length=64),
+        nullable=False,
+    )
+    op.drop_column("concept_note_uploads", "markdown_s3_key")

--- a/climate-advisor/service/tests/test_concept_note_markdown_client.py
+++ b/climate-advisor/service/tests/test_concept_note_markdown_client.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from app.services.citycatalyst_client import (
+    CityCatalystClient,
+    CityCatalystClientError,
+)
+
+
+class TrackingStream(httpx.AsyncByteStream):
+    """Yield controlled chunks and record how far the client consumed them."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self.chunks = chunks
+        self.chunks_read = 0
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self.chunks:
+            self.chunks_read += 1
+            yield chunk
+
+    async def aclose(self) -> None:
+        """Satisfy the HTTPX streaming response contract."""
+
+
+def settings(max_bytes: int) -> SimpleNamespace:
+    """Return the CityCatalyst settings used by these focused client tests."""
+    return SimpleNamespace(
+        cc_base_url=None,
+        cc_api_key=None,
+        cnb_markdown_request_max_bytes=max_bytes,
+    )
+
+
+@pytest.mark.asyncio
+async def test_markdown_client_streams_and_parses_a_bounded_artifact() -> None:
+    markdown = b"<!-- page: 1 -->\n# Plan"
+    digest = hashlib.sha256(markdown).hexdigest()
+    stream = TrackingStream([markdown[:10], markdown[10:]])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "Bearer user-token"
+        assert request.headers["X-Service-Key"] == "service-key"
+        return httpx.Response(
+            200,
+            headers={
+                "Content-Length": str(len(markdown)),
+                "X-Markdown-S3-Key": "results/upload/combined.md",
+                "X-Markdown-SHA256": digest,
+                "X-Page-Count": "1",
+            },
+            stream=stream,
+        )
+
+    with patch(
+        "app.services.citycatalyst_client.get_settings",
+        return_value=settings(len(markdown)),
+    ):
+        client = CityCatalystClient(
+            base_url="https://cc.example",
+            api_key="service-key",
+        )
+        client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        try:
+            artifact = await client.get_concept_note_markdown(
+                upload_id="upload-id",
+                token="user-token",
+            )
+        finally:
+            await client.close()
+
+    assert artifact.markdown == markdown.decode()
+    assert artifact.markdown_s3_key == "results/upload/combined.md"
+    assert artifact.sha256 == digest
+    assert artifact.page_count == 1
+    assert stream.chunks_read == 2
+
+
+@pytest.mark.asyncio
+async def test_markdown_client_rejects_declared_oversize_before_streaming() -> None:
+    stream = TrackingStream([b"never consumed"])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"Content-Length": "6"},
+            stream=stream,
+        )
+
+    with patch(
+        "app.services.citycatalyst_client.get_settings",
+        return_value=settings(5),
+    ):
+        client = CityCatalystClient(base_url="https://cc.example")
+        client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        try:
+            with pytest.raises(CityCatalystClientError) as error:
+                await client.get_concept_note_markdown(
+                    upload_id="upload-id",
+                    token="user-token",
+                )
+        finally:
+            await client.close()
+
+    assert error.value.status_code == 413
+    assert stream.chunks_read == 0
+
+
+@pytest.mark.asyncio
+async def test_markdown_client_stops_an_undeclared_oversize_stream() -> None:
+    stream = TrackingStream([b"1234", b"5678", b"not consumed"])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=stream)
+
+    with patch(
+        "app.services.citycatalyst_client.get_settings",
+        return_value=settings(5),
+    ):
+        client = CityCatalystClient(base_url="https://cc.example")
+        client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        try:
+            with pytest.raises(CityCatalystClientError) as error:
+                await client.get_concept_note_markdown(
+                    upload_id="upload-id",
+                    token="user-token",
+                )
+        finally:
+            await client.close()
+
+    assert error.value.status_code == 413
+    assert stream.chunks_read == 2

--- a/climate-advisor/service/tests/test_concept_note_markdown_ingest.py
+++ b/climate-advisor/service/tests/test_concept_note_markdown_ingest.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Iterable
+from dataclasses import replace
+from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
 import pytest
@@ -9,43 +10,62 @@ from fastapi.testclient import TestClient
 
 from app.config import get_settings
 from app.main import get_app
-from app.models.concept_note_markdown import ConceptNoteMarkdownRequest
+from app.models.concept_note_markdown import (
+    ConceptNoteMarkdownRequest,
+    ConceptNoteUploadCreateRequest,
+)
 from app.persistence.concept_notes.markdown import (
     ConceptNoteMarkdownRepository,
     ConceptNoteMarkdownRepositoryError,
+    ConceptNoteUploadSnapshot,
     get_concept_note_markdown_repository,
 )
 from app.routes.concept_note_markdown import get_citycatalyst_client
-from app.services.citycatalyst_client import CityCatalystClientError
+from app.services.citycatalyst_client import (
+    CityCatalystClientError,
+    ConceptNoteMarkdownArtifact,
+)
 
 
-class FakeIdentityClient:
-    """Resolve test tokens without sharing a CC signing secret."""
+MARKDOWN = "<!-- page: 1 -->\n# Plan"
+SHA256 = hashlib.sha256(MARKDOWN.encode()).hexdigest()
+S3_KEY = "pdf-ocr/results/concept_note_upload/upload/1/combined_markdown.md"
+
+
+class FakeCityCatalystClient:
+    """Resolve opaque identities and serve a controlled CC Markdown artifact."""
+
+    def __init__(self) -> None:
+        self.artifact = ConceptNoteMarkdownArtifact(
+            markdown=MARKDOWN,
+            markdown_s3_key=S3_KEY,
+            sha256=SHA256,
+            page_count=1,
+        )
 
     async def validate_user_identity(self, token: str) -> str:
-        """Return the canonical subject or reject an invalid token."""
         if token == "invalid":
             raise CityCatalystClientError("invalid", status_code=401)
         return token
 
+    async def get_concept_note_markdown(
+        self,
+        *,
+        upload_id: str,
+        token: str,
+    ) -> ConceptNoteMarkdownArtifact:
+        return self.artifact
+
 
 class FakeMarkdownRepository(ConceptNoteMarkdownRepository):
-    """Atomic in-memory implementation used only for API contract tests."""
+    """In-memory implementation of the authoritative upload lifecycle."""
 
     def __init__(self, run_id: UUID, owner_id: str) -> None:
         self.run_id = run_id
         self.owner_id = owner_id
-        self.uploads: dict[UUID, tuple[UUID, str]] = {}
+        self.uploads: dict[UUID, ConceptNoteUploadSnapshot] = {}
 
-    async def register_markdown(
-        self,
-        *,
-        user_id: str,
-        run_id: UUID,
-        upload_id: UUID,
-        payload: ConceptNoteMarkdownRequest,
-    ) -> None:
-        """Enforce run ownership, upload binding, and digest idempotency atomically."""
+    def authorize(self, user_id: str, run_id: UUID) -> None:
         if run_id != self.run_id:
             raise ConceptNoteMarkdownRepositoryError(
                 "concept_note_run_not_found", 404, "Run not found"
@@ -54,197 +74,287 @@ class FakeMarkdownRepository(ConceptNoteMarkdownRepository):
             raise ConceptNoteMarkdownRepositoryError(
                 "concept_note_run_forbidden", 403, "Run owner does not match"
             )
-        existing = self.uploads.get(upload_id)
-        if existing and existing[0] != run_id:
+
+    async def create_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        payload: ConceptNoteUploadCreateRequest,
+    ) -> ConceptNoteUploadSnapshot:
+        self.authorize(user_id, run_id)
+        existing = self.uploads.get(payload.upload_id)
+        if existing:
+            if (
+                existing.filename != payload.filename
+                or existing.source_label != payload.source_label
+            ):
+                raise ConceptNoteMarkdownRepositoryError(
+                    "upload_identity_conflict", 409, "Upload changed"
+                )
+            return existing
+        snapshot = ConceptNoteUploadSnapshot(
+            upload_id=payload.upload_id,
+            run_id=run_id,
+            user_id=user_id,
+            filename=payload.filename,
+            source_label=payload.source_label,
+            markdown_s3_key=None,
+            markdown_sha256=None,
+            page_count=None,
+            status="queued",
+            error_code=None,
+            received_at=datetime.now(timezone.utc),
+            completed_at=None,
+        )
+        self.uploads[payload.upload_id] = snapshot
+        return snapshot
+
+    async def get_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        self.authorize(user_id, run_id)
+        try:
+            return self.uploads[upload_id]
+        except KeyError as exc:
             raise ConceptNoteMarkdownRepositoryError(
-                "upload_run_binding_conflict", 409, "Upload belongs to another run"
-            )
-        if existing and existing[1] != payload.sha256:
+                "concept_note_upload_not_found", 404, "Upload not found"
+            ) from exc
+
+    async def register_markdown(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+        payload: ConceptNoteMarkdownRequest,
+    ) -> ConceptNoteUploadSnapshot:
+        current = await self.get_upload(
+            user_id=user_id,
+            run_id=run_id,
+            upload_id=upload_id,
+        )
+        if current.markdown_sha256:
+            if (
+                current.markdown_s3_key != payload.markdown_s3_key
+                or current.markdown_sha256 != payload.sha256
+            ):
+                raise ConceptNoteMarkdownRepositoryError(
+                    "markdown_identity_conflict", 409, "Markdown changed"
+                )
+            return current
+        updated = replace(
+            current,
+            markdown_s3_key=payload.markdown_s3_key,
+            markdown_sha256=payload.sha256,
+            page_count=payload.page_count,
+            status="ready",
+            completed_at=datetime.now(timezone.utc),
+        )
+        self.uploads[upload_id] = updated
+        return updated
+
+    async def mark_failed(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+        error_code: str,
+    ) -> ConceptNoteUploadSnapshot:
+        current = await self.get_upload(
+            user_id=user_id,
+            run_id=run_id,
+            upload_id=upload_id,
+        )
+        updated = replace(current, status="failed", error_code=error_code)
+        self.uploads[upload_id] = updated
+        return updated
+
+    async def retry_upload(
+        self,
+        *,
+        user_id: str,
+        run_id: UUID,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        current = await self.get_upload(
+            user_id=user_id,
+            run_id=run_id,
+            upload_id=upload_id,
+        )
+        if current.status == "ready":
             raise ConceptNoteMarkdownRepositoryError(
-                "markdown_identity_conflict", 409, "Upload digest cannot change"
+                "upload_not_retryable", 409, "Ready upload"
             )
-        self.uploads[upload_id] = (run_id, payload.sha256)
+        updated = replace(current, status="queued", error_code=None)
+        self.uploads[upload_id] = updated
+        return updated
+
+    async def get_delivery_context(
+        self,
+        *,
+        upload_id: UUID,
+    ) -> ConceptNoteUploadSnapshot:
+        try:
+            return self.uploads[upload_id]
+        except KeyError as exc:
+            raise ConceptNoteMarkdownRepositoryError(
+                "concept_note_upload_not_found", 404, "Upload not found"
+            ) from exc
 
 
-def payload(
-    markdown: str = "<!-- page: 1 -->\n# Plan", page_count: int = 1
-) -> dict[str, object]:
-    """Build a valid request with a digest over the exact UTF-8 Markdown."""
+def create_payload(upload_id: UUID) -> dict[str, object]:
     return {
-        "markdown": markdown,
+        "upload_id": str(upload_id),
+        "user_id": "owner-user",
         "filename": "plan.pdf",
         "source_label": "Climate Action Plan",
-        "page_count": page_count,
-        "sha256": hashlib.sha256(markdown.encode()).hexdigest(),
     }
+
+
+def pointer_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "markdown_s3_key": S3_KEY,
+        "filename": "plan.pdf",
+        "source_label": "Climate Action Plan",
+        "page_count": 1,
+        "sha256": SHA256,
+    }
+    payload.update(overrides)
+    return payload
 
 
 @pytest.fixture
 def ingest_client():
-    """Provide a client and fake atomic repository for each contract test."""
     run_id = uuid4()
     repository = FakeMarkdownRepository(run_id, "owner-user")
+    cc_client = FakeCityCatalystClient()
     app = get_app()
-    app.dependency_overrides[get_citycatalyst_client] = FakeIdentityClient
+    app.dependency_overrides[get_citycatalyst_client] = lambda: cc_client
     app.dependency_overrides[get_concept_note_markdown_repository] = lambda: repository
+    settings = get_settings()
+    original_key = settings.cc_api_key
+    settings.cc_api_key = "service-key"
     with TestClient(app) as client:
-        yield client, repository, run_id
+        yield client, repository, cc_client, run_id
+    settings.cc_api_key = original_key
     app.dependency_overrides.clear()
 
 
-def post(
-    client: TestClient, run_id: UUID, upload_id: UUID, body: dict, token="owner-user"
-):
-    """Post one Markdown artifact with the requested identity token."""
+def auth(token: str = "owner-user") -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def create_upload(client: TestClient, run_id: UUID, upload_id: UUID):
     return client.post(
-        f"/v1/concept-notes/{run_id}/uploads/{upload_id}/markdown",
-        json=body,
-        headers={"Authorization": f"Bearer {token}"} if token else {},
+        f"/v1/concept-notes/{run_id}/uploads",
+        json=create_payload(upload_id),
+        headers=auth(),
     )
 
 
-def post_stream(
-    client: TestClient,
-    run_id: UUID,
-    upload_id: UUID,
-    chunks: Iterable[bytes],
-    token: str = "owner-user",
-):
-    """Post a lazily consumed JSON byte stream without a Content-Length header."""
-    return client.post(
-        f"/v1/concept-notes/{run_id}/uploads/{upload_id}/markdown",
-        content=chunks,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-        },
-    )
-
-
-def test_missing_and_invalid_bearer_token(ingest_client) -> None:
-    client, _, run_id = ingest_client
-    assert post(client, run_id, uuid4(), payload(), token="").status_code == 401
-    assert post(client, run_id, uuid4(), payload(), token="invalid").status_code == 401
-
-
-def test_invalid_bearer_is_rejected_before_stream_consumption(ingest_client) -> None:
-    client, _, run_id = ingest_client
-    consumed_chunks: list[bytes] = []
-
-    def body_chunks() -> Iterable[bytes]:
-        chunk = b"untrusted request body"
-        consumed_chunks.append(chunk)
-        yield chunk
-
-    response = post_stream(
-        client, run_id, uuid4(), body_chunks(), token="invalid"
-    )
-
-    assert response.status_code == 401
-    assert consumed_chunks == []
-
-
-def test_owner_missing_run_and_upload_binding(ingest_client) -> None:
-    client, repository, run_id = ingest_client
-    assert post(client, uuid4(), uuid4(), payload()).status_code == 404
-    assert (
-        post(client, run_id, uuid4(), payload(), token="other-user").status_code == 403
-    )
+def test_create_requires_auth_and_run_owner(ingest_client) -> None:
+    client, _, _, run_id = ingest_client
     upload_id = uuid4()
-    repository.uploads[upload_id] = (uuid4(), payload()["sha256"])
-    response = post(client, run_id, upload_id, payload())
+    assert (
+        client.post(
+            f"/v1/concept-notes/{run_id}/uploads",
+            json=create_payload(upload_id),
+        ).status_code
+        == 401
+    )
+    assert (
+        client.post(
+            f"/v1/concept-notes/{run_id}/uploads",
+            json=create_payload(upload_id),
+            headers=auth("other-user"),
+        ).status_code
+        == 403
+    )
+
+
+def test_create_is_idempotent_and_metadata_is_immutable(ingest_client) -> None:
+    client, _, _, run_id = ingest_client
+    upload_id = uuid4()
+    assert create_upload(client, run_id, upload_id).status_code == 200
+    assert create_upload(client, run_id, upload_id).status_code == 200
+    changed = create_payload(upload_id)
+    changed["filename"] = "changed.pdf"
+    response = client.post(
+        f"/v1/concept-notes/{run_id}/uploads",
+        json=changed,
+        headers=auth(),
+    )
     assert response.status_code == 409
-    assert response.json()["code"] == "upload_run_binding_conflict"
+    assert response.json()["code"] == "upload_identity_conflict"
 
 
-def test_digest_validation_idempotency_and_identity_conflict(ingest_client) -> None:
-    client, _, run_id = ingest_client
+def test_pointer_delivery_verifies_cc_then_persists_ready(ingest_client) -> None:
+    client, repository, _, run_id = ingest_client
     upload_id = uuid4()
-    invalid = payload()
-    invalid["sha256"] = "0" * 64
-    assert (
-        post(client, run_id, upload_id, invalid).json()["code"]
-        == "markdown_digest_mismatch"
-    )
+    create_upload(client, run_id, upload_id)
+    path = f"/v1/concept-notes/{run_id}/uploads/{upload_id}/markdown"
 
-    first = post(client, run_id, upload_id, payload())
-    second = post(client, run_id, upload_id, payload())
+    first = client.post(path, json=pointer_payload(), headers=auth())
+    second = client.post(path, json=pointer_payload(), headers=auth())
+
     assert first.status_code == second.status_code == 202
-
-    changed = payload("<!-- page: 1 -->\n# Changed")
-    conflict = post(client, run_id, upload_id, changed)
-    assert conflict.status_code == 409
-    assert conflict.json()["code"] == "markdown_identity_conflict"
+    assert first.json() == {"upload_id": str(upload_id), "status": "ready"}
+    assert repository.uploads[upload_id].markdown_s3_key == S3_KEY
+    assert repository.uploads[upload_id].status == "ready"
 
 
-def test_page_and_body_size_validation(ingest_client) -> None:
-    client, _, run_id = ingest_client
-    invalid_pages = payload("<!-- page: 2 -->\n# Plan")
-    assert (
-        post(client, run_id, uuid4(), invalid_pages).json()["code"]
-        == "invalid_markdown_pages"
+def test_pointer_or_fetched_bytes_conflict_is_rejected(ingest_client) -> None:
+    client, _, cc_client, run_id = ingest_client
+    upload_id = uuid4()
+    create_upload(client, run_id, upload_id)
+    path = f"/v1/concept-notes/{run_id}/uploads/{upload_id}/markdown"
+
+    response = client.post(
+        path,
+        json=pointer_payload(markdown_s3_key="different/key.md"),
+        headers=auth(),
     )
-    mismatched_count = payload()
-    mismatched_count["page_count"] = 2
-    assert (
-        post(client, run_id, uuid4(), mismatched_count).json()["code"]
-        == "invalid_markdown_pages"
+    assert response.status_code == 409
+    assert response.json()["code"] == "markdown_identity_conflict"
+
+    cc_client.artifact = replace(cc_client.artifact, markdown="# Tampered")
+    response = client.post(path, json=pointer_payload(), headers=auth())
+    assert response.status_code == 422
+    assert response.json()["code"] == "markdown_digest_mismatch"
+
+
+def test_failure_status_and_retry_lifecycle(ingest_client) -> None:
+    client, _, _, run_id = ingest_client
+    upload_id = uuid4()
+    create_upload(client, run_id, upload_id)
+    base = f"/v1/concept-notes/{run_id}/uploads/{upload_id}"
+
+    failed = client.post(
+        f"{base}/failed",
+        json={"error_code": "mistral_unavailable"},
+        headers=auth(),
     )
-
-    settings = get_settings()
-    original_limit = settings.cnb_markdown_request_max_bytes
-    settings.cnb_markdown_request_max_bytes = 32
-    try:
-        response = post(client, run_id, uuid4(), payload())
-        assert response.status_code == 413
-        assert response.json()["code"] == "markdown_request_too_large"
-    finally:
-        settings.cnb_markdown_request_max_bytes = original_limit
+    assert failed.json()["status"] == "failed"
+    status_response = client.get(base, headers=auth())
+    assert status_response.json()["error_code"] == "mistral_unavailable"
+    retried = client.post(f"{base}/retry", headers=auth())
+    assert retried.json()["status"] == "queued"
 
 
-def test_page_count_has_no_acceptance_cap(ingest_client) -> None:
-    client, _, run_id = ingest_client
-    page_count = 1_001
-    markdown = "\n".join(
-        f"<!-- page: {page_number} -->\nPage {page_number}"
-        for page_number in range(1, page_count + 1)
-    )
+def test_delivery_context_requires_reverse_service_key(ingest_client) -> None:
+    client, _, _, run_id = ingest_client
+    upload_id = uuid4()
+    create_upload(client, run_id, upload_id)
+    path = f"/v1/concept-note-uploads/{upload_id}/delivery-context"
 
-    response = post(
-        client,
-        run_id,
-        uuid4(),
-        payload(markdown=markdown, page_count=page_count),
-    )
-
-    assert response.status_code == 202
-
-
-def test_chunked_body_without_content_length_is_bounded(ingest_client) -> None:
-    client, _, run_id = ingest_client
-    settings = get_settings()
-    original_limit = settings.cnb_markdown_request_max_bytes
-    settings.cnb_markdown_request_max_bytes = 8
-    try:
-        response = post_stream(
-            client,
-            run_id,
-            uuid4(),
-            iter((b"12345", b"67890")),
-        )
-    finally:
-        settings.cnb_markdown_request_max_bytes = original_limit
-
-    assert "Content-Length" not in response.request.headers
-    assert response.status_code == 413
-    assert response.json()["code"] == "markdown_request_too_large"
-
-
-def test_unavailable_production_repository_returns_503() -> None:
-    app = get_app()
-    app.dependency_overrides[get_citycatalyst_client] = FakeIdentityClient
-    with TestClient(app) as client:
-        response = post(client, uuid4(), uuid4(), payload())
-    app.dependency_overrides.clear()
-    assert response.status_code == 503
-    assert response.json()["code"] == "cnb_storage_unavailable"
+    assert client.get(path).status_code == 401
+    response = client.get(path, headers={"X-CC-Service-Key": "service-key"})
+    assert response.status_code == 200
+    assert response.json()["run_id"] == str(run_id)
+    assert response.json()["user_id"] == "owner-user"

--- a/climate-advisor/service/tests/test_concept_note_markdown_ingest.py
+++ b/climate-advisor/service/tests/test_concept_note_markdown_ingest.py
@@ -20,7 +20,10 @@ from app.persistence.concept_notes.markdown import (
     ConceptNoteUploadSnapshot,
     get_concept_note_markdown_repository,
 )
-from app.routes.concept_note_markdown import get_citycatalyst_client
+from app.routes.concept_note_markdown import (
+    JSON_REQUEST_MAX_BYTES,
+    get_citycatalyst_client,
+)
 from app.services.citycatalyst_client import (
     CityCatalystClientError,
     ConceptNoteMarkdownArtifact,
@@ -42,6 +45,7 @@ class FakeCityCatalystClient:
             sha256=SHA256,
             page_count=1,
         )
+        self.markdown_error: CityCatalystClientError | None = None
 
     async def validate_user_identity(self, token: str) -> str:
         if token == "invalid":
@@ -54,6 +58,8 @@ class FakeCityCatalystClient:
         upload_id: str,
         token: str,
     ) -> ConceptNoteMarkdownArtifact:
+        if self.markdown_error:
+            raise self.markdown_error
         return self.artifact
 
 
@@ -294,6 +300,45 @@ def test_create_is_idempotent_and_metadata_is_immutable(ingest_client) -> None:
     assert response.json()["code"] == "upload_identity_conflict"
 
 
+def test_json_body_limit_applies_without_content_length(ingest_client) -> None:
+    client, _, _, run_id = ingest_client
+    body = iter(
+        [
+            b'{"padding":"',
+            b"a" * JSON_REQUEST_MAX_BYTES,
+            b'"}',
+        ]
+    )
+
+    response = client.post(
+        f"/v1/concept-notes/{run_id}/uploads",
+        content=body,
+        headers={**auth(), "Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 413
+    assert response.json()["code"] == "upload_request_too_large"
+
+
+def test_json_body_limit_rejects_declared_oversize_before_reading(
+    ingest_client,
+) -> None:
+    client, _, _, run_id = ingest_client
+
+    response = client.post(
+        f"/v1/concept-notes/{run_id}/uploads",
+        content=b"{}",
+        headers={
+            **auth(),
+            "Content-Type": "application/json",
+            "Content-Length": str(JSON_REQUEST_MAX_BYTES + 1),
+        },
+    )
+
+    assert response.status_code == 413
+    assert response.json()["code"] == "upload_request_too_large"
+
+
 def test_pointer_delivery_verifies_cc_then_persists_ready(ingest_client) -> None:
     client, repository, _, run_id = ingest_client
     upload_id = uuid4()
@@ -327,6 +372,25 @@ def test_pointer_or_fetched_bytes_conflict_is_rejected(ingest_client) -> None:
     response = client.post(path, json=pointer_payload(), headers=auth())
     assert response.status_code == 422
     assert response.json()["code"] == "markdown_digest_mismatch"
+
+
+def test_terminal_cc_verification_error_is_not_made_retryable(ingest_client) -> None:
+    client, _, cc_client, run_id = ingest_client
+    upload_id = uuid4()
+    create_upload(client, run_id, upload_id)
+    cc_client.markdown_error = CityCatalystClientError(
+        "Stored Markdown failed its integrity check",
+        status_code=409,
+    )
+
+    response = client.post(
+        f"/v1/concept-notes/{run_id}/uploads/{upload_id}/markdown",
+        json=pointer_payload(),
+        headers=auth(),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["code"] == "cc_markdown_verification_failed"
 
 
 def test_failure_status_and_retry_lifecycle(ingest_client) -> None:

--- a/climate-advisor/service/tests/test_concept_note_markdown_ingest.py
+++ b/climate-advisor/service/tests/test_concept_note_markdown_ingest.py
@@ -422,3 +422,22 @@ def test_delivery_context_requires_reverse_service_key(ingest_client) -> None:
     assert response.status_code == 200
     assert response.json()["run_id"] == str(run_id)
     assert response.json()["user_id"] == "owner-user"
+
+
+def test_delivery_context_audits_rejected_key_without_logging_credential(
+    ingest_client,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client, _, _, run_id = ingest_client
+    upload_id = uuid4()
+    create_upload(client, run_id, upload_id)
+    supplied_key = "unexpected-service-key"
+    path = f"/v1/concept-note-uploads/{upload_id}/delivery-context"
+
+    with caplog.at_level("WARNING", logger="app.routes.concept_note_markdown"):
+        response = client.get(path, headers={"X-CC-Service-Key": supplied_key})
+
+    assert response.status_code == 401
+    assert response.json()["code"] == "invalid_service_key"
+    assert str(upload_id) in caplog.text
+    assert supplied_key not in caplog.text

--- a/climate-advisor/service/tests/test_concept_note_upload_pointer_migration.py
+++ b/climate-advisor/service/tests/test_concept_note_upload_pointer_migration.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import Mock
+
+
+def load_migration() -> ModuleType:
+    path = (
+        Path(__file__).parents[1]
+        / "migrations"
+        / "versions"
+        / "20260730_120000_concept_note_upload_pointers.py"
+    )
+    spec = importlib.util.spec_from_file_location("cnb_pointer_migration", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_upgrade_replaces_inline_markdown_with_nullable_pointer() -> None:
+    migration = load_migration()
+    operations = Mock()
+    migration.op = operations
+
+    migration.upgrade()
+
+    added_column = operations.add_column.call_args.args[1]
+    assert added_column.name == "markdown_s3_key"
+    assert added_column.nullable is True
+    nullable_columns = {
+        call.args[1]
+        for call in operations.alter_column.call_args_list
+        if call.kwargs.get("nullable") is True
+    }
+    assert nullable_columns == {"markdown_sha256", "page_count"}
+    operations.drop_column.assert_called_once_with(
+        "concept_note_uploads", "markdown_text"
+    )
+
+
+def test_downgrade_restores_parent_schema_shape() -> None:
+    migration = load_migration()
+    operations = Mock()
+    migration.op = operations
+
+    migration.downgrade()
+
+    altered = {
+        call.args[1]: call.kwargs for call in operations.alter_column.call_args_list
+    }
+    assert altered["markdown_text"]["nullable"] is False
+    assert altered["markdown_sha256"]["nullable"] is False
+    assert altered["page_count"]["nullable"] is False
+    operations.execute.assert_called_once()
+    operations.drop_column.assert_called_once_with(
+        "concept_note_uploads", "markdown_s3_key"
+    )

--- a/climate-advisor/service/tests/test_concept_note_upload_repository.py
+++ b/climate-advisor/service/tests/test_concept_note_upload_repository.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.db import Base
+from app.models.concept_note_markdown import (
+    ConceptNoteMarkdownRequest,
+    ConceptNoteUploadCreateRequest,
+)
+from app.models.db.concept_note import ConceptNoteRun, ConceptNoteUpload
+from app.persistence.concept_notes.markdown import (
+    ConceptNoteMarkdownRepositoryError,
+    SqlAlchemyConceptNoteMarkdownRepository,
+)
+
+
+@pytest.mark.asyncio
+async def test_repository_persists_nullable_then_immutable_pointer(
+    tmp_path,
+) -> None:
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{(tmp_path / 'cnb.db').as_posix()}"
+    )
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(
+                lambda sync_connection: Base.metadata.create_all(
+                    sync_connection,
+                    tables=[
+                        ConceptNoteRun.__table__,
+                        ConceptNoteUpload.__table__,
+                    ],
+                )
+            )
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        run_id = uuid4()
+        upload_id = uuid4()
+        async with session_factory() as session, session.begin():
+            session.add(
+                ConceptNoteRun(
+                    run_id=run_id,
+                    user_id="owner-user",
+                    name="Test run",
+                    city_id=str(uuid4()),
+                    idempotency_key=uuid4(),
+                    request_fingerprint="a" * 64,
+                    context_summary={},
+                    permission_summary={},
+                )
+            )
+
+        repository = SqlAlchemyConceptNoteMarkdownRepository(session_factory)
+        created = await repository.create_upload(
+            user_id="owner-user",
+            run_id=run_id,
+            payload=ConceptNoteUploadCreateRequest(
+                upload_id=upload_id,
+                user_id="owner-user",
+                filename="plan.pdf",
+                source_label="Plan",
+            ),
+        )
+        assert created.status == "queued"
+        assert created.markdown_s3_key is None
+        assert created.markdown_sha256 is None
+        assert created.page_count is None
+
+        pointer = ConceptNoteMarkdownRequest(
+            markdown_s3_key="pdf-ocr/results/result.md",
+            filename="plan.pdf",
+            source_label="Plan",
+            page_count=3,
+            sha256="b" * 64,
+        )
+        ready = await repository.register_markdown(
+            user_id="owner-user",
+            run_id=run_id,
+            upload_id=upload_id,
+            payload=pointer,
+        )
+        replayed = await repository.register_markdown(
+            user_id="owner-user",
+            run_id=run_id,
+            upload_id=upload_id,
+            payload=pointer,
+        )
+        assert ready.status == replayed.status == "ready"
+        assert ready.markdown_s3_key == pointer.markdown_s3_key
+
+        with pytest.raises(ConceptNoteMarkdownRepositoryError) as conflict:
+            await repository.register_markdown(
+                user_id="owner-user",
+                run_id=run_id,
+                upload_id=upload_id,
+                payload=pointer.model_copy(
+                    update={"markdown_s3_key": "different/result.md"}
+                ),
+            )
+        assert conflict.value.code == "markdown_identity_conflict"
+    finally:
+        await engine.dispose()

--- a/docs/ConceptNoteBuilderArchitecture.md
+++ b/docs/ConceptNoteBuilderArchitecture.md
@@ -26,14 +26,13 @@ data and configuration, not by rebuilding the workflow.
 
 ## Scope
 
-Implementation baseline (2026-07-29): only GHGI inventory PDFs are currently
-enqueued in CC. The generic CC OCR/delivery model, authenticated CA
-Markdown-ingest contract, and compact CNB GHGI city-context route are
-implemented. The city-context adapter uses the documented run/context tables
-through `CA_DATABASE_URL`. The run-start/read foundation and Alembic migration
-for those tables are implemented. CA also persists authenticated Markdown
-handoffs in `concept_note_uploads`. `ConceptNoteUpload`, CC Concept Note upload
-routes/UI, downstream indexing, and the broader CNB schema remain deferred.
+Implementation baseline (2026-07-30): CC accepts authorized run-scoped CNB PDF
+uploads and reuses the shared `PdfOcrJob` worker. CA creates the authoritative
+`concept_note_uploads` row before CC stores or queues the PDF. CC stores source
+and result objects under deterministic keys, delivers only the result pointer
+and immutable metadata, and exposes the Markdown to CA through an authenticated
+internal read boundary. The consolidated CNB frontend and downstream context
+selection remain deferred.
 
 In scope:
 
@@ -189,21 +188,21 @@ flowchart LR
 
 ## State Ownership
 
-| State                                                                      | Owner                          | Reason                                                                                           |
-| -------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------ |
-| City profile, project, GHGI, CCRA, and persisted HIAP context              | CityCatalyst                   | Existing product source of truth and permission model.                                           |
-| Chat threads and messages                                                  | CityCatalyst                   | Keeps durable user conversation state with the product permission boundary.                      |
-| Concept-note run state                                                     | Climate Advisor (`CA_DATABASE_URL`) | Pre-commit workflow state provisioned by the CA Alembic chain.                              |
-| Context bundle snapshot                                                    | Climate Advisor (`CA_DATABASE_URL`) | Reusable run input/output initialized transactionally with each run.                       |
-| CN upload/run associations and received Markdown                          | Climate Advisor (`CA_DATABASE_URL`) | Registers the optional Markdown handoff with immutable run and digest binding.              |
-| Selected source context                                                    | datateam managed CNB database  | Keeps excerpts selected for review and export.                                                   |
-| Uploaded source objects, OCR result objects, and their S3 pointers         | CityCatalyst                   | Reuses authenticated CC upload, S3 storage, project/city permissions, and the CC result catalog. |
-| Document chapters and revisions                                            | datateam managed CNB database  | Draft document state before export.                                                              |
-| Funder profiles and criteria                                               | datateam managed CNB database  | Shared curated corpus, reusable across cities and agents.                                        |
-| Funding opportunities and funded projects                                  | datateam managed CNB database  | Shared funding records distinguished by `is_opportunity`.                                        |
-| Exported DOCX/PDF file references                                          | datateam managed CNB database  | Workflow output artifacts.                                                                       |
-| PDF-to-Markdown conversion                                                 | CityCatalyst                   | Owns Mistral OCR, queueing, retries, validation, authoritative storage, and result pointers.     |
-| Optional Markdown handoff                                                  | CityCatalyst → Climate Advisor | CC sends the completed `.md` only when a CA workflow needs it; CA never participates in OCR.     |
+| State                                                              | Owner                               | Reason                                                                                           |
+| ------------------------------------------------------------------ | ----------------------------------- | ------------------------------------------------------------------------------------------------ |
+| City profile, project, GHGI, CCRA, and persisted HIAP context      | CityCatalyst                        | Existing product source of truth and permission model.                                           |
+| Chat threads and messages                                          | CityCatalyst                        | Keeps durable user conversation state with the product permission boundary.                      |
+| Concept-note run state                                             | Climate Advisor (`CA_DATABASE_URL`) | Pre-commit workflow state provisioned by the CA Alembic chain.                                   |
+| Context bundle snapshot                                            | Climate Advisor (`CA_DATABASE_URL`) | Reusable run input/output initialized transactionally with each run.                             |
+| CN upload/run associations and Markdown S3 pointers                | Climate Advisor (`CA_DATABASE_URL`) | Owns the run binding, lifecycle, label, and immutable result identity.                           |
+| Selected source context                                            | datateam managed CNB database       | Keeps excerpts selected for review and export.                                                   |
+| Uploaded source objects, OCR result objects, and their S3 pointers | CityCatalyst                        | Reuses authenticated CC upload, S3 storage, project/city permissions, and the CC result catalog. |
+| Document chapters and revisions                                    | datateam managed CNB database       | Draft document state before export.                                                              |
+| Funder profiles and criteria                                       | datateam managed CNB database       | Shared curated corpus, reusable across cities and agents.                                        |
+| Funding opportunities and funded projects                          | datateam managed CNB database       | Shared funding records distinguished by `is_opportunity`.                                        |
+| Exported DOCX/PDF file references                                  | datateam managed CNB database       | Workflow output artifacts.                                                                       |
+| PDF-to-Markdown conversion                                         | CityCatalyst                        | Owns Mistral OCR, queueing, retries, validation, authoritative storage, and result pointers.     |
+| Markdown pointer delivery                                          | CityCatalyst → Climate Advisor      | CC sends a stable object key and metadata; CA verifies bytes through authenticated CC.           |
 
 ## Data Infrastructure Boundary
 
@@ -241,8 +240,7 @@ flowchart LR
     subgraph CCDB["CityCatalyst PostgreSQL"]
         Inventory["ImportedInventoryFile<br/>(existing inventory source)"]
         Chat["Chat threads + messages<br/>(CC-owned conversation state)"]
-        CNUpload["ConceptNoteUpload<br/>(new CNB source record)"]
-        OCR["PdfOcrJob<br/>(new shared OCR job)"]
+        OCR["PdfOcrJob<br/>(shared OCR job)"]
     end
 
     subgraph CCS3["Existing CityCatalyst S3"]
@@ -252,54 +250,22 @@ flowchart LR
 
     subgraph CNBDB["CNB workflow storage (CA_DATABASE_URL)"]
         Run["concept_note_runs"]
-        Received["concept_note_uploads<br/>(optional CA ingest record)"]
+        Upload["concept_note_uploads<br/>(authoritative upload record)"]
     end
 
     Inventory -.->|"inventory_import + id"| OCR
-    CNUpload -.->|"concept_note_upload + upload_id"| OCR
-    CNUpload --> Source
+    Upload -.->|"concept_note_upload + upload_id"| OCR
+    Upload -.->|"deterministic upload_id key"| Source
     OCR --> Markdown
     Chat -.->|"thread_id integration identifier"| Run
-    Run --> Received
-    Markdown -.->|"optional API delivery using upload_id"| Received
+    Run --> Upload
+    Markdown -.->|"pointer + immutable metadata"| Upload
 ```
 
 ### CityCatalyst PostgreSQL
 
-CC adds two tables for the shared conversion path. They are owned and migrated
-with the CityCatalyst application.
-
-#### `ConceptNoteUpload`
-
-This table is the authoritative CC source record for a Concept Note PDF. It is
-separate from Climate Advisor's received-Markdown `concept_note_uploads` table
-and from the existing CC `UserFile` model.
-
-```text
-upload_id              uuid primary key
-run_id                 uuid not null
-user_id                uuid not null
-city_id                uuid not null
-project_id             uuid null
-filename               string not null
-source_label           string null
-mime_type              string not null
-size_bytes             bigint not null
-source_s3_key          string not null
-source_sha256          string not null
-created_at             timestamp not null
-deleted_at             timestamp null
-```
-
-Rules:
-
-- `run_id` is an integration identifier, not a foreign key into another
-  database.
-- `upload_id` is immutable and is reused as `PdfOcrJob.source_id`.
-- The source PDF is immutable. Replacing it creates a new `upload_id`.
-- The row stores the authoritative source pointer and permission scope, but no
-  OCR status or Markdown bytes.
-- Source deletion and OCR-result retention follow the same CC file lifecycle.
+CC adds no Concept Note upload table, model, or migration. The existing
+`PdfOcrJob` table is the only CC database record used by this flow.
 
 #### `PdfOcrJob`
 
@@ -341,8 +307,8 @@ Rules:
 
 - `source_type = inventory_import` resolves `source_id` through the existing
   `ImportedInventoryFile` table.
-- `source_type = concept_note_upload` resolves `source_id` through
-  `ConceptNoteUpload.upload_id`.
+- `source_type = concept_note_upload` resolves its deterministic source key
+  directly from the CA-owned `upload_id`.
 - Because the source relationship is polymorphic, `source_id` is resolved and
   authorized by application code rather than a database foreign key.
 - OCR state, retries, leases, and result metadata are independent from optional
@@ -358,11 +324,11 @@ Markdown to `InventoryExtractionService` before the import advances to
 
 ### Existing CityCatalyst S3
 
-| Object                  | Authoritative pointer             | Lifecycle                               |
-| ----------------------- | --------------------------------- | --------------------------------------- |
-| Inventory source PDF    | `ImportedInventoryFile.s3Key`     | Existing inventory import lifecycle.    |
-| Concept Note source PDF | `ConceptNoteUpload.source_s3_key` | Concept Note upload lifecycle in CC.    |
-| Combined Markdown       | `PdfOcrJob.result_s3_key`         | Same lifecycle as its immutable source. |
+| Object                  | Authoritative pointer         | Lifecycle                                 |
+| ----------------------- | ----------------------------- | ----------------------------------------- |
+| Inventory source PDF    | `ImportedInventoryFile.s3Key` | Existing inventory import lifecycle.      |
+| Concept Note source PDF | Deterministic `upload_id` key | CNB upload lifecycle coordinated with CA. |
+| Combined Markdown       | `PdfOcrJob.result_s3_key`     | Same lifecycle as its immutable source.   |
 
 The combined Markdown key follows
 `pdf-ocr/results/{source_type}/{source_id}/{attempt_count}/combined_markdown.md`.
@@ -370,14 +336,13 @@ The combined Markdown key follows
 ### Climate Advisor Workflow Database
 
 The `concept_note_uploads` table is provisioned by the Climate Advisor Alembic
-chain. A row is created only when CC optionally delivers completed Markdown to
-CA. It stores the received Markdown, its digest and page count, and downstream
-ingest state. It stores no source/result S3 key, Mistral configuration, OCR
-attempt, lease, or authoritative artifact pointer.
+chain. CA creates the row before CC stores or queues the source. The row stores
+filename, label, lifecycle state, immutable digest/page metadata, and a nullable
+stable CC S3 key after conversion. It stores no Markdown bytes, presigned URL,
+Mistral configuration, OCR attempt, or lease.
 
-`concept_note_uploads.upload_id` equals `ConceptNoteUpload.upload_id`, while
-`concept_note_uploads.run_id` associates the received Markdown with the CNB run.
-The upload identity is checked through API and repository contracts without a
+`concept_note_uploads.upload_id` is reused as `PdfOcrJob.source_id`. The upload
+identity is checked through API and repository contracts without a
 cross-database foreign key to CC. Within the CA workflow database,
 `concept_note_uploads.run_id` references `concept_note_runs.run_id` with
 cascading deletion.
@@ -408,16 +373,16 @@ flowchart TB
 
 ### Step Scope Table
 
-| Step                   | Main context                                                                                        | Enabled tool groups                              |
-| ---------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| `selecting_scope`      | user, city, project candidates                                                                      | workflow control, CC project reads               |
-| `ingesting_user_files` | CC OCR/delivery status, CA Markdown-ingest status, candidate source excerpts                        | deterministic document ingest operations; no LLM |
-| `profiling_funder`     | selected funder, template, criteria                                                                 | CNB reference table tools                        |
+| Step                   | Main context                                                                                        | Enabled tool groups                               |
+| ---------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `selecting_scope`      | user, city, project candidates                                                                      | workflow control, CC project reads                |
+| `ingesting_user_files` | CC OCR/delivery status, CA Markdown-ingest status, candidate source excerpts                        | deterministic document ingest operations; no LLM  |
+| `profiling_funder`     | selected funder, template, criteria                                                                 | CNB reference table tools                         |
 | `matching_examples`    | ingested project-upload fields, funder profile, project KB filters                                  | internal `ProjectMatchingService`; no agent tools |
-| `assembling_context`   | CC summaries, selected upload excerpts, funder rubric/template, matched funded projects, known gaps | internal `ContextBundleService`; no agent tools  |
-| `interviewing`         | gaps, known facts, required template fields                                                         | interview tools, document read tools             |
-| `drafting_document`    | chapter plan, evidence map, examples                                                                | chapter draft tools, evidence tools              |
-| `editing_document`     | selected chapter/revision                                                                           | document edit tools                              |
+| `assembling_context`   | CC summaries, selected upload excerpts, funder rubric/template, matched funded projects, known gaps | internal `ContextBundleService`; no agent tools   |
+| `interviewing`         | gaps, known facts, required template fields                                                         | interview tools, document read tools              |
+| `drafting_document`    | chapter plan, evidence map, examples                                                                | chapter draft tools, evidence tools               |
+| `editing_document`     | selected chapter/revision                                                                           | document edit tools                               |
 
 Export is not a workflow step for the LLM. It is a document workspace button
 that calls export preflight and generation routes against the current chapters
@@ -813,7 +778,7 @@ erDiagram
         string uploaded_by_user_id
         string filename
         string source_label
-        text markdown_text
+        string markdown_s3_key
         string markdown_sha256
         int page_count
         string ingest_status
@@ -914,17 +879,16 @@ the identifier into the Climate Advisor workflow.
 revision.
 
 For uploads, `upload_id` is created by the authenticated CityCatalyst upload
-route and identifies the immutable CC source record. When CNB needs the source,
-CA first receives that ID with the completed Markdown, verifies current run
-permission, and creates or reuses the CNB run association. An upload ID already
-bound to another run is rejected.
+route. CA first creates or replays the run-bound upload row; only then does CC
+store the PDF under a deterministic key and create or reuse the OCR job. An
+upload ID already bound to another run or immutable filename/label is rejected.
 
-CA stores the received `markdown_text`, its verified `markdown_sha256`, page
-count, source label, and downstream `ingest_status`. These values are immutable
-for an `upload_id`; replacement creates a new upload. This copy makes CA ingest
-restart-safe, but the CC S3 object and CC result pointer remain authoritative.
-CNB storage never receives a source/result S3 key, signed URL, or opaque CC file
-pointer.
+After conversion, CA verifies the artifact through CC's authenticated internal
+Markdown read endpoint, then stores `markdown_s3_key`, the verified
+`markdown_sha256`, page count, source label, and `ingest_status`. These values
+are immutable for an `upload_id`; replacement creates a new upload. The stored
+key is stable and never a presigned URL. Later context assembly reads the CNB
+row and asks CC for Markdown by `upload_id`; CA receives no bucket credentials.
 
 ### Evidence Links
 
@@ -1203,7 +1167,7 @@ need to pass the applicable gates before it can be scored.
 
 | Hard filter                     | What it excludes before scoring                                                                                                 |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Canonical funder                | Projects whose required `funder_id` does not match the selected funder.                                                          |
+| Canonical funder                | Projects whose required `funder_id` does not match the selected funder.                                                         |
 | Eligible geography              | Projects outside the configured geography fallback path for the opportunity, such as Minnesota, Midwest, then US.               |
 | Finance route / instrument type | Examples from the wrong funding route, such as comparing a loan against a competitive grant.                                    |
 | Project category                | Projects in unrelated sectors or categories.                                                                                    |
@@ -1423,7 +1387,7 @@ Rules:
 - Replays the same normalized request for a user's `idempotency_key` and
   returns the original `run_id` with `created: false`.
 - Rejects reuse of that idempotency key with changed input as `409
-  idempotency_key_reused`.
+idempotency_key_reused`.
 - Does not yet create document chapters or load the selected funder template;
   the response directs the next backend step to `load_context`.
 
@@ -1585,15 +1549,15 @@ Rules:
 
 #### `POST /v1/concept-notes/{run_id}/uploads/{upload_id}/markdown`
 
-Optionally receives completed Markdown from CityCatalyst after CC has finished
-and persisted PDF conversion. This is a service-to-service handoff, not an LLM
-tool and not an OCR trigger.
+Receives the stable CC object key and immutable metadata after CC has finished
+and persisted PDF conversion. This is a service-to-service pointer handoff, not
+an LLM tool and not an OCR trigger.
 
 Input:
 
 ```json
 {
-  "markdown": "<!-- page: 1 -->\n# Completed CC-produced Markdown",
+  "markdown_s3_key": "pdf-ocr/results/concept_note_upload/{upload_id}/1/combined_markdown.md",
   "filename": "string",
   "source_label": "Climate Action Plan",
   "page_count": 12,
@@ -1601,18 +1565,16 @@ Input:
 }
 ```
 
-The MVP handoff sends the full Markdown inline. CA enforces a separately
-configured JSON request-body safety limit, and CC rejects deliveries above the
-matching configured guard before sending. This operational safeguard does not
-define source-PDF size or page-count acceptance; the shared 20 MB source-PDF
-limit remains the only document acceptance limit.
+CA does not trust the pointer alone. It requests the Markdown by `upload_id`
+from CC's authenticated internal read route, verifies the returned key, digest,
+page count, page markers, and content, then persists the pointer.
 
 Output:
 
 ```json
 {
   "upload_id": "uuid",
-  "status": "processing"
+  "status": "ready"
 }
 ```
 
@@ -1621,7 +1583,8 @@ Rules:
 - Uses the existing CC-issued user-scoped bearer authentication and rechecks
   current run permission.
 - Rejects an `upload_id` already associated with another run.
-- Validates the supplied SHA-256 digest before durably registering the Markdown.
+- Fetches the stored object through authenticated CC and validates the supplied
+  SHA-256 digest before durably registering its pointer.
 - Requires the completed Markdown to satisfy the
   [Markdown-shape requirements](#pdf-conversion-and-optional-markdown-handoff)
   before CNB source processing begins.
@@ -1975,13 +1938,13 @@ flowchart TB
 
 Example registry rows:
 
-| Capability id                          | Step                | Operation      | Writes             | Confirmation               |
-| -------------------------------------- | ------------------- | -------------- | ------------------ | -------------------------- |
-| `concept_note.funder.get_profile`      | `profiling_funder`  | query          | no                 | no                         |
-| `concept_note.document.add_chapter`    | `drafting_document` | command        | CNB document       | sometimes                  |
-| `concept_note.document.delete_chapter` | `editing_document`  | command        | CNB document       | yes for non-empty/required |
-| `concept_note.document.edit_text`      | `editing_document`  | command        | CNB revision       | sometimes                  |
-| `concept_note.document.link_evidence`  | `drafting_document` | command        | CNB evidence links | no                         |
+| Capability id                          | Step                | Operation | Writes             | Confirmation               |
+| -------------------------------------- | ------------------- | --------- | ------------------ | -------------------------- |
+| `concept_note.funder.get_profile`      | `profiling_funder`  | query     | no                 | no                         |
+| `concept_note.document.add_chapter`    | `drafting_document` | command   | CNB document       | sometimes                  |
+| `concept_note.document.delete_chapter` | `editing_document`  | command   | CNB document       | yes for non-empty/required |
+| `concept_note.document.edit_text`      | `editing_document`  | command   | CNB revision       | sometimes                  |
+| `concept_note.document.link_evidence`  | `drafting_document` | command   | CNB evidence links | no                         |
 
 Export preflight, DOCX generation, and PDF generation are button-triggered route
 actions. They are not registered in the scoped agent tool registry.
@@ -2020,20 +1983,20 @@ UI_CONTEXT
 
 The UI needs typed events for chat and document state.
 
-| Event                                    | Purpose                                                                                                                            |
-| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `concept_note_run_started`               | Run id and initial status.                                                                                                         |
-| `concept_note_context_bundle_ready`      | Context bundle is ready. This generic readiness event does not expose matched-project details.                                    |
-| `document_chapter_added`                 | Chapter inserted.                                                                                                                  |
-| `document_chapter_deleted`               | Chapter soft-deleted.                                                                                                              |
-| `document_chapter_restored`              | Chapter restored.                                                                                                                  |
-| `document_chapter_updated`               | New revision created.                                                                                                              |
-| `document_gap_added`                     | Gap or blocker added.                                                                                                              |
-| `document_evidence_linked`               | Evidence review link added.                                                                                                        |
-| `document_delete_confirmation_requested` | UI must confirm delete.                                                                                                            |
-| `document_edit_confirmation_requested`   | UI must confirm sensitive edit.                                                                                                    |
-| `concept_note_export_ready`              | DOCX or PDF export created.                                                                                                        |
-| `concept_note_export_failed`             | Export failed with stable reason.                                                                                                  |
+| Event                                    | Purpose                                                                                        |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `concept_note_run_started`               | Run id and initial status.                                                                     |
+| `concept_note_context_bundle_ready`      | Context bundle is ready. This generic readiness event does not expose matched-project details. |
+| `document_chapter_added`                 | Chapter inserted.                                                                              |
+| `document_chapter_deleted`               | Chapter soft-deleted.                                                                          |
+| `document_chapter_restored`              | Chapter restored.                                                                              |
+| `document_chapter_updated`               | New revision created.                                                                          |
+| `document_gap_added`                     | Gap or blocker added.                                                                          |
+| `document_evidence_linked`               | Evidence review link added.                                                                    |
+| `document_delete_confirmation_requested` | UI must confirm delete.                                                                        |
+| `document_edit_confirmation_requested`   | UI must confirm sensitive edit.                                                                |
+| `concept_note_export_ready`              | DOCX or PDF export created.                                                                    |
+| `concept_note_export_failed`             | Export failed with stable reason.                                                              |
 
 ## Export Pipeline
 
@@ -2116,21 +2079,21 @@ POST /api/v1/internal/ca/capabilities/ccra/summary
 The implementation should stay organized by responsibility, not by a prescribed
 file layout.
 
-| Responsibility                | Owner                            | Boundary                                                                                                                                                                                                  |
-| ----------------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Chat thread/message storage   | CityCatalyst                     | Persists durable conversation state and supplies the authorized `thread_id` to the CNB workflow as a cross-database integration identifier.                                                             |
-| Workflow orchestration        | Climate Advisor                  | Starts/resumes runs, resolves active step, scopes tools, streams responses.                                                                                                                               |
-| CNB workflow foundation       | Climate Advisor                  | Its Alembic chain provisions and accesses `concept_note_runs`, `concept_note_context_bundles`, and `concept_note_uploads` through `CA_DATABASE_URL`.                                                       |
-| Extended CNB storage access   | datateam managed CNB database    | Climate Advisor uses typed contracts for later chapters, revisions, gaps, evidence, and exports; CC-608 does not provision those tables.                                                                |
-| Funding reference access      | datateam managed CNB database    | Climate Advisor reads funders, funding records, templates, criteria, and evidence from CNB reference tables.                                                                                              |
-| Document tools                | Climate Advisor                  | Mutates draft document state through the CNB storage contract only.                                                                                                                                       |
-| Source and OCR result storage | CityCatalyst                     | Authenticates the user, stores source PDFs and authoritative Markdown in CC S3, and owns all source/result pointers. No storage pointer or signed result URL is handed to CA.                             |
-| PDF-to-Markdown execution     | CityCatalyst                     | Owns the PostgreSQL queue, authenticated processor endpoint, Mistral configuration and calls, retries, validation, result persistence, and optional Markdown delivery.                                    |
-| CNB Markdown ingestion        | Climate Advisor                  | Optionally accepts completed Markdown, durably registers its digest and metadata, then performs CN-specific excerpt selection, indexing, summarization, and context-bundle updates. It owns no OCR state. |
-| CC context loading            | CityCatalyst                     | Provides bounded city, project, GHGI, CCRA, and read-only persisted HIAP summaries through internal capabilities; HIAP assembly never starts or repairs prioritization.                                  |
-| CC bridge routes              | CityCatalyst                     | Authenticated browser-facing proxy into CA workflow routes.                                                                                                                                               |
-| Capability registry           | CityCatalyst and Climate Advisor | Defines step-scoped capability exposure; no flat tool bag.                                                                                                                                                |
-| UI workspace                  | CityCatalyst                     | Chat, chapter outline, editor, evidence/gap views, upload status, export controls.                                                                                                                        |
+| Responsibility                | Owner                            | Boundary                                                                                                                                                                                                                                                       |
+| ----------------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Chat thread/message storage   | CityCatalyst                     | Persists durable conversation state and supplies the authorized `thread_id` to the CNB workflow as a cross-database integration identifier.                                                                                                                    |
+| Workflow orchestration        | Climate Advisor                  | Starts/resumes runs, resolves active step, scopes tools, streams responses.                                                                                                                                                                                    |
+| CNB workflow foundation       | Climate Advisor                  | Its Alembic chain provisions and accesses `concept_note_runs`, `concept_note_context_bundles`, and `concept_note_uploads` through `CA_DATABASE_URL`.                                                                                                           |
+| Extended CNB storage access   | datateam managed CNB database    | Climate Advisor uses typed contracts for later chapters, revisions, gaps, evidence, and exports; CC-608 does not provision those tables.                                                                                                                       |
+| Funding reference access      | datateam managed CNB database    | Climate Advisor reads funders, funding records, templates, criteria, and evidence from CNB reference tables.                                                                                                                                                   |
+| Document tools                | Climate Advisor                  | Mutates draft document state through the CNB storage contract only.                                                                                                                                                                                            |
+| Source and OCR result storage | CityCatalyst                     | Authenticates the user, stores source PDFs and authoritative Markdown in CC S3, and owns all source/result objects. CA receives only the stable Markdown key and immutable metadata, never bucket credentials, a source-PDF key, or a presigned URL.           |
+| PDF-to-Markdown execution     | CityCatalyst                     | Owns the PostgreSQL queue, authenticated processor endpoint, Mistral configuration and calls, retries, validation, result persistence, and pointer delivery.                                                                                                   |
+| CNB Markdown ingestion        | Climate Advisor                  | Creates the run-bound upload row, verifies completed Markdown through authenticated CC, and durably registers its stable key, digest, page count, and lifecycle status. Later context assembly owns excerpt selection; CA owns no OCR state or Markdown bytes. |
+| CC context loading            | CityCatalyst                     | Provides bounded city, project, GHGI, CCRA, and read-only persisted HIAP summaries through internal capabilities; HIAP assembly never starts or repairs prioritization.                                                                                        |
+| CC bridge routes              | CityCatalyst                     | Authenticated browser-facing proxy into CA workflow routes.                                                                                                                                                                                                    |
+| Capability registry           | CityCatalyst and Climate Advisor | Defines step-scoped capability exposure; no flat tool bag.                                                                                                                                                                                                     |
+| UI workspace                  | CityCatalyst                     | Chat, chapter outline, editor, evidence/gap views, upload status, export controls.                                                                                                                                                                             |
 
 ## Failure Handling
 

--- a/docs/ConceptNoteBuilderArchitecture.md
+++ b/docs/ConceptNoteBuilderArchitecture.md
@@ -67,8 +67,9 @@ workflow, following the same direction as the Stationary Energy workflow:
    but not durable chat.
 3. The datateam managed CNB reference database stores reusable funder and
    funded-project tables behind typed integration contracts.
-4. PDF ingestion should use the shared CC converter. CC owns Mistral OCR and
-   optionally passes the completed Markdown to CA for CNB ingestion.
+4. PDF ingestion uses the shared CC converter. CC owns Mistral OCR and storage,
+   hands CA the stable result pointer, and serves verified Markdown through the
+   authenticated internal read route.
 5. The agent gets a scoped tool pack for the active workflow step, not a flat
    list of every possible operation.
 
@@ -365,7 +366,7 @@ flowchart TB
     Edit --> Draft
     Draft --> Complete([completed])
 
-    IngestNote["CC owns PDF conversion and Markdown storage.<br/>CA receives .md only when needed; selected excerpts enter the context bundle."]
+    IngestNote["CC owns PDF conversion and Markdown storage.<br/>CA stores the object pointer and reads bytes through authenticated CC."]
     ContextNote["Context bundle combines CC data,<br/>selected source excerpts, funder rubric/template,<br/>and matched funded projects."]
     Ingest -.-> IngestNote
     Context -.-> ContextNote
@@ -878,10 +879,13 @@ the identifier into the Climate Advisor workflow.
 `(chapter_id, revision_number)` pair so each chapter has one unambiguous latest
 revision.
 
-For uploads, `upload_id` is created by the authenticated CityCatalyst upload
-route. CA first creates or replays the run-bound upload row; only then does CC
-store the PDF under a deterministic key and create or reuse the OCR job. An
-upload ID already bound to another run or immutable filename/label is rejected.
+For uploads, `upload_id` is derived by the authenticated CityCatalyst upload
+route from the run, user, immutable filename/label, and PDF content digest. An
+identical request therefore replays the same identity, while changed bytes or
+metadata create a new upload. CA first creates or replays the run-bound upload
+row; only then does CC store the PDF under a deterministic key and create or
+reuse the OCR job. An upload ID already bound to another run or immutable
+filename/label is rejected.
 
 After conversion, CA verifies the artifact through CC's authenticated internal
 Markdown read endpoint, then stores `markdown_s3_key`, the verified
@@ -1197,41 +1201,53 @@ The converted artifact follows these Markdown-shape requirements:
   present; and
 - narrative sections remain available for CNB evidence and context selection.
 
-These requirements govern converter output. CA remains an optional Markdown
-consumer and does not participate in OCR.
+These requirements govern converter output. CA verifies and consumes Markdown
+only through the authenticated CC read boundary and does not participate in OCR.
 
-Each PDF has a durable CC-created `upload_id`. CC converts it internally with
-`source_type = concept_note_upload` and `source_id = upload_id`. A run may
-contain many uploads, so `run_id`, filename, and S3 keys are not conversion
-identities. The upload route enforces the shared 20 MB source-PDF upload limit,
-and the CC processor enforces the ten-minute job timeout. The 20 MB limit does
-not apply to the resulting Markdown artifact or the optional CA request body.
-There is no page-count acceptance limit. `page_count` remains result metadata
-validated against the ordered Markdown page markers.
+Each PDF has a durable CC-derived `upload_id`. Identical run, user, immutable
+filename/label, and PDF bytes derive the same ID, making request replay
+idempotent without allowing different content to overwrite the source. CC
+converts it internally with `source_type = concept_note_upload` and
+`source_id = upload_id`. A run may contain many distinct uploads. The upload
+route enforces the shared 20 MB source-PDF upload limit, and the CC processor
+enforces the ten-minute job timeout. The 20 MB limit does not apply to the
+resulting Markdown artifact. There is no page-count acceptance limit.
+`page_count` remains result metadata validated against the ordered Markdown page
+markers.
 
-The browser sends PDF bytes only to the authenticated CC upload route. CA never
-receives the source PDF, S3 credentials, S3 keys, signed result URLs, Mistral
-configuration, or OCR retry instructions.
+The browser sends PDF bytes only to the authenticated CC upload route. CA
+receives the stable Markdown **object key** as pointer metadata, but never the
+source PDF, bucket credentials, AWS access keys, signed URLs, Mistral
+configuration, or OCR retry instructions. The object key is not an access
+credential: CA cannot read CC S3 directly. It retrieves Markdown by `upload_id`
+through CC's authenticated internal read route; CC resolves the stored
+`PdfOcrJob.result_s3_key`, reads S3, verifies SHA-256, and streams the bytes.
 
 Each upload is handled independently:
 
-1. `POST .../{run_id}/uploads` verifies run access, stores the PDF in CC,
-   creates the immutable CC source record, creates or reuses the CC OCR job, and
-   returns `202`.
+1. `POST .../{run_id}/uploads` verifies run access, derives or replays the
+   immutable upload identity, creates or replays the authoritative CA row,
+   stores the PDF in CC, creates or reuses the CC OCR job, and returns `202`.
 2. The CC processor converts the PDF, validates the Markdown shape, stores the
    authoritative `.md` in CC S3, and records its pointer and SHA-256 digest in
    CC PostgreSQL.
 3. CC marks OCR `succeeded`. Conversion is complete even if CA is unavailable.
-4. When CNB needs the document, CC optionally calls
-   `POST /v1/concept-notes/{run_id}/uploads/{upload_id}/markdown` with the
-   Markdown, filename, source label, page count, and digest. It uses the existing
+4. CC calls
+   `POST /v1/concept-notes/{run_id}/uploads/{upload_id}/markdown` with the stable
+   Markdown object key, filename, source label, page count, and digest. It sends
+   no Markdown bytes in this pointer-delivery request and uses the existing
    CC-issued user-scoped bearer token.
-5. CA rechecks run permission, rejects an upload ID already bound to another
-   run, validates the digest, durably registers the Markdown, and returns `202`.
-6. CA then performs excerpt selection, indexing, summarization, and context
+5. CA rechecks run permission and calls CC's authenticated internal Markdown
+   read route by `upload_id`. CC reads the object and returns verified bytes plus
+   the stable key, digest, and page-count headers.
+6. CA validates those bytes against the delivered metadata, rejects an upload ID
+   already bound to another run, durably registers the pointer, and returns
+   `202`.
+7. CA can then perform excerpt selection, indexing, summarization, and context
    bundle rebuilding. These steps are not part of conversion.
-7. A failed OCR retry may call Mistral again. A failed CA handoff retries the
-   stored Markdown only and never repeats successful OCR.
+8. A failed OCR retry may call Mistral again. A failed pointer delivery or
+   authenticated read retries the stored result only and never repeats
+   successful OCR.
 
 Repeated handoff with the same upload and digest is idempotent. A different
 digest for the same immutable upload returns
@@ -1239,7 +1255,7 @@ digest for the same immutable upload returns
 another upload in the same run.
 
 Other document types require a separate CC normalizer before they can enter the
-optional CA Markdown-ingest boundary.
+CA pointer-registration and authenticated Markdown-read boundary.
 
 ## Document Workspace
 
@@ -1593,8 +1609,10 @@ Rules:
 - Repeated delivery of the same immutable upload and digest is idempotent. A
   different digest for the same upload returns
   `409 markdown_identity_conflict`.
-- Receives no source PDF, S3 key, signed URL, Mistral configuration, or CC OCR
-  status and never writes CC conversion state.
+- Receives no source PDF, S3 credentials, signed URL, Mistral configuration, or
+  CC OCR status and never writes CC conversion state. It does receive the stable
+  Markdown object key as opaque pointer identity, but can retrieve bytes only
+  through authenticated CC.
 
 #### `concept_note_process_markdown`
 

--- a/docs/ConceptNoteBuilderArchitecture.md
+++ b/docs/ConceptNoteBuilderArchitecture.md
@@ -256,7 +256,7 @@ flowchart LR
 
     Inventory -.->|"inventory_import + id"| OCR
     Upload -.->|"concept_note_upload + upload_id"| OCR
-    Upload -.->|"deterministic upload_id key"| Source
+    Upload -.->|"UUID v4 upload_id key"| Source
     OCR --> Markdown
     Chat -.->|"thread_id integration identifier"| Run
     Run --> Upload
@@ -328,7 +328,7 @@ Markdown to `InventoryExtractionService` before the import advances to
 | Object                  | Authoritative pointer         | Lifecycle                                 |
 | ----------------------- | ----------------------------- | ----------------------------------------- |
 | Inventory source PDF    | `ImportedInventoryFile.s3Key` | Existing inventory import lifecycle.      |
-| Concept Note source PDF | Deterministic `upload_id` key | CNB upload lifecycle coordinated with CA. |
+| Concept Note source PDF | UUID v4 `upload_id` key       | CNB upload lifecycle coordinated with CA. |
 | Combined Markdown       | `PdfOcrJob.result_s3_key`     | Same lifecycle as its immutable source.   |
 
 The combined Markdown key follows
@@ -879,12 +879,12 @@ the identifier into the Climate Advisor workflow.
 `(chapter_id, revision_number)` pair so each chapter has one unambiguous latest
 revision.
 
-For uploads, `upload_id` is derived by the authenticated CityCatalyst upload
-route from the run, user, immutable filename/label, and PDF content digest. An
-identical request therefore replays the same identity, while changed bytes or
-metadata create a new upload. CA first creates or replays the run-bound upload
-row; only then does CC store the PDF under a deterministic key and create or
-reuse the OCR job. An upload ID already bound to another run or immutable
+For uploads, the authenticated CityCatalyst upload route generates a new UUID v4
+`upload_id` for each accepted initial request. CA first creates the run-bound
+upload row; only then does CC store the PDF under a key derived from that ID and
+create the OCR job. Retries after registration use the existing run-scoped
+upload ID through the explicit retry route rather than submitting the initial
+upload again. An upload ID already bound to another run or immutable
 filename/label is rejected.
 
 After conversion, CA verifies the artifact through CC's authenticated internal
@@ -1225,9 +1225,9 @@ through CC's authenticated internal read route; CC resolves the stored
 
 Each upload is handled independently:
 
-1. `POST .../{run_id}/uploads` verifies run access, derives or replays the
-   immutable upload identity, creates or replays the authoritative CA row,
-   stores the PDF in CC, creates or reuses the CC OCR job, and returns `202`.
+1. `POST .../{run_id}/uploads` verifies run access, generates a UUID v4 upload
+   identity, creates the authoritative CA row, stores the PDF in CC, creates the
+   CC OCR job, and returns `202`.
 2. The CC processor converts the PDF, validates the Markdown shape, stores the
    authoritative `.md` in CC S3, and records its pointer and SHA-256 digest in
    CC PostgreSQL.


### PR DESCRIPTION
## Stack

1. #2937 — Climate Advisor upload persistence
2. **#2938 — CityCatalyst PDF OCR integration** (this PR)
## Summary

- add authenticated CNB upload, status, retry, and internal Markdown-read routes
- store source PDFs under deterministic S3 keys derived from `upload_id`
- reuse the existing `PdfOcrJob` and support both inventory and Concept Note upload sources
- deliver stable Markdown object references to Climate Advisor
- separate OCR retry from delivery-only retry
- update the Concept Note Builder architecture documentation

## Scope

CityCatalyst backend, tests, and documentation only. This PR contains 13 files. It adds no frontend files, CityCatalyst models, or CityCatalyst migrations.

## Validation

- `24 passed` across four focused Jest suites
- `npx tsc --noEmit` passed
- `git diff --check` passed
- exact-content preservation verified across all 24 original CC-609 paths
- two preserved Jest files retain their existing Prettier warnings; no formatting changes were introduced during the split

## Recovery

The original combined CC-609 head is preserved at `codex/CC-609-pre-ca-cc-split-backup-06ba57b` (`06ba57ba541b7c1f94a9764e555e323b3603c11d`).