### PR TITLE
`fix(CC-652): disable invite-step continue until project, email, and city are set

### DIFF
--- a/app/src/app/[lng]/cities/onboarding/setup/page.tsx
+++ b/app/src/app/[lng]/cities/onboarding/setup/page.tsx
@@ -104,6 +104,8 @@ export default function OnboardingSetup(props: {
   const [createdCityId, setCreatedCityId] = useState<string | null>(null);
   const [isSubmittingStep, setIsSubmittingStep] = useState(false);
   const [isFinishing, setIsFinishing] = useState(false);
+  // Continue on the invite step requires project + email(s) + city (CC-652).
+  const [canSubmitInvite, setCanSubmitInvite] = useState(false);
 
   const inviteStepRef = useRef<InviteCollaboratorsStepRef>(null);
 
@@ -326,7 +328,11 @@ export default function OnboardingSetup(props: {
             />
           )}
           {activeStep === inviteCollaboratorsStepIndex && (
-            <InviteCollaboratorsStep ref={inviteStepRef} lng={lng} />
+            <InviteCollaboratorsStep
+              ref={inviteStepRef}
+              lng={lng}
+              onValidityChange={setCanSubmitInvite}
+            />
           )}
         </Box>
         <Box
@@ -399,6 +405,7 @@ export default function OnboardingSetup(props: {
                     px="24px"
                     h="64px"
                     loading={isFinishing}
+                    disabled={!canSubmitInvite || isFinishing}
                     onClick={async () => {
                       try {
                         await inviteStepRef.current?.sendInvites();

--- a/app/src/i18n/locales/de/onboarding.json
+++ b/app/src/i18n/locales/de/onboarding.json
@@ -39,6 +39,7 @@
   "inventory-title": "GPC Basic Emissions-Inventar - Jahr {{year}}",
   "done-details": "Sie haben ihr Stadt-Profile erstellt, um mit der Erstellung Ihres GPC Basic GHG Inventars zu beginnen.",
   "check-dashboard": "Dashboard überprüfen",
+  "add-new-city": "Neue Stadt hinzufügen",
   "add-new-inventory": "Neues Inventar hinzufügen",
   "information-required": "Diese Informationen sind erforderlich und beeinflussen die Genauigkeit Ihres Treibhausgasinventars.",
   "year-placeholder": "Jahr",

--- a/app/src/i18n/locales/en/onboarding.json
+++ b/app/src/i18n/locales/en/onboarding.json
@@ -120,6 +120,7 @@
   "geographical-boundaries": "Geographical boundaries",
   "done-heading": "Your city is all set up!",
   "done-description": "Great job! You can create and manage your GHG emissions inventory anytime from your dashboard.",
+  "add-new-city": "Add new city",
   "add-new-inventory": "Add new inventory",
   "inventory-title": "GPC Basic Emission Inventory - Year {{year}}",
   "done-details": "You created your city profile to start your GPC Basic GHG inventory.",

--- a/app/src/i18n/locales/es/onboarding.json
+++ b/app/src/i18n/locales/es/onboarding.json
@@ -36,6 +36,7 @@
   "total-land-area": "Superficie total del terreno",
   "geographical-boundaries": "Límites geográficos",
   "done-heading": "Inventario creado con éxito<br />",
+  "add-new-city": "Agregar nueva ciudad",
   "add-new-inventory": "Crear otro inventario",
   "inventory-title": "Inventario Básico de Emisiones GPC - Año {{year}}",
   "done-details": "Creaste tu perfil de ciudad para comenzar tu inventario de GEI con metodología GPC Básico.",

--- a/app/src/i18n/locales/fr/onboarding.json
+++ b/app/src/i18n/locales/fr/onboarding.json
@@ -114,6 +114,7 @@
   "geographical-boundaries": "Limites géographiques",
   "done-heading": "Votre inventaire d'émissions de GES est prêt à démarrer !",
   "done-description": "Excellent travail ! Vous pouvez revoir, ajouter et mettre à jour vos données d'inventaire à tout moment. Commencez à compléter votre inventaire d'émissions de GES dès maintenant !",
+  "add-new-city": "Ajouter une nouvelle ville",
   "add-new-inventory": "Ajouter un nouvel inventaire",
   "inventory-title": "Inventaire Basique des Émissions GPC - Année {{year}}",
   "done-details": "Vous avez créé votre profil de ville pour commencer votre inventaire de GES de base GPC.",

--- a/app/src/i18n/locales/pt/onboarding.json
+++ b/app/src/i18n/locales/pt/onboarding.json
@@ -39,6 +39,7 @@
   "inventory-title": "Inventário de Emissões Básico GPC - Ano {{year}}",
   "done-details": "Você criou seu perfil da cidade para iniciar seu inventário básico de GEE do GPC.",
   "check-dashboard": "Ver Painel",
+  "add-new-city": "Adicionar nova cidade",
   "add-new-inventory": "Adicionar novo inventário",
   "information-required": "Esta informação é obrigatória e afeta a precisão do seu inventário de GEE.",
   "year-placeholder": "Ano",


### PR DESCRIPTION
## Summary

Prevents users from continuing past the invite collaborators onboarding step without selecting a project, adding an email, and choosing a city. Also adds the missing `add-new-city` translation used on the onboarding done page.

## Changes

- Wire `InviteCollaboratorsStep` `onValidityChange` into the onboarding setup Continue button
- Disable Continue until project, invite email(s), and city are selected
- Add `add-new-city` to onboarding locales (`en`, `de`, `es`, `fr`, `pt`)

## How to test

1. Open `/en/cities/onboarding/setup/?project=...` and reach the invite collaborators step
2. Confirm Continue starts disabled
3. Enable Continue only after selecting a project, adding an email, and selecting a city
4. Confirm Skip still finishes onboarding
5. On the done page, confirm **Add new city** shows the translated label

## Ticket

[CC-652](https://linear.app/openearth/issue/CC-652/invite-collaborators-allows-continuing-without-selecting-a-project)