### PR TITLE
CC-612: Fix GHGI module not enabled by default after onboarding

### DIFF
--- a/app/src/app/api/v1/city/route.ts
+++ b/app/src/app/api/v1/city/route.ts
@@ -130,10 +130,11 @@ import createHttpError from "http-errors";
 import { NextResponse } from "next/server";
 import { randomUUID } from "node:crypto";
 import { logger } from "@/services/logger";
-import { DEFAULT_PROJECT_ID } from "@/util/constants";
+import { DEFAULT_PROJECT_ID, Modules } from "@/util/constants";
 import EmailService from "@/backend/EmailService";
 import UserService from "@/backend/UserService";
 import { PermissionService } from "@/backend/permissions/PermissionService";
+import { ModuleAccessService } from "@/backend/ModuleAccessService";
 import { Project } from "@/models/Project";
 
 export const POST = apiHandler(async (req, { session }) => {
@@ -170,6 +171,24 @@ export const POST = apiHandler(async (req, { session }) => {
         },
         "Project ID is not provided, defaulting to organization's default project",
       );
+
+      // GHGI is the baseline module every project should have access to, so
+      // the GHG Inventory module shows up on the dashboard right after
+      // onboarding instead of requiring a manual admin step. Check rather
+      // than relying solely on `projectCreated` so projects that were
+      // created without any ProjectModules rows (e.g. by this same code
+      // path before this fix) get self-healed on next use too.
+      const hasGhgiAccess = await ModuleAccessService.hasModuleAccess(
+        defaultProject.projectId,
+        Modules.GHGI.id,
+      );
+      if (!hasGhgiAccess) {
+        await ModuleAccessService.enableModuleAccess(
+          defaultProject.projectId,
+          Modules.GHGI.id,
+        );
+      }
+
       body.projectId = defaultProject.projectId;
     } else {
       logger.info("Project ID is not provided, defaulting to Default Project ");


### PR DESCRIPTION
## Summary

QA feedback on CC-612: after completing onboarding as an org-admin, the GHG Inventory module wasn't shown on the dashboard by default. New default projects created during onboarding had no `ProjectModules` rows, so GHGI access was never enabled.

## Changes

- Enable GHGI module access on the org-admin's default project in `POST /api/v1/city` whenever it's missing, right after the project is resolved/created.
- Check-then-enable rather than only on creation, so orgs whose default project was already created during the regression window get self-healed on next city creation too.

## How to test

1. Sign up / log in as a new org-admin and complete onboarding (create a city, no need to create an inventory).
2. Land on the dashboard (`/cities/[cityId]`) and confirm the GHG Inventory module card is visible instead of "No modules" / empty state.
3. For an org that already has a default project with zero modules (pre-existing regression case), create another city and confirm GHGI access gets backfilled.

## Ticket

https://linear.app/openearth/issue/CC-612/onboarding-readjust-admin-user-flow-according-to-figma