### PR TITLE
docs(meed): integration status and reference-data contract analysis

### DIFF
--- a/docs/MeedIntegrationStatus.md
+++ b/docs/MeedIntegrationStatus.md
@@ -115,9 +115,9 @@ Plus mechanical migration work: snake_case renames, `meta.total` → `meta.total
 
 ---
 
-## Deploy plumbing (Mirco / Piotr)
+## Deploy plumbing
 
-Both are plain repo edits with no secrets. All three hiap-meed service names are confirmed from `hiap-meed/k8s/service-*.yml`, so the exact values are known — what is needed is review and agreement, not investigation.
+Both are plain repo edits with no secrets, set in the GitHub workflows so a dev redeploy picks them up. The three hiap-meed service names below are **confirmed by the hiap-meed author** and match `hiap-meed/k8s/service-*.yml`.
 
 **1. `HIAP_MEED_API_URL` does not exist.** `HIAP_API_URL` is not in `k8s/cc-web-deploy.yml` — it is set at deploy time by `kubectl set env`:
 
@@ -131,6 +131,8 @@ Both are plain repo edits with no secrets. All three hiap-meed service names are
 Service names verified from `hiap-meed/k8s/service-{dev,test,prod}.yml` — all `ClusterIP` on port 80 → container 8000, no ingress, so they resolve only from inside the cluster.
 
 **2. `MEED_MODULE` is not in dev's flags.** `NEXT_PUBLIC_FEATURE_FLAGS` appears three times in `web-develop.yml` (lines 41, 88, 483) — build-time and runtime. All three need it.
+
+Whether the module should be flag-gated at all is a product decision, not a technical constraint. What is factual: the module *is* gated today. `HomePage.tsx:293` filters `Modules.MEED.id` out of the tool accordion unless `MEED_MODULE` is present, so without the flag the module is invisible on dev — reachable only by typing the URL, and then only if the project has been granted the module. Removing the gate instead of setting the flag is equally valid; it just has to be a decision rather than an oversight.
 
 **Both are safe to land ahead of us.** On `develop` today the module has zero files and `MEED_MODULE` is not a defined flag, so the flag string is inert and the env var unused. There is no ordering dependency in either direction.
 

--- a/docs/MeedIntegrationStatus.md
+++ b/docs/MeedIntegrationStatus.md
@@ -16,6 +16,8 @@ What remains splits cleanly into two piles that do **not** block each other.
 
 **Module delivery — our sequencing choice.** PR #2956 is held in draft **deliberately**, so that what reaches dev does something real rather than being a flag-gated shell. That is a product decision, not a blocker awaiting anyone.
 
+**One open question**, set out at the end of this document. `hiap-meed-service-dev` is `ClusterIP` with no ingress, so `HIAP_MEED_API_URL` can only be exercised from inside the cluster — the first genuine test of the connection therefore has to happen on dev, after something is merged. Whether that is a small connectivity-only change first or a single merge of the whole module is a deploy-pipeline decision, not a frontend one.
+
 ---
 
 ## Architecture, briefly
@@ -112,7 +114,7 @@ Service names verified from `hiap-meed/k8s/service-{dev,test,prod}.yml` — all 
 
 **3. No client, no routes.** Nothing calls hiap-meed. Needs `MeedApiService.ts`, modelled on `backend/hiap/HiapApiService.ts`. This is the half of item 1 that is ours — the workflow supplies the value, our code has to read it.
 
-**4. PR #2956 is held in draft deliberately**, so that what reaches dev does something real rather than being a flag-gated shell. Not a blocker awaiting review — a sequencing choice.
+**4. PR #2956 is held in draft deliberately**, so that what reaches dev does something real rather than being a flag-gated shell. Not a blocker awaiting review — a sequencing choice. See *Open decision* below.
 
 ### Making connectivity verifiable
 
@@ -122,7 +124,7 @@ hiap-meed exposes `GET /health` → `{"status":"healthy"}`. A diagnostic proxy r
 GET /api/v1/city/{city}/modules/meed/health → { url, status, latencyMs }
 ```
 
-turns "is this connected?" into one URL in a browser — no UI walk, no waiting on a 60-second prioritize call to discover an env var was missing. It separates *is the network wired* from *is the payload right*, which otherwise get conflated in-cluster. Pair it with logging the resolved URL at module load (the `HiapService.ts:30` precedent).
+would answer "is this connected?" from one URL, separating *is the network wired* from *is the payload right* — two failures that are otherwise indistinguishable from inside the cluster. Logging the resolved `HIAP_MEED_API_URL` at module load (the `HiapService.ts:30` precedent) serves the same purpose. Whether this is worth a separate merge is the open decision below.
 
 ---
 
@@ -140,13 +142,29 @@ Note: **prioritize does not depend on #2982.** The hiap-meed pod fetches its own
 
 ---
 
-## Sequencing
+## Open decision: how to sequence the first deployment
 
-1. **Wiring PR** — env var (4 files), `MEED_MODULE` in dev flags, `MeedApiService` skeleton, health route. Nothing user-facing, independent of #2982, mergeable immediately. Proves the pod reaches hiap-meed before any real integration exists.
-2. **#2956 merges when the integration is real** — deliberately held so that dev gets a working module, not a shell. Worth noting the cost of holding: 109 files diverging from `develop`, and the reference-data migration adds more. The wiring PR above is the hedge — it puts something concrete and provable on dev without merging the module.
-3. **Prioritize POST** — kills the mock and lights up regulations, processing and results.
-4. **Reference-data migration** — 5 incremental PRs once #2982 is deployed. Carries frontend bugs 1–8.
-5. **Reports** — measure, then decide.
+`HIAP_MEED_API_URL` cannot be verified from a laptop. `hiap-meed-service-dev` is `ClusterIP` with no ingress, so it resolves only from inside the cluster — meaning the first genuine test of the connection can only happen on dev, after something is merged.
+
+#2956 is held in draft so that what reaches dev is a working module rather than a flag-gated shell. That leaves an ordering question:
+
+**Option A — connectivity first.** Merge a small, non-UI change that adds `MeedApiService` and a diagnostic route, so the connection can be confirmed on dev before the module lands. The module PR follows once the wiring is proven.
+
+- Confirms `HIAP_MEED_API_URL` resolves and the pod reaches the service, independently of whether any payload is correct
+- Two merges instead of one; adds code to `develop` that no user-facing feature consumes yet
+
+**Option B — single merge.** Add the deploy values and merge #2956 together, and verify the connection at that point.
+
+- One merge, one review cycle
+- If `HIAP_MEED_API_URL` is wrong or the service is unreachable, that surfaces at the same moment as everything else, against a 109-file change
+
+The trade-off is diagnostic isolation versus merge count. Either works; the choice belongs to whoever owns the deploy pipeline.
+
+## Sequencing after that
+
+1. **Prioritize POST** — replaces the mock and lights up regulations, processing and results.
+2. **Reference-data migration** — 5 incremental PRs once #2982 is deployed. Carries frontend bugs 1–8.
+3. **Reports** — measure, then decide.
 
 Frontend bugs 1–4 are visible and independent of the migration; they can be pulled forward cheaply if a demo is imminent.
 

--- a/docs/MeedIntegrationStatus.md
+++ b/docs/MeedIntegrationStatus.md
@@ -1,0 +1,146 @@
+# Actions & Plans v2 (MEED): integration status
+
+Where the module stands, what is owed by whom, and what is needed to test on dev.
+
+Companions: [`MeedReferenceDataContractDiff.md`](./MeedReferenceDataContractDiff.md) — the field-by-field contract analysis and its resolution — and `MeedModuleImplementation.md`, which documents what was built and lands with [PR #2956](https://github.com/Open-Earth-Foundation/CityCatalyst/pull/2956) (not yet on `develop`).
+
+---
+
+## Summary
+
+The backend contract is **functionally complete**. [PR #2982](https://github.com/Open-Earth-Foundation/CityCatalyst/pull/2982) is approved and merge-clean, and 6 of the 7 gaps we raised were closed in full; the seventh was declined with sound reasoning. Every field the module renders now has a source.
+
+**The critical path is now the frontend.** Three things block a dev test, none of them large:
+
+1. `HIAP_MEED_API_URL` does not exist anywhere in the repo
+2. `MEED_MODULE` is not in dev's `NEXT_PUBLIC_FEATURE_FLAGS`
+3. PR #2956 is still a draft — dev deploys from `develop`, so none of our code reaches dev until it merges
+
+---
+
+## Architecture, briefly
+
+**78 files:** 72 under `app/src/app/[lng]/cities/[cityId]/MEED/`, plus 5 proxy routes, 1 backend service, and a 177-line contract file.
+
+```
+MEED/
+├── layout.tsx + MEEDClientLayout.tsx   page metadata + module access gate
+├── page.tsx                            redirects to the newest inventory
+├── (8 logic files)                     steps · navigation · status · gate · state
+├── components/          14 files       shared chrome + primitives
+└── [inventory]/         46 files       11 screens
+```
+
+**The spine.** `steps.ts` is the canonical 7-step list with ranking weights (emissions 55, context 23, regulations 23, preferences 22, policy 22 optional, finance 23), and it drives the stepper, hub cards and pre-flight from one place. `meedGate.ts` is the single `computeMeedGate()`. `navigation.ts` owns the `?from=` return contract. `useMeedRanking.ts` is the single read point for "does a ranking exist".
+
+**Primitives.** 14 components, all thin data-mapping layers over existing Chakra/CityCatalyst components — no new visual language was invented.
+
+**Data layer.** 5 RTK endpoints (tag `Meed`) → 5 proxy routes → `MeedGlobalApiService` → Global API. Auth is enforced **only** in the proxy routes via `UserService.findUserCity(cityId, context.session)`; the browser never touches the Global API. That is the deliberate change from the prototype, which made 16 direct browser calls upstream.
+
+**State.** Entirely client-side today, keyed `meed:{inventoryId}:*` (`preferences`, `exclusions`, `step:{key}`, `ranking`). No MEED database tables. Two invariants to preserve when this moves server-side: **`confirmed` never regresses** (a data refresh must not undo a human acknowledgement), and **rankings are fingerprinted against their inputs**, so the UI can say "your answers changed since this was generated" rather than silently serving a stale list.
+
+**Navigation.** A graph, not a line — every step is reachable from hub cards, stepper, breadcrumb or URL. `?from=` means editing a step from pre-flight returns you to pre-flight. Only the final generate action is gated, and the gate always explains itself next to the disabled button.
+
+### Real vs. mock today
+
+| Live upstream | CityCatalyst data | Input / derived | Not yet real |
+|---|---|---|---|
+| context, policy, finance | emissions (GHGI cross-read), hub | preferences, pre-flight | regulations *(precondition)*, processing *(8s animation)*, results *(empty, or mock behind a flag)* |
+
+**6 of 11 screens already render live data.** The three that do not are exactly the three that need the prioritizer.
+
+---
+
+## Owed by the backend
+
+All minor; none blocking.
+
+| # | Ask | Why it matters |
+|---|---|---|
+| 1 | **Structured `warnings`** — `{code, params}` instead of English prose | The module ships in 5 languages and cannot translate the current strings. The only outstanding item with user-visible impact |
+| 2 | **`datasource` / `version_label` on `CityIndicatorResponse`** | `INDICATOR_META` hardcodes citations like `"ENDISC 2015"` that live data contradicts (`cl-ine-censo` / `2024`). Without the field we should drop the Source column rather than show a wrong citation |
+| 3 | **Documented vocabulary for `policy_support_category`** | Until then the field goes unused and we keep our own thresholds |
+
+**Declined, and reasonably:** the 5-project / 5+5-opportunity caps mirror the evidence selection plan generation uses. We adapt the copy — `n_reachable_opportunities` reports 30 where we show 5, so the UI must read "5 of 30 shown" rather than silently contradict itself.
+
+**Correction we owe:** an earlier version of the contract diff credited the migration with uncapped policy evidence. That was wrong — the upstream default is already 5 per action and hiap-meed does not pass `top_evidence_limit`. The document has been corrected.
+
+---
+
+## Owed by the frontend
+
+All verified against live upstream data. These are **pre-existing bugs, not migration costs.**
+
+| # | Bug | Impact | Where |
+|---|---|---|---|
+| 1 | **Every action shows "Cross-sector"** — we read a `sector` key that exists on 0 of 102 actions | Whole Sector column, every top-pick card, every detail panel | `results/components/actionCatalog.ts:63` |
+| 2 | **Project costs 1000× too high** — `amount_unit` is `CLP_thousands` on 500/500 projects; we assume millions | Every project card | `finance/labels.ts:223` |
+| 3 | **15% of actions show "Unknown route"** — no branch for `"needs technical assistance"` | Finance table and filter chips | `finance/labels.ts:48` |
+| 4 | **Chilean cities described wrongly** — `profile` is `"Support-ready"` on 102/102, no branch | City profile card | `finance/labels.ts:126` |
+| 5 | **Unknown-scope policy evidence counted as National** | Latent today; the new `scope` is nullable | `policy/policyAggregates.ts` |
+| 6 | **Null-score rows silently dropped** — finance and policy both filter on `typeof === "number"` | Latent; the new contract returns nulls explicitly | `finance/types.ts`, `policy/policyRows.ts` |
+| 7 | **Error cards have never rendered** — `MeedGlobalApiService` swallows every failure to `null` | "Broken" is indistinguishable from "no data" | `backend/meed/MeedGlobalApiService.ts` |
+| 8 | **`warnings[]` never surfaced** | We cannot tell a user their data is partial | all screens |
+| 9 | **Access gate does not withhold render** — `useModuleAccessLayout` only blocks when an `inventory` param is present; the MEED layout has only `{lng, cityId}` | Children render, then redirect asynchronously | `MEEDClientLayout.tsx` |
+| 10 | **`MEED_MODULE` hides the tile, not the routes** — a direct URL still loads, subject only to module access | Worth a deliberate decision | `HomePage.tsx:293` |
+| 11 | **All 5 endpoints typed `unknown`** with casts at the use site | ~150 lines of hand-rolled narrowing, no schema safety | `services/api.ts:209-238` |
+
+Plus mechanical migration work: snake_case renames, `meta.total` → `meta.total_records`, projects array is `projects[]` not `data[]`, a two-group opportunities layout, and **omit `?language=`** — it validates against `("en","es")` only, so `?language=pt` returns 422, while omitting it returns all localizations including `pt`. That is the only route to Portuguese action names.
+
+---
+
+## Wiring needed to test on dev
+
+**1. `HIAP_MEED_API_URL` does not exist.** `HIAP_API_URL` is not in `k8s/cc-web-deploy.yml` — it is set at deploy time by `kubectl set env`:
+
+- `.github/workflows/web-develop.yml:479` → add `"HIAP_MEED_API_URL=http://hiap-meed-service-dev" \`
+- `web-test.yml:259` and `web-tag.yml:242` → same, with the test/prod service names
+- `app/env.example` beside line 65 → `HIAP_MEED_API_URL="http://localhost:8000"`
+
+**2. `MEED_MODULE` is not in dev's flags.** `NEXT_PUBLIC_FEATURE_FLAGS` appears three times in `web-develop.yml` (lines 41, 88, 483) — build-time and runtime. All three need it.
+
+**3. No client, no routes.** Nothing calls hiap-meed. Needs `MeedApiService.ts`, modelled on `backend/hiap/HiapApiService.ts`.
+
+**4. PR #2956 is a draft.** Safe to merge — everything sits behind `MEED_MODULE`, which is off in dev's flag list — but nothing of ours reaches dev until it does.
+
+### Making connectivity verifiable
+
+hiap-meed exposes `GET /health` → `{"status":"healthy"}`. A diagnostic proxy route:
+
+```
+GET /api/v1/city/{city}/modules/meed/health → { url, status, latencyMs }
+```
+
+turns "is this connected?" into one URL in a browser — no UI walk, no waiting on a 60-second prioritize call to discover an env var was missing. It separates *is the network wired* from *is the payload right*, which otherwise get conflated in-cluster. Pair it with logging the resolved URL at module load (the `HiapService.ts:30` precedent).
+
+---
+
+## Endpoint status
+
+| Endpoint | Status |
+|---|---|
+| 7 reference-data GETs | Contract complete, #2982 approved, not deployed. 5 replace existing proxies, 2 are new (opportunities, projects), 1 unused (mitigation-feasibility) |
+| `POST /v1/prioritize` | Contract stable, types already in `util/types/meed.ts`, **not wired** |
+| `POST /v1/prioritize/exclusions/preview` | Not wired. Feeds pre-flight's confirmed-exclusions card, which today nothing ever writes to |
+| `POST /v1/reports/output-plan` | Not wired. Sync vs. async to be decided by measurement, not assumption |
+| `POST /v1/explanations/translate` | Not wired; fallback path only |
+
+Note: **prioritize does not depend on #2982.** The hiap-meed pod fetches its own reference data, so the ranking can be wired while the GETs are still in review.
+
+---
+
+## Sequencing
+
+1. **Wiring PR** — env var (4 files), `MEED_MODULE` in dev flags, `MeedApiService` skeleton, health route. Nothing user-facing, independent of #2982, mergeable immediately. Proves the pod reaches hiap-meed before any real integration exists.
+2. **Get #2956 reviewed and merged.** 109 files; review lead time likely exceeds any of the code above, and everything queues behind it.
+3. **Prioritize POST** — kills the mock and lights up regulations, processing and results.
+4. **Reference-data migration** — 5 incremental PRs once #2982 is deployed. Carries frontend bugs 1–8.
+5. **Reports** — measure, then decide.
+
+Frontend bugs 1–4 are visible and independent of the migration; they can be pulled forward cheaply if a demo is imminent.
+
+## Verification
+
+- **Wiring:** hit the health route on dev; expect `{status:"healthy"}` and the resolved in-cluster URL in the pod logs.
+- **Locally, without cluster access:** `cd hiap-meed && docker compose up` (port 8000, real upstream), then `HIAP_MEED_API_URL=http://localhost:8000`. Use `CL ANT` (attributes + policy + finance + opportunities) and `BR SAO` (policy + finance; no attributes upstream).
+- **Regression:** `npx tsc --noEmit`, `npm run build`, and one load of a non-MEED city page with the flag off.

--- a/docs/MeedIntegrationStatus.md
+++ b/docs/MeedIntegrationStatus.md
@@ -146,19 +146,26 @@ Note: **prioritize does not depend on #2982.** The hiap-meed pod fetches its own
 
 `HIAP_MEED_API_URL` cannot be verified from a laptop. `hiap-meed-service-dev` is `ClusterIP` with no ingress, so it resolves only from inside the cluster — meaning the first genuine test of the connection can only happen on dev, after something is merged.
 
-#2956 is held in draft so that what reaches dev is a working module rather than a flag-gated shell. That leaves an ordering question:
+#2956 is held in draft so that what reaches dev is a working module rather than a flag-gated shell. That leaves an ordering question — and the answer is not constrained to all-or-nothing.
 
-**Option A — connectivity first.** Merge a small, non-UI change that adds `MeedApiService` and a diagnostic route, so the connection can be confirmed on dev before the module lands. The module PR follows once the wiring is proven.
+**#2956 is not a monolith.** It is 14 commits along deliberate seams, several of which stand alone:
 
-- Confirms `HIAP_MEED_API_URL` resolves and the pod reaches the service, independently of whether any payload is correct
-- Two merges instead of one; adds code to `develop` that no user-facing feature consumes yet
+| Commit | Scope | Independently mergeable? |
+|---|---|---|
+| `803b5da6a` fix(theme): `radii.full` as a stadium radius | **Root-level, unrelated to MEED.** Fixes progress bars, slider tracks and pill chips rendering as ellipses app-wide | Yes — benefits GHGI and others regardless of MEED |
+| `290f3eb2c` scaffold — routes, registration, feature flag | Module registration + `MEED_MODULE` definition | Yes — makes the flag real without shipping screens |
+| `596eb4596` wizard shell + contract types | `util/types/meed.ts`, the hiap-meed contract | Yes — types only, no runtime surface |
+| `142ebb737` … `29549dd3d` | The 11 screens, primitives, hub, results | Sequential; these build on each other |
+| `64f8fa975` docs | Implementation notes | Yes |
 
-**Option B — single merge.** Add the deploy values and merge #2956 together, and verify the connection at that point.
+So the range of options is wider than one merge or two. Some combinations worth knowing exist:
 
-- One merge, one review cycle
-- If `HIAP_MEED_API_URL` is wrong or the service is unreachable, that surfaces at the same moment as everything else, against a 109-file change
+- The theme fix can go on its own at any time — it is a defect on `develop` today, independent of this work.
+- Registration and contract types can land before any screen does, which makes `MEED_MODULE` and `HIAP_MEED_API_URL` meaningful without exposing UI.
+- A connectivity-only change (`MeedApiService` plus a diagnostic route) can confirm the pod reaches the service before any of the above.
+- Or the whole thing lands together once the prioritizer is wired.
 
-The trade-off is diagnostic isolation versus merge count. Either works; the choice belongs to whoever owns the deploy pipeline.
+The trade-off across all of these is the same: how much is in flight at the moment the wiring is first exercised, versus how many review cycles it costs. We have no constraint that forces any particular split — the commits are already clean enough to slice wherever suits review and deployment.
 
 ## Sequencing after that
 

--- a/docs/MeedIntegrationStatus.md
+++ b/docs/MeedIntegrationStatus.md
@@ -14,8 +14,6 @@ What remains splits cleanly into two piles that do **not** block each other.
 
 **Deploy plumbing — reviewable now, independent of us.** Two values are missing from the deploy workflows: `HIAP_MEED_API_URL` and `MEED_MODULE` in dev's `NEXT_PUBLIC_FEATURE_FLAGS`. Both are plain repo edits, not cluster operations and not secrets. Critically, **both are inert until our code lands** — on `develop` today the module has zero files and `MEED_MODULE` is not even a defined flag, so adding them changes nothing and risks nothing. They can go in whenever it suits.
 
-**One functional gap remains on the backend side:** legal screening data is not exposed as a reference-data endpoint, so the Regulations step cannot render until a ranking has run. Detail under *Owed by the backend*, ask 4.
-
 **Module delivery — our sequencing choice.** PR #2956 is held in draft **deliberately**, so that what reaches dev does something real rather than being a flag-gated shell. That is a product decision, not a blocker awaiting anyone.
 
 **One open question**, set out at the end of this document. `hiap-meed-service-dev` is `ClusterIP` with no ingress, so `HIAP_MEED_API_URL` can only be exercised from inside the cluster — the first genuine test of the connection therefore has to happen on dev, after something is merged. Whether that is a small connectivity-only change first or a single merge of the whole module is a deploy-pipeline decision, not a frontend one.
@@ -53,7 +51,7 @@ MEED/
 | **CityCatalyst data** | emissions (GHGI cross-read), hub | Working |
 | **Input / derived — no upstream data by design** | preferences (a form), pre-flight (a summary of stored answers), processing (a transition) | Working as intended |
 | **Requires the prioritizer** | results | Inherent — a ranking must exist first |
-| **Blocked on missing data** | **regulations** | See backend ask 4 |
+| **Not yet wired** | **regulations** | Needs a prioritize call on the screen — ours to fix, see below |
 
 Counting "screens with live data" is misleading: preferences, pre-flight and processing were never meant to show upstream data. Only **two** screens are unfinished — results, which legitimately needs a ranking, and **regulations, which is the one genuine defect**: it sits at step 3 of 7 but cannot render anything until step 7 has run.
 
@@ -61,34 +59,37 @@ Counting "screens with live data" is misleading: preferences, pre-flight and pro
 
 ## Owed by the backend
 
-One functional, three minor.
+Three, all minor. None blocking.
 
 | # | Ask | Why it matters |
 |---|---|---|
-| **4** | **Expose action legal assessments as a reference-data endpoint** — e.g. `GET /v1/cities/{locode}/action-legal-assessments?country_code=` | **Functional, not polish.** Legal screening currently surfaces only inside the prioritize response, so the Regulations screen — step 3 of 7 — stays empty until the ranking at step 7 has run. See below |
 | 1 | **Structured `warnings`** — `{code, params}` instead of English prose | The module ships in 5 languages and cannot translate the current strings |
 | 2 | **`datasource` / `version_label` on `CityIndicatorResponse`** | `INDICATOR_META` hardcodes citations like `"ENDISC 2015"` that live data contradicts (`cl-ine-censo` / `2024`). Without the field we should drop the Source column rather than show a wrong citation |
 | 3 | **Documented vocabulary for `policy_support_category`** | Until then the field goes unused and we keep our own thresholds |
 
-### Ask 4 in detail — why Regulations cannot render during the flow
+### Why Regulations is empty — and why it is ours to fix, not the backend's
 
-The intended behaviour is that each wizard step shows its own evidence as the user moves through: emissions, socioeconomic context, legal screening, then policy and finance. Regulations is the only step that cannot do this, and the reason is data availability rather than a design choice on our side. Three findings, all verified:
+Regulations sits at step 3 of 7 but renders nothing today: `regulations/page.tsx:149` hard-codes `useState<MeedPrioritizeCityResult | null>(null)` with a `TODO(meed backend)`.
 
-1. **Not among the seven reference-data GETs.** The published route list is attributes, action-pathways, action-policy-scores, action-mitigation-feasibility-scores, climate-finance/feasibility, climate-finance/opportunities, climate-finance/projects. Legal assessments are absent.
-2. **The upstream API returns nothing.** `GET /api/v1/action-legal-assessments?country_code=BR` and `=CL` both return **0 rows** against `ccglobal.openearth.dev`.
-3. **The real source is S3, which CityCatalyst cannot reach.** hiap-meed defaults to `HIAP_MEED_LEGAL_DATA_SOURCE=s3` against the `test-global-api` bucket. Its own API client carries the note *"use HIAP_MEED_LEGAL_DATA_SOURCE=s3"*.
+An earlier draft of this document raised it as a backend ask, on the reasoning that legal screening surfaces only inside the prioritize response and there is no reference-data endpoint for it. That reasoning was wrong about the conclusion. **The prototype solves it without any new endpoint**, and we should do the same.
 
-So legal screening reaches a consumer through exactly one path today: the prioritize response, via `removed_actions[].legal` and `metadata.hard_filter_evidence_by_action_id`. The prioritizer is the only component that reads the bucket.
+`pages/RegulationsLaws.tsx:307-332` in the prototype: on mount it reads its cached pipeline result, and when there is none it calls the prioritizer immediately —
 
-`regulations/page.tsx:149` therefore hard-codes `useState<MeedPrioritizeCityResult | null>(null)` with a `TODO(meed backend)`. That is not a placeholder awaiting frontend work — there is no source to read from.
+```ts
+// No cached result — run the pipeline now so the user sees legal data at step 3.
+// Strategic preferences default gracefully when not yet filled in (steps 4–6).
+runPipelineForCity(locode, { topN: 20, createExplanations: false })
+```
 
-**No partial workaround exists.** `POST /v1/prioritize/exclusions/preview` previews *user-chosen* exclusions (sector tags, co-benefit keys, free text); it does not evaluate legal blocking.
+— then renders `legalExcluded` / `legalFlagged` from the response. It uses `createExplanations: false`, so the call skips LLM generation and is the cheap variant.
 
-What would unblock it: a per-city or per-country endpoint returning each action's legal verdict and reason, using the same S3-backed selection the prioritizer already applies, so Regulations renders at step 3 exactly as policy and finance do at steps 5 and 6.
+This works because **legal screening is preference-independent**. Hard filters are evaluated against the city, its country and the action catalog; they do not consult sectors, co-benefits, timeframes or weights. Running the prioritizer before the user has filled in steps 4–6 therefore yields the same legal verdicts it would yield at the end, and `buildCityInput` supplies defaults for everything not yet answered (weights 55/22/23, empty preference and exclusion lists).
 
-**Declined, and reasonably:** the 5-project / 5+5-opportunity caps mirror the evidence selection plan generation uses. We adapt the copy — `n_reachable_opportunities` reports 30 where we show 5, so the UI must read "5 of 30 shown" rather than silently contradict itself.
+**What our port should do:** call `POST /v1/prioritize` from the Regulations screen when no ranking is cached for the inventory, read `removed_actions[].legal` and `metadata.hard_filter_evidence_by_action_id`, and show a loading state while it runs. The final generate at step 7 re-runs with the user's actual answers.
 
-**Correction we owe:** an earlier version of the contract diff credited the migration with uncapped policy evidence. That was wrong — the upstream default is already 5 per action and hiap-meed does not pass `top_evidence_limit`. The document has been corrected.
+Two costs worth stating: the prioritizer is called twice in a full pass, and the user waits on a mid-wizard screen for a call that is not instant. The prototype accepted both, and shows a spinner plus an error state (`legalLoading` / `legalError`) rather than an empty panel.
+
+**Not a substitute:** `POST /v1/prioritize/exclusions/preview` evaluates user-chosen exclusions (sector tags, co-benefit keys, free text), not legal blocking.
 
 ---
 

--- a/docs/MeedIntegrationStatus.md
+++ b/docs/MeedIntegrationStatus.md
@@ -14,6 +14,8 @@ What remains splits cleanly into two piles that do **not** block each other.
 
 **Deploy plumbing — reviewable now, independent of us.** Two values are missing from the deploy workflows: `HIAP_MEED_API_URL` and `MEED_MODULE` in dev's `NEXT_PUBLIC_FEATURE_FLAGS`. Both are plain repo edits, not cluster operations and not secrets. Critically, **both are inert until our code lands** — on `develop` today the module has zero files and `MEED_MODULE` is not even a defined flag, so adding them changes nothing and risks nothing. They can go in whenever it suits.
 
+**One functional gap remains on the backend side:** legal screening data is not exposed as a reference-data endpoint, so the Regulations step cannot render until a ranking has run. Detail under *Owed by the backend*, ask 4.
+
 **Module delivery — our sequencing choice.** PR #2956 is held in draft **deliberately**, so that what reaches dev does something real rather than being a flag-gated shell. That is a product decision, not a blocker awaiting anyone.
 
 **One open question**, set out at the end of this document. `hiap-meed-service-dev` is `ClusterIP` with no ingress, so `HIAP_MEED_API_URL` can only be exercised from inside the cluster — the first genuine test of the connection therefore has to happen on dev, after something is merged. Whether that is a small connectivity-only change first or a single merge of the whole module is a deploy-pipeline decision, not a frontend one.
@@ -45,23 +47,44 @@ MEED/
 
 ### Real vs. mock today
 
-| Live upstream | CityCatalyst data | Input / derived | Not yet real |
-|---|---|---|---|
-| context, policy, finance | emissions (GHGI cross-read), hub | preferences, pre-flight | regulations *(precondition)*, processing *(8s animation)*, results *(empty, or mock behind a flag)* |
+| Category | Screens | State |
+|---|---|---|
+| **Live upstream data** | context, policy, finance | Working |
+| **CityCatalyst data** | emissions (GHGI cross-read), hub | Working |
+| **Input / derived — no upstream data by design** | preferences (a form), pre-flight (a summary of stored answers), processing (a transition) | Working as intended |
+| **Requires the prioritizer** | results | Inherent — a ranking must exist first |
+| **Blocked on missing data** | **regulations** | See backend ask 4 |
 
-**6 of 11 screens already render live data.** The three that do not are exactly the three that need the prioritizer.
+Counting "screens with live data" is misleading: preferences, pre-flight and processing were never meant to show upstream data. Only **two** screens are unfinished — results, which legitimately needs a ranking, and **regulations, which is the one genuine defect**: it sits at step 3 of 7 but cannot render anything until step 7 has run.
 
 ---
 
 ## Owed by the backend
 
-All minor; none blocking.
+One functional, three minor.
 
 | # | Ask | Why it matters |
 |---|---|---|
-| 1 | **Structured `warnings`** — `{code, params}` instead of English prose | The module ships in 5 languages and cannot translate the current strings. The only outstanding item with user-visible impact |
+| **4** | **Expose action legal assessments as a reference-data endpoint** — e.g. `GET /v1/cities/{locode}/action-legal-assessments?country_code=` | **Functional, not polish.** Legal screening currently surfaces only inside the prioritize response, so the Regulations screen — step 3 of 7 — stays empty until the ranking at step 7 has run. See below |
+| 1 | **Structured `warnings`** — `{code, params}` instead of English prose | The module ships in 5 languages and cannot translate the current strings |
 | 2 | **`datasource` / `version_label` on `CityIndicatorResponse`** | `INDICATOR_META` hardcodes citations like `"ENDISC 2015"` that live data contradicts (`cl-ine-censo` / `2024`). Without the field we should drop the Source column rather than show a wrong citation |
 | 3 | **Documented vocabulary for `policy_support_category`** | Until then the field goes unused and we keep our own thresholds |
+
+### Ask 4 in detail — why Regulations cannot render during the flow
+
+The intended behaviour is that each wizard step shows its own evidence as the user moves through: emissions, socioeconomic context, legal screening, then policy and finance. Regulations is the only step that cannot do this, and the reason is data availability rather than a design choice on our side. Three findings, all verified:
+
+1. **Not among the seven reference-data GETs.** The published route list is attributes, action-pathways, action-policy-scores, action-mitigation-feasibility-scores, climate-finance/feasibility, climate-finance/opportunities, climate-finance/projects. Legal assessments are absent.
+2. **The upstream API returns nothing.** `GET /api/v1/action-legal-assessments?country_code=BR` and `=CL` both return **0 rows** against `ccglobal.openearth.dev`.
+3. **The real source is S3, which CityCatalyst cannot reach.** hiap-meed defaults to `HIAP_MEED_LEGAL_DATA_SOURCE=s3` against the `test-global-api` bucket. Its own API client carries the note *"use HIAP_MEED_LEGAL_DATA_SOURCE=s3"*.
+
+So legal screening reaches a consumer through exactly one path today: the prioritize response, via `removed_actions[].legal` and `metadata.hard_filter_evidence_by_action_id`. The prioritizer is the only component that reads the bucket.
+
+`regulations/page.tsx:149` therefore hard-codes `useState<MeedPrioritizeCityResult | null>(null)` with a `TODO(meed backend)`. That is not a placeholder awaiting frontend work — there is no source to read from.
+
+**No partial workaround exists.** `POST /v1/prioritize/exclusions/preview` previews *user-chosen* exclusions (sector tags, co-benefit keys, free text); it does not evaluate legal blocking.
+
+What would unblock it: a per-city or per-country endpoint returning each action's legal verdict and reason, using the same S3-backed selection the prioritizer already applies, so Regulations renders at step 3 exactly as policy and finance do at steps 5 and 6.
 
 **Declined, and reasonably:** the 5-project / 5+5-opportunity caps mirror the evidence selection plan generation uses. We adapt the copy — `n_reachable_opportunities` reports 30 where we show 5, so the UI must read "5 of 30 shown" rather than silently contradict itself.
 

--- a/docs/MeedIntegrationStatus.md
+++ b/docs/MeedIntegrationStatus.md
@@ -10,11 +10,11 @@ Companions: [`MeedReferenceDataContractDiff.md`](./MeedReferenceDataContractDiff
 
 The backend contract is **functionally complete**. [PR #2982](https://github.com/Open-Earth-Foundation/CityCatalyst/pull/2982) is approved and merge-clean, and 6 of the 7 gaps we raised were closed in full; the seventh was declined with sound reasoning. Every field the module renders now has a source.
 
-**The critical path is now the frontend.** Three things block a dev test, none of them large:
+What remains splits cleanly into two piles that do **not** block each other.
 
-1. `HIAP_MEED_API_URL` does not exist anywhere in the repo
-2. `MEED_MODULE` is not in dev's `NEXT_PUBLIC_FEATURE_FLAGS`
-3. PR #2956 is still a draft — dev deploys from `develop`, so none of our code reaches dev until it merges
+**Deploy plumbing — reviewable now, independent of us.** Two values are missing from the deploy workflows: `HIAP_MEED_API_URL` and `MEED_MODULE` in dev's `NEXT_PUBLIC_FEATURE_FLAGS`. Both are plain repo edits, not cluster operations and not secrets. Critically, **both are inert until our code lands** — on `develop` today the module has zero files and `MEED_MODULE` is not even a defined flag, so adding them changes nothing and risks nothing. They can go in whenever it suits.
+
+**Module delivery — our sequencing choice.** PR #2956 is held in draft **deliberately**, so that what reaches dev does something real rather than being a flag-gated shell. That is a product decision, not a blocker awaiting anyone.
 
 ---
 
@@ -89,19 +89,30 @@ Plus mechanical migration work: snake_case renames, `meta.total` → `meta.total
 
 ---
 
-## Wiring needed to test on dev
+## Deploy plumbing (Mirco / Piotr)
+
+Both are plain repo edits with no secrets. All three hiap-meed service names are confirmed from `hiap-meed/k8s/service-*.yml`, so the exact values are known — what is needed is review and agreement, not investigation.
 
 **1. `HIAP_MEED_API_URL` does not exist.** `HIAP_API_URL` is not in `k8s/cc-web-deploy.yml` — it is set at deploy time by `kubectl set env`:
 
-- `.github/workflows/web-develop.yml:479` → add `"HIAP_MEED_API_URL=http://hiap-meed-service-dev" \`
-- `web-test.yml:259` and `web-tag.yml:242` → same, with the test/prod service names
-- `app/env.example` beside line 65 → `HIAP_MEED_API_URL="http://localhost:8000"`
+| File | Line | Value |
+|---|---|---|
+| `.github/workflows/web-develop.yml` | 479 | `"HIAP_MEED_API_URL=http://hiap-meed-service-dev" \` |
+| `.github/workflows/web-test.yml` | 259 | `"HIAP_MEED_API_URL=http://hiap-meed-service-test" \` |
+| `.github/workflows/web-tag.yml` | 242 | `"HIAP_MEED_API_URL=http://hiap-meed-service-prod" \` |
+| `app/env.example` | ~65 | `HIAP_MEED_API_URL="http://localhost:8000"` |
+
+Service names verified from `hiap-meed/k8s/service-{dev,test,prod}.yml` — all `ClusterIP` on port 80 → container 8000, no ingress, so they resolve only from inside the cluster.
 
 **2. `MEED_MODULE` is not in dev's flags.** `NEXT_PUBLIC_FEATURE_FLAGS` appears three times in `web-develop.yml` (lines 41, 88, 483) — build-time and runtime. All three need it.
 
-**3. No client, no routes.** Nothing calls hiap-meed. Needs `MeedApiService.ts`, modelled on `backend/hiap/HiapApiService.ts`.
+**Both are safe to land ahead of us.** On `develop` today the module has zero files and `MEED_MODULE` is not a defined flag, so the flag string is inert and the env var unused. There is no ordering dependency in either direction.
 
-**4. PR #2956 is a draft.** Safe to merge — everything sits behind `MEED_MODULE`, which is off in dev's flag list — but nothing of ours reaches dev until it does.
+## Module delivery (ours)
+
+**3. No client, no routes.** Nothing calls hiap-meed. Needs `MeedApiService.ts`, modelled on `backend/hiap/HiapApiService.ts`. This is the half of item 1 that is ours — the workflow supplies the value, our code has to read it.
+
+**4. PR #2956 is held in draft deliberately**, so that what reaches dev does something real rather than being a flag-gated shell. Not a blocker awaiting review — a sequencing choice.
 
 ### Making connectivity verifiable
 
@@ -132,7 +143,7 @@ Note: **prioritize does not depend on #2982.** The hiap-meed pod fetches its own
 ## Sequencing
 
 1. **Wiring PR** — env var (4 files), `MEED_MODULE` in dev flags, `MeedApiService` skeleton, health route. Nothing user-facing, independent of #2982, mergeable immediately. Proves the pod reaches hiap-meed before any real integration exists.
-2. **Get #2956 reviewed and merged.** 109 files; review lead time likely exceeds any of the code above, and everything queues behind it.
+2. **#2956 merges when the integration is real** — deliberately held so that dev gets a working module, not a shell. Worth noting the cost of holding: 109 files diverging from `develop`, and the reference-data migration adds more. The wiring PR above is the hedge — it puts something concrete and provable on dev without merging the module.
 3. **Prioritize POST** — kills the mock and lights up regulations, processing and results.
 4. **Reference-data migration** — 5 incremental PRs once #2982 is deployed. Carries frontend bugs 1–8.
 5. **Reports** — measure, then decide.

--- a/docs/MeedReferenceDataContractDiff.md
+++ b/docs/MeedReferenceDataContractDiff.md
@@ -1,0 +1,274 @@
+# MEED reference data: prototype endpoints vs. the hiap-meed contract
+
+**Purpose:** establish what it takes for the Actions & Plans v2 module to stop calling the Global API directly and read everything through hiap-meed.
+
+**Target state:** zero direct Global API calls from CityCatalyst. Every read goes through hiap-meed, so the data the user sees on screen and the data the prioritizer ranks on are the same data, selected by the same rules. Today they are two independent fetches of the same upstream, which is exactly the divergence this migration exists to remove.
+
+This is a gap analysis against that fixed destination, not a menu of options.
+
+**Sources.** Contract: `hiap-meed/app/modules/reference_data/models.py` on branch `cc-603-implement-apis` ([PR #2982](https://github.com/Open-Earth-Foundation/CityCatalyst/pull/2982), open, mergeable, blocked on review). Every response model sets `extra="forbid"`, so the field lists below are exhaustive — nothing extra rides along. Consumer side: the module as it stands on `feat/meed-module-scaffold` ([PR #2956](https://github.com/Open-Earth-Foundation/CityCatalyst/pull/2956)).
+
+---
+
+## Status: resolved
+
+**This document did its job.** It was written against the first draft of the contract, which dropped 17 fields the module renders. The backend author addressed **6 of the 7 asks in full**; the seventh was declined with sound reasoning. The contract is now functionally complete for our UI — every field the module renders has a source.
+
+The per-endpoint analysis below is kept as the record of what was asked and why. Each ask now carries its outcome.
+
+| Ask | Outcome |
+|---|---|
+| 1. Per-action policy evidence strength | ✅ `evidence_strength`, `signal_strength`, `signal_type`, plus `document_type`, `signal_relation`, `doc_relevance` — originals passed through unchanged |
+| 2. Project cost / funder / match confidence | ✅ all, plus `sector`, `project_name_i18n`, and `amount_unit` (not asked for) |
+| 3. Catalog sector / co-benefits / emissions | ✅ `co_benefits` and `emissions{sector_number, gpc_reference_number, impact_*}`. Sector is **derivable, not top-level** — see below |
+| 4. Indicator category | ✅ `category` on `indicators[]` |
+| 5. Finance `inputs` | ✅ exact match to our `FeasibilityInputs`, including two fields we declared but never read |
+| 6. `signal_type` + vocabulary | ✅ the synthetic `relevance` was removed in favour of upstream originals |
+| 7. The 5-item caps | ❌ **declined** — they mirror the evidence selection plan generation uses, not a browsing catalogue. We adapt the copy instead |
+
+### On sector — the ask was wrong, and it exposed a bug of ours
+
+Global API provides **no top-level action sector**; it provides `emissions.sector_number` and `gpc_reference_number`. Verified across all 102 catalog actions. Deriving the tag is therefore *our* work, using the backend's own `SECTOR_NUMBER_TO_TAG` (`prioritizer/utils/sector_mapping.py`) — the same map the prioritizer matches sector preferences through.
+
+That check also caught a live defect: `actionCatalog.ts:63` reads a `sector` key that has never existed upstream, so `sectorLabel` always falls through and **every action currently displays "Cross-sector"** in the ranked table, the top-pick cards and the detail panel.
+
+### Outstanding, all minor and non-blocking
+
+1. **Structured `warnings`** (`{code, params}` instead of English prose) — the module ships in 5 languages and cannot translate the current strings. The only one with user-visible impact.
+2. **`datasource` / `version_label` on `CityIndicatorResponse`** — `INDICATOR_META` hardcodes citations like `"ENDISC 2015"` that live data contradicts (`cl-ine-censo` / `2024`). Without the field we should drop the Source column rather than display a wrong citation.
+3. **Documented vocabulary for `policy_support_category`** — until then we keep our own thresholds and the field goes unused.
+
+---
+
+## 1. City attributes
+
+`GET /api/v0/city_attributes/{locode}` → `GET /v1/cities/{locode}/attributes`
+
+Consumer: `context/indicators.ts:304`, `context/page.tsx:314`. 34 known indicator keys, 4 promoted to cards.
+
+Structure changes from a **map keyed by indicator name** to an **array of records** — mechanical, fine.
+
+| Today | New | Status |
+|---|---|---|
+| `city.<key>.attribute_value` | `indicators[].value` | renamed; type widens to `float \| str \| null` (we filter on `number` today) |
+| `city.<key>.attribute_units` | `indicators[].unit` | renamed |
+| `city.<key>.attribute_category` | — | **dropped** |
+| — | `city.population_size`, `area_km2`, `population_density`, `region_name`, `country_code` | **gained** as first-class fields |
+
+**What breaks:** `attribute_category` is the qualitative band (`very high` → `very low`) behind the level chip on every indicator. `buildIndicators` reads it directly and `INDICATOR_META` validates against it. Without it, all 34 indicators lose their band and become bare numbers — the user can see 8.1% unemployment but not whether that is high for a city like theirs.
+
+**Workaround:** none that is honest. We could bucket client-side, but the thresholds are upstream domain knowledge, and inventing them would be fabricating an assessment.
+
+**Ask:** add `category: str | None` to `CityIndicatorResponse`. → ✅ **delivered.**
+
+---
+
+## 2. Action pathways
+
+`GET /api/v1/action-pathways` → `GET /v1/action-pathways?language=`
+
+Consumer: `results/components/actionCatalog.ts:35` (`buildActionIndex`), used by 4 screens — landing, results, policy, processing.
+
+| Today | New | Status |
+|---|---|---|
+| `actionId` / `ActionID` | `action_id` | renamed — and the dual-casing tolerance can go, backend normalizes |
+| `actionName` / `ActionName` | `action_name` | renamed |
+| `description` | `description` | same |
+| `timelineForImplementation` | `implementation_timeline` | renamed |
+| `sector` / `Sector` | — | **dropped** |
+| `coBenefits` / `CoBenefits` | — | **dropped** |
+| `emissions.impact_numeric` / `impact_text` | — | **dropped** |
+| — | `name_i18n`, `description_i18n` | **gained** |
+| — | `action_type`, `investment_cost` | **gained** |
+
+**What breaks:**
+- `sector` drives sector chips and grouping on results, and `gpcToSectorTag`.
+- `coBenefits` is the fallback in `coBenefits.ts:127-146` when the prioritize response's `evidence_summary` carries none, and feeds `CoBenefitStrip`.
+- `emissions.impact_numeric` is the 1–5 impact level on results cards.
+
+**Workarounds, all partial:** `sector` is recoverable per-action from the finance feasibility endpoint — but only for actions that have a finance row. `coBenefits` degrades to whatever `evidence_summary` provides. `emissions.impact_numeric` is a *catalog attribute* (this action's inherent potential); `impact_score` in the prioritize response is a *contextual score* (this action against this city's inventory). Substituting one for the other would silently change what the number means.
+
+**Gained, and worth naming:** `name_i18n` / `description_i18n` mean action names finally render in Spanish and Portuguese. The module ships in 5 languages and currently shows every action name in English. This alone is a strong argument for the migration.
+
+**Ask:** add `sector`, `co_benefits`, and the emissions impact fields to `ActionPathwayResponse`. → ✅ **`co_benefits` and `emissions` delivered.** `sector` does not exist upstream — we derive it from `emissions.sector_number` (see Status above).
+
+---
+
+## 3. Action policy scores — *was the largest loss, now resolved*
+
+`GET /api/v1/cities/{locode}/action-policy-scores?top_evidence_limit=5` → `GET /v1/cities/{locode}/action-policy-scores`
+
+Consumers: `policy/policyRows.ts`, `policy/policyAggregates.ts`, `policy/components/PolicyActionRow.tsx`.
+
+| Today | New | Status |
+|---|---|---|
+| `scores[].src_action_id` | `scores[].action_id` | renamed |
+| `scores[].policy_support_score` | same | same |
+| `policy_evidence[].document_name` | same | same |
+| `policy_evidence[].document_type` | `policy_evidence[].scope` | **improved** — backend now does the `parcc`→Regional / `paccc`→Municipal mapping, so `docScope()` is deleted |
+| `policy_evidence[].evidence_strength` | — | **dropped** |
+| `policy_evidence[].signal_strength` | — | **dropped** |
+| `policy_evidence[].signal_type` | — | **dropped** |
+| *(computed client-side)* | `aggregates.{national,regional,municipal}` | **gained** — `computePolicyAggregates` is deleted |
+| — | `policy_support_category`, `finding_count`, `document_count` | **gained** |
+| `top_evidence_limit=5` | *(parameter not accepted)* | **no change** — the upstream default is already 5 per action, and hiap-meed does not pass the parameter. Verified live: 102 actions, 510 evidence rows, max 5 each |
+
+**What breaks, precisely.** The policy table has five columns: Action · Score · National · Regional · Municipal. The last three are **per-action** meters computed in `derivePolicyRows` as `scopeMax[scope] = max(evidenceStrengthNum(ev))` over that action's evidence — and `evidenceStrengthNum` reads `evidence_strength`, falling back to `signal_strength`. Both are gone, so `scopeMax` cannot be computed, **three of five columns go blank**, and `sortPolicyRows` loses three of its four sort keys.
+
+The new `aggregates` do **not** substitute. They are three city-level numbers for the summary header; the columns are per-action. We gain the header and lose the table.
+
+`signal_type` additionally drives the evidence chips (`SIGNAL_TYPE_KEYS`: action / funding / governance / sector_priority / target). The new `relevance: str | None` may cover some of this, but its vocabulary is undocumented — the only example value is `"supporting"`.
+
+**Workaround:** none. The numeric strength is not in the response in any form.
+
+**Ask (highest priority):** → ✅ **delivered.** `PolicyEvidenceResponse` now carries `evidence_strength`, `signal_strength`, `signal_type`, `signal_relation`, `doc_relevance` and the original `document_type`, so `derivePolicyRows` keeps working and all five columns survive. `scope` is now `national|regional|municipal|null` — unknown-scope evidence must contribute to no scope aggregate rather than defaulting to National, which is a bug in our current `docScope`. The original ask was for either a numeric strength or per-action scope scores:
+
+```
+scores[].scope_scores: { national: float|null, regional: float|null, municipal: float|null }
+```
+
+That would let us delete `derivePolicyRows`' scope loop entirely and keep the table. Also worth confirming the controlled vocabulary for `relevance`.
+
+---
+
+## 4. Action mitigation-feasibility scores
+
+`GET /v1/cities/{locode}/action-mitigation-feasibility-scores?country_code=`
+
+**New endpoint, no current consumer.** Pure gain: `action_score`, `rank_within_city`, `dimension_scores{}` per action. The module has no feasibility view today; this could power one, and `rank_within_city` is a natural sort for the results table.
+
+No migration work. Listed for completeness.
+
+---
+
+## 5. Financial feasibility
+
+`GET /api/v1/cities/{locode}/climate-finance/feasibility?country_code=` → same path under hiap-meed
+
+Consumers: `finance/types.ts:53`, `finance/page.tsx`, `finance/components/{FeasibilityRow,RowDetail}.tsx`.
+
+| Today | New | Status |
+|---|---|---|
+| `action_id`, `action_name`, `sector`, `route`, `reason` | same | same |
+| `financial_feasibility` | same, but **nullable** | see below |
+| `inputs.action.capital_intensity` | — | **dropped** |
+| `inputs.action.preparation_complexity` | — | **dropped** |
+| `inputs.city.profile` | — | **dropped** |
+| `inputs.finance.n_reachable_opportunities` | — | **dropped** |
+| `links.opportunities` / `links.projects` | — | **replaced** by §6 and §7 — an improvement |
+
+**Nullability is a bug fix on our side.** `extractFeasibilityRows` currently requires `typeof financial_feasibility === "number"` and **silently drops every row without a score**. The new contract returns those rows explicitly, ordered last. We must keep them and render "no score available" — the user should see that an action was assessed and had no finance data, not that it does not exist.
+
+**What breaks:** `RowDetail` renders capital intensity, preparation complexity, city profile and reachable-opportunity count. All four disappear. `inputs.finance.fund_access` and `inputs.evidence.n_existing_projects` are also dropped but are declared-and-unread, so no impact.
+
+**Ask:** restore `inputs`, or a slimmer explicit object. → ✅ **delivered in full**, including `fund_access` and `n_existing_projects`.
+
+---
+
+## 6. Climate-finance opportunities — **fully covered**
+
+Follow `links.opportunities` via `…/modules/meed/finance/follow?link=` → `GET /v1/climate-finance/opportunities?country_code=&sector=&route=`
+
+Consumer: `finance/components/OpportunityCard.tsx`, via `useGetMeedFinanceLinkQuery`.
+
+| Today | New | Status |
+|---|---|---|
+| `opportunity_name`, `funder_name` | same | same — these are the only two we render |
+| `instrument`, `status`, `source_url` | same | present; **we declare but never render them** — could now light up the `STATUS_KEYS`/`STATUS_TONE` maps already sitting unused in `labels.ts:189` |
+| `amount_note`, `notes` | — | dropped, both unread — no impact |
+| *(flat list)* | `current[]` + `monitor[]`, with `recurrence` on monitor | **structural change** |
+| `meta.total` | `meta.total_records` | rename in `extractLinkedList` |
+
+**Two real changes.** The response now splits into current and monitoring groups — a UI improvement (recurring closed calls are genuinely different from open ones) but it needs a two-group layout rather than one list. And results are capped at **5 current + 5 monitoring**, backend-owned; today the followed link returns more.
+
+**Net: this endpoint is strictly better.** It also lets us delete the `finance/follow` proxy route, `useGetMeedFinanceLinkQuery`, and the arbitrary-URL-following security guard in `MeedGlobalApiService.followLink`.
+
+**Ask:** none. → The 5+5 cap is **confirmed intentional** — it mirrors the evidence selection plan generation uses. We change the copy to "5 of 30 shown" so the count and the list stop contradicting each other.
+
+---
+
+## 7. Climate-finance projects — **second-largest loss**
+
+Follow `links.projects` + `?limit=50` → `GET /v1/climate-finance/projects?country_code=&action_id=`
+
+Consumer: `finance/components/ProjectCard.tsx`.
+
+| Today | New | Status |
+|---|---|---|
+| `project_name` | same | same |
+| `jurisdiction`, `lifecycle_stage`, `funding_channel` | same | same |
+| `cost_total` | — | **dropped** |
+| `funding_sources[].funder_name` | — | **dropped** |
+| `action_matches[].confidence` | — | **dropped** |
+| `project_name_i18n` | — | **dropped** (falls back to `project_name` — minor) |
+| `sector` | — | **dropped** |
+| `?limit=50` | *(capped at 5)* | **10× fewer results** |
+
+**What breaks:** `ProjectCard` renders a confidence tag, a cost field, a funder field and a sector field. All four are gone, leaving name + jurisdiction + lifecycle + channel. The card loses its two most decision-relevant facts — how much a comparable project cost, and who paid for it.
+
+`confidence` matters separately: it is how the user knows whether this project is genuinely comparable or a loose match. Without it every project is presented with equal authority.
+
+**Workaround:** none.
+
+**Ask (second priority):** → ✅ **delivered in full** — `cost_total`, `funding_sources[]` (with per-source `amount`/`amount_unit`), `action_matches[].confidence`, `sector`, `project_name_i18n`, plus `amount_unit` at project level, which fixes a 1000× display error on our side (`formatClpMillions` assumes millions; live data is `CLP_thousands`). The 5-project cap is **confirmed intentional**.
+
+---
+
+## What unification deletes
+
+Real simplification, worth stating alongside the asks:
+
+- **`MeedGlobalApiService.ts`** — the whole file, including `followLink`'s `/api/v1/cities/` path guard, which exists only because we let the browser drive an arbitrary upstream URL.
+- **`…/modules/meed/finance/follow/route.ts`** and `useGetMeedFinanceLinkQuery`.
+- **`policyAggregates.computePolicyAggregates`**, `docScope`, `SIGNAL_STRENGTH_NUM` — all replaced by backend `aggregates` and `scope`.
+- **Dual-casing tolerance** in `buildActionIndex` (`actionId` / `ActionID`, ×6 fields).
+- `GLOBAL_API_URL` as a MEED dependency — the module stops needing to know the Global API exists.
+
+## What unification gains
+
+1. **Screen and ranking agree by construction** — the reason to do this.
+2. **`name_i18n` / `description_i18n`** — action names in Spanish and Portuguese, instead of English everywhere. (3 of our 5 shipped languages; `de` and `fr` do not exist upstream.)
+3. **Backend `aggregates`** — one less client-side calculation to keep in sync.
+4. **`warnings[]` on every response** — we currently have no way to tell the user their data is partial. This is the first time the backend can say so.
+5. **`meta.generated_at_utc`** — provenance we can show next to a ranking.
+6. **A mitigation-feasibility endpoint** we do not use yet.
+
+---
+
+## Asks, in priority order
+
+| # | Endpoint | Ask | Outcome |
+|---|---|---|---|
+| 1 | policy scores | per-action scope scores, or a numeric strength on `policy_evidence[]` | ✅ numeric `evidence_strength` + all signal fields restored |
+| 2 | projects | `cost_total`, `funding_sources[]`, per-project match `confidence` | ✅ delivered, plus `sector`, `project_name_i18n`, `amount_unit` |
+| 3 | action pathways | `sector`, `co_benefits`, emissions impact | ✅ `co_benefits` + `emissions`; `sector` derived from `sector_number` |
+| 4 | city attributes | `category` on `indicators[]` | ✅ delivered |
+| 5 | finance feasibility | `inputs` (or a slimmer drivers object) | ✅ delivered in full |
+| 6 | policy scores | documented vocabulary for `relevance`; `signal_type` | ✅ synthetic `relevance` dropped for upstream originals |
+| 7 | opportunities / projects | confirm the 5 / 5+5 caps are intended for a browsing UI | ❌ declined — intentional; we change the copy |
+
+### Still open
+
+| # | Ask | Impact |
+|---|---|---|
+| 8 | Structured `warnings` (`{code, params}`, not English prose) | Untranslatable in a 5-language module — the only outstanding item with user-visible impact |
+| 9 | `datasource` / `version_label` on `CityIndicatorResponse` | We display hardcoded citations that live data contradicts; without it, drop the Source column |
+| 10 | Documented vocabulary for `policy_support_category` | Field goes unused; we keep our own thresholds |
+
+## Changes we must make regardless
+
+Independent of any amendment:
+
+- **Keep null-scored finance rows.** `extractFeasibilityRows` drops them today; that is a bug the new contract exposes.
+- **Rename** `src_action_id`→`action_id`, `attribute_value`→`value`, `timelineForImplementation`→`implementation_timeline`, `meta.total`→`meta.total_records`.
+- **Two-group opportunities layout** for `current[]` / `monitor[]`.
+- **Type the responses properly.** All five current MEED RTK endpoints are typed `unknown` with a cast at the use site. The new contract is strict and generated from Pydantic — there is no excuse to keep casting.
+- **Surface `warnings[]`.** Every response carries it and no screen reads it today.
+
+## Recommendation
+
+*(Original recommendation, now acted on: the asks went to the backend team as a single batch and 6 of 7 were delivered. The migration can proceed without removing information from any screen.)*
+
+The standing principle still holds: where a field is genuinely unavailable, drop the affected UI rather than keep a parallel Global API call to fill the gap — a second fetch of the same upstream is precisely the divergence this work exists to eliminate, and re-introducing it for cosmetic parity would trade the actual goal for the appearance of it.
+
+Sequencing note: none of this blocks `POST /v1/prioritize`. The hiap-meed pod fetches its own reference data, so the ranking can be wired while these are still being negotiated.

--- a/docs/MeedReferenceDataContractDiff.md
+++ b/docs/MeedReferenceDataContractDiff.md
@@ -34,9 +34,10 @@ That check also caught a live defect: `actionCatalog.ts:63` reads a `sector` key
 
 ### Outstanding, all minor and non-blocking
 
-1. **Structured `warnings`** (`{code, params}` instead of English prose) — the module ships in 5 languages and cannot translate the current strings. The only one with user-visible impact.
-2. **`datasource` / `version_label` on `CityIndicatorResponse`** — `INDICATOR_META` hardcodes citations like `"ENDISC 2015"` that live data contradicts (`cl-ine-censo` / `2024`). Without the field we should drop the Source column rather than display a wrong citation.
-3. **Documented vocabulary for `policy_support_category`** — until then we keep our own thresholds and the field goes unused.
+1. **Expose action legal assessments as an eighth reference-data endpoint.** The only *functional* gap: legal screening surfaces solely inside the prioritize response, so the Regulations step cannot render until a ranking exists. Detail in the open-asks table below.
+2. **Structured `warnings`** (`{code, params}` instead of English prose) — the module ships in 5 languages and cannot translate the current strings.
+3. **`datasource` / `version_label` on `CityIndicatorResponse`** — `INDICATOR_META` hardcodes citations like `"ENDISC 2015"` that live data contradicts (`cl-ine-censo` / `2024`). Without the field we should drop the Source column rather than display a wrong citation.
+4. **Documented vocabulary for `policy_support_category`** — until then we keep our own thresholds and the field goes unused.
 
 ---
 
@@ -251,9 +252,10 @@ Real simplification, worth stating alongside the asks:
 
 | # | Ask | Impact |
 |---|---|---|
-| 8 | Structured `warnings` (`{code, params}`, not English prose) | Untranslatable in a 5-language module — the only outstanding item with user-visible impact |
-| 9 | `datasource` / `version_label` on `CityIndicatorResponse` | We display hardcoded citations that live data contradicts; without it, drop the Source column |
-| 10 | Documented vocabulary for `policy_support_category` | Field goes unused; we keep our own thresholds |
+| **8** | **Expose action legal assessments as a reference-data endpoint** (an eighth GET) | **Functional.** Legal screening reaches consumers only via the prioritize response, so the Regulations screen — step 3 of 7 — cannot render until step 7 has run. The upstream `action-legal-assessments` API returns 0 rows for BR and CL; the real source is the S3 bucket hiap-meed reads with `HIAP_MEED_LEGAL_DATA_SOURCE=s3`, which CityCatalyst cannot reach. `POST /v1/prioritize/exclusions/preview` is not a substitute — it evaluates user-chosen exclusions, not legal blocking |
+| 9 | Structured `warnings` (`{code, params}`, not English prose) | Untranslatable in a 5-language module |
+| 10 | `datasource` / `version_label` on `CityIndicatorResponse` | We display hardcoded citations that live data contradicts; without it, drop the Source column |
+| 11 | Documented vocabulary for `policy_support_category` | Field goes unused; we keep our own thresholds |
 
 ## Changes we must make regardless
 

--- a/docs/MeedReferenceDataContractDiff.md
+++ b/docs/MeedReferenceDataContractDiff.md
@@ -34,10 +34,9 @@ That check also caught a live defect: `actionCatalog.ts:63` reads a `sector` key
 
 ### Outstanding, all minor and non-blocking
 
-1. **Expose action legal assessments as an eighth reference-data endpoint.** The only *functional* gap: legal screening surfaces solely inside the prioritize response, so the Regulations step cannot render until a ranking exists. Detail in the open-asks table below.
-2. **Structured `warnings`** (`{code, params}` instead of English prose) — the module ships in 5 languages and cannot translate the current strings.
-3. **`datasource` / `version_label` on `CityIndicatorResponse`** — `INDICATOR_META` hardcodes citations like `"ENDISC 2015"` that live data contradicts (`cl-ine-censo` / `2024`). Without the field we should drop the Source column rather than display a wrong citation.
-4. **Documented vocabulary for `policy_support_category`** — until then we keep our own thresholds and the field goes unused.
+1. **Structured `warnings`** (`{code, params}` instead of English prose) — the module ships in 5 languages and cannot translate the current strings.
+2. **`datasource` / `version_label` on `CityIndicatorResponse`** — `INDICATOR_META` hardcodes citations like `"ENDISC 2015"` that live data contradicts (`cl-ine-censo` / `2024`). Without the field we should drop the Source column rather than display a wrong citation.
+3. **Documented vocabulary for `policy_support_category`** — until then we keep our own thresholds and the field goes unused.
 
 ---
 
@@ -252,10 +251,9 @@ Real simplification, worth stating alongside the asks:
 
 | # | Ask | Impact |
 |---|---|---|
-| **8** | **Expose action legal assessments as a reference-data endpoint** (an eighth GET) | **Functional.** Legal screening reaches consumers only via the prioritize response, so the Regulations screen — step 3 of 7 — cannot render until step 7 has run. The upstream `action-legal-assessments` API returns 0 rows for BR and CL; the real source is the S3 bucket hiap-meed reads with `HIAP_MEED_LEGAL_DATA_SOURCE=s3`, which CityCatalyst cannot reach. `POST /v1/prioritize/exclusions/preview` is not a substitute — it evaluates user-chosen exclusions, not legal blocking |
-| 9 | Structured `warnings` (`{code, params}`, not English prose) | Untranslatable in a 5-language module |
-| 10 | `datasource` / `version_label` on `CityIndicatorResponse` | We display hardcoded citations that live data contradicts; without it, drop the Source column |
-| 11 | Documented vocabulary for `policy_support_category` | Field goes unused; we keep our own thresholds |
+| 8 | Structured `warnings` (`{code, params}`, not English prose) | Untranslatable in a 5-language module |
+| 9 | `datasource` / `version_label` on `CityIndicatorResponse` | We display hardcoded citations that live data contradicts; without it, drop the Source column |
+| 10 | Documented vocabulary for `policy_support_category` | Field goes unused; we keep our own thresholds |
 
 ## Changes we must make regardless
 


### PR DESCRIPTION
Two coordination documents for **Actions & Plans v2 (MEED)**, deliberately kept out of [#2956](https://github.com/Open-Earth-Foundation/CityCatalyst/pull/2956) so they can be read now rather than after a 109-file review.

Docs only — no code, no behaviour change.

### `MeedReferenceDataContractDiff.md`

The field-by-field analysis of the hiap-meed reference-data contract against what the module actually renders, plus its resolution.

It was written against the first draft of [#2982](https://github.com/Open-Earth-Foundation/CityCatalyst/pull/2982), which dropped 17 fields the UI depends on. **6 of the 7 asks were then delivered in full**; the seventh (the 5-item caps) was declined with sound reasoning. Each ask now carries its outcome inline, so the document is both the record of what was asked and the current state.

Two things worth flagging to reviewers:

- **A correction on our side.** The earlier version credited the migration with uncapped policy evidence. That was wrong — the upstream default is already 5 per action and hiap-meed doesn't pass `top_evidence_limit`. Corrected here. @Mirco, this was in the doc you worked from.
- **The `sector` ask was wrong, and it exposed a bug of ours.** Global API provides no top-level action sector — verified across all 102 catalog actions. Deriving it from `emissions.sector_number` is our work. That check also showed `actionCatalog.ts:63` reads a `sector` key that has never existed, so **every action currently displays "Cross-sector"** in the ranked table, top-pick cards and detail panel.

**Three small asks remain open, all non-blocking:** structured `warnings` (the current English prose can't be translated, and the module ships in 5 languages), `datasource`/`version_label` on city indicators, and a documented vocabulary for `policy_support_category`.

An earlier revision of this PR raised a fourth — an eighth reference-data endpoint for legal assessments, so the Regulations screen could render at step 3 instead of after the ranking. **That has been retracted.** The prototype solves it with no new endpoint: `RegulationsLaws.tsx` calls the prioritizer on mount when nothing is cached (`createExplanations: false`, so no LLM) and renders the legal screening from the response. It works because hard filters evaluate city, country and the action catalog only — they are preference-independent, so running before steps 4–6 are answered gives the same verdicts. It's a frontend fix, and the doc now says so.

On screen coverage, the doc also corrects a metric I'd been quoting. "6 of 11 screens render live data" conflated an input form, a summary and a transition screen with genuine gaps. **Only two screens are unfinished:** results, which legitimately needs a ranking, and regulations — the one real defect, per the ask above.

The remaining work splits into two piles that **do not block each other**:

**Deploy plumbing — reviewable now, independent of the module.** Two values are missing from the deploy workflows: `HIAP_MEED_API_URL` and `MEED_MODULE` in dev's `NEXT_PUBLIC_FEATURE_FLAGS`. Plain repo edits, no secrets, no cluster operations. The doc pins the exact value per environment, verified from `hiap-meed/k8s/service-{dev,test,prod}.yml`, so this is a review rather than an investigation.

Worth stating plainly: **these are inert until our code lands.** On `develop` today the MEED module has zero files and `MEED_MODULE` isn't even a defined flag — so the flag string does nothing and the env var is unused. They can go in whenever it suits, with no ordering dependency in either direction.

**Module delivery — our sequencing choice.** #2956 is held in draft **deliberately**, so that what reaches dev does something real rather than a flag-gated shell. That's a product decision, not a blocker awaiting review.

**One open decision for whoever owns the deploy pipeline**, set out at the end of the doc. `hiap-meed-service-dev` is `ClusterIP` with no ingress, so `HIAP_MEED_API_URL` can only be exercised from inside the cluster — the first genuine test of the connection has to happen on dev, after something is merged.

Worth knowing: **#2956 is not all-or-nothing.** It's 14 commits along deliberate seams and several stand alone — including `803b5da6a`, a root-level theme fix (`radii.full` as a stadium radius) that is a defect on `develop` today and unrelated to MEED entirely. Registration, contract types and a connectivity-only change can each land ahead of any screen. The doc lists which commits are independently mergeable and takes no position on how to slice them.

The doc also lists 11 frontend defects we own and will fix, four of which are visible today (the "Cross-sector" bug above; project costs rendering 1000× too high because `amount_unit` is `CLP_thousands` and we assume millions; 15% of actions showing "Unknown route"; and Chilean cities described with the wrong profile).

One note for whoever picks up the integration: **prioritize does not depend on #2982.** The hiap-meed pod fetches its own reference data, so the ranking can be wired while the GETs are still in review.

### Note

`MeedModuleImplementation.md` is referenced but not included — it lands with #2956, so that link resolves once that PR merges.
