### PR TITLE
feat(api): CC-598 create MEED ranking route and data models

### DIFF
--- a/app/migrations/20260817120341-create-meed-action-ranked.cjs
+++ b/app/migrations/20260817120341-create-meed-action-ranked.cjs
@@ -51,6 +51,11 @@ module.exports = {
         allowNull: false,
         defaultValue: {},
       },
+      weights: {
+        type: Sequelize.JSONB,
+        allowNull: false,
+        defaultValue: {},
+      },
       created: {
         type: Sequelize.DATE,
         allowNull: false,

--- a/app/migrations/20260817120341-create-meed-action-ranked.cjs
+++ b/app/migrations/20260817120341-create-meed-action-ranked.cjs
@@ -44,7 +44,11 @@ module.exports = {
         type: Sequelize.FLOAT,
         allowNull: false,
       },
-      // TODO do we need evidence summary?
+      evidenceSummary: {
+        type: Sequelize.JSONB,
+        allowNull: false,
+        defaultValue: {},
+      },
       // this contains keys for each language
       explanations: {
         type: Sequelize.JSONB,

--- a/app/migrations/20260817120341-create-meed-action-ranked.cjs
+++ b/app/migrations/20260817120341-create-meed-action-ranked.cjs
@@ -24,6 +24,14 @@ module.exports = {
         type: Sequelize.TEXT,
         allowNull: false,
       },
+      rank: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      final_score: {
+        type: Sequelize.FLOAT,
+        allowNull: false,
+      },
       lang: {
         type: Sequelize.TEXT,
         allowNull: false,
@@ -46,7 +54,7 @@ module.exports = {
     });
   },
 
-  async down(queryInterface, Sequelize) {
+  async down(queryInterface) {
     await queryInterface.dropTable("MeedActionRanked");
   },
 };

--- a/app/migrations/20260817120341-create-meed-action-ranked.cjs
+++ b/app/migrations/20260817120341-create-meed-action-ranked.cjs
@@ -51,11 +51,6 @@ module.exports = {
         allowNull: false,
         defaultValue: {},
       },
-      is_selected: {
-        type: Sequelize.BOOLEAN,
-        allowNull: false,
-        defaultValue: true,
-      },
       created: {
         type: Sequelize.DATE,
         allowNull: false,

--- a/app/migrations/20260817120341-create-meed-action-ranked.cjs
+++ b/app/migrations/20260817120341-create-meed-action-ranked.cjs
@@ -32,9 +32,24 @@ module.exports = {
         type: Sequelize.FLOAT,
         allowNull: false,
       },
-      lang: {
-        type: Sequelize.TEXT,
+      impact_score: {
+        type: Sequelize.FLOAT,
         allowNull: false,
+      },
+      alignment_score: {
+        type: Sequelize.FLOAT,
+        allowNull: false,
+      },
+      feasibilityScore: {
+        type: Sequelize.FLOAT,
+        allowNull: false,
+      },
+      // TODO do we need evidence summary?
+      // this contains keys for each language
+      explanations: {
+        type: Sequelize.JSONB,
+        allowNull: false,
+        defaultValue: {},
       },
       is_selected: {
         type: Sequelize.BOOLEAN,

--- a/app/migrations/20260817120341-create-meed-action-ranked.cjs
+++ b/app/migrations/20260817120341-create-meed-action-ranked.cjs
@@ -1,0 +1,52 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable("MeedActionRanked", {
+      id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        primaryKey: true,
+        defaultValue: Sequelize.UUIDV4,
+      },
+      inventory_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: "Inventory",
+          key: "inventory_id",
+        },
+        onUpdate: "CASCADE",
+        onDelete: "CASCADE",
+      },
+      action_id: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      lang: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      is_selected: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: true,
+      },
+      created: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+      last_updated: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable("MeedActionRanked");
+  },
+};

--- a/app/migrations/20260818104133-create-meed-action-removed.cjs
+++ b/app/migrations/20260818104133-create-meed-action-removed.cjs
@@ -1,0 +1,98 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable("MeedActionRemoved", {
+      id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        primaryKey: true,
+        defaultValue: Sequelize.UUIDV4,
+      },
+      inventory_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: "Inventory",
+          key: "inventory_id",
+        },
+        onUpdate: "CASCADE",
+        onDelete: "CASCADE",
+      },
+      action_id: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      action_name: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      removal_reason: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      removal_source: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      is_selected: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: true,
+      },
+
+      // legal sub-object
+      verdict_category: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      ownership_category: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      restrictions_category: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+
+      // these contain keys for each language
+      ownership_description: {
+        type: Sequelize.JSONB,
+        allowNull: false,
+        defaultValue: {},
+      },
+      restrictions_description: {
+        type: Sequelize.JSONB,
+        allowNull: false,
+        defaultValue: {},
+      },
+      legal_justification: {
+        type: Sequelize.JSONB,
+        allowNull: false,
+        defaultValue: {},
+      },
+
+      legal_references: {
+        type: Sequelize.ARRAY(Sequelize.TEXT),
+        allowNull: false,
+        defaultValue: [],
+      },
+
+      created: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+      last_updated: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable("MeedActionRemoved");
+  },
+};

--- a/app/migrations/20260818104133-create-meed-action-removed.cjs
+++ b/app/migrations/20260818104133-create-meed-action-removed.cjs
@@ -36,11 +36,6 @@ module.exports = {
         type: Sequelize.TEXT,
         allowNull: false,
       },
-      is_selected: {
-        type: Sequelize.BOOLEAN,
-        allowNull: false,
-        defaultValue: true,
-      },
 
       // legal sub-object
       verdict_category: {

--- a/app/src/app/api/v1/city/[city]/meed/rank/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/rank/route.ts
@@ -12,7 +12,7 @@ import z from "zod";
  *       - meed
  *       - city
  *     operationId: createMeedRanking
- *     summary: Starts and retrieves MEED+ ranking for a given city
+ *     summary: Starts and retrieves MEED+ ranking for a given inventory
  *     description: Runs the ranking process in the MEED service, stores the result and returns ranked and removed actions.
  *     parameters:
  *       - in: path
@@ -128,7 +128,7 @@ import z from "zod";
 
 const runRankingRequest = z.object({
   // for CC internal use
-  inventoryId: z.string(),
+  inventoryId: z.string().uuid(),
 
   // passed along to hiap-meed microservice
   requestedLanguages: z.array(z.string()),
@@ -158,5 +158,144 @@ export const POST = apiHandler(async (req, { session }) => {
   await PermissionService.canAccessInventory(session, inventoryId);
 
   const result = await MeedApiService.runRanking(inventoryId, requestBody);
+  return NextResponse.json({ data: result });
+});
+
+/**
+ * @swagger
+ * /api/v1/city/{city}/meed/rank:
+ *   get:
+ *     tags:
+ *       - meed
+ *       - city
+ *     operationId: getMeedRanking
+ *     summary: Fetches MEED+ ranking for a given inventory from the database
+ *     description: Fetches ranking from the database and returns ranked and removed actions.
+ *     parameters:
+ *       - in: path
+ *         name: city
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: query
+ *         name: inventoryId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Ranking retrieved
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     rankedActions:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           id:
+ *                             type: string
+ *                             format: uuid
+ *                           inventoryId:
+ *                             type: string
+ *                             format: uuid
+ *                           actionId:
+ *                             type: string
+ *                           rank:
+ *                             type: number
+ *                           finalScore:
+ *                             type: number
+ *                           impactScore:
+ *                             type: number
+ *                           alignmentScore:
+ *                             type: number
+ *                           feasibilityScore:
+ *                             type: number
+ *                           explanations:
+ *                             type: object
+ *                             properties:
+ *                               en:
+ *                                 type: string
+ *                               es:
+ *                                 type: string
+ *                           created:
+ *                             type: string
+ *                             format: date-time
+ *                           lastUpdated:
+ *                             type: string
+ *                             format: date-time
+ *                     removedActions:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           id:
+ *                             type: string
+ *                             format: uuid
+ *                           inventoryId:
+ *                             type: string
+ *                             format: uuid
+ *                           actionId:
+ *                             type: string
+ *                           actionName:
+ *                             type: string
+ *                           removalReason:
+ *                             type: string
+ *                           removalSource:
+ *                             type: string
+ *                           verdictCategory:
+ *                             type: string
+ *                           ownershipCategory:
+ *                             type: string
+ *                           restrictionsCategory:
+ *                             type: string
+ *                           ownershipDescription:
+ *                             type: object
+ *                             properties:
+ *                               en:
+ *                                 type: string
+ *                               es:
+ *                                 type: string
+ *                           restrictionsDescription:
+ *                             type: object
+ *                             properties:
+ *                               en:
+ *                                 type: string
+ *                               es:
+ *                                 type: string
+ *                           legalJustification:
+ *                             type: object
+ *                             properties:
+ *                               en:
+ *                                 type: string
+ *                               es:
+ *                                 type: string
+ *                           legalReferences:
+ *                             type: array
+ *                             items:
+ *                               type: string
+ *                           created:
+ *                             type: string
+ *                             format: date-time
+ *                           lastUpdated:
+ *                             type: string
+ *                             format: date-time
+ */
+
+const getRankingQuery = z.object({
+  inventoryId: z.string().uuid(),
+});
+export const GET = apiHandler(async (_req, { session, searchParams }) => {
+  const { inventoryId } = getRankingQuery.parse(searchParams);
+  await PermissionService.canAccessInventory(session, inventoryId);
+
+  const result = await MeedApiService.getRanking(inventoryId);
   return NextResponse.json({ data: result });
 });

--- a/app/src/app/api/v1/city/[city]/meed/rank/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/rank/route.ts
@@ -225,6 +225,15 @@ export const POST = apiHandler(async (req, { session }) => {
  *                                 type: string
  *                               es:
  *                                 type: string
+ *                           weights:
+ *                             type: object
+ *                             properties:
+ *                               impact:
+ *                                 type: number
+ *                               alignment:
+ *                                 type: number
+ *                               feasibility:
+ *                                 type: number
  *                           created:
  *                             type: string
  *                             format: date-time

--- a/app/src/app/api/v1/city/[city]/meed/rank/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/rank/route.ts
@@ -55,6 +55,9 @@ import z from "zod";
  *                             type: number
  *                           feasibilityScore:
  *                             type: number
+ *                           evidenceSummary:
+ *                             type: object
+ *                             additionalProperties: true
  *                           explanations:
  *                             type: object
  *                             properties:
@@ -218,6 +221,9 @@ export const POST = apiHandler(async (req, { session }) => {
  *                             type: number
  *                           feasibilityScore:
  *                             type: number
+ *                           evidenceSummary:
+ *                             type: object
+ *                             additionalProperties: true
  *                           explanations:
  *                             type: object
  *                             properties:

--- a/app/src/app/api/v1/city/[city]/meed/rank/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/rank/route.ts
@@ -1,0 +1,113 @@
+import MeedApiService from "@/backend/MeedApiService";
+import { PermissionService } from "@/backend/permissions/PermissionService";
+import { apiHandler } from "@/util/api";
+import { NextResponse } from "next/server";
+import z from "zod";
+
+/**
+ * @swagger
+ * /api/v1/city/{city}/meed/rank:
+ *   post:
+ *     tags:
+ *       - meed
+ *       - city
+ *     operationId: createMeedRanking
+ *     summary: Starts and retrieves MEED+ ranking for a given city
+ *     description:
+ *     parameters:
+ *       - in: path
+ *         name: city
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Ranking retrieved
+ *         content:
+ *           application/json:
+ *             schema:
+ *             // TODO adjust to returned data schema
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     cityId:
+ *                       type: string
+ *                       format: uuid
+ *                     name:
+ *                       type: string
+ *                     region:
+ *                       type: string
+ *                       nullable: true
+ *                     country:
+ *                       type: string
+ *                       nullable: true
+ *                     locode:
+ *                       type: string
+ *                       nullable: true
+ *                     population:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           year:
+ *                             type: number
+ *                           population:
+ *                             type: number
+ *                     boundaries:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           boundaryId:
+ *                             type: string
+ *                             format: uuid
+ *                           name:
+ *                             type: string
+ */
+
+const runRankingRequest = z.object({
+  // for CC internal use
+  inventoryId: z.string(),
+
+  // passed along to hiap-meed microservice
+  requestedLanguages: z.array(z.string()),
+  topN: z.number().int().optional(),
+  createExplanations: z.boolean().default(false).optional(),
+  cityDataList: z.array(
+    z.object({
+      excludedActionIds: z.array(z.string()).default([]),
+      weightsOverride: z.record(z.number()),
+      cityStrategicPreferencesSectors: z.array(z.string()),
+      cityStrategicPreferenceTimeframes: z
+        .array(z.enum(["short", "medium", "long", "no_preference"]))
+        .default(["no_preference"]),
+      cityStrategicPreferenceCoBenefitKeys: z.array(z.string()).default([]),
+
+      // TODO this comes from our DB instead
+      locode: z.string().min(1),
+      countryCode: z.string().min(2).max(2),
+      populationSize: z.number().int().optional(),
+      cityEmissionsData: z.object({
+        inventoryYear: z.number().int().optional(),
+        gpcData: z.record(z.object({})),
+      }),
+    }),
+  ),
+});
+
+export type RunRankingRequest = Omit<
+  z.infer<typeof runRankingRequest>,
+  "inventoryId"
+>;
+
+export const POST = apiHandler(async (req, { session }) => {
+  const body = runRankingRequest.parse(await req.json());
+  const { inventoryId, ...requestBody } = body;
+  await PermissionService.canAccessInventory(session, inventoryId);
+
+  const result = await MeedApiService.runRanking(inventoryId, requestBody);
+  return NextResponse.json({ data: result });
+});

--- a/app/src/app/api/v1/city/[city]/meed/rank/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/rank/route.ts
@@ -27,45 +27,107 @@ import z from "zod";
  *         content:
  *           application/json:
  *             schema:
- *             // TODO adjust to returned data schema
  *               type: object
  *               properties:
  *                 data:
  *                   type: object
  *                   properties:
- *                     cityId:
- *                       type: string
- *                       format: uuid
- *                     name:
- *                       type: string
- *                     region:
- *                       type: string
- *                       nullable: true
- *                     country:
- *                       type: string
- *                       nullable: true
- *                     locode:
- *                       type: string
- *                       nullable: true
- *                     population:
+ *                     rankedActions:
  *                       type: array
  *                       items:
  *                         type: object
  *                         properties:
- *                           year:
- *                             type: number
- *                           population:
- *                             type: number
- *                     boundaries:
- *                       type: array
- *                       items:
- *                         type: object
- *                         properties:
- *                           boundaryId:
+ *                           id:
  *                             type: string
  *                             format: uuid
- *                           name:
+ *                           inventoryId:
  *                             type: string
+ *                             format: uuid
+ *                           actionId:
+ *                             type: string
+ *                           rank:
+ *                             type: number
+ *                           finalScore:
+ *                             type: number
+ *                           impactScore:
+ *                             type: number
+ *                           alignmentScore:
+ *                             type: number
+ *                           feasibilityScore:
+ *                             type: number
+ *                           explanations:
+ *                             type: object
+ *                             properties:
+ *                               en:
+ *                                 type: string
+ *                               es:
+ *                                 type: string
+ *                           isSelected:
+ *                             type: boolean
+ *                           created:
+ *                             type: string
+ *                             format: date-time
+ *                           lastUpdated:
+ *                             type: string
+ *                             format: date-time
+ *                     removedActions:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           id:
+ *                             type: string
+ *                             format: uuid
+ *                           inventoryId:
+ *                             type: string
+ *                             format: uuid
+ *                           actionId:
+ *                             type: string
+ *                           actionName:
+ *                             type: string
+ *                           removalReason:
+ *                             type: string
+ *                           removalSource:
+ *                             type: string
+ *                           verdictCategory:
+ *                             type: string
+ *                           ownershipCategory:
+ *                             type: string
+ *                           restrictionsCategory:
+ *                             type: string
+ *                           ownershipDescription:
+ *                             type: object
+ *                             properties:
+ *                               en:
+ *                                 type: string
+ *                               es:
+ *                                 type: string
+ *                           restrictionsDescription:
+ *                             type: object
+ *                             properties:
+ *                               en:
+ *                                 type: string
+ *                               es:
+ *                                 type: string
+ *                           legalJustification:
+ *                             type: object
+ *                             properties:
+ *                               en:
+ *                                 type: string
+ *                               es:
+ *                                 type: string
+ *                           legalReferences:
+ *                             type: array
+ *                             items:
+ *                               type: string
+ *                           isSelected:
+ *                             type: boolean
+ *                           created:
+ *                             type: string
+ *                             format: date-time
+ *                           lastUpdated:
+ *                             type: string
+ *                             format: date-time
  */
 
 const runRankingRequest = z.object({

--- a/app/src/app/api/v1/city/[city]/meed/rank/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/rank/route.ts
@@ -62,8 +62,6 @@ import z from "zod";
  *                                 type: string
  *                               es:
  *                                 type: string
- *                           isSelected:
- *                             type: boolean
  *                           created:
  *                             type: string
  *                             format: date-time
@@ -120,8 +118,6 @@ import z from "zod";
  *                             type: array
  *                             items:
  *                               type: string
- *                           isSelected:
- *                             type: boolean
  *                           created:
  *                             type: string
  *                             format: date-time

--- a/app/src/app/api/v1/city/[city]/meed/rank/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/rank/route.ts
@@ -80,7 +80,7 @@ const runRankingRequest = z.object({
     z.object({
       excludedActionIds: z.array(z.string()).default([]),
       weightsOverride: z.record(z.number()),
-      cityStrategicPreferencesSectors: z.array(z.string()),
+      cityStrategicPreferenceSectors: z.array(z.string()),
       cityStrategicPreferenceTimeframes: z
         .array(z.enum(["short", "medium", "long", "no_preference"]))
         .default(["no_preference"]),

--- a/app/src/app/api/v1/city/[city]/meed/rank/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/rank/route.ts
@@ -13,7 +13,7 @@ import z from "zod";
  *       - city
  *     operationId: createMeedRanking
  *     summary: Starts and retrieves MEED+ ranking for a given city
- *     description:
+ *     description: Runs the ranking process in the MEED service, stores the result and returns ranked and removed actions.
  *     parameters:
  *       - in: path
  *         name: city

--- a/app/src/app/api/v1/city/[city]/meed/rank/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/rank/route.ts
@@ -85,15 +85,6 @@ const runRankingRequest = z.object({
         .array(z.enum(["short", "medium", "long", "no_preference"]))
         .default(["no_preference"]),
       cityStrategicPreferenceCoBenefitKeys: z.array(z.string()).default([]),
-
-      // TODO this comes from our DB instead
-      locode: z.string().min(1),
-      countryCode: z.string().min(2).max(2),
-      populationSize: z.number().int().optional(),
-      cityEmissionsData: z.object({
-        inventoryYear: z.number().int().optional(),
-        gpcData: z.record(z.object({})),
-      }),
     }),
   ),
 });

--- a/app/src/backend/InventoryService.ts
+++ b/app/src/backend/InventoryService.ts
@@ -141,7 +141,6 @@ export class InventoryService {
     }
 
     return {
-      //methodology?.id,
       activityType:
         methodology?.activityTypeField && data[methodology.activityTypeField]
           ? data[methodology.activityTypeField]

--- a/app/src/backend/InventoryService.ts
+++ b/app/src/backend/InventoryService.ts
@@ -1,8 +1,18 @@
 import { db } from "@/models";
 import { QueryTypes } from "sequelize";
 import { PermissionService } from "./permissions/PermissionService";
-import { type AppSession } from "@/lib/auth";
-import { Inventory } from "@/models/Inventory";
+import type { AppSession } from "@/lib/auth";
+import type { Inventory } from "@/models/Inventory";
+import type { ActivityValue } from "@/models/ActivityValue";
+import type { InventoryValue } from "@/models/InventoryValue";
+import {
+  findMethodology,
+  MANUAL_INPUT_HIERARCHY,
+  type DirectMeasure,
+  type Methodology,
+} from "@/util/form-schema";
+
+type ResolvedMethodology = Methodology | DirectMeasure;
 
 export class InventoryService {
   static async getInventoryIdByCityId(cityId: string): Promise<string> {
@@ -77,5 +87,75 @@ export class InventoryService {
 
     inventory.totalEmissions = sum != null ? Number(sum) : null;
     return inventory;
+  }
+
+  static resolveMethodology(
+    inventoryValue: InventoryValue,
+  ): ResolvedMethodology | undefined {
+    const gpcRefNo = inventoryValue.gpcReferenceNumber;
+    const methodologyId = inventoryValue.inputMethodology;
+    console.log("meth id", methodologyId);
+    if (!gpcRefNo || !methodologyId) return undefined;
+
+    if (methodologyId === "direct-measure") {
+      return MANUAL_INPUT_HIERARCHY[gpcRefNo]?.directMeasure;
+    }
+    return findMethodology(methodologyId, gpcRefNo);
+  }
+
+  static getActivityTitleKey(
+    activity: ActivityValue,
+    methodology?: ResolvedMethodology,
+  ): string {
+    const fromMetadata = activity.metadata?.activityTitle?.toString();
+    if (fromMetadata) return fromMetadata;
+
+    if (methodology && "activities" in methodology) {
+      const fromSchema = methodology.activities?.[0]?.["activity-title"];
+      if (fromSchema) return fromSchema;
+    }
+
+    if (methodology?.activityUnitsField) {
+      return `activity-${methodology.activityUnitsField}`;
+    }
+
+    return "activity-value";
+  }
+
+  static extractActivityFields(
+    activity: ActivityValue,
+    inventoryValue: InventoryValue,
+  ) {
+    const methodology = this.resolveMethodology(inventoryValue);
+    const data = activity.activityData ?? {};
+    const titleKey = this.getActivityTitleKey(activity, methodology);
+    console.log("Methodology", methodology);
+    const notationKey =
+      inventoryValue.unavailableReason &&
+      inventoryValue.unavailableReason.length > 0
+        ? inventoryValue.unavailableReason
+        : undefined;
+    let activityUnit = (
+      data[`${titleKey}-unit`] ?? data["activity-unit"]
+    )?.toString();
+    console.log("unit pre", activityUnit);
+    if (activityUnit?.startsWith("units-")) {
+      activityUnit = activityUnit.slice("units-".length);
+    }
+    console.log("unit post", activityUnit);
+
+    return {
+      //methodology?.id,
+      activityType:
+        methodology?.activityTypeField && data[methodology.activityTypeField]
+          ? data[methodology.activityTypeField]
+          : undefined,
+      totalEmissions: activity.co2eq,
+      totalEmissionsUnit: "kg",
+      activityValue: data[titleKey] ?? data["activity-value"],
+      activityUnit,
+      dataSource: activity.dataSource?.datasourceName ?? data["data-source"],
+      notationKey,
+    };
   }
 }

--- a/app/src/backend/InventoryService.ts
+++ b/app/src/backend/InventoryService.ts
@@ -94,7 +94,6 @@ export class InventoryService {
   ): ResolvedMethodology | undefined {
     const gpcRefNo = inventoryValue.gpcReferenceNumber;
     const methodologyId = inventoryValue.inputMethodology;
-    console.log("meth id", methodologyId);
     if (!gpcRefNo || !methodologyId) return undefined;
 
     if (methodologyId === "direct-measure") {
@@ -129,7 +128,6 @@ export class InventoryService {
     const methodology = this.resolveMethodology(inventoryValue);
     const data = activity.activityData ?? {};
     const titleKey = this.getActivityTitleKey(activity, methodology);
-    console.log("Methodology", methodology);
     const notationKey =
       inventoryValue.unavailableReason &&
       inventoryValue.unavailableReason.length > 0
@@ -138,11 +136,9 @@ export class InventoryService {
     let activityUnit = (
       data[`${titleKey}-unit`] ?? data["activity-unit"]
     )?.toString();
-    console.log("unit pre", activityUnit);
     if (activityUnit?.startsWith("units-")) {
       activityUnit = activityUnit.slice("units-".length);
     }
-    console.log("unit post", activityUnit);
 
     return {
       //methodology?.id,

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -64,17 +64,12 @@ type MeedResponseActionRemoved = {
     verdict_category?: string;
     ownership_category?: string;
     restrictions_category?: string;
-    // TODO use this once MEED API returns translation objects
-    /* ownership_description?: Record<string, string>;
-    restrictions_description?: Record<string, string>;
-    legal_justification?: Record<string, string>; */
-    ownership_description?: string;
-    ownership_description_es?: string;
-    restrictions_description?: string;
-    restrictions_description_es?: string;
-    legal_justification_en?: string;
-    legal_justification?: string;
     legal_references?: string[];
+
+    // these have a key for each requested language
+    ownership_description?: Record<string, string>;
+    restrictions_description?: Record<string, string>;
+    legal_justification?: Record<string, string>;
   };
 };
 
@@ -192,11 +187,6 @@ export default class MeedApiService {
         requestData: fullRequest,
         meta: {
           requestId: randomUUID(),
-          generatedAtUtc: new Date().toISOString(),
-          backendConsumer: "CityCatalyst",
-          upstreamProvider: "CityCatalyst",
-          apiContext: { endpoint: "/v1/prioritize" },
-          totalRecords: 1,
         },
       }),
       headers: {
@@ -257,19 +247,9 @@ export default class MeedApiService {
             verdictCategory: action.legal.verdict_category,
             ownershipCategory: action.legal.ownership_category,
             restrictionsCategory: action.legal.restrictions_category,
-            // TODO adjust once the MEED API returns translation objects for these
-            ownershipDescription: {
-              en: action.legal.ownership_description,
-              es: action.legal.ownership_description_es,
-            },
-            restrictionsDescription: {
-              en: action.legal.restrictions_description,
-              es: action.legal.restrictions_description_es,
-            },
-            legalJustification: {
-              en: action.legal.legal_justification_en,
-              es: action.legal.legal_justification,
-            },
+            ownershipDescription: action.legal.ownership_description,
+            restrictionsDescription: action.legal.restrictions_description,
+            legalJustification: action.legal.legal_justification,
             legalReferences: action.legal.legal_references,
           }),
           { transaction },

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -51,6 +51,7 @@ type MeedResponseActionRanked = {
   impact_score: number;
   alignment_score: number;
   feasibility_score: number;
+  evidence_summary: Record<string, object>;
   explanations: Record<string, string>;
 };
 
@@ -163,7 +164,7 @@ export default class MeedApiService {
         requestData: fullRequest,
         meta: {
           requestId: randomUUID(),
-          generatedAtUtc: new Date().toUTCString(),
+          generatedAtUtc: new Date().toISOString(),
           backendConsumer: "CityCatalyst",
           upstreamProvider: "CityCatalyst",
           apiContext: { endpoint: "/v1/prioritize" },
@@ -211,6 +212,7 @@ export default class MeedApiService {
           alignmentScore: action.alignment_score,
           feasibilityScore: action.feasibility_score,
           explanations: action.explanations,
+          evidenceSummary: action.evidence_summary,
           weights,
         })),
         { transaction },

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -178,7 +178,6 @@ export default class MeedApiService {
     const result = await response.json();
     const resultString = JSON.stringify(result, null, 2);
 
-    console.log("MEED result", resultString);
     if (response.status != 200 || result.detail) {
       throw new createHttpError.BadRequest("MEED API error: " + resultString);
     }
@@ -238,5 +237,20 @@ export default class MeedApiService {
     });
 
     return data;
+  }
+
+  public static async getRanking(inventoryId: string) {
+    const rankedActions = await db.models.MeedActionRanked.findAll({
+      where: {
+        inventoryId,
+      },
+    });
+    const removedActions = await db.models.MeedActionRemoved.findAll({
+      where: {
+        inventoryId,
+      },
+    });
+
+    return { rankedActions, removedActions };
   }
 }

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -186,6 +186,7 @@ export default class MeedApiService {
       result.results[0].ranked_actions;
     const removedActionsRaw: MeedResponseActionRemoved[] =
       result.results[0].removed_actions;
+    const weights = result.results[0].metadata.weights;
 
     // save result to database
     const data = await db.sequelize?.transaction(async (transaction) => {
@@ -210,6 +211,7 @@ export default class MeedApiService {
           alignmentScore: action.alignment_score,
           feasibilityScore: action.feasibility_score,
           explanations: action.explanations,
+          weights,
         })),
         { transaction },
       );

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -189,6 +189,16 @@ export default class MeedApiService {
 
     // save result to database
     const data = await db.sequelize?.transaction(async (transaction) => {
+      // delete previous data if it's present
+      await db.models.MeedActionRanked.destroy({
+        where: { inventoryId },
+        transaction,
+      });
+      await db.models.MeedActionRemoved.destroy({
+        where: { inventoryId },
+        transaction,
+      });
+
       const rankedActions = await db.models.MeedActionRanked.bulkCreate(
         rankedActionsRaw.map((action) => ({
           id: randomUUID(),

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -136,18 +136,46 @@ export default class MeedApiService {
                 inventoryValue.unavailableReason.length > 0
                   ? inventoryValue.unavailableReason
                   : undefined;
+              let activities = inventoryValue.activityValues.map((activity) => {
+                const fields = InventoryService.extractActivityFields(
+                  activity,
+                  inventoryValue,
+                );
+                return fields as GpcActivity;
+              });
+
+              // make sure direct measure data is represented even if there are no activities
+              if (activities.length === 0 && (inventoryValue.co2eq ?? 0) > 0) {
+                activities = [
+                  {
+                    activityType: "direct-measure",
+                    totalEmissions: Number(inventoryValue.co2eq) ?? 0,
+                    totalEmissionsUnit: "kg",
+                    dataSource: inventoryValue.dataSource?.datasourceName,
+                    notationKey: inventoryValue.unavailableReason ?? undefined,
+                  },
+                ];
+              }
+
+              // validation for duplicate or missing GPC reference numbers
+              if (!inventoryValue.gpcReferenceNumber) {
+                throw new createHttpError.BadRequest(
+                  "Missing GPC reference number for InventoryValue " +
+                    inventoryValue.id,
+                );
+              }
+              if (acc.hasOwnProperty(inventoryValue.gpcReferenceNumber)) {
+                throw new createHttpError.BadRequest(
+                  "Duplicate GPC reference number in inventory: " +
+                    inventoryValue.gpcReferenceNumber,
+                );
+              }
 
               return {
                 ...acc,
                 [inventoryValue.gpcReferenceNumber ?? ""]: {
                   notationKey,
-                  activities: inventoryValue.activityValues.map((activity) => {
-                    const fields = InventoryService.extractActivityFields(
-                      activity,
-                      inventoryValue,
-                    );
-                    return fields as GpcActivity;
-                  }),
+                  activities,
                 },
               };
             },

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -2,6 +2,7 @@ import { RunRankingRequest } from "@/app/api/v1/city/[city]/meed/rank/route";
 import { db } from "@/models";
 import PopulationService from "./PopulationService";
 import createHttpError from "http-errors";
+import { InventoryService } from "./InventoryService";
 
 const MEED_API_URL = process.env.HIAP_MEED_BACKEND_URL + "/v1/";
 
@@ -95,20 +96,22 @@ export default class MeedApiService {
           inventoryYear: inventory.year ?? 0,
           gpcData: inventoryValues.reduce(
             (acc, inventoryValue) => {
+              const notationKey =
+                inventoryValue.unavailableReason &&
+                inventoryValue.unavailableReason.length > 0
+                  ? inventoryValue.unavailableReason
+                  : undefined;
+
               return {
                 ...acc,
                 [inventoryValue.gpcReferenceNumber ?? ""]: {
-                  notationKey: inventoryValue.unavailableReason ?? undefined,
+                  notationKey,
                   activities: inventoryValue.activityValues.map((activity) => {
-                    return {
-                      activityType: activity.activityData?.activityType, // TODO?
-                      totalEmissions: activity.co2eq,
-                      totalEmissionsUnit: "kg",
-                      activityValue: activity.activityData?.activityValue, // TODO?
-                      activityUnit: activity.activityData?.activityUnit, // TODO?
-                      dataSource: activity.dataSource.datasourceName, // TODO is this what we need here
-                      notationKey: undefined, // not tracked at this level, it's on the InventoryValue level
-                    } as GpcActivity;
+                    const fields = InventoryService.extractActivityFields(
+                      activity,
+                      inventoryValue,
+                    );
+                    return fields as GpcActivity;
                   }),
                 },
               };
@@ -119,6 +122,7 @@ export default class MeedApiService {
       };
     });
 
+    /*
     const result = await fetch(MEED_API_URL + "prioritize", {
       method: "POST",
       body: JSON.stringify(fullRequest),
@@ -130,5 +134,8 @@ export default class MeedApiService {
     // TODO save result to database
 
     return result.json();
+    */
+
+    return fullRequest;
   }
 }

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -150,7 +150,7 @@ export default class MeedApiService {
     }
 
     console.log("MEED result", resultString);
-    const actions = result.data.results[0].ranked_action_ids;
+    const actions = result.data.results[0].ranked_actions;
 
     // TODO save result to database
 

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -44,6 +44,39 @@ type GpcActivity = {
   notationKey?: string;
 };
 
+type MeedResponseActionRanked = {
+  action_id: string;
+  rank: number;
+  final_score: number;
+  impact_score: number;
+  alignment_score: number;
+  feasibility_score: number;
+  explanations: Record<string, string>;
+};
+
+type MeedResponseActionRemoved = {
+  action_id: string;
+  action_name: string;
+  removal_reason?: string;
+  removal_source?: string;
+  legal: {
+    verdict_category?: string;
+    ownership_category?: string;
+    restrictions_category?: string;
+    // TODO use this once MEED API returns translation objects
+    /* ownership_description?: Record<string, string>;
+    restrictions_description?: Record<string, string>;
+    legal_justification?: Record<string, string>; */
+    ownership_description?: string;
+    ownership_description_es?: string;
+    restrictions_description?: string;
+    restrictions_description_es?: string;
+    legal_justification_en?: string;
+    legal_justification?: string;
+    legal_references?: string[];
+  };
+};
+
 export default class MeedApiService {
   public static async runRanking(
     inventoryId: string,
@@ -124,6 +157,7 @@ export default class MeedApiService {
       };
     });
 
+    // make API request to MEED API
     const response = await fetch(MEED_API_URL + "prioritize", {
       method: "POST",
       body: JSON.stringify({
@@ -144,16 +178,68 @@ export default class MeedApiService {
 
     const result = await response.json();
     const resultString = JSON.stringify(result, null, 2);
-    // TODO replace with only first condition when MEED API status responses are fixed
-    if (response.status != 200 || result.data.detail) {
+
+    console.log("MEED result", resultString);
+    if (response.status != 200 || result.detail) {
       throw new createHttpError.BadRequest("MEED API error: " + resultString);
     }
 
-    console.log("MEED result", resultString);
-    const actions = result.data.results[0].ranked_actions;
+    const rankedActionsRaw: MeedResponseActionRanked[] =
+      result.results[0].ranked_actions;
+    const removedActionsRaw: MeedResponseActionRemoved[] =
+      result.results[0].removed_actions;
 
-    // TODO save result to database
+    // save result to database
+    const data = await db.sequelize?.transaction(async (transaction) => {
+      const rankedActions = await db.models.MeedActionRanked.bulkCreate(
+        rankedActionsRaw.map((action) => ({
+          id: randomUUID(),
+          inventoryId,
+          actionId: action.action_id,
+          rank: action.rank,
+          finalScore: action.final_score,
+          impactScore: action.impact_score,
+          alignmentScore: action.alignment_score,
+          feasibilityScore: action.feasibility_score,
+          explanations: action.explanations,
+          isSelected: false, // TODO should we pre-select the top actions?
+        })),
+        { transaction },
+      );
+      const removedActions = await db.models.MeedActionRemoved.bulkCreate(
+        removedActionsRaw.map(
+          (action) => ({
+            id: randomUUID(),
+            inventoryId,
+            actionId: action.action_id,
+            actionName: action.action_name,
+            removalReason: action.removal_reason,
+            removalSource: action.removal_source,
+            verdictCategory: action.legal.verdict_category,
+            ownershipCategory: action.legal.ownership_category,
+            restrictionsCategory: action.legal.restrictions_category,
+            // TODO adjust once the MEED API returns translation objects for these
+            ownershipDescription: {
+              en: action.legal.ownership_description,
+              es: action.legal.ownership_description_es,
+            },
+            restrictionsDescription: {
+              en: action.legal.restrictions_description,
+              es: action.legal.restrictions_description_es,
+            },
+            legalJustification: {
+              en: action.legal.legal_justification_en,
+              es: action.legal.legal_justification,
+            },
+            legalReferences: action.legal.legal_references,
+            isSelected: false,
+          }),
+          { transaction },
+        ),
+      );
+      return { rankedActions, removedActions };
+    });
 
-    return result; // result.json();
+    return data;
   }
 }

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -202,7 +202,6 @@ export default class MeedApiService {
           alignmentScore: action.alignment_score,
           feasibilityScore: action.feasibility_score,
           explanations: action.explanations,
-          isSelected: false, // TODO should we pre-select the top actions?
         })),
         { transaction },
       );
@@ -232,7 +231,6 @@ export default class MeedApiService {
               es: action.legal.legal_justification,
             },
             legalReferences: action.legal.legal_references,
-            isSelected: false,
           }),
           { transaction },
         ),

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -90,8 +90,9 @@ export default class MeedApiService {
     fullRequest.cityDataList = requestBody.cityDataList.map((cityData) => {
       return {
         ...cityData,
-        locode: inventory.city.locode ?? "",
-        countryCode: inventory.city.countryLocode ?? "",
+        // TODO restore
+        locode: "CL IQQ", // inventory.city.locode ?? "",
+        countryCode: "CL", //inventory.city.countryLocode ?? "",
         populationSize: population ?? 0,
         cityEmissionsData: {
           inventoryYear: inventory.year ?? 0,
@@ -123,7 +124,7 @@ export default class MeedApiService {
       };
     });
 
-    const result = await fetch(MEED_API_URL + "prioritize", {
+    const response = await fetch(MEED_API_URL + "prioritize", {
       method: "POST",
       body: JSON.stringify({
         requestData: fullRequest,
@@ -141,11 +142,18 @@ export default class MeedApiService {
       },
     });
 
-    const json = await result.json();
-    console.log("MEED result", JSON.stringify(json, null, 2));
+    const result = await response.json();
+    const resultString = JSON.stringify(result, null, 2);
+    // TODO replace with only first condition when MEED API status responses are fixed
+    if (response.status != 200 || result.data.detail) {
+      throw new createHttpError.BadRequest("MEED API error: " + resultString);
+    }
+
+    console.log("MEED result", resultString);
+    const actions = result.data.results[0].ranked_action_ids;
 
     // TODO save result to database
 
-    return json; // result.json();
+    return result; // result.json();
   }
 }

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -13,7 +13,7 @@ type RunRankingFullRequest = {
   cityDataList: {
     excludedActionIds: string[];
     weightsOverride: Record<string, number>;
-    cityStrategicPreferencesSectors: string[];
+    cityStrategicPreferenceSectors: string[];
     cityStrategicPreferenceTimeframes: string[];
     cityStrategicPreferenceCoBenefitKeys: string[];
 

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -3,8 +3,9 @@ import { db } from "@/models";
 import PopulationService from "./PopulationService";
 import createHttpError from "http-errors";
 import { InventoryService } from "./InventoryService";
+import { randomUUID } from "node:crypto";
 
-const MEED_API_URL = process.env.HIAP_MEED_BACKEND_URL + "/v1/";
+const MEED_API_URL = process.env.HIAP_MEED_API_URL + "/v1/";
 
 type RunRankingFullRequest = {
   requestedLanguages: string[];
@@ -122,20 +123,29 @@ export default class MeedApiService {
       };
     });
 
-    /*
     const result = await fetch(MEED_API_URL + "prioritize", {
       method: "POST",
-      body: JSON.stringify(fullRequest),
+      body: JSON.stringify({
+        requestData: fullRequest,
+        meta: {
+          requestId: randomUUID(),
+          generatedAtUtc: new Date().toUTCString(),
+          backendConsumer: "CityCatalyst",
+          upstreamProvider: "CityCatalyst",
+          apiContext: { endpoint: "/v1/prioritize" },
+          totalRecords: 1,
+        },
+      }),
       headers: {
         "Content-Type": "application/json",
       },
     });
 
+    const json = await result.json();
+    console.log("MEED result", JSON.stringify(json, null, 2));
+
     // TODO save result to database
 
-    return result.json();
-    */
-
-    return fullRequest;
+    return json; // result.json();
   }
 }

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -1,0 +1,95 @@
+import { RunRankingRequest } from "@/app/api/v1/city/[city]/meed/rank/route";
+import { db } from "@/models";
+import PopulationService from "./PopulationService";
+import createHttpError from "http-errors";
+
+const MEED_API_URL = process.env.HIAP_MEED_BACKEND_URL + "/v1/";
+
+export default class MeedApiService {
+  public static async runRanking(
+    inventoryId: string,
+    requestBody: RunRankingRequest,
+  ): Promise<unknown> {
+    const inventory = await db.models.Inventory.findOne({
+      where: { inventoryId },
+      include: [
+        {
+          model: db.models.City,
+          as: "city",
+          include: [{ model: db.models.Population, as: "populations" }],
+        },
+      ],
+    });
+
+    if (!inventory) {
+      throw new createHttpError.NotFound("Inventory not found");
+    }
+
+    if (!inventory.cityId || !inventory.year) {
+      throw new createHttpError.BadRequest(
+        "Inventory has no city or year assigned",
+      );
+    }
+
+    const { population } = await PopulationService.getPopulationDataForCityYear(
+      inventory.cityId,
+      inventory.year,
+    );
+    const inventoryValues = await db.models.InventoryValue.findAll({
+      where: { inventoryId },
+      include: [
+        {
+          model: db.models.ActivityValue,
+          as: "activityValues",
+          include: [{ model: db.models.DataSource, as: "dataSource" }],
+        },
+      ],
+    });
+
+    requestBody.cityDataList = requestBody.cityDataList.map((cityData) => {
+      return {
+        ...cityData,
+        locode: inventory.city.locode ?? "",
+        countryCode: inventory.city.countryLocode ?? "",
+        populationSize: population ?? 0,
+        cityEmissionsData: {
+          year: inventory.year,
+          gpcData: inventoryValues.reduce(
+            (acc, inventoryValue) => {
+              return {
+                ...acc,
+                [inventoryValue.gpcReferenceNumber ?? ""]: {
+                  notationKey: inventoryValue.unavailableReason,
+                  activities: inventoryValue.activityValues.map((activity) => {
+                    return {
+                      activityType: activity.activityData?.activityType, // TODO?
+                      totalEmissions: activity.co2eq,
+                      totalEmissionsUnit: "kg",
+                      activityValue: activity.activityData?.activityValue, // TODO?
+                      activityUnit: activity.activityData?.activityUnit, // TODO?
+                      dataSource: activity.dataSource.datasourceName, // TODO is this what we need here
+                      notationKey: null, // not tracked at this level, it's on the InventoryValue level
+                    };
+                  }),
+                },
+              };
+            },
+            {} as Record<string, unknown>,
+          ),
+        },
+      };
+    });
+
+    const result = await fetch(MEED_API_URL + "prioritize", {
+      method: "POST",
+      body: JSON.stringify(requestBody),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    // TODO save result to database
+
+    return result.json();
+  }
+}

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -123,9 +123,8 @@ export default class MeedApiService {
     fullRequest.cityDataList = requestBody.cityDataList.map((cityData) => {
       return {
         ...cityData,
-        // TODO restore
-        locode: "CL IQQ", // inventory.city.locode ?? "",
-        countryCode: "CL", //inventory.city.countryLocode ?? "",
+        locode: inventory.city.locode ?? "",
+        countryCode: inventory.city.countryLocode ?? "",
         populationSize: population ?? 0,
         cityEmissionsData: {
           inventoryYear: inventory.year ?? 0,

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -5,6 +5,43 @@ import createHttpError from "http-errors";
 
 const MEED_API_URL = process.env.HIAP_MEED_BACKEND_URL + "/v1/";
 
+type RunRankingFullRequest = {
+  requestedLanguages: string[];
+  topN?: number;
+  createExplanations: boolean;
+  cityDataList: {
+    excludedActionIds: string[];
+    weightsOverride: Record<string, number>;
+    cityStrategicPreferencesSectors: string[];
+    cityStrategicPreferenceTimeframes: string[];
+    cityStrategicPreferenceCoBenefitKeys: string[];
+
+    // properties below are added from inventory data in database
+    locode: string;
+    countryCode: string;
+    populationSize: number;
+    cityEmissionsData: {
+      inventoryYear: number;
+      gpcData: Record<string, GpcDataEntry>;
+    };
+  }[];
+};
+
+type GpcDataEntry = {
+  notationKey?: string;
+  activities: GpcActivity[];
+};
+
+type GpcActivity = {
+  activityType?: string;
+  totalEmissions?: number;
+  totalEmissionsUnit?: string;
+  activityValue?: number;
+  activityUnit?: string;
+  dataSource?: string;
+  notationKey?: string;
+};
+
 export default class MeedApiService {
   public static async runRanking(
     inventoryId: string,
@@ -46,20 +83,22 @@ export default class MeedApiService {
       ],
     });
 
-    requestBody.cityDataList = requestBody.cityDataList.map((cityData) => {
+    // enrich frontend request with inventory data from database
+    const fullRequest = requestBody as RunRankingFullRequest;
+    fullRequest.cityDataList = requestBody.cityDataList.map((cityData) => {
       return {
         ...cityData,
         locode: inventory.city.locode ?? "",
         countryCode: inventory.city.countryLocode ?? "",
         populationSize: population ?? 0,
         cityEmissionsData: {
-          year: inventory.year,
+          inventoryYear: inventory.year ?? 0,
           gpcData: inventoryValues.reduce(
             (acc, inventoryValue) => {
               return {
                 ...acc,
                 [inventoryValue.gpcReferenceNumber ?? ""]: {
-                  notationKey: inventoryValue.unavailableReason,
+                  notationKey: inventoryValue.unavailableReason ?? undefined,
                   activities: inventoryValue.activityValues.map((activity) => {
                     return {
                       activityType: activity.activityData?.activityType, // TODO?
@@ -68,13 +107,13 @@ export default class MeedApiService {
                       activityValue: activity.activityData?.activityValue, // TODO?
                       activityUnit: activity.activityData?.activityUnit, // TODO?
                       dataSource: activity.dataSource.datasourceName, // TODO is this what we need here
-                      notationKey: null, // not tracked at this level, it's on the InventoryValue level
-                    };
+                      notationKey: undefined, // not tracked at this level, it's on the InventoryValue level
+                    } as GpcActivity;
                   }),
                 },
               };
             },
-            {} as Record<string, unknown>,
+            {} as Record<string, GpcDataEntry>,
           ),
         },
       };
@@ -82,7 +121,7 @@ export default class MeedApiService {
 
     const result = await fetch(MEED_API_URL + "prioritize", {
       method: "POST",
-      body: JSON.stringify(requestBody),
+      body: JSON.stringify(fullRequest),
       headers: {
         "Content-Type": "application/json",
       },

--- a/app/src/models/MeedActionRanked.ts
+++ b/app/src/models/MeedActionRanked.ts
@@ -11,6 +11,7 @@ export interface MeedActionRankedAttributes {
   impactScore?: number;
   alignmentScore?: number;
   feasibilityScore?: number;
+  evidenceSummary?: Record<string, object>;
   explanations?: Record<string, string>;
   weights?: Record<string, number>;
   created?: Date;
@@ -38,6 +39,7 @@ export class MeedActionRanked
   declare impactScore?: number;
   declare alignmentScore?: number;
   declare feasibilityScore?: number;
+  declare evidenceSummary?: Record<string, object>;
   declare explanations?: Record<string, string>;
   declare weights?: Record<string, number>;
   declare created?: Date;
@@ -96,6 +98,11 @@ export class MeedActionRanked
         feasibilityScore: {
           type: DataTypes.DOUBLE,
           allowNull: false,
+        },
+        evidenceSummary: {
+          type: DataTypes.JSONB,
+          allowNull: false,
+          defaultValue: {},
         },
         explanations: {
           type: DataTypes.JSONB,

--- a/app/src/models/MeedActionRanked.ts
+++ b/app/src/models/MeedActionRanked.ts
@@ -11,7 +11,8 @@ export interface MeedActionRankedAttributes {
   impactScore?: number;
   alignmentScore?: number;
   feasibilityScore?: number;
-  explanations?: object;
+  explanations?: Record<string, string>;
+  weights?: Record<string, number>;
   created?: Date;
   lastUpdated?: Date;
 }
@@ -37,7 +38,8 @@ export class MeedActionRanked
   declare impactScore?: number;
   declare alignmentScore?: number;
   declare feasibilityScore?: number;
-  declare explanations?: object;
+  declare explanations?: Record<string, string>;
+  declare weights?: Record<string, number>;
   declare created?: Date;
   declare lastUpdated?: Date;
 
@@ -96,6 +98,11 @@ export class MeedActionRanked
           allowNull: false,
         },
         explanations: {
+          type: DataTypes.JSONB,
+          allowNull: false,
+          defaultValue: {},
+        },
+        weights: {
           type: DataTypes.JSONB,
           allowNull: false,
           defaultValue: {},

--- a/app/src/models/MeedActionRanked.ts
+++ b/app/src/models/MeedActionRanked.ts
@@ -108,6 +108,17 @@ export class MeedActionRanked
           defaultValue: true,
           field: "is_selected",
         },
+        created: {
+          type: DataTypes.DATE,
+          allowNull: false,
+          defaultValue: DataTypes.NOW,
+        },
+        lastUpdated: {
+          field: "last_updated",
+          type: DataTypes.DATE,
+          allowNull: false,
+          defaultValue: DataTypes.NOW,
+        },
       },
       {
         sequelize,

--- a/app/src/models/MeedActionRanked.ts
+++ b/app/src/models/MeedActionRanked.ts
@@ -1,0 +1,118 @@
+import * as Sequelize from 'sequelize';
+import { DataTypes, Model, Optional } from 'sequelize';
+import type { Inventory, InventoryId } from './Inventory';
+
+export interface MeedActionRankedAttributes {
+  id: string;
+  inventoryId: string;
+  actionId: string;
+  rank: number;
+  finalScore: number;
+  impactScore: number;
+  alignmentScore: number;
+  feasibilityScore: number;
+  explanations: object;
+  isSelected: boolean;
+  created: Date;
+  lastUpdated: Date;
+}
+
+export type MeedActionRankedPk = "id";
+export type MeedActionRankedId = MeedActionRanked[MeedActionRankedPk];
+export type MeedActionRankedOptionalAttributes = "explanations" | "isSelected" | "created" | "lastUpdated";
+export type MeedActionRankedCreationAttributes = Optional<MeedActionRankedAttributes, MeedActionRankedOptionalAttributes>;
+
+export class MeedActionRanked extends Model<MeedActionRankedAttributes, MeedActionRankedCreationAttributes> implements MeedActionRankedAttributes {
+  id!: string;
+  inventoryId!: string;
+  actionId!: string;
+  rank!: number;
+  finalScore!: number;
+  impactScore!: number;
+  alignmentScore!: number;
+  feasibilityScore!: number;
+  explanations!: object;
+  isSelected!: boolean;
+  created!: Date;
+  lastUpdated!: Date;
+
+  // MeedActionRanked belongsTo Inventory via inventoryId
+  inventory!: Inventory;
+  getInventory!: Sequelize.BelongsToGetAssociationMixin<Inventory>;
+  setInventory!: Sequelize.BelongsToSetAssociationMixin<Inventory, InventoryId>;
+  createInventory!: Sequelize.BelongsToCreateAssociationMixin<Inventory>;
+
+  static initModel(sequelize: Sequelize.Sequelize): typeof MeedActionRanked {
+    return MeedActionRanked.init({
+    id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      primaryKey: true
+    },
+    inventoryId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: {
+        model: 'Inventory',
+        key: 'inventory_id'
+      },
+      field: 'inventory_id'
+    },
+    actionId: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: 'action_id'
+    },
+    rank: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    finalScore: {
+      type: DataTypes.DOUBLE,
+      allowNull: false,
+      field: 'final_score'
+    },
+    impactScore: {
+      type: DataTypes.DOUBLE,
+      allowNull: false,
+      field: 'impact_score'
+    },
+    alignmentScore: {
+      type: DataTypes.DOUBLE,
+      allowNull: false,
+      field: 'alignment_score'
+    },
+    feasibilityScore: {
+      type: DataTypes.DOUBLE,
+      allowNull: false
+    },
+    explanations: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: {}
+    },
+    isSelected: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+      field: 'is_selected'
+    }
+  }, {
+    sequelize,
+    tableName: 'MeedActionRanked',
+    schema: 'public',
+    timestamps: true,
+    createdAt: 'created',
+    updatedAt: 'last_updated',
+    indexes: [
+      {
+        name: "MeedActionRanked_pkey",
+        unique: true,
+        fields: [
+          { name: "id" },
+        ]
+      },
+    ]
+  });
+  }
+}

--- a/app/src/models/MeedActionRanked.ts
+++ b/app/src/models/MeedActionRanked.ts
@@ -1,118 +1,129 @@
-import * as Sequelize from 'sequelize';
-import { DataTypes, Model, Optional } from 'sequelize';
-import type { Inventory, InventoryId } from './Inventory';
+import * as Sequelize from "sequelize";
+import { DataTypes, Model, Optional } from "sequelize";
+import type { Inventory, InventoryId } from "./Inventory";
 
 export interface MeedActionRankedAttributes {
   id: string;
-  inventoryId: string;
-  actionId: string;
-  rank: number;
-  finalScore: number;
-  impactScore: number;
-  alignmentScore: number;
-  feasibilityScore: number;
-  explanations: object;
-  isSelected: boolean;
-  created: Date;
-  lastUpdated: Date;
+  inventoryId?: string;
+  actionId?: string;
+  rank?: number;
+  finalScore?: number;
+  impactScore?: number;
+  alignmentScore?: number;
+  feasibilityScore?: number;
+  explanations?: object;
+  isSelected?: boolean;
+  created?: Date;
+  lastUpdated?: Date;
 }
 
 export type MeedActionRankedPk = "id";
 export type MeedActionRankedId = MeedActionRanked[MeedActionRankedPk];
-export type MeedActionRankedOptionalAttributes = "explanations" | "isSelected" | "created" | "lastUpdated";
-export type MeedActionRankedCreationAttributes = Optional<MeedActionRankedAttributes, MeedActionRankedOptionalAttributes>;
+export type MeedActionRankedOptionalAttributes =
+  "explanations" | "isSelected" | "created" | "lastUpdated";
+export type MeedActionRankedCreationAttributes = Optional<
+  MeedActionRankedAttributes,
+  MeedActionRankedOptionalAttributes
+>;
 
-export class MeedActionRanked extends Model<MeedActionRankedAttributes, MeedActionRankedCreationAttributes> implements MeedActionRankedAttributes {
-  id!: string;
-  inventoryId!: string;
-  actionId!: string;
-  rank!: number;
-  finalScore!: number;
-  impactScore!: number;
-  alignmentScore!: number;
-  feasibilityScore!: number;
-  explanations!: object;
-  isSelected!: boolean;
-  created!: Date;
-  lastUpdated!: Date;
+export class MeedActionRanked
+  extends Model<MeedActionRankedAttributes, MeedActionRankedCreationAttributes>
+  implements MeedActionRankedAttributes
+{
+  declare id: string;
+  declare inventoryId?: string;
+  declare actionId?: string;
+  declare rank?: number;
+  declare finalScore?: number;
+  declare impactScore?: number;
+  declare alignmentScore?: number;
+  declare feasibilityScore?: number;
+  declare explanations?: object;
+  declare isSelected?: boolean;
+  declare created?: Date;
+  declare lastUpdated?: Date;
 
   // MeedActionRanked belongsTo Inventory via inventoryId
-  inventory!: Inventory;
-  getInventory!: Sequelize.BelongsToGetAssociationMixin<Inventory>;
-  setInventory!: Sequelize.BelongsToSetAssociationMixin<Inventory, InventoryId>;
-  createInventory!: Sequelize.BelongsToCreateAssociationMixin<Inventory>;
+  declare inventory: Inventory;
+  declare getInventory: Sequelize.BelongsToGetAssociationMixin<Inventory>;
+  declare setInventory: Sequelize.BelongsToSetAssociationMixin<
+    Inventory,
+    InventoryId
+  >;
+  declare createInventory: Sequelize.BelongsToCreateAssociationMixin<Inventory>;
 
   static initModel(sequelize: Sequelize.Sequelize): typeof MeedActionRanked {
-    return MeedActionRanked.init({
-    id: {
-      type: DataTypes.UUID,
-      allowNull: false,
-      primaryKey: true
-    },
-    inventoryId: {
-      type: DataTypes.UUID,
-      allowNull: false,
-      references: {
-        model: 'Inventory',
-        key: 'inventory_id'
-      },
-      field: 'inventory_id'
-    },
-    actionId: {
-      type: DataTypes.TEXT,
-      allowNull: false,
-      field: 'action_id'
-    },
-    rank: {
-      type: DataTypes.INTEGER,
-      allowNull: false
-    },
-    finalScore: {
-      type: DataTypes.DOUBLE,
-      allowNull: false,
-      field: 'final_score'
-    },
-    impactScore: {
-      type: DataTypes.DOUBLE,
-      allowNull: false,
-      field: 'impact_score'
-    },
-    alignmentScore: {
-      type: DataTypes.DOUBLE,
-      allowNull: false,
-      field: 'alignment_score'
-    },
-    feasibilityScore: {
-      type: DataTypes.DOUBLE,
-      allowNull: false
-    },
-    explanations: {
-      type: DataTypes.JSONB,
-      allowNull: false,
-      defaultValue: {}
-    },
-    isSelected: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: true,
-      field: 'is_selected'
-    }
-  }, {
-    sequelize,
-    tableName: 'MeedActionRanked',
-    schema: 'public',
-    timestamps: true,
-    createdAt: 'created',
-    updatedAt: 'last_updated',
-    indexes: [
+    return MeedActionRanked.init(
       {
-        name: "MeedActionRanked_pkey",
-        unique: true,
-        fields: [
-          { name: "id" },
-        ]
+        id: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          primaryKey: true,
+        },
+        inventoryId: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          references: {
+            model: "Inventory",
+            key: "inventory_id",
+          },
+          field: "inventory_id",
+        },
+        actionId: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+          field: "action_id",
+        },
+        rank: {
+          type: DataTypes.INTEGER,
+          allowNull: false,
+        },
+        finalScore: {
+          type: DataTypes.DOUBLE,
+          allowNull: false,
+          field: "final_score",
+        },
+        impactScore: {
+          type: DataTypes.DOUBLE,
+          allowNull: false,
+          field: "impact_score",
+        },
+        alignmentScore: {
+          type: DataTypes.DOUBLE,
+          allowNull: false,
+          field: "alignment_score",
+        },
+        feasibilityScore: {
+          type: DataTypes.DOUBLE,
+          allowNull: false,
+        },
+        explanations: {
+          type: DataTypes.JSONB,
+          allowNull: false,
+          defaultValue: {},
+        },
+        isSelected: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+          defaultValue: true,
+          field: "is_selected",
+        },
       },
-    ]
-  });
+      {
+        sequelize,
+        tableName: "MeedActionRanked",
+        schema: "public",
+        timestamps: true,
+        createdAt: "created",
+        updatedAt: "last_updated",
+        indexes: [
+          {
+            name: "MeedActionRanked_pkey",
+            unique: true,
+            fields: [{ name: "id" }],
+          },
+        ],
+      },
+    );
   }
 }

--- a/app/src/models/MeedActionRanked.ts
+++ b/app/src/models/MeedActionRanked.ts
@@ -12,7 +12,6 @@ export interface MeedActionRankedAttributes {
   alignmentScore?: number;
   feasibilityScore?: number;
   explanations?: object;
-  isSelected?: boolean;
   created?: Date;
   lastUpdated?: Date;
 }
@@ -20,7 +19,7 @@ export interface MeedActionRankedAttributes {
 export type MeedActionRankedPk = "id";
 export type MeedActionRankedId = MeedActionRanked[MeedActionRankedPk];
 export type MeedActionRankedOptionalAttributes =
-  "explanations" | "isSelected" | "created" | "lastUpdated";
+  "explanations" | "created" | "lastUpdated";
 export type MeedActionRankedCreationAttributes = Optional<
   MeedActionRankedAttributes,
   MeedActionRankedOptionalAttributes
@@ -39,7 +38,6 @@ export class MeedActionRanked
   declare alignmentScore?: number;
   declare feasibilityScore?: number;
   declare explanations?: object;
-  declare isSelected?: boolean;
   declare created?: Date;
   declare lastUpdated?: Date;
 
@@ -101,12 +99,6 @@ export class MeedActionRanked
           type: DataTypes.JSONB,
           allowNull: false,
           defaultValue: {},
-        },
-        isSelected: {
-          type: DataTypes.BOOLEAN,
-          allowNull: false,
-          defaultValue: true,
-          field: "is_selected",
         },
         created: {
           type: DataTypes.DATE,

--- a/app/src/models/MeedActionRemoved.ts
+++ b/app/src/models/MeedActionRemoved.ts
@@ -1,152 +1,172 @@
-import * as Sequelize from 'sequelize';
-import { DataTypes, Model, Optional } from 'sequelize';
-import type { Inventory, InventoryId } from './Inventory';
+import * as Sequelize from "sequelize";
+import { DataTypes, Model, Optional } from "sequelize";
+import type { Inventory, InventoryId } from "./Inventory";
 
 export interface MeedActionRemovedAttributes {
   id: string;
-  inventoryId: string;
-  actionId: string;
-  actionName: string;
-  removalReason: string;
-  removalSource: string;
-  isSelected: boolean;
-  verdictCategory: string;
-  ownershipCategory: string;
-  restrictionsCategory: string;
-  ownershipDescription: object;
-  restrictionsDescription: object;
-  legalJustification: object;
-  legalReferences: string[];
-  created: Date;
-  lastUpdated: Date;
+  inventoryId?: string;
+  actionId?: string;
+  actionName?: string;
+  removalReason?: string;
+  removalSource?: string;
+  isSelected?: boolean;
+  verdictCategory?: string;
+  ownershipCategory?: string;
+  restrictionsCategory?: string;
+  ownershipDescription?: object;
+  restrictionsDescription?: object;
+  legalJustification?: object;
+  legalReferences?: string[];
+  created?: Date;
+  lastUpdated?: Date;
 }
 
 export type MeedActionRemovedPk = "id";
 export type MeedActionRemovedId = MeedActionRemoved[MeedActionRemovedPk];
-export type MeedActionRemovedOptionalAttributes = "isSelected" | "ownershipDescription" | "restrictionsDescription" | "legalJustification" | "legalReferences" | "created" | "lastUpdated";
-export type MeedActionRemovedCreationAttributes = Optional<MeedActionRemovedAttributes, MeedActionRemovedOptionalAttributes>;
+export type MeedActionRemovedOptionalAttributes =
+  | "isSelected"
+  | "ownershipDescription"
+  | "restrictionsDescription"
+  | "legalJustification"
+  | "legalReferences"
+  | "created"
+  | "lastUpdated";
+export type MeedActionRemovedCreationAttributes = Optional<
+  MeedActionRemovedAttributes,
+  MeedActionRemovedOptionalAttributes
+>;
 
-export class MeedActionRemoved extends Model<MeedActionRemovedAttributes, MeedActionRemovedCreationAttributes> implements MeedActionRemovedAttributes {
-  id!: string;
-  inventoryId!: string;
-  actionId!: string;
-  actionName!: string;
-  removalReason!: string;
-  removalSource!: string;
-  isSelected!: boolean;
-  verdictCategory!: string;
-  ownershipCategory!: string;
-  restrictionsCategory!: string;
-  ownershipDescription!: object;
-  restrictionsDescription!: object;
-  legalJustification!: object;
-  legalReferences!: string[];
-  created!: Date;
-  lastUpdated!: Date;
+export class MeedActionRemoved
+  extends Model<
+    MeedActionRemovedAttributes,
+    MeedActionRemovedCreationAttributes
+  >
+  implements MeedActionRemovedAttributes
+{
+  declare id: string;
+  declare inventoryId?: string;
+  declare actionId?: string;
+  declare actionName?: string;
+  declare removalReason?: string;
+  declare removalSource?: string;
+  declare isSelected?: boolean;
+  declare verdictCategory?: string;
+  declare ownershipCategory?: string;
+  declare restrictionsCategory?: string;
+  declare ownershipDescription?: object;
+  declare restrictionsDescription?: object;
+  declare legalJustification?: object;
+  declare legalReferences?: string[];
+  declare created?: Date;
+  declare lastUpdated?: Date;
 
   // MeedActionRemoved belongsTo Inventory via inventoryId
-  inventory!: Inventory;
-  getInventory!: Sequelize.BelongsToGetAssociationMixin<Inventory>;
-  setInventory!: Sequelize.BelongsToSetAssociationMixin<Inventory, InventoryId>;
-  createInventory!: Sequelize.BelongsToCreateAssociationMixin<Inventory>;
+  declare inventory: Inventory;
+  declare getInventory: Sequelize.BelongsToGetAssociationMixin<Inventory>;
+  declare setInventory: Sequelize.BelongsToSetAssociationMixin<
+    Inventory,
+    InventoryId
+  >;
+  declare createInventory: Sequelize.BelongsToCreateAssociationMixin<Inventory>;
 
   static initModel(sequelize: Sequelize.Sequelize): typeof MeedActionRemoved {
-    return MeedActionRemoved.init({
-    id: {
-      type: DataTypes.UUID,
-      allowNull: false,
-      primaryKey: true
-    },
-    inventoryId: {
-      type: DataTypes.UUID,
-      allowNull: false,
-      references: {
-        model: 'Inventory',
-        key: 'inventory_id'
-      },
-      field: 'inventory_id'
-    },
-    actionId: {
-      type: DataTypes.TEXT,
-      allowNull: false,
-      field: 'action_id'
-    },
-    actionName: {
-      type: DataTypes.TEXT,
-      allowNull: false,
-      field: 'action_name'
-    },
-    removalReason: {
-      type: DataTypes.TEXT,
-      allowNull: false,
-      field: 'removal_reason'
-    },
-    removalSource: {
-      type: DataTypes.TEXT,
-      allowNull: false,
-      field: 'removal_source'
-    },
-    isSelected: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: true,
-      field: 'is_selected'
-    },
-    verdictCategory: {
-      type: DataTypes.TEXT,
-      allowNull: false,
-      field: 'verdict_category'
-    },
-    ownershipCategory: {
-      type: DataTypes.TEXT,
-      allowNull: false,
-      field: 'ownership_category'
-    },
-    restrictionsCategory: {
-      type: DataTypes.TEXT,
-      allowNull: false,
-      field: 'restrictions_category'
-    },
-    ownershipDescription: {
-      type: DataTypes.JSONB,
-      allowNull: false,
-      defaultValue: {},
-      field: 'ownership_description'
-    },
-    restrictionsDescription: {
-      type: DataTypes.JSONB,
-      allowNull: false,
-      defaultValue: {},
-      field: 'restrictions_description'
-    },
-    legalJustification: {
-      type: DataTypes.JSONB,
-      allowNull: false,
-      defaultValue: {},
-      field: 'legal_justification'
-    },
-    legalReferences: {
-      type: DataTypes.ARRAY(DataTypes.TEXT),
-      allowNull: false,
-      defaultValue: ["ARRAY[]"],
-      field: 'legal_references'
-    }
-  }, {
-    sequelize,
-    tableName: 'MeedActionRemoved',
-    schema: 'public',
-    timestamps: true,
-    createdAt: 'created',
-    updatedAt: 'last_updated',
-    indexes: [
+    return MeedActionRemoved.init(
       {
-        name: "MeedActionRemoved_pkey",
-        unique: true,
-        fields: [
-          { name: "id" },
-        ]
+        id: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          primaryKey: true,
+        },
+        inventoryId: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          references: {
+            model: "Inventory",
+            key: "inventory_id",
+          },
+          field: "inventory_id",
+        },
+        actionId: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+          field: "action_id",
+        },
+        actionName: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+          field: "action_name",
+        },
+        removalReason: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+          field: "removal_reason",
+        },
+        removalSource: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+          field: "removal_source",
+        },
+        isSelected: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+          defaultValue: true,
+          field: "is_selected",
+        },
+        verdictCategory: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+          field: "verdict_category",
+        },
+        ownershipCategory: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+          field: "ownership_category",
+        },
+        restrictionsCategory: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+          field: "restrictions_category",
+        },
+        ownershipDescription: {
+          type: DataTypes.JSONB,
+          allowNull: false,
+          defaultValue: {},
+          field: "ownership_description",
+        },
+        restrictionsDescription: {
+          type: DataTypes.JSONB,
+          allowNull: false,
+          defaultValue: {},
+          field: "restrictions_description",
+        },
+        legalJustification: {
+          type: DataTypes.JSONB,
+          allowNull: false,
+          defaultValue: {},
+          field: "legal_justification",
+        },
+        legalReferences: {
+          type: DataTypes.ARRAY(DataTypes.TEXT),
+          allowNull: false,
+          defaultValue: ["ARRAY[]"],
+          field: "legal_references",
+        },
       },
-    ]
-  });
+      {
+        sequelize,
+        tableName: "MeedActionRemoved",
+        schema: "public",
+        timestamps: true,
+        createdAt: "created",
+        updatedAt: "last_updated",
+        indexes: [
+          {
+            name: "MeedActionRemoved_pkey",
+            unique: true,
+            fields: [{ name: "id" }],
+          },
+        ],
+      },
+    );
   }
 }

--- a/app/src/models/MeedActionRemoved.ts
+++ b/app/src/models/MeedActionRemoved.ts
@@ -16,7 +16,6 @@ export interface MeedActionRemovedAttributes {
   restrictionsDescription?: object;
   legalJustification?: object;
   legalReferences?: string[];
-  isSelected?: boolean;
   created?: Date;
   lastUpdated?: Date;
 }
@@ -24,7 +23,6 @@ export interface MeedActionRemovedAttributes {
 export type MeedActionRemovedPk = "id";
 export type MeedActionRemovedId = MeedActionRemoved[MeedActionRemovedPk];
 export type MeedActionRemovedOptionalAttributes =
-  | "isSelected"
   | "ownershipDescription"
   | "restrictionsDescription"
   | "legalJustification"
@@ -56,7 +54,6 @@ export class MeedActionRemoved
   declare restrictionsDescription?: object;
   declare legalJustification?: object;
   declare legalReferences?: string[];
-  declare isSelected?: boolean;
   declare created?: Date;
   declare lastUpdated?: Date;
 
@@ -105,12 +102,6 @@ export class MeedActionRemoved
           type: DataTypes.TEXT,
           allowNull: false,
           field: "removal_source",
-        },
-        isSelected: {
-          type: DataTypes.BOOLEAN,
-          allowNull: false,
-          defaultValue: true,
-          field: "is_selected",
         },
         verdictCategory: {
           type: DataTypes.TEXT,

--- a/app/src/models/MeedActionRemoved.ts
+++ b/app/src/models/MeedActionRemoved.ts
@@ -151,6 +151,17 @@ export class MeedActionRemoved
           defaultValue: ["ARRAY[]"],
           field: "legal_references",
         },
+        created: {
+          type: DataTypes.DATE,
+          allowNull: false,
+          defaultValue: DataTypes.NOW,
+        },
+        lastUpdated: {
+          field: "last_updated",
+          type: DataTypes.DATE,
+          allowNull: false,
+          defaultValue: DataTypes.NOW,
+        },
       },
       {
         sequelize,

--- a/app/src/models/MeedActionRemoved.ts
+++ b/app/src/models/MeedActionRemoved.ts
@@ -9,7 +9,6 @@ export interface MeedActionRemovedAttributes {
   actionName?: string;
   removalReason?: string;
   removalSource?: string;
-  isSelected?: boolean;
   verdictCategory?: string;
   ownershipCategory?: string;
   restrictionsCategory?: string;
@@ -17,6 +16,7 @@ export interface MeedActionRemovedAttributes {
   restrictionsDescription?: object;
   legalJustification?: object;
   legalReferences?: string[];
+  isSelected?: boolean;
   created?: Date;
   lastUpdated?: Date;
 }
@@ -49,7 +49,6 @@ export class MeedActionRemoved
   declare actionName?: string;
   declare removalReason?: string;
   declare removalSource?: string;
-  declare isSelected?: boolean;
   declare verdictCategory?: string;
   declare ownershipCategory?: string;
   declare restrictionsCategory?: string;
@@ -57,6 +56,7 @@ export class MeedActionRemoved
   declare restrictionsDescription?: object;
   declare legalJustification?: object;
   declare legalReferences?: string[];
+  declare isSelected?: boolean;
   declare created?: Date;
   declare lastUpdated?: Date;
 

--- a/app/src/models/MeedActionRemoved.ts
+++ b/app/src/models/MeedActionRemoved.ts
@@ -1,0 +1,152 @@
+import * as Sequelize from 'sequelize';
+import { DataTypes, Model, Optional } from 'sequelize';
+import type { Inventory, InventoryId } from './Inventory';
+
+export interface MeedActionRemovedAttributes {
+  id: string;
+  inventoryId: string;
+  actionId: string;
+  actionName: string;
+  removalReason: string;
+  removalSource: string;
+  isSelected: boolean;
+  verdictCategory: string;
+  ownershipCategory: string;
+  restrictionsCategory: string;
+  ownershipDescription: object;
+  restrictionsDescription: object;
+  legalJustification: object;
+  legalReferences: string[];
+  created: Date;
+  lastUpdated: Date;
+}
+
+export type MeedActionRemovedPk = "id";
+export type MeedActionRemovedId = MeedActionRemoved[MeedActionRemovedPk];
+export type MeedActionRemovedOptionalAttributes = "isSelected" | "ownershipDescription" | "restrictionsDescription" | "legalJustification" | "legalReferences" | "created" | "lastUpdated";
+export type MeedActionRemovedCreationAttributes = Optional<MeedActionRemovedAttributes, MeedActionRemovedOptionalAttributes>;
+
+export class MeedActionRemoved extends Model<MeedActionRemovedAttributes, MeedActionRemovedCreationAttributes> implements MeedActionRemovedAttributes {
+  id!: string;
+  inventoryId!: string;
+  actionId!: string;
+  actionName!: string;
+  removalReason!: string;
+  removalSource!: string;
+  isSelected!: boolean;
+  verdictCategory!: string;
+  ownershipCategory!: string;
+  restrictionsCategory!: string;
+  ownershipDescription!: object;
+  restrictionsDescription!: object;
+  legalJustification!: object;
+  legalReferences!: string[];
+  created!: Date;
+  lastUpdated!: Date;
+
+  // MeedActionRemoved belongsTo Inventory via inventoryId
+  inventory!: Inventory;
+  getInventory!: Sequelize.BelongsToGetAssociationMixin<Inventory>;
+  setInventory!: Sequelize.BelongsToSetAssociationMixin<Inventory, InventoryId>;
+  createInventory!: Sequelize.BelongsToCreateAssociationMixin<Inventory>;
+
+  static initModel(sequelize: Sequelize.Sequelize): typeof MeedActionRemoved {
+    return MeedActionRemoved.init({
+    id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      primaryKey: true
+    },
+    inventoryId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: {
+        model: 'Inventory',
+        key: 'inventory_id'
+      },
+      field: 'inventory_id'
+    },
+    actionId: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: 'action_id'
+    },
+    actionName: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: 'action_name'
+    },
+    removalReason: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: 'removal_reason'
+    },
+    removalSource: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: 'removal_source'
+    },
+    isSelected: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+      field: 'is_selected'
+    },
+    verdictCategory: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: 'verdict_category'
+    },
+    ownershipCategory: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: 'ownership_category'
+    },
+    restrictionsCategory: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: 'restrictions_category'
+    },
+    ownershipDescription: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: {},
+      field: 'ownership_description'
+    },
+    restrictionsDescription: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: {},
+      field: 'restrictions_description'
+    },
+    legalJustification: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: {},
+      field: 'legal_justification'
+    },
+    legalReferences: {
+      type: DataTypes.ARRAY(DataTypes.TEXT),
+      allowNull: false,
+      defaultValue: ["ARRAY[]"],
+      field: 'legal_references'
+    }
+  }, {
+    sequelize,
+    tableName: 'MeedActionRemoved',
+    schema: 'public',
+    timestamps: true,
+    createdAt: 'created',
+    updatedAt: 'last_updated',
+    indexes: [
+      {
+        name: "MeedActionRemoved_pkey",
+        unique: true,
+        fields: [
+          { name: "id" },
+        ]
+      },
+    ]
+  });
+  }
+}

--- a/app/src/models/init-models.ts
+++ b/app/src/models/init-models.ts
@@ -115,6 +115,16 @@ import type {
   ImportMappingFeedbackCreationAttributes,
 } from "./ImportMappingFeedback";
 import { ImportMappingFeedback as _ImportMappingFeedback } from "./ImportMappingFeedback";
+import { MeedActionRanked as _MeedActionRanked } from "./MeedActionRanked";
+import type {
+  MeedActionRankedAttributes,
+  MeedActionRankedCreationAttributes,
+} from "./MeedActionRanked";
+import { MeedActionRemoved as _MeedActionRemoved } from "./MeedActionRemoved";
+import type {
+  MeedActionRemovedAttributes,
+  MeedActionRemovedCreationAttributes,
+} from "./MeedActionRemoved";
 import type {
   MethodologyAttributes,
   MethodologyCreationAttributes,
@@ -282,6 +292,8 @@ export {
   _PdfOcrJob as PdfOcrJob,
   _NativeInputCatalog as NativeInputCatalog,
   _ImportMappingFeedback as ImportMappingFeedback,
+  _MeedActionRanked as MeedActionRanked,
+  _MeedActionRemoved as MeedActionRemoved,
   _Methodology as Methodology,
   _Organization as Organization,
   _Project as Project,
@@ -365,6 +377,10 @@ export type {
   NativeInputCatalogCreationAttributes,
   ImportMappingFeedbackAttributes,
   ImportMappingFeedbackCreationAttributes,
+  MeedActionRankedAttributes,
+  MeedActionRankedCreationAttributes,
+  MeedActionRemovedAttributes,
+  MeedActionRemovedCreationAttributes,
   MethodologyAttributes,
   MethodologyCreationAttributes,
   OrganizationAttributes,
@@ -461,6 +477,8 @@ export function initModels(sequelize: Sequelize) {
   const PdfOcrJob = _PdfOcrJob.initModel(sequelize);
   const NativeInputCatalog = _NativeInputCatalog.initModel(sequelize);
   const ImportMappingFeedback = _ImportMappingFeedback.initModel(sequelize);
+  const MeedActionRanked = _MeedActionRanked.initModel(sequelize);
+  const MeedActionRemoved = _MeedActionRemoved.initModel(sequelize);
   const Methodology = _Methodology.initModel(sequelize);
   const Organization = _Organization.initModel(sequelize);
   const Project = _Project.initModel(sequelize);
@@ -1108,6 +1126,24 @@ export function initModels(sequelize: Sequelize) {
     foreignKey: "hiaRankingId",
   });
 
+  // Associations for MeedActionRanked and MeedActionRemoved
+  MeedActionRanked.belongsTo(Inventory, {
+    as: "inventory",
+    foreignKey: "inventoryId",
+  });
+  Inventory.hasMany(MeedActionRanked, {
+    as: "meedActionRankeds",
+    foreignKey: "inventoryId",
+  });
+  MeedActionRemoved.belongsTo(Inventory, {
+    as: "inventory",
+    foreignKey: "inventoryId",
+  });
+  Inventory.hasMany(MeedActionRemoved, {
+    as: "meedActionRemoveds",
+    foreignKey: "inventoryId",
+  });
+
   // Associations for UnrankedActionSelection
   UnrankedActionSelectionModel.belongsTo(Inventory, {
     as: "inventory",
@@ -1227,6 +1263,8 @@ export function initModels(sequelize: Sequelize) {
     PdfOcrJob: PdfOcrJob,
     NativeInputCatalog: NativeInputCatalog,
     ImportMappingFeedback: ImportMappingFeedback,
+    MeedActionRanked: MeedActionRanked,
+    MeedActionRemoved: MeedActionRemoved,
     Methodology: Methodology,
     Organization: Organization,
     Project: Project,


### PR DESCRIPTION
## Summary

Implements API route `/api/v1/city/CITY_ID/meed/rank`, along with the `MeedActionRanked` and `MeedActionRemoved` data models.

## Changes

- Created MeedApiService for interacting with the MEED microservice
- Implements API route `/api/v1/city/CITY_ID/meed/rank`
- Creates data models MeedActionRanked and MeedActionRemoved along with the respective migrations

## How to test

Make an API request to `/api/v1/city/CITY_ID/meed/rank` with the following body:
```json
{
  "inventoryId": "27aaf288-a90b-4600-8e1f-7f8f3cc1c78a",
  "requestedLanguages": ["en"],
  "topN": 5,
  "createExplanations": true,
  "cityDataList": [
    {
      "excludedActionIds": [],
      "weightsOverride": {},
      "cityStrategicPreferenceSectors": ["stationary_energy"],
      "cityStrategicPreferenceTimeframes": ["short"],
      "cityStrategicPreferenceCoBenefitKeys": []
    }
  ]
}
```

Verify data is returned after ~20 seconds (the model is run during the request in the MEED service).

## Ticket

CC-598