### PR TITLE
CC-614: Fix year selectors in inventory setup screens

### DIFF
--- a/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/GHGIInventoryDetailsStep.tsx
+++ b/app/src/app/[lng]/cities/[cityId]/GHGI/onboarding/GHGIInventoryDetailsStep.tsx
@@ -16,10 +16,9 @@ import {
   Link,
   Text,
 } from "@chakra-ui/react";
-import { MdCheck, MdWarning } from "react-icons/md";
+import { MdWarning } from "react-icons/md";
 import { Trans } from "react-i18next";
 import { CustomRadio, RadioGroup } from "@/components/ui/custom-radio";
-import { InputGroup } from "@/components/ui/input-group";
 import {
   SelectContent,
   SelectItem,
@@ -58,7 +57,6 @@ export default function GHGIInventoryDetailsStep({
     selectedGlobalWarmingPotentialValue,
     setSelectedGlobalWarmingPotentialValue,
   ] = useState("");
-  let year;
   const inventoryGoalOptions: string[] = [
     InventoryTypeEnum.GPC_BASIC,
     InventoryTypeEnum.GPC_BASIC_PLUS,
@@ -147,46 +145,32 @@ export default function GHGIInventoryDetailsStep({
                 </Box>
               }
             >
-              <InputGroup
-                endElement={
-                  !!year && (
-                    <Icon
-                      as={MdCheck}
-                      color="semantic.success"
-                      boxSize={4}
-                      mt={2}
-                      mr={10}
-                    />
-                  )
-                }
+              <SelectRoot
+                collection={yearsCollection}
+                size="lg"
+                w="400px"
+                _placeholder={{ color: "content.tertiary" }}
+                data-testid="ghgi-inventory-details-year"
+                {...register("year", {
+                  required: t("inventory-year-required"),
+                })}
               >
-                <SelectRoot
-                  collection={yearsCollection}
-                  size="lg"
-                  w="400px"
-                  _placeholder={{ color: "content.tertiary" }}
-                  data-testid="ghgi-inventory-details-year"
-                  {...register("year", {
-                    required: t("inventory-year-required"),
-                  })}
-                >
-                  <SelectLabel />
-                  <SelectTrigger shadow="1dp">
-                    <SelectValueText
-                      placeholder={t("inventory-year-placeholder")}
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {yearsCollection.items.map(
-                      (year: { label: string; value: string }, i: number) => (
-                        <SelectItem item={year} key={i}>
-                          {year.label}
-                        </SelectItem>
-                      ),
-                    )}
-                  </SelectContent>
-                </SelectRoot>
-              </InputGroup>
+                <SelectLabel />
+                <SelectTrigger shadow="1dp">
+                  <SelectValueText
+                    placeholder={t("inventory-year-placeholder")}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {yearsCollection.items.map(
+                    (year: { label: string; value: string }, i: number) => (
+                      <SelectItem item={year} key={i}>
+                        {year.label}
+                      </SelectItem>
+                    ),
+                  )}
+                </SelectContent>
+              </SelectRoot>
             </Field>
           </Box>
         </Box>

--- a/app/src/components/steps/GHGI/set-inventory-details-step.tsx
+++ b/app/src/components/steps/GHGI/set-inventory-details-step.tsx
@@ -17,10 +17,9 @@ import {
   List,
   Text,
 } from "@chakra-ui/react";
-import { MdCheck, MdWarning } from "react-icons/md";
+import { MdWarning } from "react-icons/md";
 import { Trans } from "react-i18next";
 import { RadioGroup } from "@/components/ui/custom-radio";
-import { InputGroup } from "@/components/ui/input-group";
 import {
   SelectContent,
   SelectItem,
@@ -124,48 +123,34 @@ export default function SetInventoryDetailsStep({
                 </Box>
               }
             >
-              <InputGroup
-                endElement={
-                  (selectedYearArray?.length ?? 0) > 0 && (
-                    <Icon
-                      as={MdCheck}
-                      color="semantic.success"
-                      boxSize={4}
-                      mt={2}
-                      mr={10}
-                    />
-                  )
-                }
+              <SelectRoot
+                collection={yearsCollection}
+                size="lg"
+                w="400px"
+                _placeholder={{ color: "content.tertiary" }}
+                data-testid="inventory-details-year"
+                {...register("year", {
+                  required: t("inventory-year-required"),
+                })}
+                value={selectedYearArray}
+                onValueChange={({ value }) => setSelectedYearArray(value)}
               >
-                <SelectRoot
-                  collection={yearsCollection}
-                  size="lg"
-                  w="400px"
-                  _placeholder={{ color: "content.tertiary" }}
-                  data-testid="inventory-details-year"
-                  {...register("year", {
-                    required: t("inventory-year-required"),
-                  })}
-                  value={selectedYearArray}
-                  onValueChange={({ value }) => setSelectedYearArray(value)}
-                >
-                  <SelectLabel />
-                  <SelectTrigger shadow="1dp">
-                    <SelectValueText
-                      placeholder={t("inventory-year-placeholder")}
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {yearsCollection.items.map(
-                      (year: { label: string; value: string }, i: number) => (
-                        <SelectItem item={year} key={i}>
-                          {year.label}
-                        </SelectItem>
-                      ),
-                    )}
-                  </SelectContent>
-                </SelectRoot>
-              </InputGroup>
+                <SelectLabel />
+                <SelectTrigger shadow="1dp">
+                  <SelectValueText
+                    placeholder={t("inventory-year-placeholder")}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {yearsCollection.items.map(
+                    (year: { label: string; value: string }, i: number) => (
+                      <SelectItem item={year} key={i}>
+                        {year.label}
+                      </SelectItem>
+                    ),
+                  )}
+                </SelectContent>
+              </SelectRoot>
             </Field>
           </Box>
         </Box>

--- a/app/src/components/steps/GHGI/set-population-data-step.tsx
+++ b/app/src/components/steps/GHGI/set-population-data-step.tsx
@@ -22,9 +22,8 @@ import {
   Text,
 } from "@chakra-ui/react";
 import FormattedThousandsNumber from "@/components/FormattedThousandsNumberInput";
-import { MdCheck, MdErrorOutline, MdInfoOutline } from "react-icons/md";
+import { MdErrorOutline, MdInfoOutline } from "react-icons/md";
 import { Field } from "@/components/ui/field";
-import { InputGroup } from "../../ui/input-group";
 import { logger } from "@/services/logger";
 import {
   NativeSelectField,
@@ -67,14 +66,6 @@ export default function SetPopulationDataStep({
 }) {
   const yearInput = watch("year");
   const year: number | null = yearInput ? parseInt(yearInput) : null;
-
-  // Watch population values
-  const cityPopulation = watch("cityPopulation");
-  const cityPopulationYear = watch("cityPopulationYear");
-  const regionPopulation = watch("regionPopulation");
-  const regionPopulationYear = watch("regionPopulationYear");
-  const countryPopulation = watch("countryPopulation");
-  const countryPopulationYear = watch("countryPopulationYear");
 
   const yearsCollection = createListCollection({
     items: years.map((year) => ({ label: year.toString(), value: year })),
@@ -272,63 +263,50 @@ export default function SetPopulationDataStep({
                 )
               }
             >
-              <InputGroup
-                endElement={
-                  !!countryPopulationYear &&
-                  !!countryPopulation && (
-                    <Icon
-                      as={MdCheck}
-                      color="semantic.success"
-                      boxSize={4}
-                      mt={2}
-                      mr={8}
-                    />
-                  )
-                }
-              >
-                <Controller
-                  name="countryPopulationYear"
-                  control={control}
-                  rules={{
-                    required: t("inventory-year-required"),
-                  }}
-                  render={({ field }) => (
-                    <NativeSelectRoot
-                      size="lg"
-                      w="217px"
-                      borderRadius="4px"
-                      borderWidth="1px"
-                      borderColor={
-                        errors?.countryPopulationYear?.message
-                          ? "sentiment.negativeDefault"
-                          : ""
-                      }
-                      background={
-                        errors?.countryPopulationYear?.message
-                          ? "sentiment.negativeOverlay"
-                          : ""
-                      }
+              <Controller
+                name="countryPopulationYear"
+                control={control}
+                rules={{
+                  required: t("inventory-year-required"),
+                }}
+                render={({ field }) => (
+                  <NativeSelectRoot
+                    size="lg"
+                    w="217px"
+                    borderRadius="4px"
+                    borderWidth="1px"
+                    borderColor={
+                      errors?.countryPopulationYear?.message
+                        ? "sentiment.negativeDefault"
+                        : ""
+                    }
+                    background={
+                      errors?.countryPopulationYear?.message
+                        ? "sentiment.negativeOverlay"
+                        : ""
+                    }
+                  >
+                    <NativeSelectField
+                      name="countryPopulationYear"
+                      value={field.value ?? ""}
+                      onChange={(e) => {
+                        field.onChange(
+                          e.target.value ? parseInt(e.target.value) : null,
+                        );
+                      }}
                     >
-                      <NativeSelectField
-                        name="countryPopulationYear"
-                        value={field.value}
-                        placeholder={t("inventory-year-placeholder")}
-                        onChange={(e) => {
-                          field.onChange(
-                            e.target.value ? parseInt(e.target.value) : null,
-                          );
-                        }}
-                      >
-                        {years.map((year) => (
-                          <option key={year} value={year}>
-                            {year}
-                          </option>
-                        ))}
-                      </NativeSelectField>
-                    </NativeSelectRoot>
-                  )}
-                />
-              </InputGroup>
+                      <option value="" disabled hidden>
+                        {t("inventory-year-placeholder")}
+                      </option>
+                      {years.map((year) => (
+                        <option key={year} value={year}>
+                          {year}
+                        </option>
+                      ))}
+                    </NativeSelectField>
+                  </NativeSelectRoot>
+                )}
+              />
             </Field>
           </Box>
         </Box>
@@ -393,63 +371,50 @@ export default function SetPopulationDataStep({
                 </Text>
               }
             >
-              <InputGroup
-                endElement={
-                  !!regionPopulationYear &&
-                  !!regionPopulation && (
-                    <Icon
-                      as={MdCheck}
-                      color="semantic.success"
-                      boxSize={4}
-                      mt={2}
-                      mr={8}
-                    />
-                  )
-                }
-              >
-                <Controller
-                  name="regionPopulationYear"
-                  control={control}
-                  rules={{
-                    required: t("inventory-year-required"),
-                  }}
-                  render={({ field }) => (
-                    <NativeSelectRoot
-                      size="lg"
-                      w="217px"
-                      borderRadius="4px"
-                      borderWidth="1px"
-                      borderColor={
-                        errors?.regionPopulationYear?.message
-                          ? "sentiment.negativeDefault"
-                          : ""
-                      }
-                      background={
-                        errors?.regionPopulationYear?.message
-                          ? "sentiment.negativeOverlay"
-                          : ""
-                      }
+              <Controller
+                name="regionPopulationYear"
+                control={control}
+                rules={{
+                  required: t("inventory-year-required"),
+                }}
+                render={({ field }) => (
+                  <NativeSelectRoot
+                    size="lg"
+                    w="217px"
+                    borderRadius="4px"
+                    borderWidth="1px"
+                    borderColor={
+                      errors?.regionPopulationYear?.message
+                        ? "sentiment.negativeDefault"
+                        : ""
+                    }
+                    background={
+                      errors?.regionPopulationYear?.message
+                        ? "sentiment.negativeOverlay"
+                        : ""
+                    }
+                  >
+                    <NativeSelectField
+                      name="regionPopulationYear"
+                      value={field.value ?? ""}
+                      onChange={(e) => {
+                        field.onChange(
+                          e.target.value ? parseInt(e.target.value) : null,
+                        );
+                      }}
                     >
-                      <NativeSelectField
-                        name="regionPopulationYear"
-                        value={field.value}
-                        placeholder={t("inventory-year-placeholder")}
-                        onChange={(e) => {
-                          field.onChange(
-                            e.target.value ? parseInt(e.target.value) : null,
-                          );
-                        }}
-                      >
-                        {years.map((year) => (
-                          <option key={year} value={year}>
-                            {year}
-                          </option>
-                        ))}
-                      </NativeSelectField>
-                    </NativeSelectRoot>
-                  )}
-                />
-              </InputGroup>
+                      <option value="" disabled hidden>
+                        {t("inventory-year-placeholder")}
+                      </option>
+                      {years.map((year) => (
+                        <option key={year} value={year}>
+                          {year}
+                        </option>
+                      ))}
+                    </NativeSelectField>
+                  </NativeSelectRoot>
+                )}
+              />
             </Field>
           </Box>
         </Box>
@@ -518,63 +483,50 @@ export default function SetPopulationDataStep({
                 )
               }
             >
-              <InputGroup
-                endElement={
-                  !!cityPopulationYear &&
-                  !!cityPopulation && (
-                    <Icon
-                      as={MdCheck}
-                      color="semantic.success"
-                      boxSize={4}
-                      mt={2}
-                      mr={8}
-                    />
-                  )
-                }
-              >
-                <Controller
-                  name="cityPopulationYear"
-                  control={control}
-                  rules={{
-                    required: t("inventory-year-required"),
-                  }}
-                  render={({ field }) => (
-                    <NativeSelectRoot
-                      size="lg"
-                      w="217px"
-                      borderRadius="4px"
-                      borderWidth="1px"
-                      borderColor={
-                        errors?.cityPopulationYear?.message
-                          ? "sentiment.negativeDefault"
-                          : ""
-                      }
-                      background={
-                        errors?.cityPopulationYear?.message
-                          ? "sentiment.negativeOverlay"
-                          : ""
-                      }
+              <Controller
+                name="cityPopulationYear"
+                control={control}
+                rules={{
+                  required: t("inventory-year-required"),
+                }}
+                render={({ field }) => (
+                  <NativeSelectRoot
+                    size="lg"
+                    w="217px"
+                    borderRadius="4px"
+                    borderWidth="1px"
+                    borderColor={
+                      errors?.cityPopulationYear?.message
+                        ? "sentiment.negativeDefault"
+                        : ""
+                    }
+                    background={
+                      errors?.cityPopulationYear?.message
+                        ? "sentiment.negativeOverlay"
+                        : ""
+                    }
+                  >
+                    <NativeSelectField
+                      name="cityPopulationYear"
+                      value={field.value ?? ""}
+                      onChange={(e) => {
+                        field.onChange(
+                          e.target.value ? parseInt(e.target.value) : null,
+                        );
+                      }}
                     >
-                      <NativeSelectField
-                        name="cityPopulationYear"
-                        value={field.value}
-                        placeholder={t("inventory-year-placeholder")}
-                        onChange={(e) => {
-                          field.onChange(
-                            e.target.value ? parseInt(e.target.value) : null,
-                          );
-                        }}
-                      >
-                        {years.map((year) => (
-                          <option key={year} value={year}>
-                            {year}
-                          </option>
-                        ))}
-                      </NativeSelectField>
-                    </NativeSelectRoot>
-                  )}
-                />
-              </InputGroup>
+                      <option value="" disabled hidden>
+                        {t("inventory-year-placeholder")}
+                      </option>
+                      {years.map((year) => (
+                        <option key={year} value={year}>
+                          {year}
+                        </option>
+                      ))}
+                    </NativeSelectField>
+                  </NativeSelectRoot>
+                )}
+              />
             </Field>
           </Box>
         </HStack>


### PR DESCRIPTION
## Summary
- Population year selects (`cityPopulationYear`, `regionPopulationYear`, `countryPopulationYear` in `set-population-data-step.tsx`) now render "Select year" as a `disabled hidden` placeholder option instead of a normal, selectable `<option value="">` — Chakra's `placeholder` prop alone doesn't prevent reselection.
- Removed the green checkmark (`MdCheck` in `InputGroup`'s `endElement`) and its dead validation state from all four year selectors (the 3 population fields + the "Inventory year" field in `set-inventory-details-step.tsx` and `GHGIInventoryDetailsStep.tsx`). That wrapper had `pointer-events: auto` and sat on top of the dropdown's chevron, silently swallowing clicks meant for the arrow.
- Found along the way: the "Inventory year" checkmark in `GHGIInventoryDetailsStep.tsx` was gated on `let year;` — a variable declared but never assigned — so it was dead code that could never have rendered.

## Test plan
- [ ] Onboarding "Add population data" step: leave each of the 3 year fields empty → placeholder shown, not selectable from the dropdown list
- [ ] Onboarding "Add population data" step: pick a year on each of the 3 fields → year shows, no checkmark, "Select year" no longer reachable
- [ ] Onboarding "Inventory details" step (both onboarding entry points: `cities/onboarding/setup` and `cities/[cityId]/GHGI/onboarding/setup`) → click directly on the dropdown arrow (not just the text) → dropdown opens
- [ ] `npx tsc --noEmit` and `npx eslint` pass on all three changed files (verified — no new errors vs. baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)