### PR TITLE
fix(CC-615): simplify 404 page copy and update CTA text

### DIFF
--- a/app/src/components/not-found-page.tsx
+++ b/app/src/components/not-found-page.tsx
@@ -49,16 +49,6 @@ export function NotFoundPage({ lng }: NotFoundPageProps) {
         >
           404
         </Text>
-        <Text
-          mb="48px"
-          w="0px"
-          width="400px"
-          textAlign="center"
-          lineHeight="32px"
-          letterSpacing="wide"
-        >
-          {t("not-found-description")}
-        </Text>
         <Button
           onClick={() => router.push("/")}
           gap="8px"
@@ -66,7 +56,7 @@ export function NotFoundPage({ lng }: NotFoundPageProps) {
           px="24px"
           fontSize="body.md"
         >
-          {t("goto-dashboard")}
+          {t("back-to-tools")}
           <Icon as={MdArrowForward} />
         </Button>
       </Box>

--- a/app/src/i18n/locales/de/not-found.json
+++ b/app/src/i18n/locales/de/not-found.json
@@ -1,6 +1,5 @@
 {
-  "not-found-description": "Scheint, als wären wir in den Emissionsnebel geraten. Bitte kehren Sie zum Dashboard zurück",
-  "goto-dashboard": "Gehe zum Dashboard",
+  "back-to-tools": "Zuruck zu den Tools",
   "invite-not-valid": "Diese Einladung ist nicht mehr gültig",
   "invite-not-valid-description": "Der Link, den Sie verwenden, ist entweder abgelaufen oder wurde bereits eingelöst.\n Bitte bitten Sie den Einladenden, ihn Ihnen erneut zu senden.\n Wenn Sie denken, dass dies ein Fehler ist, bitte",
   "contact-us": "kontaktieren Sie uns.",

--- a/app/src/i18n/locales/de/not-found.json
+++ b/app/src/i18n/locales/de/not-found.json
@@ -1,5 +1,5 @@
 {
-  "back-to-tools": "Zuruck zu den Tools",
+  "back-to-tools": "Zurück zu den Tools",
   "invite-not-valid": "Diese Einladung ist nicht mehr gültig",
   "invite-not-valid-description": "Der Link, den Sie verwenden, ist entweder abgelaufen oder wurde bereits eingelöst.\n Bitte bitten Sie den Einladenden, ihn Ihnen erneut zu senden.\n Wenn Sie denken, dass dies ein Fehler ist, bitte",
   "contact-us": "kontaktieren Sie uns.",

--- a/app/src/i18n/locales/en/not-found.json
+++ b/app/src/i18n/locales/en/not-found.json
@@ -1,6 +1,5 @@
 {
-  "not-found-description": "Seems like we've wandered into the emission mist. Please go back to the dashboard",
-  "goto-dashboard": "Go to dashboard",
+  "back-to-tools": "Back to tools",
   "invite-not-valid": "This invitation is not valid",
   "invite-not-valid-description": "The link you are using is either expired, claimed or you do not have permission to access it.\n Please ask the inviter to resend it to you.\n If you think this is a mistake, please",
   "contact-us": "contact us.",

--- a/app/src/i18n/locales/es/not-found.json
+++ b/app/src/i18n/locales/es/not-found.json
@@ -1,6 +1,5 @@
 {
-  "not-found-description": "Parece que nos hemos adentrado en la niebla de emisiones. Por favor, regresa al panel de control",
-  "goto-dashboard": "Ir al tablero",
+  "back-to-tools": "Volver a herramientas",
   "invite-not-valid": "Esta invitación ya no es válida",
   "invite-not-valid-description": "El enlace que estás usando ha expirado o ya fue reclamado.\n Por favor, pide al invitador que te lo reenvíe.\n Si crees que esto es un error, por favor",
   "contact-us": "contáctanos.",

--- a/app/src/i18n/locales/fr/not-found.json
+++ b/app/src/i18n/locales/fr/not-found.json
@@ -1,6 +1,5 @@
 {
-  "not-found-description": "On dirait que nous nous sommes égarés dans le brouillard des émissions. Veuillez retourner au tableau de bord",
-  "goto-dashboard": "Accéder au tableau de bord",
+  "back-to-tools": "Retour aux outils",
   "invite-not-valid": "Cette invitation n'est pas valide",
   "invite-not-valid-description": "\"Le lien que vous utilisez est soit expiré, soit revendiqué, soit vous n'avez pas la permission d'y accéder.\nVeuillez demander à l'invitant de vous le renvoyer.\nSi vous pensez que c'est une erreur, veuillez\"",
   "contact-us": "contactez-nous.",

--- a/app/src/i18n/locales/pt/not-found.json
+++ b/app/src/i18n/locales/pt/not-found.json
@@ -1,6 +1,5 @@
 {
-  "not-found-description": "Parece que nos perdemos na névoa das emissões. Por favor, volte para o painel",
-  "goto-dashboard": "Ir para o painel",
+  "back-to-tools": "Voltar para ferramentas",
   "invite-not-valid": "Este convite não é mais válido",
   "invite-not-valid-description": "O link que você está usando está expirado ou já foi reivindicado.\n Por favor, peça ao convidador para reenviá-lo para você.\n Se você acha que isso é um erro, por favor,",
   "contact-us": "entre em contato conosco.",


### PR DESCRIPTION
## Summary

Simplifies the 404 page by removing the descriptive paragraph and rewording the primary action to point users back to tools more clearly.

## Changes

- Remove the `not-found-description` block from the 404 page UI
- Rename the CTA translation key to `back-to-tools`
- Update the 404 button text across `en`, `de`, `es`, `fr`, and `pt` locales

## How to test

1. Open a non-existent route and confirm the 404 page no longer shows the description text
2. Verify the CTA button still renders correctly and uses the updated “back to tools” wording
3. Spot-check the localized 404 page in the supported languages
