### PR TITLE
fix: CC-704 don't require ranking ID for action plan generation

### DIFF
--- a/app/src/app/api/v1/city/[city]/hiap/action-plan/generate/route.ts
+++ b/app/src/app/api/v1/city/[city]/hiap/action-plan/generate/route.ts
@@ -15,14 +15,14 @@ const generateRankingRequest = z.object({
 
 /**
  * @swagger
- * /api/v1/city/{city}/hiap/action-plan/generate/{rankingId}:
+ * /api/v1/city/{city}/hiap/action-plan/generate:
  *   post:
  *     tags:
  *       - city
  *       - hiap
- *     operationId: postCityHiapActionPlanGenerateRankingId
+ *     operationId: postCityHiapActionPlanGenerate
  *     summary: Generate action plan for a specific ranking
- *     description: Generate a new action plan based on the provided action and ranking ID. The city ID is extracted from the route parameter.
+ *     description: Generate a new action plan based on the provided action. The city ID is extracted from the route parameter.
  *     parameters:
  *       - in: path
  *         name: city
@@ -30,12 +30,6 @@ const generateRankingRequest = z.object({
  *         schema:
  *           type: string
  *         description: City ID
- *       - in: path
- *         name: rankingId
- *         required: true
- *         schema:
- *           type: string
- *         description: Ranking ID
  *     requestBody:
  *       required: true
  *       content:

--- a/app/src/components/ClimateActionCard.tsx
+++ b/app/src/components/ClimateActionCard.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Box, Button, Card, Icon, Text } from "@chakra-ui/react";
 import { TFunction } from "i18next";
 import { TopPickIcon } from "@/components/icons";

--- a/app/src/components/HIAP/GeneratePlanDrawer.tsx
+++ b/app/src/components/HIAP/GeneratePlanDrawer.tsx
@@ -64,7 +64,6 @@ export const GeneratePlanDrawer = ({
         inventoryId: inventoryId || "",
         cityLocode: cityLocode,
         lng: action.lang,
-        rankingId: action.hiaRankingId,
       });
 
       // Show immediate toast notification that generation has started

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -1500,7 +1500,6 @@ export const api = createApi({
           cityLocode: string;
           lng?: string;
           cityId: string;
-          rankingId: string;
         }
       >({
         query: ({
@@ -1509,16 +1508,14 @@ export const api = createApi({
           cityId,
           lng,
           cityLocode,
-          rankingId,
         }: {
           action: HIAction;
           inventoryId: string;
           cityId: string;
           cityLocode?: string;
           lng?: string;
-          rankingId: string;
         }) => ({
-          url: `city/${cityId}/hiap/action-plan/generate/${rankingId}`,
+          url: `city/${cityId}/hiap/action-plan/generate`,
           method: "POST",
           body: { action, inventoryId, cityLocode, lng },
         }),

--- a/app/tests/api/city-hiap-action_plan.jest.ts
+++ b/app/tests/api/city-hiap-action_plan.jest.ts
@@ -35,7 +35,7 @@ import {
   PATCH as updateActionPlan,
   DELETE as deleteActionPlan,
 } from "@/app/api/v1/city/[city]/hiap/action-plan/[id]/route";
-import { POST as generateActionPlan } from "@/app/api/v1/city/[city]/hiap/action-plan/generate/[rankingId]/route";
+import { POST as generateActionPlan } from "@/app/api/v1/city/[city]/hiap/action-plan/generate/route";
 
 import * as HiapApiService from "@/backend/hiap/HiapApiService";
 
@@ -569,7 +569,6 @@ describe("City HIAP Prioritization API", () => {
       const res = await generateActionPlan(req, {
         params: Promise.resolve({
           city: testData.cityId,
-          rankingId: ranking.id,
         }),
       });
 
@@ -603,7 +602,6 @@ describe("City HIAP Prioritization API", () => {
       const res = await generateActionPlan(req, {
         params: Promise.resolve({
           city: testData.cityId,
-          rankingId: randomUUID(),
         }),
       });
 


### PR DESCRIPTION
Fixes not being able to generate an action plan for unranked actions in HIAP.

Changing the path of the actiin plan generation route was required as unranked actions don't have a ranking ID, which made the request fail because of a missing URL path parameter.