### PR TITLE
fix: adds filter to prvent duplicate list of organizations

### DIFF
--- a/app/src/components/navigation-bar.tsx
+++ b/app/src/components/navigation-bar.tsx
@@ -240,78 +240,75 @@ export function NavigationBar({
         {/* Menu Items */}
         <Box display="flex" gap="48px" alignItems="center">
           {children}
-          <Box display="flex">
-            <Box display="flex">
-              <MenuRoot
-                onOpenChange={(details) => {
-                  setLanguageMenuOpen(details.open);
-                }}
-                open={isLanguageMenuOpen}
-                variant="solid"
-              >
-                <MenuTrigger asChild>
-                  <Button
-                    color="base.light"
-                    minW="120px"
-                    minH="48px"
-                    variant="ghost"
-                    textTransform="none"
-                    whiteSpace="nowrap"
+          <Box display="flex" gap="32px">
+            <MenuRoot
+              onOpenChange={(details) => {
+                setLanguageMenuOpen(details.open);
+              }}
+              open={isLanguageMenuOpen}
+              variant="solid"
+            >
+              <MenuTrigger asChild>
+                <Button
+                  color="base.light"
+                  minW="auto"
+                  minH="48px"
+                  variant="ghost"
+                  textTransform="none"
+                  whiteSpace="nowrap"
+                  justifyContent="space-between"
+                  px="8px"
+                  gap="16px"
+                >
+                  <Box display="flex" alignItems="center" gap="3">
+                    <CircleFlag
+                      countryCode={
+                        countryFromLanguage(i18next.language) === "pt"
+                          ? "br"
+                          : countryFromLanguage(i18next.language)
+                      }
+                      width="24"
+                    />
+
+                    <Text
+                      fontSize="title.sm"
+                      fontWeight="medium"
+                      letterSpacing="wide"
+                      lineHeight="20"
+                    >
+                      {i18next.language.toUpperCase()}
+                    </Text>
+
+                    <Icon
+                      as={isLanguageMenuOpen ? MdArrowDropUp : MdArrowDropDown}
+                      boxSize={6}
+                    />
+                  </Box>
+                </Button>
+              </MenuTrigger>
+              <MenuContent minW="140px" zIndex={2000}>
+                {languages.map((language) => (
+                  <MenuItem
+                    value={language}
+                    onClick={() => onChangeLanguage(language)}
+                    key={language}
                   >
-                    <Box display="flex" alignItems="center" gap="3">
+                    <Box display="flex" alignItems="center">
                       <CircleFlag
                         countryCode={
-                          countryFromLanguage(i18next.language) === "pt"
+                          countryFromLanguage(language) === "pt"
                             ? "br"
-                            : countryFromLanguage(i18next.language)
+                            : countryFromLanguage(language)
                         }
                         width="24"
+                        style={{ marginRight: "16px" }}
                       />
-
-                      <Text
-                        fontSize="title.sm"
-                        fontWeight="medium"
-                        letterSpacing="wide"
-                        lineHeight="20"
-                      >
-                        {i18next.language.toUpperCase()}
-                      </Text>
-
-                      <Icon
-                        as={
-                          isLanguageMenuOpen ? MdArrowDropUp : MdArrowDropDown
-                        }
-                        boxSize={6}
-                      />
+                      <Text fontSize="title.md">{language.toUpperCase()}</Text>
                     </Box>
-                  </Button>
-                </MenuTrigger>
-                <MenuContent minW="140px" zIndex={2000}>
-                  {languages.map((language) => (
-                    <MenuItem
-                      value={language}
-                      onClick={() => onChangeLanguage(language)}
-                      key={language}
-                    >
-                      <Box display="flex" alignItems="center">
-                        <CircleFlag
-                          countryCode={
-                            countryFromLanguage(language) === "pt"
-                              ? "br"
-                              : countryFromLanguage(language)
-                          }
-                          width="24"
-                          style={{ marginRight: "16px" }}
-                        />
-                        <Text fontSize="title.md">
-                          {language.toUpperCase()}
-                        </Text>
-                      </Box>
-                    </MenuItem>
-                  ))}
-                </MenuContent>
-              </MenuRoot>
-            </Box>
+                  </MenuItem>
+                ))}
+              </MenuContent>
+            </MenuRoot>
             {organizations && organizations.length > 1 && (
               <Box display="flex">
                 <MenuRoot
@@ -324,75 +321,87 @@ export function NavigationBar({
                   <MenuTrigger asChild>
                     <Button
                       color="base.light"
-                      minW="160px"
+                      minW="auto"
                       minH="48px"
                       variant="ghost"
                       textTransform="none"
                       whiteSpace="nowrap"
+                      px="8px"
+                      justifyContent="space-between"
+                      gap="16px"
                     >
-                      <Box display="flex" alignItems="center" gap="3">
-                        <Box
-                          display="flex"
-                          alignItems="center"
-                          justifyContent="center"
-                          boxSize="32px"
-                          borderRadius="full"
-                          bg="interactive.connected"
-                          color="base.light"
-                        >
-                          <Icon as={MdCardTravel} boxSize={4} />
-                        </Box>
-                        <Text
-                          maxW="140px"
-                          overflow="hidden"
-                          textOverflow="ellipsis"
-                          whiteSpace="nowrap"
-                          fontSize="title.sm"
-                          fontWeight="medium"
-                          letterSpacing="wide"
-                          lineHeight="20"
-                        >
-                          {currentOrganizationName}
-                        </Text>
-                        <Icon
-                          as={isOrgMenuOpen ? MdArrowDropUp : MdArrowDropDown}
-                          boxSize={6}
-                        />
+                      <Box
+                        display="flex"
+                        alignItems="center"
+                        justifyContent="center"
+                        boxSize="32px"
+                        borderRadius="full"
+                        bg="interactive.connected"
+                        color="base.light"
+                      >
+                        <Icon as={MdCardTravel} boxSize={4} />
                       </Box>
+                      <Text
+                        maxW="140px"
+                        overflow="hidden"
+                        textOverflow="ellipsis"
+                        whiteSpace="nowrap"
+                        fontSize="title.sm"
+                        fontWeight="medium"
+                        letterSpacing="wide"
+                        lineHeight="20"
+                      >
+                        {currentOrganizationName}
+                      </Text>
+                      <Icon
+                        as={isOrgMenuOpen ? MdArrowDropUp : MdArrowDropDown}
+                        boxSize={6}
+                      />
                     </Button>
                   </MenuTrigger>
                   <MenuContent minW="220px" zIndex={2000}>
-                    {organizations.map((org) => (
-                      <MenuItem
-                        value={org.organizationId}
-                        onClick={() => onChangeOrganization(org.organizationId)}
-                        key={org.organizationId}
-                      >
-                        <Box
-                          display="flex"
-                          alignItems="center"
-                          justifyContent="space-between"
-                          w="full"
+                    {/* only show unique organizations and not duplicates */}
+                    {organizations
+                      .filter(
+                        (org, index, self) =>
+                          index ===
+                          self.findIndex(
+                            (t) => t.organizationId === org.organizationId,
+                          ),
+                      )
+                      .map((org) => (
+                        <MenuItem
+                          value={org.organizationId}
+                          onClick={() =>
+                            onChangeOrganization(org.organizationId)
+                          }
+                          key={org.organizationId}
                         >
-                          <Text
-                            fontSize="title.md"
-                            overflow="hidden"
-                            textOverflow="ellipsis"
-                            whiteSpace="nowrap"
+                          <Box
+                            display="flex"
+                            alignItems="center"
+                            justifyContent="space-between"
+                            w="full"
                           >
-                            {org.name}
-                          </Text>
-                          {org.organizationId ===
-                            organization?.organizationId && (
-                            <Icon
-                              as={MdCheck}
-                              boxSize={5}
-                              color="interactive.secondary"
-                            />
-                          )}
-                        </Box>
-                      </MenuItem>
-                    ))}
+                            <Text
+                              fontSize="title.md"
+                              overflow="hidden"
+                              textOverflow="ellipsis"
+                              whiteSpace="nowrap"
+                            >
+                              {org.name}
+                            </Text>
+                            {org.organizationId ===
+                              organization?.organizationId && (
+                              <Icon
+                                as={MdCheck}
+                                boxSize={5}
+                                color="interactive.secondary"
+                              />
+                            )}
+                          </Box>
+                        </MenuItem>
+                      ))}
                   </MenuContent>
                 </MenuRoot>
               </Box>
@@ -409,13 +418,8 @@ export function NavigationBar({
                     setUserMenuHighlight(value.highlightedValue)
                   }
                 >
-                  <MenuTrigger
-                    asChild
-                    whiteSpace="nowrap"
-                    textTransform="none"
-                    ml={8}
-                  >
-                    <Button variant="ghost" p="s" minW="220px" minH="48px">
+                  <MenuTrigger asChild whiteSpace="nowrap" textTransform="none">
+                    <Button variant="ghost" px="8px" minW="220px" minH="48px">
                       <Box display="flex" alignItems="center" gap="4">
                         <Avatar
                           height="32px"
@@ -580,9 +584,8 @@ export function NavigationBar({
               i18nKey="account-frozen-warning-text"
               values={{
                 email:
-                  env("NEXT_PUBLIC_SUPPORT_EMAILS")?.split(",").join(
-                    " or ",
-                  ) || "info@openearth.org",
+                  env("NEXT_PUBLIC_SUPPORT_EMAILS")?.split(",").join(" or ") ||
+                  "info@openearth.org",
               }}
               t={t}
               components={{


### PR DESCRIPTION
## Summary

Tightens spacing and sizing in the top navigation bar so language, organization, and user menus align more cleanly with the design system. Also deduplicates organizations in the org switcher.

## Changes

- Reduce fixed min-widths on language/org triggers (`minW="auto"`) and align padding/`gap` between menu controls
- Group language + org menus with a consistent `32px` gap; remove extra nesting and user-menu left margin
- Deduplicate orgs in the org dropdown by `organizationId` so the same org does not appear twice

## How to test

1. Open any authenticated page with the main nav.
2. Confirm language, organization (if multi-org), and user avatar menus look evenly spaced without oversized empty trigger width.
3. With an account that returns duplicate org entries, open the org menu and confirm each org appears once.
4. Switch language and organization; confirm behavior is unchanged.

## Ticket

[CC-654](https://linear.app/openearth/issue/CC-654/fix-navigation-bar-spacing-and-organization-selector-ui-issues)