### PR TITLE
CC-621: Fix org logo blink and brand theme sync

### DIFF
--- a/app/src/app/[lng]/cities/layout.tsx
+++ b/app/src/app/[lng]/cities/layout.tsx
@@ -31,15 +31,15 @@ export default function CitiesLayout(props: {
     });
 
   useEffect(() => {
-    if (orgData) {
-      const newOrgState = normalizeOrganizationState(orgData);
+    if (!orgData) return;
 
-      if (hasOrganizationChanged(organization, newOrgState)) {
-        setOrganization(newOrgState);
-      }
-      setTheme(orgData?.theme?.themeKey ?? "blue_theme");
-    } else {
-      setTheme("blue_theme");
+    const newOrgState = normalizeOrganizationState(orgData);
+
+    if (hasOrganizationChanged(organization, newOrgState)) {
+      setOrganization(newOrgState);
+    }
+    if (orgData.theme?.themeKey) {
+      setTheme(orgData.theme.themeKey);
     }
   }, [isOrgDataLoading, orgData, organization, setOrganization, setTheme]);
 

--- a/app/src/app/[lng]/settings/account/BrandSettingsTab.tsx
+++ b/app/src/app/[lng]/settings/account/BrandSettingsTab.tsx
@@ -58,7 +58,8 @@ const BrandSettingsTab = ({
       items: themeOptions
         ? themeOptions?.map((theme) => ({
             value: theme.themeId,
-            key: theme.themeKey,
+            // Do not name this `key` — collection/React treat that specially.
+            themeKey: theme.themeKey,
             label: t(theme.themeKey),
             color: KeyColorMapping[theme.themeKey as themeType],
           }))
@@ -82,11 +83,22 @@ const BrandSettingsTab = ({
     return options?.items.find((item) => item.value === selectedTheme);
   }, [selectedTheme, options?.items]);
 
+  // Keep select selection in sync with saved org themeId.
   useEffect(() => {
-    if (organization) {
-      setSelectedTheme((organization?.themeId as string) ?? blueTheme?.themeId);
+    if (organization?.themeId) {
+      setSelectedTheme(organization.themeId as string);
+    } else if (blueTheme?.themeId) {
+      setSelectedTheme(blueTheme.themeId);
     }
-  }, [organization, blueTheme, setSelectedTheme]);
+  }, [organization?.themeId, blueTheme?.themeId]);
+
+  // Drive next-themes from the org record (updated immediately on save via cache patch).
+  useEffect(() => {
+    const themeKey = organization?.theme?.themeKey;
+    if (themeKey) {
+      setTheme(themeKey);
+    }
+  }, [organization?.theme?.themeKey, setTheme]);
 
   const { showErrorToast } = UseErrorToast({
     title: t("error-message"),
@@ -99,11 +111,20 @@ const BrandSettingsTab = ({
   const handleSubmit = async () => {
     if (!organization?.organizationId) return;
 
+    const nextThemeKey =
+      themeOptions?.find((theme) => theme.themeId === selectedTheme)
+        ?.themeKey ?? "blue_theme";
+    const previousThemeKey = organization?.theme?.themeKey ?? "blue_theme";
+
+    // Optimistic apply; org query cache is patched with the same themeKey on success.
+    setTheme(nextThemeKey);
+
     try {
       const response = await setWhiteLabel({
         organizationId: organization?.organizationId,
         whiteLabelData: {
           themeId: selectedTheme,
+          themeKey: nextThemeKey,
           logo: file ? file : undefined,
           clearLogoUrl: clearImage,
         },
@@ -116,12 +137,17 @@ const BrandSettingsTab = ({
 
       setFile(null);
       setClearImage(false);
-      setTheme(selectedThemeValue?.key as string);
       setOrganization({
         logoUrl: response?.logoUrl ?? null,
       });
+      // Persist theme for next-themes, then reload so branding remounts cleanly.
+      setTheme(nextThemeKey);
       showSuccessToast();
+      window.setTimeout(() => {
+        window.location.reload();
+      }, 400);
     } catch (err) {
+      setTheme(previousThemeKey);
       logger.error({ err: err }, "Failed to update white label settings:");
       showErrorToast();
     }
@@ -132,12 +158,6 @@ const BrandSettingsTab = ({
       selectedTheme !== organization?.themeId || file !== null || clearImage
     );
   }, [selectedTheme, organization?.themeId, file, clearImage]);
-
-  useEffect(() => {
-    if (organization) {
-      setSelectedTheme((organization?.themeId as string) ?? blueTheme?.themeId);
-    }
-  }, [organization, blueTheme, setSelectedTheme]);
 
   return (
     <Box backgroundColor="white" p={6} borderRadius="8px" boxShadow="shadow-lg">

--- a/app/src/backend/UserService.ts
+++ b/app/src/backend/UserService.ts
@@ -71,7 +71,16 @@ export default class UserService {
             {
               model: db.models.Organization,
               as: "organization",
-              attributes: ["organizationId", "name"],
+              // Include branding fields used by GET /city/:city/organization
+              // (logoUrl/theme). Omitting them made Home sync wipe logoUrl and
+              // fight cities/layout's getOrganization sync (CC-621 blink).
+              attributes: [
+                "organizationId",
+                "name",
+                "logoUrl",
+                "active",
+                "themeId",
+              ],
             },
           ],
         },

--- a/app/src/components/HomePageJN/HomePage.tsx
+++ b/app/src/components/HomePageJN/HomePage.tsx
@@ -133,15 +133,15 @@ export default function HomePage({
     ) ?? {};
 
   useEffect(() => {
-    if (orgData) {
-      const newOrgState = normalizeOrganizationState(orgData);
+    if (!orgData) return;
 
-      if (hasOrganizationChanged(organization, newOrgState)) {
-        setOrganization(newOrgState);
-      }
-      setTheme(orgData?.theme?.themeKey ?? "blue_theme");
-    } else if (!isOrgDataLoading && !orgData) {
-      setTheme("blue_theme");
+    const newOrgState = normalizeOrganizationState(orgData);
+
+    if (hasOrganizationChanged(organization, newOrgState)) {
+      setOrganization(newOrgState);
+    }
+    if (orgData.theme?.themeKey) {
+      setTheme(orgData.theme.themeKey);
     }
   }, [isOrgDataLoading, orgData, organization, setOrganization, setTheme]);
 

--- a/app/src/hooks/organization-context-provider/use-organizational-context.tsx
+++ b/app/src/hooks/organization-context-provider/use-organizational-context.tsx
@@ -74,6 +74,7 @@ export const OrganizationContextProvider = ({
     });
 
   const [showFrozenModal, setShowFrozenModal] = useState(false);
+  const [hasHydrated, setHasHydrated] = useState(false);
 
   const dispatch = useAppDispatch();
 
@@ -81,12 +82,26 @@ export const OrganizationContextProvider = ({
     const stored = localStorage.getItem("organization");
     if (stored) {
       const parsed = JSON.parse(stored) as OrganizationState;
-      setOrganizationState((prev) => {
-        return hasOrganizationChanged(prev, parsed) ? parsed : prev;
-      });
+      setOrganizationState(parsed);
       dispatch(setOrganizationAction(parsed));
     }
+    setHasHydrated(true);
   }, [dispatch]);
+
+  // Keep Redux + localStorage in sync after React state commits.
+  // Side effects must not run inside the setState updater (that updates
+  // NavigationBar while OrganizationContextProvider is still rendering).
+  useEffect(() => {
+    if (!hasHydrated) return;
+
+    if (!organization) {
+      localStorage.removeItem("organization");
+      dispatch(clearOrganizationAction());
+      return;
+    }
+    localStorage.setItem("organization", JSON.stringify(organization));
+    dispatch(setOrganizationAction(organization));
+  }, [organization, dispatch, hasHydrated]);
 
   const setOrganization = (updates: Partial<OrganizationState>) => {
     setOrganizationState((prev) => {
@@ -95,17 +110,12 @@ export const OrganizationContextProvider = ({
         active: true,
         organizationId: undefined,
       };
-      const next = { ...baseState, ...updates };
-      localStorage.setItem("organization", JSON.stringify(next));
-      dispatch(setOrganizationAction(next));
-      return next;
+      return { ...baseState, ...updates };
     });
   };
 
   const clearOrganization = () => {
     setOrganizationState(null);
-    localStorage.removeItem("organization");
-    dispatch(clearOrganizationAction());
   };
 
   const isFrozenCheck = (): boolean => {

--- a/app/src/hooks/use-inventory-organization.ts
+++ b/app/src/hooks/use-inventory-organization.ts
@@ -24,13 +24,15 @@ export function useInventoryOrganization(
   const { setTheme } = useTheme();
 
   useEffect(() => {
-    if (orgData) {
-      const newOrgState = normalizeOrganizationState(orgData);
+    if (!orgData) return;
 
-      if (hasOrganizationChanged(organization, newOrgState)) {
-        setOrganization(newOrgState);
-      }
-      setTheme((orgData?.theme?.themeKey as string) || "blue_theme");
+    const newOrgState = normalizeOrganizationState(orgData);
+
+    if (hasOrganizationChanged(organization, newOrgState)) {
+      setOrganization(newOrgState);
+    }
+    if (orgData.theme?.themeKey) {
+      setTheme(orgData.theme.themeKey as string);
     }
   }, [
     isInventoryOrgDataLoading,

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -1547,6 +1547,7 @@ export const api = createApi({
           organizationId: string;
           whiteLabelData: {
             themeId: string;
+            themeKey?: string;
             logo?: File;
             clearLogoUrl?: boolean;
           };
@@ -1568,8 +1569,41 @@ export const api = createApi({
             body: formData,
           };
         },
-        transformResponse: (response: { data: OrganizationResponse }) =>
-          response.data,
+        transformResponse: (response: {
+          data: { logoUrl?: string | null; themeId?: string };
+        }) => response.data,
+        // Patch org cache immediately so the Brand tab's theme effect applies
+        // the saved theme without waiting for a full Organization refetch.
+        async onQueryStarted(
+          { organizationId, whiteLabelData },
+          { dispatch, queryFulfilled },
+        ) {
+          try {
+            const { data } = await queryFulfilled;
+            const themeKey = whiteLabelData.themeKey;
+
+            dispatch(
+              api.util.updateQueryData(
+                "getOrganization",
+                organizationId,
+                (draft) => {
+                  draft.themeId = whiteLabelData.themeId;
+                  if (data?.logoUrl !== undefined) {
+                    draft.logoUrl = data.logoUrl ?? undefined;
+                  }
+                  if (themeKey) {
+                    draft.theme = {
+                      themeId: whiteLabelData.themeId,
+                      themeKey,
+                    };
+                  }
+                },
+              ),
+            );
+          } catch {
+            // Leave cache alone; invalidation refetch will reconcile.
+          }
+        },
         invalidatesTags: ["Organizations", "Organization"],
       }),
       getThemes: builder.query({


### PR DESCRIPTION
## Summary

Stops the organization logo from blinking with the CityCatalyst logo after brand settings changes, and keeps brand theme application stable after save.

## Changes

- Include `logoUrl`, `active`, and `themeId` on city organization payloads from `findUserCity`
- Apply brand theme from resolved `themeKey` and patch org cache on branding save
- Avoid forcing `blue_theme` when org data is briefly missing
- Move org context Redux/localStorage sync out of the React state updater
- Reload the page after a successful brand save so theme/logo remount cleanly

## How to test

1. As an org admin, open Settings → Brand settings.
2. Change primary color and/or logo, then Save.
3. Confirm toast appears, page reloads, and the selected theme/logo stick.
4. Open city home and confirm the org logo does not blink with the CityCatalyst logo.
5. Navigate between home and inventory and confirm theme stays consistent.

## Ticket

[CC-621](https://linear.app/openearth/issue/CC-621/organization-logo-blinks-back-and-forth-with-citycatalyst-logo-in)
