### PR TITLE
CC-707: Fix duplicate password requirement message on reset page

### DIFF
--- a/app/src/app/[lng]/auth/update-password/page.tsx
+++ b/app/src/app/[lng]/auth/update-password/page.tsx
@@ -2,14 +2,12 @@
 
 import PasswordInput from "@/components/password-input";
 import { useTranslation } from "@/i18n/client";
-import { MdInfoOutline } from "react-icons/md";
-import { Button, Heading, Text, Icon, Box } from "@chakra-ui/react";
+import { Button, Heading, Text, Box } from "@chakra-ui/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState, use } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { logger } from "@/services/logger";
 import { getApiErrorMessage } from "@/util/helpers";
-import { Field } from "@/components/ui/field";
 
 type Inputs = {
   password: string;
@@ -74,29 +72,14 @@ export default function UpdatePassword(props: {
       </Text>
       <form onSubmit={handleSubmit(onSubmit)}>
         <Box display="flex" flexDirection="column" gap="16px">
-          <Field
-            helperText={
-              <>
-                <Icon
-                  as={MdInfoOutline}
-                  color="#2351DC"
-                  mr={1.5}
-                  mt={-0.5}
-                  boxSize={4}
-                />
-                {t("password-hint")}
-              </>
-            }
-          >
-            <PasswordInput
-              register={register}
-              error={errors.password}
-              name={t("new-password")}
-              t={t}
-              shouldValidate
-              watchPassword={watchPassword}
-            ></PasswordInput>
-          </Field>
+          <PasswordInput
+            register={register}
+            error={errors.password}
+            name={t("new-password")}
+            t={t}
+            shouldValidate
+            watchPassword={watchPassword}
+          />
           <PasswordInput
             register={register}
             error={errors.confirmPassword}


### PR DESCRIPTION
## Summary

Fixes the password requirement message being displayed twice on the password reset page (`/auth/update-password`).

## Changes

- Removed the redundant `Field`/`helperText` wrapper around the "New Password" input, which duplicated the hint that `PasswordInput` already renders internally when `shouldValidate` is set.
- Cleaned up now-unused imports (`Field`, `Icon`, `MdInfoOutline`).

## How to test

1. Run `npm run dev` and open `/en/auth/update-password?token=<any>`.
2. Click into the "New Password" field and type a short/invalid password.
3. Confirm the requirement message ("Your password must be at least 8 characters long and contain one uppercase letter and one number.") appears only once, below the field — matching the behavior already used on the signup page.

## Ticket

CC-707
