### PR TITLE
CC-748: Route test web to HIAP test

### DIFF
--- a/.github/workflows/web-test.yml
+++ b/.github/workflows/web-test.yml
@@ -256,7 +256,7 @@ jobs:
             "NEXTAUTH_URL=https://citycatalyst-test.openearth.dev" \
             "NEXT_PUBLIC_API_URL=https://citycatalyst-test.openearth.dev" \
             "GLOBAL_API_URL=https://ccglobal-test.openearth.dev" \
-            "HIAP_API_URL=http://hiap-service-dev" \
+            "HIAP_API_URL=http://hiap-service-test" \
             "HIAP_MEED_API_URL=http://hiap-meed-service-test" \
             "NEXT_PUBLIC_OPENCLIMATE_API_URL=https://openclimate.openearth.dev" \
             "OPENCLIMATE_API_URL=https://openclimate.openearth.dev" \


### PR DESCRIPTION
## Summary

Routes the CityCatalyst test web deployment to `hiap-service-test` instead of `hiap-service-dev`. This keeps test web requests and HIAP processing in the same environment.

## Verification

- Cherry-picked the single deployment wiring commit from `develop`.
- `web-test.yml` parses as valid YAML.
- The diff contains only the HIAP test service address change.

## Deployment

Merging this PR into `main` triggers the web-test deployment workflow.