### PR TITLE
feat: added column for matching rules in policy alignment

### DIFF
--- a/global-api/data-model/physical-model/schema.dbml
+++ b/global-api/data-model/physical-model/schema.dbml
@@ -367,6 +367,8 @@ Table "modelled"."action_policy_signals" {
   "doc_relevance" varchar [not null]
   "signal_summary" text [not null]
   "evidence_text" text [not null]
+  "match_type" varchar
+  "match_reason" text
   "page" integer [not null]
   "release_id" uuid [not null]
   "created_at" timestamptz [not null]

--- a/global-api/data-model/physical-model/schema.md
+++ b/global-api/data-model/physical-model/schema.md
@@ -327,6 +327,8 @@ erDiagram
         string doc_relevance
         string signal_summary
         string evidence_text
+        string match_type
+        string match_reason
         int page
         string release_id "FK"
         datetime created_at

--- a/global-api/migrations/versions/a7c4e91b3d05_add_match_type_reason_to_action_policy_signals.py
+++ b/global-api/migrations/versions/a7c4e91b3d05_add_match_type_reason_to_action_policy_signals.py
@@ -1,0 +1,50 @@
+"""add match_type and match_reason to modelled.action_policy_signals
+
+Revision ID: a7c4e91b3d05
+Revises: c3f9a7e1d2b8
+Create Date: 2026-08-17 00:00:00.000000
+
+Nullable columns on individual policy evidence rows:
+- match_type: how the finding relates to the action (direct, indirect, contextual)
+- match_reason: free-text explanation of that classification
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "a7c4e91b3d05"
+down_revision: Union[str, None] = "c3f9a7e1d2b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "action_policy_signals",
+        sa.Column("match_type", sa.String(), nullable=True),
+        schema="modelled",
+    )
+    op.add_column(
+        "action_policy_signals",
+        sa.Column("match_reason", sa.Text(), nullable=True),
+        schema="modelled",
+    )
+    op.create_check_constraint(
+        "ck_action_policy_signals_match_type",
+        "action_policy_signals",
+        "match_type IS NULL OR match_type IN ('direct', 'indirect', 'contextual')",
+        schema="modelled",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_action_policy_signals_match_type",
+        "action_policy_signals",
+        schema="modelled",
+        type_="check",
+    )
+    op.drop_column("action_policy_signals", "match_reason", schema="modelled")
+    op.drop_column("action_policy_signals", "match_type", schema="modelled")


### PR DESCRIPTION
Add match_type and match_reason on modelled.action_policy_signals so policy-alignment evidence can record how each finding relates to an action (direct, indirect, or contextual) and why.

Includes the Alembic migration and physical-model schema updates. match_type is nullable with a check constraint; match_reason is free-text.