### PR TITLE
CC-746: Fix HIAP ranking-ready email 404 link

### DIFF
--- a/app/src/backend/ActionPlanEmailService.ts
+++ b/app/src/backend/ActionPlanEmailService.ts
@@ -5,6 +5,7 @@ import { User } from "@/models/User";
 import { logger } from "@/services/logger";
 import i18next from "@/i18n/server";
 import { LANGUAGES } from "@/util/types";
+import { buildHiapInventoryUrl } from "@/util/hiap-routes";
 
 export interface SendActionPlanEmailInput {
   user: User;
@@ -112,15 +113,14 @@ export default class ActionPlanEmailService {
   }
 
   /**
-   * Build the URL to view the action plan
+   * Build the URL to view the action plan on the city-scoped HIAP page.
    */
   public static buildActionPlanUrl(
     cityId: string,
     inventoryId: string,
     language: string = "en",
   ): string {
-    const baseUrl = process.env.HOST || "http://localhost:3000";
-    return `${baseUrl}/${language}/cities/${cityId}/HIAP/${inventoryId}`;
+    return buildHiapInventoryUrl(cityId, inventoryId, language);
   }
 
   /**

--- a/app/src/backend/EmailService.ts
+++ b/app/src/backend/EmailService.ts
@@ -26,6 +26,7 @@ import InviteUserTemplate from "@/lib/emails/InviteUserTemplate";
 import confirmRegistrationTemplate from "@/lib/emails/confirmRegistrationTemplate";
 import { UserFileResponse } from "@/util/types";
 import HiapRankingReadyTemplate from "@/lib/emails/HiapRankingReadyTemplate";
+import { buildHiapInventoryUrl } from "@/util/hiap-routes";
 
 interface EmailTranslation {
   subject: string;
@@ -800,18 +801,23 @@ export default class EmailService {
   public static async sendHiapRankingReadyEmail({
     actionType,
     user,
+    cityId,
+    inventoryId,
   }: {
     actionType: ACTION_TYPES;
     user: User;
+    cityId: string;
+    inventoryId: string;
   }) {
-    const host = process.env.HOST ?? "http://localhost:3000";
-    const url = `${host}/hiap/`;
+    const language = user.preferredLanguage || LANGUAGES.en;
+    // Must be the city-scoped HIAP page — `/hiap/` is not a valid app route (CC-746).
+    const url = buildHiapInventoryUrl(cityId, inventoryId, language);
     try {
       const html = await render(
         HiapRankingReadyTemplate({
           url,
           user: user,
-          language: user.preferredLanguage,
+          language,
         }),
       );
 

--- a/app/src/backend/hiap/HiapService.ts
+++ b/app/src/backend/hiap/HiapService.ts
@@ -897,7 +897,7 @@ export const checkActionRankingJob = async (
     // Send email notification when job completes successfully
     if (user && mergedRanked.length > 0) {
       try {
-        await sendRankedReadyEmail(user, type);
+        await sendRankedReadyEmail(user, type, ranking.inventoryId);
         logger.info(
           { userId: user.userId, actionType: type },
           "Sent prioritization ready email",
@@ -1237,8 +1237,26 @@ export async function copyRankedActionsToLang(
 }
 
 // Helper: Send email to user that the ranking is ready
-async function sendRankedReadyEmail(user: User, actionType: ACTION_TYPES) {
-  await EmailService.sendHiapRankingReadyEmail({ actionType, user });
+async function sendRankedReadyEmail(
+  user: User,
+  actionType: ACTION_TYPES,
+  inventoryId: string,
+) {
+  const inventory = await db.models.Inventory.findByPk(inventoryId);
+  if (!inventory?.cityId) {
+    logger.error(
+      { inventoryId },
+      "Cannot send HIAP ranking ready email: inventory has no cityId",
+    );
+    return;
+  }
+
+  await EmailService.sendHiapRankingReadyEmail({
+    actionType,
+    user,
+    cityId: inventory.cityId,
+    inventoryId,
+  });
 }
 
 // Main orchestrator

--- a/app/src/util/hiap-routes.ts
+++ b/app/src/util/hiap-routes.ts
@@ -1,0 +1,28 @@
+/**
+ * City-scoped HIAP URL helpers used by app navigation and notification emails.
+ */
+
+/** Build a city-scoped HIAP inventory path. */
+export function getHiapInventoryPath(
+  lng: string,
+  cityId: string,
+  inventoryId: string,
+): string {
+  return `/${lng}/cities/${cityId}/HIAP/${inventoryId}`;
+}
+
+/**
+ * Build an absolute HIAP inventory URL for emails and other external links.
+ * Strips a trailing slash from HOST so we never produce `//en/...`.
+ */
+export function buildHiapInventoryUrl(
+  cityId: string,
+  inventoryId: string,
+  language: string = "en",
+): string {
+  const baseUrl = (process.env.HOST || "http://localhost:3000").replace(
+    /\/$/,
+    "",
+  );
+  return `${baseUrl}${getHiapInventoryPath(language, cityId, inventoryId)}`;
+}

--- a/app/tests/hiap-routes.jest.ts
+++ b/app/tests/hiap-routes.jest.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for city-scoped HIAP URL helpers used by notification emails.
+ */
+import { afterEach, describe, expect, it } from "@jest/globals";
+import {
+  buildHiapInventoryUrl,
+  getHiapInventoryPath,
+} from "@/util/hiap-routes";
+
+describe("hiap-routes", () => {
+  const originalHost = process.env.HOST;
+
+  afterEach(() => {
+    if (originalHost === undefined) {
+      delete process.env.HOST;
+    } else {
+      process.env.HOST = originalHost;
+    }
+  });
+
+  it("builds the city-scoped HIAP path", () => {
+    expect(
+      getHiapInventoryPath(
+        "en",
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+      ),
+    ).toBe(
+      "/en/cities/11111111-1111-1111-1111-111111111111/HIAP/22222222-2222-2222-2222-222222222222",
+    );
+  });
+
+  it("builds an absolute email URL from HOST", () => {
+    process.env.HOST = "https://citycatalyst.openearth.dev";
+
+    expect(
+      buildHiapInventoryUrl(
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+        "es",
+      ),
+    ).toBe(
+      "https://citycatalyst.openearth.dev/es/cities/11111111-1111-1111-1111-111111111111/HIAP/22222222-2222-2222-2222-222222222222",
+    );
+  });
+
+  it("strips a trailing slash from HOST", () => {
+    process.env.HOST = "https://citycatalyst.io/";
+
+    expect(
+      buildHiapInventoryUrl(
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+      ),
+    ).toBe(
+      "https://citycatalyst.io/en/cities/11111111-1111-1111-1111-111111111111/HIAP/22222222-2222-2222-2222-222222222222",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes HIAP ranking-ready email CTAs that linked to `/hiap/` (not a real route) and returned 404. Links now open the city-scoped HIAP inventory page.

## Changes

- Build ranking-ready email URLs as `/{lng}/cities/{cityId}/HIAP/{inventoryId}`
- Resolve `cityId` from the ranking inventory before sending
- Share URL helpers with action-plan ready emails and add unit tests

## How to test

1. Trigger HIAP prioritization for a city inventory until the ranking-ready email is sent.
2. Click the email CTA and confirm it opens `/[lng]/cities/[cityId]/HIAP/[inventoryId]` (not `/hiap/`).
3. Optionally confirm action-plan ready emails still use the same city-scoped path.

## Ticket

[CC-746](https://linear.app/openearth/issue/CC-746/hiap-action-plan-email-redirects-to-404-error)
