### PR TITLE
CC-712: Center onboarding illustration and fix mobile nav overflow

### DIFF
--- a/app/src/app/[lng]/cities/onboarding/page.tsx
+++ b/app/src/app/[lng]/cities/onboarding/page.tsx
@@ -56,51 +56,65 @@ export default function Onboarding(props: {
     : `${pathname}/setup`;
 
   return (
-    <>
-      <Box w={"1090px"} maxW="full" mx="auto">
-        <Box display="flex" gap="55px" alignItems="center">
-          <Box w="full" h="full" display="flex" flexDir="column" gap="24px">
-            <Text
-              fontFamily="heading"
-              fontWeight="600"
-              lineHeight="16px"
-              letterSpacing="1.5px"
-              textTransform="uppercase"
-              color="content.tertiary"
-              fontSize="title.sm"
-              data-testid="start-page-title"
-            >
-              {t("welcome-top")}
-            </Text>
-            <Heading
-              as="h1"
-              color="content.alternative"
-              fontSize="display.sm"
-              lineHeight="44px"
-              fontWeight="600"
-              fontStyle="normal"
-              data-testid="start-page-heading"
-            >
-              {t("welcome-title")}
-            </Heading>
-            <Text
-              color="content.tertiary"
-              fontSize="body.lg"
-              lineHeight="24px"
-              fontWeight="400"
-              letterSpacing="wide"
-              data-testid="start-page-description"
-            >
-              {t("welcome-description")}
-            </Text>
-          </Box>
-          <Box>
-            <Image
-              src="/assets/onboarding-building-illustration.png"
-              alt="buildings.png"
-              height={420}
-              width={900}
-            />
+    <Box
+      w="full"
+      h="calc(100vh - 80px)"
+      display="flex"
+      flexDirection="column"
+      justifyContent={{ base: "space-between", md: "center" }}
+    >
+      <Box
+        w="full"
+        pt={{ base: "32px", md: 0 }}
+        display="flex"
+        alignItems={{ base: "flex-start", md: "center" }}
+        justifyContent="center"
+      >
+        <Box w={"1090px"} maxW="full" mx="auto">
+          <Box display="flex" gap="55px" alignItems="center">
+            <Box w="full" h="full" display="flex" flexDir="column" gap="24px">
+              <Text
+                fontFamily="heading"
+                fontWeight="600"
+                lineHeight="16px"
+                letterSpacing="1.5px"
+                textTransform="uppercase"
+                color="content.tertiary"
+                fontSize="title.sm"
+                data-testid="start-page-title"
+              >
+                {t("welcome-top")}
+              </Text>
+              <Heading
+                as="h1"
+                color="content.alternative"
+                fontSize="display.sm"
+                lineHeight="44px"
+                fontWeight="600"
+                fontStyle="normal"
+                data-testid="start-page-heading"
+              >
+                {t("welcome-title")}
+              </Heading>
+              <Text
+                color="content.tertiary"
+                fontSize="body.lg"
+                lineHeight="24px"
+                fontWeight="400"
+                letterSpacing="wide"
+                data-testid="start-page-description"
+              >
+                {t("welcome-description")}
+              </Text>
+            </Box>
+            <Box display={{ base: "none", md: "block" }}>
+              <Image
+                src="/assets/onboarding-building-illustration.png"
+                alt="buildings.png"
+                height={420}
+                width={900}
+              />
+            </Box>
           </Box>
         </Box>
       </Box>
@@ -108,7 +122,7 @@ export default function Onboarding(props: {
         bg="base.light"
         h="145px"
         w="full"
-        pos="fixed"
+        pos={{ base: "static", md: "fixed" }}
         bottom="0"
         left="0"
         data-onboarding-bottom-bar
@@ -131,7 +145,7 @@ export default function Onboarding(props: {
           display="flex"
           justifyContent="end"
           py="32px"
-          px="175px"
+          px={{ base: 4, md: "175px" }}
           gap="16px"
         >
           <Button
@@ -150,6 +164,6 @@ export default function Onboarding(props: {
           </Button>
         </Box>
       </Box>
-    </>
+    </Box>
   );
 }

--- a/app/src/components/navigation-bar.tsx
+++ b/app/src/components/navigation-bar.tsx
@@ -169,10 +169,10 @@ export function NavigationBar({
         display="flex"
         justifyContent="space-between"
         flexDirection="row"
-        px={8}
+        px={{ base: 4, md: 8 }}
         py={4}
         alignItems="center"
-        gap={12}
+        gap={{ base: 2, md: 12 }}
         position="relative"
         zIndex={50}
         w="full"
@@ -216,13 +216,13 @@ export function NavigationBar({
                   />
                 </Link>
               )}
-              <Link href={homePath}>
+              <Link href={homePath} display={{ base: "none", md: "block" }}>
                 <Heading size="lg" color="base.light">
                   {t("title")}
                 </Heading>
               </Link>
               {moduleName && (
-                <>
+                <Box display={{ base: "none", md: "flex" }} alignItems="center" gap={2}>
                   <Separator
                     orientation="vertical"
                     height="5"
@@ -231,16 +231,16 @@ export function NavigationBar({
                   <Heading size="lg" color="base.light" fontWeight="normal">
                     {moduleName}
                   </Heading>
-                </>
+                </Box>
               )}
             </HStack>
           )}
         </Box>
 
         {/* Menu Items */}
-        <Box display="flex" gap="48px" alignItems="center">
+        <Box display="flex" gap={{ base: "12px", md: "48px" }} alignItems="center">
           {children}
-          <Box display="flex" gap="32px">
+          <Box display="flex" gap={{ base: "8px", md: "32px" }}>
             <MenuRoot
               onOpenChange={(details) => {
                 setLanguageMenuOpen(details.open);
@@ -271,6 +271,7 @@ export function NavigationBar({
                     />
 
                     <Text
+                      display={{ base: "none", md: "block" }}
                       fontSize="title.sm"
                       fontWeight="medium"
                       letterSpacing="wide"
@@ -310,7 +311,7 @@ export function NavigationBar({
               </MenuContent>
             </MenuRoot>
             {organizations && organizations.length > 1 && (
-              <Box display="flex">
+              <Box display={{ base: "none", md: "flex" }}>
                 <MenuRoot
                   onOpenChange={(details) => {
                     setOrgMenuOpen(details.open);
@@ -419,7 +420,12 @@ export function NavigationBar({
                   }
                 >
                   <MenuTrigger asChild whiteSpace="nowrap" textTransform="none">
-                    <Button variant="ghost" px="8px" minW="220px" minH="48px">
+                    <Button
+                      variant="ghost"
+                      px="8px"
+                      minW={{ base: "auto", md: "220px" }}
+                      minH="48px"
+                    >
                       <Box display="flex" alignItems="center" gap="4">
                         <Avatar
                           height="32px"
@@ -430,6 +436,7 @@ export function NavigationBar({
                           src={session.user?.image}
                         />
                         <Text
+                          display={{ base: "none", md: "block" }}
                           w="120px"
                           overflow="hidden"
                           textOverflow="ellipsis"


### PR DESCRIPTION
## Summary

Fixes the onboarding welcome screen's content (heading + illustration) not being centered, and makes the page responsive on mobile. Also fixes a pre-existing, app-wide mobile navbar bug surfaced while testing this page.

## Changes

- `cities/onboarding/page.tsx`: wrapped the welcome content and bottom CTA bar in a single full-height flex column (`h="calc(100vh - 80px)"`). Desktop centers the content both axes with the CTA bar fixed at the bottom, as originally intended. Mobile stacks content at the top and pins the CTA/stepper row to the true bottom of the page via `justify-content: space-between` — no manual gap tuning, works for any content length.
- The building illustration is hidden below the `md` breakpoint (it didn't scale down cleanly and rendered as a squished icon on narrow screens).
- `navigation-bar.tsx`: fixed an unrelated, pre-existing horizontal-overflow bug — the navbar didn't fit on mobile widths, requiring horizontal scroll to reach the user avatar menu. Hid/compacted non-essential labels (org switcher, language code text, username text) below `md`; the org switcher remains reachable via the mobile hamburger drawer, which already duplicates it.

## How to test

1. Run `npm run dev`, log in, and visit `/en/cities/onboarding`.
2. **Desktop** (≥768px wide): confirm the heading, description, and illustration are centered both horizontally and vertically in the space between the navbar and the CTA bar.
3. **Mobile** (e.g. Chrome DevTools device mode, 414×896): confirm the illustration is hidden, content sits near the top, and the "Get Started" button sits at the bottom of the page with no large empty gap or overflow.
4. On mobile, confirm the navbar (hamburger, logo, language flag, avatar) all fit within the viewport with no horizontal scrollbar, and the avatar dropdown still opens and offers Settings/Log out.

## Ticket

CC-712
