### PR TITLE
[1/3] CC-606: Add Climate Advisor run listing

### DIFF
--- a/climate-advisor/README.md
+++ b/climate-advisor/README.md
@@ -594,13 +594,24 @@ empty `concept_note_context_bundles` row in one transaction. The run starts as
 Creation is idempotent per `(user_id, idempotency_key)`. Replaying the same
 normalized request returns the original run with HTTP `200` and
 `created: false`; using that key with different input returns HTTP `409`.
+
+`GET /v1/concept-notes?user_id=...&city_id=...` validates the same token identity
+and live city access, then returns only that user's runs for the selected city.
+Runs are ordered by `updated_at`, `created_at`, and `run_id`, all descending, so
+the result is stable and most-recently-updated first. Upload registration and
+failed, retry, or ready lifecycle transitions refresh the parent run's
+`updated_at`. Each item includes the durable `run_id`, optional chat `thread_id`,
+stored scope identifiers, lifecycle fields, timestamps, and `progress_summary`
+copied from the persisted `context_summary`.
+
 `GET /v1/concept-notes/{run_id}?user_id=...` returns only an owned run and
-revalidates current city access before responding. The Alembic revision
-`20260729_120000` provisions `concept_note_runs`,
-`concept_note_context_bundles`, and `concept_note_uploads` in
-`CA_DATABASE_URL`. When `thread_id` is supplied, the start operation also
-requires that durable chat thread to belong to the authenticated user; it
-remains an integration identifier rather than a run-table foreign key.
+revalidates current city access before responding. It exposes the same persisted
+status, workflow step, and progress summary as the list contract. The Alembic
+revision `20260729_120000` provisions `concept_note_runs`,
+`concept_note_context_bundles`, and `concept_note_uploads` in `CA_DATABASE_URL`.
+When `thread_id` is supplied, the start operation also requires that durable
+chat thread to belong to the authenticated user; it remains an integration
+identifier rather than a run-table foreign key.
 
 CityCatalyst exposes authenticated proxy routes at
 `POST /api/v1/concept-notes/start` and

--- a/climate-advisor/service/app/models/concept_note_runs.py
+++ b/climate-advisor/service/app/models/concept_note_runs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -51,21 +51,33 @@ class ConceptNoteStartRequest(BaseModel):
         return self
 
 
-class ConceptNoteRunResponse(BaseModel):
-    """Persisted concept-note run returned by start and detail endpoints."""
+class ConceptNoteRunListItemResponse(BaseModel):
+    """Stable display and resume fields for one concept-note run."""
 
     run_id: UUID
     thread_id: UUID | None = None
-    user_id: str
-    name: str
-    city_id: str
+    name: str = Field(min_length=1)
+    city_id: UUID
     project_id: str | None = None
     funder_id: UUID | None = None
     selected_funding_record_id: UUID | None = None
-    status: Literal["active"]
-    workflow_step: Literal["assembling_context"]
+    status: str = Field(min_length=1)
+    workflow_step: str = Field(min_length=1)
+    progress_summary: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime
+    updated_at: datetime
+
+
+class ConceptNoteRunListResponse(BaseModel):
+    """Authorized concept-note runs for one user and city."""
+
+    runs: list[ConceptNoteRunListItemResponse] = Field(default_factory=list)
+
+
+class ConceptNoteRunResponse(ConceptNoteRunListItemResponse):
+    """Persisted concept-note run returned by start and detail endpoints."""
+
+    user_id: str
     next_action: Literal["load_context"] = "load_context"
     created: bool
     trace_id: str | None = None
-    created_at: datetime
-    updated_at: datetime

--- a/climate-advisor/service/app/persistence/concept_notes/markdown.py
+++ b/climate-advisor/service/app/persistence/concept_notes/markdown.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID
 
 from sqlalchemy import func, select
@@ -200,7 +200,7 @@ class SqlAlchemyConceptNoteMarkdownRepository(ConceptNoteMarkdownRepository):
         """Create or idempotently replay one pre-conversion upload."""
         try:
             async with self._session_factory() as session, session.begin():
-                await _require_owned_run(
+                run = await _require_owned_run(
                     session=session,
                     user_id=user_id,
                     run_id=run_id,
@@ -249,6 +249,9 @@ class SqlAlchemyConceptNoteMarkdownRepository(ConceptNoteMarkdownRepository):
                     )
                     return _snapshot(existing)
 
+                # Keep dashboard ordering aligned with upload lifecycle activity.
+                _touch_run(run)
+                await session.flush()
                 await session.refresh(upload)
                 return _snapshot(upload)
         except ConceptNoteMarkdownRepositoryError:
@@ -304,7 +307,7 @@ class SqlAlchemyConceptNoteMarkdownRepository(ConceptNoteMarkdownRepository):
         """Persist one immutable CC Markdown pointer and mark it ready."""
         try:
             async with self._session_factory() as session, session.begin():
-                await _require_owned_run(
+                run = await _require_owned_run(
                     session=session,
                     user_id=user_id,
                     run_id=run_id,
@@ -342,6 +345,8 @@ class SqlAlchemyConceptNoteMarkdownRepository(ConceptNoteMarkdownRepository):
                 upload.ingest_error_code = None
                 upload.ingest_started_at = upload.ingest_started_at or func.now()
                 upload.ingest_completed_at = func.now()
+                # Keep dashboard ordering aligned with upload lifecycle activity.
+                _touch_run(run)
                 await session.flush()
                 await session.refresh(upload)
                 return _snapshot(upload)
@@ -366,7 +371,7 @@ class SqlAlchemyConceptNoteMarkdownRepository(ConceptNoteMarkdownRepository):
         """Mark a non-ready upload failed without deleting its identity."""
         try:
             async with self._session_factory() as session, session.begin():
-                await _require_owned_run(
+                run = await _require_owned_run(
                     session=session,
                     user_id=user_id,
                     run_id=run_id,
@@ -390,6 +395,8 @@ class SqlAlchemyConceptNoteMarkdownRepository(ConceptNoteMarkdownRepository):
                 upload.ingest_status = "failed"
                 upload.ingest_error_code = error_code
                 upload.ingest_completed_at = func.now()
+                # Keep dashboard ordering aligned with upload lifecycle activity.
+                _touch_run(run)
                 await session.flush()
                 await session.refresh(upload)
                 return _snapshot(upload)
@@ -413,7 +420,7 @@ class SqlAlchemyConceptNoteMarkdownRepository(ConceptNoteMarkdownRepository):
         """Return a failed upload to queued state."""
         try:
             async with self._session_factory() as session, session.begin():
-                await _require_owned_run(
+                run = await _require_owned_run(
                     session=session,
                     user_id=user_id,
                     run_id=run_id,
@@ -437,6 +444,8 @@ class SqlAlchemyConceptNoteMarkdownRepository(ConceptNoteMarkdownRepository):
                 upload.ingest_status = "queued"
                 upload.ingest_error_code = None
                 upload.ingest_completed_at = None
+                # Keep dashboard ordering aligned with upload lifecycle activity.
+                _touch_run(run)
                 await session.flush()
                 await session.refresh(upload)
                 return _snapshot(upload)
@@ -498,6 +507,11 @@ async def _require_owned_run(
             "Concept Note run belongs to another user",
         )
     return run
+
+
+def _touch_run(run: ConceptNoteRun) -> None:
+    """Record upload lifecycle activity on the parent run."""
+    run.updated_at = datetime.now(timezone.utc)
 
 
 def _require_upload_binding(

--- a/climate-advisor/service/app/persistence/concept_notes/runs.py
+++ b/climate-advisor/service/app/persistence/concept_notes/runs.py
@@ -115,3 +115,25 @@ class ConceptNoteRunRepository:
             )
         )
         return result.scalar_one_or_none()
+
+    async def list_for_user_city(
+        self,
+        *,
+        user_id: str,
+        city_id: str,
+    ) -> list[ConceptNoteRun]:
+        """Load a user's runs for one city in deterministic activity order."""
+        query = (
+            select(ConceptNoteRun)
+            .where(
+                ConceptNoteRun.user_id == user_id,
+                ConceptNoteRun.city_id == city_id,
+            )
+            .order_by(
+                ConceptNoteRun.updated_at.desc(),
+                ConceptNoteRun.created_at.desc(),
+                ConceptNoteRun.run_id.desc(),
+            )
+        )
+        result = await self.session.execute(query)
+        return list(result.scalars().all())

--- a/climate-advisor/service/app/routes/concept_note_runs.py
+++ b/climate-advisor/service/app/routes/concept_note_runs.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
 from app.models.concept_note_runs import (
+    ConceptNoteRunListResponse,
     ConceptNoteRunResponse,
     ConceptNoteStartRequest,
 )
@@ -16,6 +17,25 @@ from app.services.concept_note_runs import ConceptNoteRunService
 
 
 router = APIRouter()
+
+
+@router.get(
+    "/concept-notes",
+    response_model=ConceptNoteRunListResponse,
+)
+async def list_concept_note_runs(
+    user_id: str = Query(..., min_length=1),
+    city_id: UUID = Query(...),
+    authorization: str | None = Header(default=None),
+    session: AsyncSession = Depends(get_session),
+) -> ConceptNoteRunListResponse:
+    """Return the authenticated user's runs for one accessible city."""
+    service = ConceptNoteRunService(session)
+    return await service.list_runs(
+        requested_user_id=user_id,
+        city_id=city_id,
+        authorization=authorization,
+    )
 
 
 @router.post(

--- a/climate-advisor/service/app/services/concept_note_runs.py
+++ b/climate-advisor/service/app/services/concept_note_runs.py
@@ -9,10 +9,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.middleware.request_context import get_request_id
 from app.models.concept_note_runs import (
+    ConceptNoteRunListItemResponse,
+    ConceptNoteRunListResponse,
     ConceptNoteRunResponse,
     ConceptNoteStartRequest,
 )
 from app.models.db.concept_note import ConceptNoteRun
+from app.persistence.concept_notes.runs import ConceptNoteRunRepository
 from app.services.citycatalyst_client import (
     CityCatalystClient,
     CityCatalystClientError,
@@ -21,7 +24,6 @@ from app.services.cnb.funding_references import (
     FundingReferenceValidator,
     PostgresFundingReferenceValidator,
 )
-from app.persistence.concept_notes.runs import ConceptNoteRunRepository
 
 
 class ConceptNoteRunService:
@@ -91,12 +93,10 @@ class ConceptNoteRunService:
     ) -> ConceptNoteRunResponse:
         """Return an owned run after revalidating current city access."""
         token = _require_bearer_token(authorization)
-        canonical_user_id = await self._canonical_user_id(token)
-        if canonical_user_id != requested_user_id:
-            raise HTTPException(
-                status_code=403,
-                detail="Request user does not match authenticated token",
-            )
+        canonical_user_id = await self._authorize_user(
+            token=token,
+            requested_user_id=requested_user_id,
+        )
 
         run = await self.repository.get_for_user(
             run_id=run_id,
@@ -112,25 +112,64 @@ class ConceptNoteRunService:
         )
         return _to_response(run, created=False)
 
+    async def list_runs(
+        self,
+        *,
+        requested_user_id: str,
+        city_id: UUID,
+        authorization: str | None,
+    ) -> ConceptNoteRunListResponse:
+        """Return the authenticated user's runs for one accessible city."""
+        # Authorize the requested user and city before reading persisted runs.
+        token = _require_bearer_token(authorization)
+        canonical_user_id = await self._authorize_scope(
+            token=token,
+            requested_user_id=requested_user_id,
+            city_id=city_id,
+        )
+        runs = await self.repository.list_for_user_city(
+            user_id=canonical_user_id,
+            city_id=str(city_id),
+        )
+
+        # Serialize the ordered rows into the stable list contract.
+        return ConceptNoteRunListResponse(
+            runs=[_to_list_item(run) for run in runs]
+        )
+
     async def _authorize_scope(
         self,
         *,
         token: str,
         requested_user_id: str,
         city_id: UUID,
-    ) -> None:
+    ) -> str:
         """Validate token identity and CityCatalyst city access."""
+        canonical_user_id = await self._authorize_user(
+            token=token,
+            requested_user_id=requested_user_id,
+        )
+        await self._validate_city_access(
+            token=token,
+            user_id=canonical_user_id,
+            city_id=city_id,
+        )
+        return canonical_user_id
+
+    async def _authorize_user(
+        self,
+        *,
+        token: str,
+        requested_user_id: str,
+    ) -> str:
+        """Require the requested user to match the bearer-token identity."""
         canonical_user_id = await self._canonical_user_id(token)
         if canonical_user_id != requested_user_id:
             raise HTTPException(
                 status_code=403,
                 detail="Request user does not match authenticated token",
             )
-        await self._validate_city_access(
-            token=token,
-            user_id=canonical_user_id,
-            city_id=city_id,
-        )
+        return canonical_user_id
 
     async def _canonical_user_id(self, token: str) -> str:
         """Resolve a bearer token to its canonical CityCatalyst user."""
@@ -223,19 +262,28 @@ def _to_response(
     created: bool,
 ) -> ConceptNoteRunResponse:
     """Serialize one persisted run into the public API contract."""
+    list_item = _to_list_item(run)
     return ConceptNoteRunResponse(
+        **list_item.model_dump(),
+        user_id=run.user_id,
+        created=created,
+        trace_id=run.trace_id,
+    )
+
+
+def _to_list_item(run: ConceptNoteRun) -> ConceptNoteRunListItemResponse:
+    """Serialize one run into the stable list and resume contract."""
+    return ConceptNoteRunListItemResponse(
         run_id=run.run_id,
         thread_id=run.thread_id,
-        user_id=run.user_id,
         name=run.name,
         city_id=run.city_id,
         project_id=run.project_id,
         funder_id=run.funder_id,
         selected_funding_record_id=run.selected_funding_record_id,
-        status="active",
-        workflow_step="assembling_context",
-        created=created,
-        trace_id=run.trace_id,
+        status=run.status,
+        workflow_step=run.workflow_step,
+        progress_summary=run.context_summary or {},
         created_at=run.created_at,
         updated_at=run.updated_at,
     )

--- a/climate-advisor/service/tests/test_concept_note_runs.py
+++ b/climate-advisor/service/tests/test_concept_note_runs.py
@@ -1,13 +1,16 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
-from app.models.concept_note_runs import ConceptNoteStartRequest
+from app.models.concept_note_runs import (
+    ConceptNoteRunListResponse,
+    ConceptNoteStartRequest,
+)
 from app.models.db.concept_note import ConceptNoteRun
 from app.models.db.thread import Thread
 from app.persistence.concept_notes.runs import ConceptNoteRunRepository
@@ -22,12 +25,16 @@ from app.services.concept_note_runs import (
 )
 
 
-def _start_request(*, user_id: str = "owner-1") -> ConceptNoteStartRequest:
+def _start_request(
+    *,
+    user_id: str = "owner-1",
+    city_id: UUID | None = None,
+) -> ConceptNoteStartRequest:
     """Build a valid run-start request for service tests."""
     return ConceptNoteStartRequest(
         user_id=user_id,
         name="Resilient neighborhoods",
-        city_id=uuid4(),
+        city_id=city_id or uuid4(),
         idempotency_key=uuid4(),
     )
 
@@ -36,11 +43,17 @@ def _persisted_run(
     payload: ConceptNoteStartRequest,
     *,
     request_fingerprint: str,
+    run_id: UUID | None = None,
+    status: str = "active",
+    workflow_step: str = "assembling_context",
+    context_summary: dict[str, object] | None = None,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
 ) -> ConceptNoteRun:
     """Build the persisted run shape returned by the repository."""
     now = datetime.now(timezone.utc)
     return ConceptNoteRun(
-        run_id=uuid4(),
+        run_id=run_id or uuid4(),
         thread_id=payload.thread_id,
         user_id=payload.user_id,
         name=payload.name,
@@ -48,15 +61,15 @@ def _persisted_run(
         project_id=payload.project_id,
         funder_id=payload.funder_id,
         selected_funding_record_id=payload.selected_funding_record_id,
-        status="active",
-        workflow_step="assembling_context",
-        context_summary={},
+        status=status,
+        workflow_step=workflow_step,
+        context_summary=context_summary or {},
         permission_summary={},
         trace_id=None,
         idempotency_key=payload.idempotency_key,
         request_fingerprint=request_fingerprint,
-        created_at=now,
-        updated_at=now,
+        created_at=created_at or now,
+        updated_at=updated_at or now,
     )
 
 
@@ -79,6 +92,21 @@ def _run_service(
     )
     service.repository = repository
     return service, repository, cc_client, funding_validator
+
+
+async def _list_runs(
+    service: ConceptNoteRunService,
+    *,
+    user_id: str = "owner-1",
+    city_id: UUID | None = None,
+    authorization: str | None = "Bearer token",
+) -> ConceptNoteRunListResponse:
+    """List runs with the default authorized test scope."""
+    return await service.list_runs(
+        requested_user_id=user_id,
+        city_id=city_id or uuid4(),
+        authorization=authorization,
+    )
 
 
 async def test_start_run_creates_after_scope_and_reference_validation() -> None:
@@ -189,6 +217,218 @@ async def test_get_run_revalidates_city_access_owned_by_citycatalyst() -> None:
         token="token",
         user_id=payload.user_id,
     )
+
+
+async def test_list_runs_rejects_authenticated_user_mismatch() -> None:
+    """Reject a requested owner that differs from the bearer-token subject."""
+    service, repository, _, _ = _run_service(canonical_user_id="other-user")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _list_runs(service)
+
+    assert exc_info.value.status_code == 403
+    repository.list_for_user_city.assert_not_awaited()
+
+
+async def test_list_runs_maps_identity_outage_to_service_unavailable() -> None:
+    """Do not query runs when token identity cannot be validated."""
+    service, repository, cc_client, _ = _run_service()
+    cc_client.validate_user_identity.side_effect = CityCatalystClientError(
+        "CityCatalyst unavailable",
+        status_code=500,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _list_runs(service)
+
+    assert exc_info.value.status_code == 503
+    cc_client.get_city.assert_not_awaited()
+    repository.list_for_user_city.assert_not_awaited()
+
+
+async def test_list_runs_requires_bearer_token() -> None:
+    """Reject a list request without a CityCatalyst bearer token."""
+    service, repository, cc_client, _ = _run_service()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _list_runs(service, authorization=None)
+
+    assert exc_info.value.status_code == 401
+    cc_client.validate_user_identity.assert_not_awaited()
+    repository.list_for_user_city.assert_not_awaited()
+
+
+async def test_list_runs_revalidates_city_access_before_querying() -> None:
+    """Do not query persisted runs when current city access is revoked."""
+    service, repository, cc_client, _ = _run_service()
+    city_id = uuid4()
+    cc_client.get_city.side_effect = CityCatalystClientError(
+        "City access revoked",
+        status_code=403,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _list_runs(service, city_id=city_id)
+
+    assert exc_info.value.status_code == 403
+    repository.list_for_user_city.assert_not_awaited()
+
+
+async def test_list_runs_maps_city_authorization_outage_to_service_unavailable() -> None:
+    """Keep authorization integration failures distinct from access denial."""
+    service, repository, cc_client, _ = _run_service()
+    cc_client.get_city.side_effect = CityCatalystClientError(
+        "CityCatalyst unavailable",
+        status_code=500,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _list_runs(service)
+
+    assert exc_info.value.status_code == 503
+    repository.list_for_user_city.assert_not_awaited()
+
+
+async def test_list_runs_returns_stable_progress_and_resume_fields() -> None:
+    """Use persisted lifecycle and context summary in list and detail reads."""
+    payload = _start_request()
+    run = _persisted_run(
+        payload,
+        request_fingerprint=_request_fingerprint(payload),
+        status="paused",
+        workflow_step="interviewing",
+        context_summary={"ready_sources": 3},
+    )
+    service, repository, _, _ = _run_service()
+    repository.list_for_user_city.return_value = [run]
+    repository.get_for_user.return_value = run
+
+    listed = await _list_runs(
+        service,
+        user_id=payload.user_id,
+        city_id=payload.city_id,
+    )
+    detailed = await service.get_run(
+        run_id=run.run_id,
+        requested_user_id=payload.user_id,
+        authorization="Bearer token",
+    )
+
+    assert listed.runs[0].run_id == detailed.run_id == run.run_id
+    assert listed.runs[0].thread_id == detailed.thread_id
+    assert listed.runs[0].status == detailed.status == "paused"
+    assert listed.runs[0].workflow_step == detailed.workflow_step == "interviewing"
+    assert listed.runs[0].progress_summary == detailed.progress_summary == {
+        "ready_sources": 3
+    }
+
+
+async def test_list_runs_returns_empty_envelope() -> None:
+    """Represent an authorized city without runs as an empty stable list."""
+    service, repository, _, _ = _run_service()
+    repository.list_for_user_city.return_value = []
+    city_id = uuid4()
+
+    response = await _list_runs(service, city_id=city_id)
+
+    assert response.model_dump() == {"runs": []}
+
+
+async def test_list_runs_defaults_missing_context_summary() -> None:
+    """Expose an empty progress object when no context summary is persisted."""
+    payload = _start_request()
+    run = _persisted_run(
+        payload,
+        request_fingerprint=_request_fingerprint(payload),
+    )
+    run.context_summary = None
+    service, repository, _, _ = _run_service()
+    repository.list_for_user_city.return_value = [run]
+
+    response = await _list_runs(
+        service,
+        user_id=payload.user_id,
+        city_id=payload.city_id,
+    )
+
+    assert response.runs[0].progress_summary == {}
+
+
+async def test_repository_filters_and_orders_city_runs_deterministically() -> None:
+    """Filter by owner and city, then break timestamp ties with the run ID."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    session_factory: async_sessionmaker[AsyncSession] = async_sessionmaker(
+        engine,
+        expire_on_commit=False,
+    )
+    city_id = uuid4()
+    other_city_id = uuid4()
+    now = datetime.now(timezone.utc)
+    older = now - timedelta(hours=1)
+    low_tie_id = UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+    high_tie_id = UUID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(ConceptNoteRun.__table__.create)
+
+        owner_payload = _start_request(city_id=city_id)
+        other_user_payload = _start_request(user_id="other-user", city_id=city_id)
+        other_city_payload = _start_request(city_id=other_city_id)
+        runs = [
+            _persisted_run(
+                owner_payload,
+                request_fingerprint="a" * 64,
+                run_id=low_tie_id,
+                created_at=now,
+                updated_at=now,
+            ),
+            _persisted_run(
+                owner_payload.model_copy(update={"idempotency_key": uuid4()}),
+                request_fingerprint="b" * 64,
+                run_id=high_tie_id,
+                created_at=now,
+                updated_at=now,
+            ),
+            _persisted_run(
+                owner_payload.model_copy(update={"idempotency_key": uuid4()}),
+                request_fingerprint="c" * 64,
+                created_at=older,
+                updated_at=older,
+            ),
+            _persisted_run(
+                other_user_payload,
+                request_fingerprint="d" * 64,
+                updated_at=now + timedelta(hours=1),
+            ),
+            _persisted_run(
+                other_city_payload,
+                request_fingerprint="e" * 64,
+                updated_at=now + timedelta(hours=1),
+            ),
+        ]
+
+        async with session_factory() as session:
+            session.add_all(runs)
+            await session.commit()
+            repository = ConceptNoteRunRepository(session)
+
+            result = await repository.list_for_user_city(
+                user_id="owner-1",
+                city_id=str(city_id),
+            )
+
+        assert [run.run_id for run in result] == [
+            high_tie_id,
+            low_tie_id,
+            runs[2].run_id,
+        ]
+    finally:
+        await engine.dispose()
 
 
 async def test_thread_ownership_rejects_missing_and_wrong_user_threads() -> None:

--- a/climate-advisor/service/tests/test_concept_note_upload_repository.py
+++ b/climate-advisor/service/tests/test_concept_note_upload_repository.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
-from uuid import uuid4
+from datetime import datetime
+from uuid import UUID, uuid4
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 from app.db import Base
 from app.models.concept_note_markdown import (
@@ -15,6 +20,29 @@ from app.persistence.concept_notes.markdown import (
     ConceptNoteMarkdownRepositoryError,
     SqlAlchemyConceptNoteMarkdownRepository,
 )
+
+
+async def _set_run_updated_at(
+    session_factory: async_sessionmaker[AsyncSession],
+    run_id: UUID,
+    value: datetime,
+) -> None:
+    """Set a stable timestamp before exercising one lifecycle transition."""
+    async with session_factory() as session, session.begin():
+        run = await session.get(ConceptNoteRun, run_id)
+        assert run is not None
+        run.updated_at = value
+
+
+async def _get_run_updated_at(
+    session_factory: async_sessionmaker[AsyncSession],
+    run_id: UUID,
+) -> datetime:
+    """Read the parent run activity timestamp."""
+    async with session_factory() as session:
+        run = await session.get(ConceptNoteRun, run_id)
+        assert run is not None
+        return run.updated_at
 
 
 @pytest.mark.asyncio
@@ -38,6 +66,7 @@ async def test_repository_persists_nullable_then_immutable_pointer(
         session_factory = async_sessionmaker(engine, expire_on_commit=False)
         run_id = uuid4()
         upload_id = uuid4()
+        inactive_at = datetime(2020, 1, 1)
         async with session_factory() as session, session.begin():
             session.add(
                 ConceptNoteRun(
@@ -49,6 +78,7 @@ async def test_repository_persists_nullable_then_immutable_pointer(
                     request_fingerprint="a" * 64,
                     context_summary={},
                     permission_summary={},
+                    updated_at=inactive_at,
                 )
             )
 
@@ -67,6 +97,26 @@ async def test_repository_persists_nullable_then_immutable_pointer(
         assert created.markdown_s3_key is None
         assert created.markdown_sha256 is None
         assert created.page_count is None
+        assert await _get_run_updated_at(session_factory, run_id) != inactive_at
+
+        await _set_run_updated_at(session_factory, run_id, inactive_at)
+        failed = await repository.mark_failed(
+            user_id="owner-user",
+            run_id=run_id,
+            upload_id=upload_id,
+            error_code="ocr_failed",
+        )
+        assert failed.status == "failed"
+        assert await _get_run_updated_at(session_factory, run_id) != inactive_at
+
+        await _set_run_updated_at(session_factory, run_id, inactive_at)
+        retried = await repository.retry_upload(
+            user_id="owner-user",
+            run_id=run_id,
+            upload_id=upload_id,
+        )
+        assert retried.status == "queued"
+        assert await _get_run_updated_at(session_factory, run_id) != inactive_at
 
         pointer = ConceptNoteMarkdownRequest(
             markdown_s3_key="pdf-ocr/results/result.md",
@@ -75,6 +125,7 @@ async def test_repository_persists_nullable_then_immutable_pointer(
             page_count=3,
             sha256="b" * 64,
         )
+        await _set_run_updated_at(session_factory, run_id, inactive_at)
         ready = await repository.register_markdown(
             user_id="owner-user",
             run_id=run_id,
@@ -89,6 +140,7 @@ async def test_repository_persists_nullable_then_immutable_pointer(
         )
         assert ready.status == replayed.status == "ready"
         assert ready.markdown_s3_key == pointer.markdown_s3_key
+        assert await _get_run_updated_at(session_factory, run_id) != inactive_at
 
         with pytest.raises(ConceptNoteMarkdownRepositoryError) as conflict:
             await repository.register_markdown(


### PR DESCRIPTION
## Stack

This PR is layer 1 of the CC-606 native stack and now contains only the Climate Advisor run-list contract and its direct tests.

- #2974 — Climate Advisor run listing (this PR)
- #2977 — CityCatalyst wiring foundation
- #2978 — Concept Notes dashboard

The original combined-PR context is preserved below; its summary and test notes describe the complete stack.

---

## Summary

Adds the authorized Concept Note Builder run-list flow from Climate Advisor through CityCatalyst, plus the first Figma-derived dashboard screen for reviewing and resuming a city's runs.

## Changes

- add owner- and city-scoped Climate Advisor run listing with deterministic newest-first ordering and persisted lifecycle/progress fields
- add the authenticated CityCatalyst proxy, upstream contract validation, and RTK Query integration
- implement the Concept Notes dashboard with loading, error, empty, context, and run-card states
- include the existing Concept Note upload wiring harness from this branch
- add regression coverage and update Concept Note Builder runtime documentation

## How to test

1. Run `cd climate-advisor && ./.venv/Scripts/python.exe -m pytest service/tests/test_concept_note_runs.py -q`.
2. Run `cd app && npm run jest -- --runTestsByPath tests/concept-note-dashboard-utils.jest.ts tests/concept-note-runs.jest.ts --coverage=false`.
3. Run `cd app && npx tsc --noEmit`.
4. Open `/{lng}/cities/{cityId}/concept-notes` as a user authorized for that city.

## Ticket

CC-606

## Notes

- No database migration is required.
- Dashboard progress is derived only from persisted backend state; it does not infer percentages or counts.
- Targeted tests pass: 15 Climate Advisor tests and 14 CityCatalyst Jest tests. TypeScript compilation also passes.
- The repository's ESLint invocation is currently blocked before file linting by an ESLint 10 / `react/display-name` compatibility error: `contextOrFilename.getFilename is not a function`.

Recorded with sample data 


https://github.com/user-attachments/assets/9ec11779-3ed2-4c81-89e6-fbbaf7650229

