### PR TITLE
CC-708: Fix unexpected input validation in Create Organization flow

### DIFF
--- a/app/src/app/[lng]/admin/CreateOrganizationModal.tsx
+++ b/app/src/app/[lng]/admin/CreateOrganizationModal.tsx
@@ -43,7 +43,7 @@ const schema = z.object({
   planType: z.nativeEnum(OrganizationPlanType),
   projectName: z.string().min(3, "required"),
   description: z.string().min(3, "required"),
-  cityCountLimit: z.number().min(1, "required"),
+  cityCountLimit: z.coerce.number().min(1, "required"),
 });
 
 type Schema = z.infer<typeof schema>;
@@ -61,8 +61,6 @@ const CreateOrganizationModal: FC<CreateOrganizationModalProps> = ({
     handleSubmit,
     reset,
     watch,
-    setError,
-    clearErrors,
     control,
     trigger,
     formState: { errors },
@@ -362,15 +360,13 @@ const CreateOrganizationModal: FC<CreateOrganizationModalProps> = ({
                   <FormattedNumberInput
                     placeholder="00"
                     max={99999}
-                    setError={setError}
-                    clearErrors={clearErrors}
                     min={1}
                     control={control}
                     name={`cityCountLimit`}
                     t={t}
                     w="full"
                   />
-                  {errors.description && (
+                  {errors.cityCountLimit && (
                     <Box display="flex" gap="6px" alignItems="center" mt="6px">
                       <Icon as={MdWarning} color="sentiment.negativeDefault" />
                       <Text color="error" fontSize="body.sm">

--- a/app/src/app/[lng]/admin/organization/[id]/projects/CreateEditProjectModal.tsx
+++ b/app/src/app/[lng]/admin/organization/[id]/projects/CreateEditProjectModal.tsx
@@ -36,7 +36,7 @@ interface CreateEditProjectModalProps {
 const schema = z.object({
   projectName: z.string().min(3, "required"),
   description: z.string().min(3, "required"),
-  cityCountLimit: z.number().min(1, "required"),
+  cityCountLimit: z.coerce.number().min(1, "required"),
 });
 
 type Schema = z.infer<typeof schema>;
@@ -53,8 +53,6 @@ const CreateEditProjectModal: FC<CreateEditProjectModalProps> = ({
     register,
     handleSubmit,
     reset,
-    setError,
-    clearErrors,
     control,
     formState: { errors, isDirty },
   } = useForm<Schema>({
@@ -203,15 +201,13 @@ const CreateEditProjectModal: FC<CreateEditProjectModalProps> = ({
               <FormattedNumberInput
                 placeholder="00"
                 max={99999}
-                setError={setError}
-                clearErrors={clearErrors}
                 min={1}
                 control={control}
                 name={`cityCountLimit`}
                 t={t}
                 w="full"
               />
-              {errors.description && (
+              {errors.cityCountLimit && (
                 <Box display="flex" gap="6px" alignItems="center" mt="6px">
                   <Icon as={MdWarning} color="sentiment.negativeDefault" />
                   <Text color="error" fontSize="body.sm">

--- a/app/src/components/Modals/activity-modal/sections/DynamicFieldsSection.tsx
+++ b/app/src/components/Modals/activity-modal/sections/DynamicFieldsSection.tsx
@@ -160,10 +160,6 @@ export const DynamicFieldsSection = ({
                   placeholder={t("activity-data-amount-placeholder")}
                   max={f.max!}
                   id={f.id}
-                  setError={setError as unknown as UseFormSetError<FieldValues>}
-                  clearErrors={
-                    clearErrors as unknown as UseFormClearErrors<FieldValues>
-                  }
                   min={f.min!}
                   control={control}
                   name={`activity.${f.id}`}

--- a/app/src/components/formatted-number-input.tsx
+++ b/app/src/components/formatted-number-input.tsx
@@ -1,13 +1,5 @@
 import React, { useCallback, useLayoutEffect, useRef } from "react";
-import {
-  Control,
-  Controller,
-  FieldValues,
-  Path,
-  PathValue,
-  UseFormClearErrors,
-  UseFormSetError,
-} from "react-hook-form";
+import { Control, Controller, FieldValues, Path, PathValue } from "react-hook-form";
 import { Group, Input, InputAddon } from "@chakra-ui/react";
 import type { TFunction } from "i18next";
 import { NumberInputProps } from "./ui/number-input";
@@ -18,8 +10,6 @@ interface FormattedNumberInputProps<T extends FieldValues>
   extends NumberInputProps {
   control: Control<T>;
   name: Path<T>;
-  setError?: UseFormSetError<T>;
-  clearErrors?: UseFormClearErrors<T>;
   defaultValue?: PathValue<T, Path<T>>;
   isDisabled?: boolean;
   placeholder?: string;
@@ -171,20 +161,6 @@ function FormattedNumberInput<T extends FieldValues>({
       control={control}
       name={name}
       defaultValue={defaultValue}
-      rules={{
-        required: t("value-required"),
-        validate: (value) => {
-          if (value === "" || isNaN(value)) {
-            return t("value-required");
-          }
-          if (min != null && value < min) {
-            return t("value-too-low", { min });
-          }
-          if (max != null && value > max) {
-            return t("value-too-high", { max });
-          }
-        },
-      }}
       render={({ field }) => {
         const formatted = format(field.value);
         return (


### PR DESCRIPTION
## Summary

Fixes inconsistent/unexpected validation errors on the description and city-limit fields in the admin Create Organization flow (step 2) and the Add/Edit Project modal.

## Changes

- The city-limit error box was gated on `errors.description` instead of `errors.cityCountLimit` (copy/paste bug), so it showed/hid based on the wrong field's validity. Fixed in both `CreateOrganizationModal.tsx` and `CreateEditProjectModal.tsx`.
- `FormattedNumberInput` pushes a string value on every keystroke while the Zod schema expected `number`, causing an untranslated "Expected number, received string" error to flash while typing. Fixed by changing `cityCountLimit` to `z.coerce.number()` in both schemas.
- Removed dead code in `FormattedNumberInput`: a `Controller.rules` block that RHF's resolver already superseded (using untranslated i18n keys not present in the `admin` namespace), and the unused `setError`/`clearErrors` props.

## How to test

1. Run `npm run dev`, log in as admin, and open **Admin Panel → Add an organization**.
2. On step 2 ("Project"), type a value into **City limit** while leaving **Description** blank — confirm no error box appears (previously it would, incorrectly).
3. Fill in a description that's too short (e.g. `"ab"`), then type a valid city-limit value — confirm only the description shows a "This field is required" error, and the city-limit box stays clean.
4. Repeat the same checks in **Admin Panel → \<org\> → Projects → Add a project**.

## Ticket

CC-708

## Notes

The `max={99999}` city-limit cap was previously enforced only by the now-removed dead `rules` block, so it was already non-functional (Zod schema has no `.max()`). Not fixed here since it's a separate missing-validation gap, not part of this ticket's "unexpected validation" symptom — flagging as a possible fast-follow.
