### PR TITLE
CC-610: Fix empty State Name column on Projects page

### DIFF
--- a/app/src/backend/UserService.ts
+++ b/app/src/backend/UserService.ts
@@ -573,7 +573,7 @@ export default class UserService {
         {
           model: db.models.City,
           as: "cities",
-          attributes: ["cityId", "name", "countryLocode", "country"],
+          attributes: ["cityId", "name", "countryLocode", "country", "region"],
           include: [
             {
               model: db.models.Inventory,
@@ -600,7 +600,7 @@ export default class UserService {
           {
             model: db.models.City,
             as: "cities",
-            attributes: ["cityId", "name", "countryLocode", "country"],
+            attributes: ["cityId", "name", "countryLocode", "country", "region"],
             include: [
               {
                 model: db.models.Inventory,
@@ -621,7 +621,14 @@ export default class UserService {
       include: {
         model: db.models.City,
         as: "city",
-        attributes: ["cityId", "name", "countryLocode", "country", "locode"],
+        attributes: [
+          "cityId",
+          "name",
+          "countryLocode",
+          "country",
+          "locode",
+          "region",
+        ],
         include: [
           {
             model: db.models.Project,
@@ -690,6 +697,7 @@ export default class UserService {
           country: city.country as string,
           countryLocode: city.countryLocode as string,
           locode: city.locode as string,
+          region: city.region as string,
         })),
       };
     }
@@ -722,6 +730,7 @@ export default class UserService {
           country: city.country as string,
           countryLocode: city.countryLocode as string,
           locode: city.locode as string,
+          region: city.region as string,
         });
       }
     }


### PR DESCRIPTION
## Summary

The Projects page "State Name" column was always empty because the backend never fetched or returned the `region` field for cities.

## Changes

- Add `region` to the City attribute allowlists in `UserService.findAllProjectForAdminAndOwner`, `findAllProjectForProjectAdmin`, and `findAllProjectForCollaborators`
- Include `region` in the two manually mapped city response objects in `findUserProjectsAndCitiesInOrganization`

## How to test

1. Open a project's detail page (`/organization/{id}/project/{project}`) for a project whose cities have a `region` value set.
2. Confirm the "State Name" column in the cities table now shows the region instead of being blank.

## Ticket

CC-610
