### PR TITLE
Fix HIAP action-plan CI 404 from bulk suite cleanup

### DIFF
--- a/app/tests/api/bulk-hiap-prioritization.jest.ts
+++ b/app/tests/api/bulk-hiap-prioritization.jest.ts
@@ -303,16 +303,23 @@ describe("Bulk HIAP Prioritization API", () => {
   });
 
   afterEach(async () => {
-    // Clean up rankings created during tests to prevent pollution
-    await db.models.HighImpactActionRanked.destroy({
-      where: {},
-      truncate: false,
-    });
-    await db.models.HighImpactActionRanking.destroy({
-      where: { inventoryId: inventoryIds },
-    });
+    // Only wipe this suite's rankings. `where: {}` on Ranked deletes every
+    // worker's HIAP fixtures and races with city-hiap-action_plan.jest.ts in CI.
+    if (inventoryIds.length > 0) {
+      const rankings = await db.models.HighImpactActionRanking.findAll({
+        where: { inventoryId: inventoryIds },
+      });
+      const rankingIds = rankings.map((ranking) => ranking.id);
+      if (rankingIds.length > 0) {
+        await db.models.HighImpactActionRanked.destroy({
+          where: { hiaRankingId: rankingIds },
+        });
+      }
+      await db.models.HighImpactActionRanking.destroy({
+        where: { inventoryId: inventoryIds },
+      });
+    }
 
-    // Reset all mocks to ensure clean state
     jest.clearAllMocks();
   });
 

--- a/app/tests/api/city-hiap-action_plan.jest.ts
+++ b/app/tests/api/city-hiap-action_plan.jest.ts
@@ -99,17 +99,28 @@ describe("City HIAP Prioritization API", () => {
   });
 
   afterAll(async () => {
-    // Cleanup any remaining action plans
     if (inventoryId) {
-      try {
-        await db.models.ActionPlan.destroy({
-          where: { cityLocode: "XX-APT" },
+      await db.models.ActionPlan.destroy({
+        where: { cityLocode: "XX-APT" },
+      });
+      const rankings = await db.models.HighImpactActionRanking.findAll({
+        where: { inventoryId },
+      });
+      const rankingIds = rankings.map((ranking) => ranking.id);
+      if (rankingIds.length > 0) {
+        await db.models.HighImpactActionRanked.destroy({
+          where: { hiaRankingId: rankingIds },
         });
+      }
+      await db.models.HighImpactActionRanking.destroy({
+        where: { inventoryId },
+      });
+      try {
         await db.models.NativeInputCatalog.destroy({
           where: { inventoryId },
         });
       } catch {
-        // Table might not exist, that's okay
+        // Table might not exist in older test DBs
       }
       await db.models.Inventory.destroy({ where: { inventoryId } });
     }


### PR DESCRIPTION
## Summary

Stops parallel Jest workers from deleting each other's `HighImpactActionRanked` fixtures. CI was failing `city-hiap-action_plan.jest.ts` with `404 Ranked HIAP action not found` because the bulk HIAP suite's `afterEach` wiped every ranked row in the shared database.

## Changes

- Scope `bulk-hiap-prioritization.jest.ts` `afterEach` cleanup to that suite's inventories instead of `destroy({ where: {} })`
- Delete rankings and ranked rows before inventory teardown in `city-hiap-action_plan.jest.ts` so leftover HIAP rows do not fail `afterAll`

## How to test

The race is CI-specific (parallel workers, shared Postgres). Confirm `runTests` is green on this PR. Locally:

1. From `app/`, run `npx jest tests/api/city-hiap-action_plan.jest.ts tests/api/bulk-hiap-prioritization.jest.ts --runInBand`
2. Confirm both files still pass

## Notes

Seen on develop after [CC-513 `runTests`](https://github.com/Open-Earth-Foundation/CityCatalyst/actions/runs/31976327319/job/95376434122). No production code change.
