### PR TITLE
CC-651: Fix mangled external tool URLs in sidebar

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2742,9 +2742,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2760,9 +2757,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2780,9 +2774,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2798,9 +2789,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2818,9 +2806,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2836,9 +2821,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2856,9 +2838,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2875,9 +2854,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2893,9 +2869,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2919,9 +2892,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2943,9 +2913,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2969,9 +2936,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2993,9 +2957,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3019,9 +2980,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3044,9 +3002,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3068,9 +3023,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -4086,9 +4038,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4104,9 +4053,6 @@
       "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4124,9 +4070,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4142,9 +4085,6 @@
       "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -20061,6 +20001,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/app/src/components/HomePage/JNDrawer.tsx
+++ b/app/src/components/HomePage/JNDrawer.tsx
@@ -780,14 +780,24 @@ const JNDrawer = ({
                           key={stage}
                           title={t("journey." + stage)}
                           icon={stageIcons[stage]}
-                          items={modules.map((mod) => ({
-                            label:
-                              mod.name[lng] ||
-                              mod.name.en ||
-                              mod.name[Object.keys(mod.name)[0]] ||
-                              mod.id,
-                            href: `/${lng}/cities/${selectedCity}${mod.url}`,
-                          }))}
+                          items={modules.map((mod) => {
+                            // External tool URLs (e.g. Replit apps) must not be
+                            // prefixed with the city path — that produced
+                            // .../cities/{id}https://... (CC-651).
+                            const isExternal =
+                              mod.url.startsWith("http://") ||
+                              mod.url.startsWith("https://");
+                            return {
+                              label:
+                                mod.name[lng] ||
+                                mod.name.en ||
+                                mod.name[Object.keys(mod.name)[0]] ||
+                                mod.id,
+                              href: isExternal
+                                ? mod.url
+                                : `/${lng}/cities/${selectedCity}${mod.url}`,
+                            };
+                          })}
                           t={t}
                         />
                       );

--- a/app/src/components/ui/navigation-accordion.tsx
+++ b/app/src/components/ui/navigation-accordion.tsx
@@ -51,25 +51,31 @@ export const NavigationAccordion: React.FC<NavigationAccordionProps> = ({
           </Accordion.ItemTrigger>
           <Accordion.ItemContent>
             <Accordion.ItemBody border="none" pl="xl">
-              {items.map((item, index) => (
-                <Link
-                  key={index}
-                  rounded={0}
-                  w="full"
-                  h="48px"
-                  gap="12px"
-                  display="flex"
-                  alignItems="center"
-                  href={item.href}
-                  onClick={item.onClick}
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  <Text fontSize="body.lg" color="content.primary">
-                    {t(item.label)}
-                  </Text>
-                </Link>
-              ))}
+              {items.map((item, index) => {
+                const isExternal =
+                  !!item.href &&
+                  (item.href.startsWith("http://") ||
+                    item.href.startsWith("https://"));
+                return (
+                  <Link
+                    key={index}
+                    rounded={0}
+                    w="full"
+                    h="48px"
+                    gap="12px"
+                    display="flex"
+                    alignItems="center"
+                    href={item.href}
+                    onClick={item.onClick}
+                    rel={isExternal ? "noopener noreferrer" : undefined}
+                    target={isExternal ? "_blank" : undefined}
+                  >
+                    <Text fontSize="body.lg" color="content.primary">
+                      {t(item.label)}
+                    </Text>
+                  </Link>
+                );
+              })}
             </Accordion.ItemBody>
           </Accordion.ItemContent>
         </Accordion.Item>


### PR DESCRIPTION
## Summary

Fixes sidebar Tools links that prefixed external Open Earth URLs with the city path, producing mangled addresses like `/cities/{id}https://...`.

## Changes

- Resolve external module URLs as-is in the city home drawer (same rule as module cards)
- Open only external sidebar links in a new tab; keep internal tools in the same tab

## How to test

1. Open city home and expand the left drawer → Tools.
2. Click an external tool (e.g. boundary picker / Replit app).
3. Confirm it opens `https://...` in a new tab, not a CityCatalyst city URL with the external host appended.
4. Click an internal tool (e.g. GHGI) and confirm it navigates within the app on the same tab.

## Ticket

[CC-651](https://linear.app/openearth/issue/CC-651/sidebars-links-incorrect-urls)
