### PR TITLE
Fix HIAP action plan save and error/email handling

### DIFF
--- a/app/src/backend/hiap/ActionPlanService.ts
+++ b/app/src/backend/hiap/ActionPlanService.ts
@@ -462,7 +462,9 @@ export default class ActionPlanService {
         input.highImpactActionRankedId = undefined;
       }
 
-      if (input.inventoryId || input.highImpactActionRankedId) {
+      // Ranked plans must resolve against HighImpactActionRanked. Unranked plans
+      // (no ranked-row FK) skip this check so inventoryId alone does not fail save.
+      if (input.highImpactActionRankedId) {
         await this.validateHIAPActionPlanContext(input);
       }
 

--- a/app/src/backend/hiap/HiapApiService.ts
+++ b/app/src/backend/hiap/HiapApiService.ts
@@ -342,10 +342,17 @@ const startActionPlanJobImpl = async ({
 
     // Save action plan to database
     try {
+      // Ranked actions carry HighImpactActionRanked.id in `action.id` and the
+      // parent ranking UUID in `action.hiaRankingId`. Unranked actions leave
+      // hiaRankingId empty and must not pass a ranked-row FK.
+      const highImpactActionRankedId = action.hiaRankingId
+        ? action.id
+        : undefined;
+
       const { actionPlan, created } = await ActionPlanService.upsertActionPlan({
         cityId,
         actionId: action.actionId,
-        highImpactActionRankedId: action.hiaRankingId, // This should be the ranked ID, not ranking ID
+        highImpactActionRankedId,
         cityLocode,
         inventoryId,
         actionName: action.name,

--- a/app/src/backend/hiap/HiapApiService.ts
+++ b/app/src/backend/hiap/HiapApiService.ts
@@ -340,67 +340,58 @@ const startActionPlanJobImpl = async ({
       throw new Error("Invalid plan data format");
     }
 
-    // Save action plan to database
-    try {
-      // Ranked actions carry HighImpactActionRanked.id in `action.id` and the
-      // parent ranking UUID in `action.hiaRankingId`. Unranked actions leave
-      // hiaRankingId empty and must not pass a ranked-row FK.
-      const highImpactActionRankedId = action.hiaRankingId
-        ? action.id
-        : undefined;
+    // Ranked actions carry HighImpactActionRanked.id in `action.id` and the
+    // parent ranking UUID in `action.hiaRankingId`. Unranked actions leave
+    // hiaRankingId empty and must not pass a ranked-row FK.
+    const highImpactActionRankedId = action.hiaRankingId
+      ? action.id
+      : undefined;
 
-      const { actionPlan, created } = await ActionPlanService.upsertActionPlan({
-        cityId,
-        actionId: action.actionId,
-        highImpactActionRankedId,
-        cityLocode,
-        inventoryId,
-        actionName: action.name,
-        language: lng,
-        planData,
-        createdBy,
-      });
+    // Persist first; only treat the job as successful once the plan is saved.
+    const { actionPlan, created } = await ActionPlanService.upsertActionPlan({
+      cityId,
+      actionId: action.actionId,
+      highImpactActionRankedId,
+      cityLocode,
+      inventoryId,
+      actionName: action.name,
+      language: lng,
+      planData,
+      createdBy,
+    });
 
-      logger.info(
-        { actionPlanId: actionPlan.id, created },
-        `Action plan ${created ? "created" : "updated"} in database`,
-      );
+    logger.info(
+      { actionPlanId: actionPlan.id, created },
+      `Action plan ${created ? "created" : "updated"} in database`,
+    );
 
-      // Send email notification if action plan was successfully created
-      if (created && createdBy) {
-        try {
-          const user = await db.models.User.findByPk(createdBy);
-          if (user) {
-            await ActionPlanEmailService.sendActionPlanReadyEmailWithUrl(
-              user,
-              action.name,
-              planData.metadata?.cityName || cityLocode,
-              cityId,
-              inventoryId,
-              lng,
-            );
-          }
-        } catch (emailError) {
-          logger.error(
-            { error: emailError },
-            "Failed to send action plan email",
+    // Email only after a successful first-time save (not on regenerate/update).
+    if (created && createdBy) {
+      try {
+        const user = await db.models.User.findByPk(createdBy);
+        if (user) {
+          await ActionPlanEmailService.sendActionPlanReadyEmailWithUrl(
+            user,
+            action.name,
+            planData.metadata?.cityName || cityLocode,
+            cityId,
+            inventoryId,
+            lng,
           );
-          // Continue execution - email failure shouldn't break the API response
         }
+      } catch (emailError) {
+        logger.error(
+          { error: emailError },
+          "Failed to send action plan email",
+        );
+        // Plan is already saved — do not fail the request for email issues.
       }
-    } catch (dbError) {
-      logger.error(
-        { error: dbError },
-        "Failed to save action plan to database",
-      );
-      // Continue execution - don't fail the API response due to DB issues
     }
 
-    // Update state with the generated plan
     return {
       plan,
       timestamp: new Date().toISOString(),
-      actionName: action.name, // Use the action name
+      actionName: action.name,
     };
   } catch (error) {
     logger.error({ error }, "Error generating plan");

--- a/app/src/components/HIAP/GeneratePlanDrawer.tsx
+++ b/app/src/components/HIAP/GeneratePlanDrawer.tsx
@@ -56,28 +56,26 @@ export const GeneratePlanDrawer = ({
       return;
     }
 
+    // Inform the user immediately; success is confirmed by email after save.
+    const startedToastId = toaster.create({
+      title: t("plan-generation-started"),
+      description: t("plan-generation-started-description"),
+      type: "info",
+      duration: 5000,
+    });
+
     try {
-      // Start the plan generation process
-      generateActionPlan({
+      // Await so generation/save failures surface as an error toast (no email).
+      await generateActionPlan({
         action: action,
-        cityId: cityData?.cityId || "",
+        cityId: cityData.cityId,
         inventoryId: inventoryId || "",
         cityLocode: cityLocode,
         lng: action.lang,
-      });
-
-      // Show immediate toast notification that generation has started
-      toaster.create({
-        title: t("plan-generation-started"),
-        description: t("plan-generation-started-description"),
-        type: "info",
-        duration: 5000,
-      });
-
-      // Note: Plan generation happens in the background
-      // User will be notified via email when it's complete
+      }).unwrap();
     } catch (error) {
-      console.error("Failed to start plan generation:", error);
+      console.error("Failed to generate action plan:", error);
+      toaster.remove(startedToastId);
       toaster.create({
         title: t("plan-generation-failed"),
         description: t("plan-generation-failed-description"),

--- a/app/src/i18n/locales/de/hiap.json
+++ b/app/src/i18n/locales/de/hiap.json
@@ -139,7 +139,7 @@
   "plan-generation-started": "Plan-Generierung Gestartet",
   "plan-generation-started-description": "Ihr Aktionsplan wird generiert. Sie erhalten eine E-Mail-Benachrichtigung, wenn er fertig ist.",
   "plan-generation-failed": "Generierung Fehlgeschlagen",
-  "plan-generation-failed-description": "Fehler beim Starten der Plan-Generierung. Bitte versuchen Sie es erneut.",
+  "plan-generation-failed-description": "Fehler bei der Plan-Generierung. Bitte versuchen Sie es erneut.",
   "exit-selection": "Auswahl verlassen",
   "download-csv": "CSV",
   "export-as-csv": "Als CSV exportieren",

--- a/app/src/i18n/locales/en/hiap.json
+++ b/app/src/i18n/locales/en/hiap.json
@@ -150,7 +150,7 @@
   "plan-generation-started": "Plan Generation Started",
   "plan-generation-started-description": "Your action plan is being generated. You'll receive an email notification when it's ready.",
   "plan-generation-failed": "Generation Failed",
-  "plan-generation-failed-description": "Failed to start plan generation. Please try again.",
+  "plan-generation-failed-description": "Failed to generate your action plan. Please try again.",
   "reprioritization-started": "Reprioritization Started",
   "reprioritization-started-description": "Your climate actions are being re-prioritized with the latest data. You'll receive an email when complete.",
   "reprioritization-failed": "Reprioritization Failed",

--- a/app/src/i18n/locales/es/hiap.json
+++ b/app/src/i18n/locales/es/hiap.json
@@ -138,7 +138,7 @@
   "plan-generation-started": "Generación de Plan Iniciada",
   "plan-generation-started-description": "Su plan de acción se está generando. Recibirá una notificación por email cuando esté listo.",
   "plan-generation-failed": "Falló la Generación",
-  "plan-generation-failed-description": "Falló al iniciar la generación del plan. Por favor, inténtelo de nuevo.",
+  "plan-generation-failed-description": "Falló al generar el plan de acción. Por favor, inténtelo de nuevo.",
   "exit-selection": "Salir de la selección",
   "download-csv": "CSV",
   "export-as-csv": "Exportar como CSV",

--- a/app/src/i18n/locales/fr/hiap.json
+++ b/app/src/i18n/locales/fr/hiap.json
@@ -138,7 +138,7 @@
   "plan-generation-started": "Génération du Plan Commencée",
   "plan-generation-started-description": "Votre plan d'action est en cours de génération. Vous recevrez une notification par email quand il sera prêt.",
   "plan-generation-failed": "Échec de la Génération",
-  "plan-generation-failed-description": "Échec du démarrage de la génération du plan. Veuillez réessayer.",
+  "plan-generation-failed-description": "Échec de la génération du plan d'action. Veuillez réessayer.",
   "reprioritization-started": "Repriorisation Commencée",
   "reprioritization-started-description": "Vos actions climatiques sont en cours de repriorisation avec les dernières données. Vous recevrez un email à la fin.",
   "reprioritization-failed": "Échec de la Repriorisation",

--- a/app/src/i18n/locales/pt/hiap.json
+++ b/app/src/i18n/locales/pt/hiap.json
@@ -138,7 +138,7 @@
   "plan-generation-started": "Geração de Plano Iniciada",
   "plan-generation-started-description": "Seu plano de ação está sendo gerado. Você receberá uma notificação por email quando estiver pronto.",
   "plan-generation-failed": "Falha na Geração",
-  "plan-generation-failed-description": "Falha ao iniciar a geração do plano. Por favor, tente novamente.",
+  "plan-generation-failed-description": "Falha ao gerar seu plano de ação. Por favor, tente novamente.",
   "exit-selection": "Sair da seleção",
   "download-csv": "CSV",
   "export-as-csv": "Exportar como CSV",

--- a/app/tests/api/action-plan-generation.jest.ts
+++ b/app/tests/api/action-plan-generation.jest.ts
@@ -22,6 +22,7 @@ import {
 } from "../helpers/testDataCreationHelper";
 import { hiapApiWrapper } from "@/backend/hiap/HiapApiService";
 import { hiapServiceWrapper } from "@/backend/hiap/HiapService";
+import ActionPlanService from "@/backend/hiap/ActionPlanService";
 import ActionPlanEmailService from "@/backend/ActionPlanEmailService";
 import {
   ACTION_TYPES,
@@ -320,6 +321,12 @@ describe("Action Plan Generation", () => {
     });
 
     it("sends correct payload to start_plan_creation", async () => {
+      // Locode mismatch would fail DB validation; this test only covers HIAP payload.
+      jest.spyOn(ActionPlanService, "upsertActionPlan").mockResolvedValueOnce({
+        actionPlan: { id: randomUUID() } as any,
+        created: false,
+      });
+
       await hiapApiWrapper.startActionPlanJob({
         action: makeMockAction(rankedActionId, rankingId),
         cityId: testData.cityId,
@@ -497,6 +504,27 @@ describe("Action Plan Generation", () => {
 
       globalThis.fetch = mockFetch as typeof fetch;
     });
+
+    it("throws on DB save failure and does not send email", async () => {
+      jest
+        .spyOn(ActionPlanService, "upsertActionPlan")
+        .mockRejectedValueOnce(new Error("Ranked HIAP action not found"));
+
+      await expect(
+        hiapApiWrapper.startActionPlanJob({
+          action: makeMockAction(rankedActionId, rankingId),
+          cityId: testData.cityId,
+          cityLocode: "XX APT",
+          lng: LANGUAGES.en,
+          inventoryId,
+          createdBy: testData.userId,
+        }),
+      ).rejects.toThrow(/Failed to generate plan|Ranked HIAP action not found/);
+
+      expect(
+        ActionPlanEmailService.sendActionPlanReadyEmailWithUrl,
+      ).not.toHaveBeenCalled();
+    });
   });
 
   describe("startActionPlanJob - data flow", () => {
@@ -515,6 +543,12 @@ describe("Action Plan Generation", () => {
     });
 
     it("extracts country code from locode (first 2 chars)", async () => {
+      // Locode mismatch would fail DB validation; this test only covers countryCode.
+      jest.spyOn(ActionPlanService, "upsertActionPlan").mockResolvedValueOnce({
+        actionPlan: { id: randomUUID() } as any,
+        created: false,
+      });
+
       await hiapApiWrapper.startActionPlanJob({
         action: makeMockAction(rankedActionId, rankingId),
         cityId: testData.cityId,

--- a/app/tests/api/action-plan-generation.jest.ts
+++ b/app/tests/api/action-plan-generation.jest.ts
@@ -60,16 +60,20 @@ const MOCK_PLAN_RESPONSE = {
   },
 };
 
-const makeMockAction = (rankedActionId: string): AdaptationAction => ({
+const makeMockAction = (
+  rankedActionId: string,
+  rankingId: string,
+): AdaptationAction => ({
   actionId: "test-action-123",
   name: "Solar Rooftop",
-  hiaRankingId: rankedActionId,
+  // Match production HIAction shape from ActionService / HIAP status.
+  id: rankedActionId,
+  hiaRankingId: rankingId,
   type: ACTION_TYPES.Adaptation,
   lang: "en",
   GHGReductionPotential: null,
   adaptationEffectiveness: "",
 
-  id: randomUUID(),
   hazards: [],
   sectors: [],
   subsectors: [],
@@ -273,7 +277,7 @@ describe("Action Plan Generation", () => {
   describe("startActionPlanJob - success flow", () => {
     it("calls HIAP API in correct order: start, check_progress, get_plan", async () => {
       await hiapApiWrapper.startActionPlanJob({
-        action: makeMockAction(rankedActionId),
+        action: makeMockAction(rankedActionId, rankingId),
         cityId: testData.cityId,
         cityLocode: "XX APT",
         lng: LANGUAGES.en,
@@ -317,7 +321,7 @@ describe("Action Plan Generation", () => {
 
     it("sends correct payload to start_plan_creation", async () => {
       await hiapApiWrapper.startActionPlanJob({
-        action: makeMockAction(rankedActionId),
+        action: makeMockAction(rankedActionId, rankingId),
         cityId: testData.cityId,
         cityLocode: "BR SAO",
         lng: LANGUAGES.es,
@@ -342,7 +346,7 @@ describe("Action Plan Generation", () => {
 
     it("saves action plan to database", async () => {
       await hiapApiWrapper.startActionPlanJob({
-        action: makeMockAction(rankedActionId),
+        action: makeMockAction(rankedActionId, rankingId),
         cityId: testData.cityId,
         cityLocode: "XX APT",
         lng: LANGUAGES.en,
@@ -365,7 +369,7 @@ describe("Action Plan Generation", () => {
       });
 
       await hiapApiWrapper.startActionPlanJob({
-        action: makeMockAction(rankedActionId),
+        action: makeMockAction(rankedActionId, rankingId),
         cityId: testData.cityId,
         cityLocode: "XX APT",
         lng: LANGUAGES.en,
@@ -380,7 +384,7 @@ describe("Action Plan Generation", () => {
 
     it("returns plan, timestamp, and actionName", async () => {
       const result = await hiapApiWrapper.startActionPlanJob({
-        action: makeMockAction(rankedActionId),
+        action: makeMockAction(rankedActionId, rankingId),
         cityId: testData.cityId,
         cityLocode: "XX APT",
         lng: LANGUAGES.en,
@@ -405,7 +409,7 @@ describe("Action Plan Generation", () => {
 
       await expect(
         hiapApiWrapper.startActionPlanJob({
-          action: makeMockAction(rankedActionId),
+          action: makeMockAction(rankedActionId, rankingId),
           cityId: testData.cityId,
           cityLocode: "XX APT",
           lng: LANGUAGES.en,
@@ -426,7 +430,7 @@ describe("Action Plan Generation", () => {
 
       await expect(
         hiapApiWrapper.startActionPlanJob({
-          action: makeMockAction(rankedActionId),
+          action: makeMockAction(rankedActionId, rankingId),
           cityId: testData.cityId,
           cityLocode: "XX APT",
           lng: LANGUAGES.en,
@@ -447,7 +451,7 @@ describe("Action Plan Generation", () => {
 
       await expect(
         hiapApiWrapper.startActionPlanJob({
-          action: makeMockAction(rankedActionId),
+          action: makeMockAction(rankedActionId, rankingId),
           cityId: testData.cityId,
           cityLocode: "XX APT",
           lng: LANGUAGES.en,
@@ -465,7 +469,7 @@ describe("Action Plan Generation", () => {
 
       await expect(
         hiapApiWrapper.startActionPlanJob({
-          action: makeMockAction(rankedActionId),
+          action: makeMockAction(rankedActionId, rankingId),
           cityId: testData.cityId,
           cityLocode: "XX APT",
           lng: LANGUAGES.en,
@@ -483,7 +487,7 @@ describe("Action Plan Generation", () => {
 
       await expect(
         hiapApiWrapper.startActionPlanJob({
-          action: makeMockAction(rankedActionId),
+          action: makeMockAction(rankedActionId, rankingId),
           cityId: testData.cityId,
           cityLocode: "XX APT",
           lng: LANGUAGES.en,
@@ -498,7 +502,7 @@ describe("Action Plan Generation", () => {
   describe("startActionPlanJob - data flow", () => {
     it("uses getCityContextAndEmissionsData for payload", async () => {
       await hiapApiWrapper.startActionPlanJob({
-        action: makeMockAction(rankedActionId),
+        action: makeMockAction(rankedActionId, rankingId),
         cityId: testData.cityId,
         cityLocode: "XX APT",
         lng: LANGUAGES.en,
@@ -512,7 +516,7 @@ describe("Action Plan Generation", () => {
 
     it("extracts country code from locode (first 2 chars)", async () => {
       await hiapApiWrapper.startActionPlanJob({
-        action: makeMockAction(rankedActionId),
+        action: makeMockAction(rankedActionId, rankingId),
         cityId: testData.cityId,
         cityLocode: "CR SJ",
         lng: LANGUAGES.en,

--- a/app/tests/api/city-hiap-action_plan.jest.ts
+++ b/app/tests/api/city-hiap-action_plan.jest.ts
@@ -690,9 +690,10 @@ describe("City HIAP Prioritization API", () => {
 
       const requestBody = {
         action: {
+          id: rankedAction.id,
           actionId: rankedAction.actionId,
           name: "Generate Action",
-          hiaRankingId: rankedAction.id,
+          hiaRankingId: ranking.id,
         },
         inventoryId,
         cityLocode: "XX-APT",


### PR DESCRIPTION
## Summary

Fixes HIAP action plan generation failing to persist ranked plans (`Ranked HIAP action not found`) by using the ranked-action ID correctly. Also surfaces generation/save failures to the UI with an error toast, and only sends the ready email after a successful first-time DB save.

## Changes

- Pass `action.id` as `highImpactActionRankedId` for ranked actions; skip ranked-context validation for unranked plans
- Propagate DB save failures instead of returning success without a saved plan
- Await plan generation in `GeneratePlanDrawer` and show an error toast on failure
- Update generation API tests and failure copy

## How to test

1. Open HIAP for a city with ranked actions and generate an action plan.
2. Confirm the plan is saved and appears under “View Generated Plan”.
3. Confirm a ready email is sent only on first successful create.
4. Force or simulate a generation/save failure and confirm an error toast appears (no email).

## Ticket

CC-748
