### PR TITLE
CC-471: Show hazard instead of sector on adaptation action cards

### DIFF
--- a/app/src/components/ClimateActionCard.tsx
+++ b/app/src/components/ClimateActionCard.tsx
@@ -63,7 +63,9 @@ export const ClimateActionCard = ({
   };
 
   const reductionLevel = getReductionPotentialLevel();
+  const isAdaptation = action.type === "adaptation";
   const actionSector = action.sectors?.[0];
+  const actionHazard = action.hazards?.[0];
 
   return (
     <Card.Root
@@ -144,12 +146,16 @@ export const ClimateActionCard = ({
             w="full"
           >
             <LabelMedium color="content.tertiary">
-              {t("sector-name")}
+              {isAdaptation ? t("hazard-name") : t("sector-name")}
             </LabelMedium>
             <TitleSmall color="content.tertiary" textTransform="capitalize">
-              {actionSector
-                ? t("sector." + toTranslationString(actionSector))
-                : t("n-a")}
+              {isAdaptation
+                ? actionHazard
+                  ? t("hazard." + actionHazard)
+                  : t("n-a")
+                : actionSector
+                  ? t("sector." + toTranslationString(actionSector))
+                  : t("n-a")}
             </TitleSmall>
           </Box>
 

--- a/app/src/i18n/locales/de/hiap.json
+++ b/app/src/i18n/locales/de/hiap.json
@@ -40,6 +40,7 @@
   "reduction-potential": "Reduktionspotenzial",
   "high": "Hoch",
   "sector-name": "Sektor",
+  "hazard-name": "Gefahr",
   "transport": "Verkehr",
   "estimated-cost": "Geschätzte Kosten",
   "implementation-time": "Umsetzungszeit",

--- a/app/src/i18n/locales/en/hiap.json
+++ b/app/src/i18n/locales/en/hiap.json
@@ -46,6 +46,7 @@
   "reduction-potential": "Reduction potential",
   "high": "High",
   "sector-name": "Sector",
+  "hazard-name": "Hazard",
   "transport": "Transport",
   "estimated-cost": "Estimated cost",
   "implementation-time": "Implementation time",

--- a/app/src/i18n/locales/es/hiap.json
+++ b/app/src/i18n/locales/es/hiap.json
@@ -42,6 +42,7 @@
   "reduction-potential": "Potencial de reducción",
   "high": "Alto",
   "sector-name": "Sector",
+  "hazard-name": "Peligro",
   "citycatalyst-actions-title": "citycatalyst actions",
   "top-actions-for-your-city": "Principales acciones para tu ciudad",
   "top-actions-for-your-city-description": "Estas son las 40 principales acciones que recomendamos basadas en tu inventario de GEI y datos de contexto de la ciudad. Encontrarás 20 acciones para Mitigación y 20 para Adaptación en sus respectivas pestañas. Se recomienda volver a ejecutar el priorizador después de cualquier actualización o cambio relevante en los datos.",

--- a/app/src/i18n/locales/fr/hiap.json
+++ b/app/src/i18n/locales/fr/hiap.json
@@ -42,6 +42,7 @@
   "reduction-potential": "Potentiel de réduction",
   "high": "Élevé",
   "sector-name": "Secteur",
+  "hazard-name": "Danger",
   "citycatalyst-actions-title": "citycatalyst actions",
   "top-actions-for-your-city": "Principales actions pour votre ville",
   "top-actions-for-your-city-description": "Voici les 40 principales actions que nous recommandons basées sur votre inventaire GES et les données de contexte de votre ville. Vous trouverez 20 actions pour l'Atténuation et 20 pour l'Adaptation dans leurs onglets respectifs. Il est recommandé de relancer le priorisateur après toute mise à jour ou modification pertinente des données.",

--- a/app/src/i18n/locales/pt/hiap.json
+++ b/app/src/i18n/locales/pt/hiap.json
@@ -42,6 +42,7 @@
   "reduction-potential": "Potencial de redução",
   "high": "Alto",
   "sector-name": "Setor",
+  "hazard-name": "Perigo",
   "citycatalyst-actions-title": "citycatalyst actions",
   "top-actions-for-your-city": "Principais ações para sua cidade",
   "top-actions-for-your-city-description": "Estas são as 40 principais ações que recomendamos com base no seu inventário de GEE e dados de contexto da cidade. Você encontrará 20 ações para Mitigação e 20 para Adaptação em suas respectivas abas. É recomendado executar novamente o priorizador após qualquer atualização ou mudança relevante nos dados.",


### PR DESCRIPTION
## Summary

Based on the discussion with @amanda-eames adaptation actions are classified by hazard, not sector. `ClimateActionCard` was always rendering a sector label, which is often empty for adaptation actions and showed up as a missing/N-A string. The card now shows hazard for adaptation actions and sector for mitigation actions, matching the distinction `ActionDrawer` already makes.

## Changes

- `ClimateActionCard.tsx`: branch on `action.type` to read `action.hazards[0]` (adaptation) vs `action.sectors[0]` (mitigation) for both the label and value
- Added `hazard-name` translation key to `en`/`de`/`es`/`fr`/`pt` `hiap.json`
<img width="1168" height="590" alt="image" src="https://github.com/user-attachments/assets/9d420666-c560-45d0-9457-d4d1132e63a3" />


## How to test

1. Open the Top Actions view for a city and switch to the Adaptation tab.
2. Confirm each action card shows a "Hazard" label with a real hazard value (e.g. Droughts, Floods) instead of "Sector" / N/A.
3. Switch to the Mitigation tab and confirm cards still show "Sector" as before.

## Ticket

CC-471