### PR TITLE
hotpatch/1.25.1-hiap-action-branch-fixes

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "city-catalyst",
-  "version": "1.25.0-rc.0",
+  "version": "1.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "city-catalyst",
-      "version": "1.25.0-rc.0",
+      "version": "1.25.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1092.0",
         "@aws-sdk/s3-request-presigner": "^3.1092.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "city-catalyst",
-  "version": "1.25.0-rc.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/app/src/backend/ActionPlanEmailService.ts
+++ b/app/src/backend/ActionPlanEmailService.ts
@@ -5,6 +5,7 @@ import { User } from "@/models/User";
 import { logger } from "@/services/logger";
 import i18next from "@/i18n/server";
 import { LANGUAGES } from "@/util/types";
+import { buildHiapInventoryUrl } from "@/util/hiap-routes";
 
 export interface SendActionPlanEmailInput {
   user: User;
@@ -112,15 +113,14 @@ export default class ActionPlanEmailService {
   }
 
   /**
-   * Build the URL to view the action plan
+   * Build the URL to view the action plan on the city-scoped HIAP page.
    */
   public static buildActionPlanUrl(
     cityId: string,
     inventoryId: string,
     language: string = "en",
   ): string {
-    const baseUrl = process.env.HOST || "http://localhost:3000";
-    return `${baseUrl}/${language}/cities/${cityId}/HIAP/${inventoryId}`;
+    return buildHiapInventoryUrl(cityId, inventoryId, language);
   }
 
   /**

--- a/app/src/backend/EmailService.ts
+++ b/app/src/backend/EmailService.ts
@@ -26,6 +26,7 @@ import InviteUserTemplate from "@/lib/emails/InviteUserTemplate";
 import confirmRegistrationTemplate from "@/lib/emails/confirmRegistrationTemplate";
 import { UserFileResponse } from "@/util/types";
 import HiapRankingReadyTemplate from "@/lib/emails/HiapRankingReadyTemplate";
+import { buildHiapInventoryUrl } from "@/util/hiap-routes";
 
 interface EmailTranslation {
   subject: string;
@@ -800,18 +801,23 @@ export default class EmailService {
   public static async sendHiapRankingReadyEmail({
     actionType,
     user,
+    cityId,
+    inventoryId,
   }: {
     actionType: ACTION_TYPES;
     user: User;
+    cityId: string;
+    inventoryId: string;
   }) {
-    const host = process.env.HOST ?? "http://localhost:3000";
-    const url = `${host}/hiap/`;
+    const language = user.preferredLanguage || LANGUAGES.en;
+    // Must be the city-scoped HIAP page — `/hiap/` is not a valid app route (CC-746).
+    const url = buildHiapInventoryUrl(cityId, inventoryId, language);
     try {
       const html = await render(
         HiapRankingReadyTemplate({
           url,
           user: user,
-          language: user.preferredLanguage,
+          language,
         }),
       );
 

--- a/app/src/backend/hiap/ActionPlanService.ts
+++ b/app/src/backend/hiap/ActionPlanService.ts
@@ -462,7 +462,9 @@ export default class ActionPlanService {
         input.highImpactActionRankedId = undefined;
       }
 
-      if (input.inventoryId || input.highImpactActionRankedId) {
+      // Ranked plans must resolve against HighImpactActionRanked. Unranked plans
+      // (no ranked-row FK) skip this check so inventoryId alone does not fail save.
+      if (input.highImpactActionRankedId) {
         await this.validateHIAPActionPlanContext(input);
       }
 

--- a/app/src/backend/hiap/HiapApiService.ts
+++ b/app/src/backend/hiap/HiapApiService.ts
@@ -342,10 +342,17 @@ const startActionPlanJobImpl = async ({
 
     // Save action plan to database
     try {
+      // Ranked actions carry HighImpactActionRanked.id in `action.id` and the
+      // parent ranking UUID in `action.hiaRankingId`. Unranked actions leave
+      // hiaRankingId empty and must not pass a ranked-row FK.
+      const highImpactActionRankedId = action.hiaRankingId
+        ? action.id
+        : undefined;
+
       const { actionPlan, created } = await ActionPlanService.upsertActionPlan({
         cityId,
         actionId: action.actionId,
-        highImpactActionRankedId: action.hiaRankingId, // This should be the ranked ID, not ranking ID
+        highImpactActionRankedId,
         cityLocode,
         inventoryId,
         actionName: action.name,

--- a/app/src/backend/hiap/HiapApiService.ts
+++ b/app/src/backend/hiap/HiapApiService.ts
@@ -340,67 +340,58 @@ const startActionPlanJobImpl = async ({
       throw new Error("Invalid plan data format");
     }
 
-    // Save action plan to database
-    try {
-      // Ranked actions carry HighImpactActionRanked.id in `action.id` and the
-      // parent ranking UUID in `action.hiaRankingId`. Unranked actions leave
-      // hiaRankingId empty and must not pass a ranked-row FK.
-      const highImpactActionRankedId = action.hiaRankingId
-        ? action.id
-        : undefined;
+    // Ranked actions carry HighImpactActionRanked.id in `action.id` and the
+    // parent ranking UUID in `action.hiaRankingId`. Unranked actions leave
+    // hiaRankingId empty and must not pass a ranked-row FK.
+    const highImpactActionRankedId = action.hiaRankingId
+      ? action.id
+      : undefined;
 
-      const { actionPlan, created } = await ActionPlanService.upsertActionPlan({
-        cityId,
-        actionId: action.actionId,
-        highImpactActionRankedId,
-        cityLocode,
-        inventoryId,
-        actionName: action.name,
-        language: lng,
-        planData,
-        createdBy,
-      });
+    // Persist first; only treat the job as successful once the plan is saved.
+    const { actionPlan, created } = await ActionPlanService.upsertActionPlan({
+      cityId,
+      actionId: action.actionId,
+      highImpactActionRankedId,
+      cityLocode,
+      inventoryId,
+      actionName: action.name,
+      language: lng,
+      planData,
+      createdBy,
+    });
 
-      logger.info(
-        { actionPlanId: actionPlan.id, created },
-        `Action plan ${created ? "created" : "updated"} in database`,
-      );
+    logger.info(
+      { actionPlanId: actionPlan.id, created },
+      `Action plan ${created ? "created" : "updated"} in database`,
+    );
 
-      // Send email notification if action plan was successfully created
-      if (created && createdBy) {
-        try {
-          const user = await db.models.User.findByPk(createdBy);
-          if (user) {
-            await ActionPlanEmailService.sendActionPlanReadyEmailWithUrl(
-              user,
-              action.name,
-              planData.metadata?.cityName || cityLocode,
-              cityId,
-              inventoryId,
-              lng,
-            );
-          }
-        } catch (emailError) {
-          logger.error(
-            { error: emailError },
-            "Failed to send action plan email",
+    // Email only after a successful first-time save (not on regenerate/update).
+    if (created && createdBy) {
+      try {
+        const user = await db.models.User.findByPk(createdBy);
+        if (user) {
+          await ActionPlanEmailService.sendActionPlanReadyEmailWithUrl(
+            user,
+            action.name,
+            planData.metadata?.cityName || cityLocode,
+            cityId,
+            inventoryId,
+            lng,
           );
-          // Continue execution - email failure shouldn't break the API response
         }
+      } catch (emailError) {
+        logger.error(
+          { error: emailError },
+          "Failed to send action plan email",
+        );
+        // Plan is already saved — do not fail the request for email issues.
       }
-    } catch (dbError) {
-      logger.error(
-        { error: dbError },
-        "Failed to save action plan to database",
-      );
-      // Continue execution - don't fail the API response due to DB issues
     }
 
-    // Update state with the generated plan
     return {
       plan,
       timestamp: new Date().toISOString(),
-      actionName: action.name, // Use the action name
+      actionName: action.name,
     };
   } catch (error) {
     logger.error({ error }, "Error generating plan");

--- a/app/src/backend/hiap/HiapService.ts
+++ b/app/src/backend/hiap/HiapService.ts
@@ -897,7 +897,7 @@ export const checkActionRankingJob = async (
     // Send email notification when job completes successfully
     if (user && mergedRanked.length > 0) {
       try {
-        await sendRankedReadyEmail(user, type);
+        await sendRankedReadyEmail(user, type, ranking.inventoryId);
         logger.info(
           { userId: user.userId, actionType: type },
           "Sent prioritization ready email",
@@ -1237,8 +1237,26 @@ export async function copyRankedActionsToLang(
 }
 
 // Helper: Send email to user that the ranking is ready
-async function sendRankedReadyEmail(user: User, actionType: ACTION_TYPES) {
-  await EmailService.sendHiapRankingReadyEmail({ actionType, user });
+async function sendRankedReadyEmail(
+  user: User,
+  actionType: ACTION_TYPES,
+  inventoryId: string,
+) {
+  const inventory = await db.models.Inventory.findByPk(inventoryId);
+  if (!inventory?.cityId) {
+    logger.error(
+      { inventoryId },
+      "Cannot send HIAP ranking ready email: inventory has no cityId",
+    );
+    return;
+  }
+
+  await EmailService.sendHiapRankingReadyEmail({
+    actionType,
+    user,
+    cityId: inventory.cityId,
+    inventoryId,
+  });
 }
 
 // Main orchestrator

--- a/app/src/components/HIAP/GeneratePlanDrawer.tsx
+++ b/app/src/components/HIAP/GeneratePlanDrawer.tsx
@@ -56,28 +56,26 @@ export const GeneratePlanDrawer = ({
       return;
     }
 
+    // Inform the user immediately; success is confirmed by email after save.
+    const startedToastId = toaster.create({
+      title: t("plan-generation-started"),
+      description: t("plan-generation-started-description"),
+      type: "info",
+      duration: 5000,
+    });
+
     try {
-      // Start the plan generation process
-      generateActionPlan({
+      // Await so generation/save failures surface as an error toast (no email).
+      await generateActionPlan({
         action: action,
-        cityId: cityData?.cityId || "",
+        cityId: cityData.cityId,
         inventoryId: inventoryId || "",
         cityLocode: cityLocode,
         lng: action.lang,
-      });
-
-      // Show immediate toast notification that generation has started
-      toaster.create({
-        title: t("plan-generation-started"),
-        description: t("plan-generation-started-description"),
-        type: "info",
-        duration: 5000,
-      });
-
-      // Note: Plan generation happens in the background
-      // User will be notified via email when it's complete
+      }).unwrap();
     } catch (error) {
-      console.error("Failed to start plan generation:", error);
+      console.error("Failed to generate action plan:", error);
+      toaster.remove(startedToastId);
       toaster.create({
         title: t("plan-generation-failed"),
         description: t("plan-generation-failed-description"),

--- a/app/src/i18n/locales/de/hiap.json
+++ b/app/src/i18n/locales/de/hiap.json
@@ -139,7 +139,7 @@
   "plan-generation-started": "Plan-Generierung Gestartet",
   "plan-generation-started-description": "Ihr Aktionsplan wird generiert. Sie erhalten eine E-Mail-Benachrichtigung, wenn er fertig ist.",
   "plan-generation-failed": "Generierung Fehlgeschlagen",
-  "plan-generation-failed-description": "Fehler beim Starten der Plan-Generierung. Bitte versuchen Sie es erneut.",
+  "plan-generation-failed-description": "Fehler bei der Plan-Generierung. Bitte versuchen Sie es erneut.",
   "exit-selection": "Auswahl verlassen",
   "download-csv": "CSV",
   "export-as-csv": "Als CSV exportieren",

--- a/app/src/i18n/locales/en/hiap.json
+++ b/app/src/i18n/locales/en/hiap.json
@@ -150,7 +150,7 @@
   "plan-generation-started": "Plan Generation Started",
   "plan-generation-started-description": "Your action plan is being generated. You'll receive an email notification when it's ready.",
   "plan-generation-failed": "Generation Failed",
-  "plan-generation-failed-description": "Failed to start plan generation. Please try again.",
+  "plan-generation-failed-description": "Failed to generate your action plan. Please try again.",
   "reprioritization-started": "Reprioritization Started",
   "reprioritization-started-description": "Your climate actions are being re-prioritized with the latest data. You'll receive an email when complete.",
   "reprioritization-failed": "Reprioritization Failed",

--- a/app/src/i18n/locales/es/hiap.json
+++ b/app/src/i18n/locales/es/hiap.json
@@ -138,7 +138,7 @@
   "plan-generation-started": "Generación de Plan Iniciada",
   "plan-generation-started-description": "Su plan de acción se está generando. Recibirá una notificación por email cuando esté listo.",
   "plan-generation-failed": "Falló la Generación",
-  "plan-generation-failed-description": "Falló al iniciar la generación del plan. Por favor, inténtelo de nuevo.",
+  "plan-generation-failed-description": "Falló al generar el plan de acción. Por favor, inténtelo de nuevo.",
   "exit-selection": "Salir de la selección",
   "download-csv": "CSV",
   "export-as-csv": "Exportar como CSV",

--- a/app/src/i18n/locales/fr/hiap.json
+++ b/app/src/i18n/locales/fr/hiap.json
@@ -138,7 +138,7 @@
   "plan-generation-started": "Génération du Plan Commencée",
   "plan-generation-started-description": "Votre plan d'action est en cours de génération. Vous recevrez une notification par email quand il sera prêt.",
   "plan-generation-failed": "Échec de la Génération",
-  "plan-generation-failed-description": "Échec du démarrage de la génération du plan. Veuillez réessayer.",
+  "plan-generation-failed-description": "Échec de la génération du plan d'action. Veuillez réessayer.",
   "reprioritization-started": "Repriorisation Commencée",
   "reprioritization-started-description": "Vos actions climatiques sont en cours de repriorisation avec les dernières données. Vous recevrez un email à la fin.",
   "reprioritization-failed": "Échec de la Repriorisation",

--- a/app/src/i18n/locales/pt/hiap.json
+++ b/app/src/i18n/locales/pt/hiap.json
@@ -138,7 +138,7 @@
   "plan-generation-started": "Geração de Plano Iniciada",
   "plan-generation-started-description": "Seu plano de ação está sendo gerado. Você receberá uma notificação por email quando estiver pronto.",
   "plan-generation-failed": "Falha na Geração",
-  "plan-generation-failed-description": "Falha ao iniciar a geração do plano. Por favor, tente novamente.",
+  "plan-generation-failed-description": "Falha ao gerar seu plano de ação. Por favor, tente novamente.",
   "exit-selection": "Sair da seleção",
   "download-csv": "CSV",
   "export-as-csv": "Exportar como CSV",

--- a/app/src/util/hiap-routes.ts
+++ b/app/src/util/hiap-routes.ts
@@ -1,0 +1,28 @@
+/**
+ * City-scoped HIAP URL helpers used by app navigation and notification emails.
+ */
+
+/** Build a city-scoped HIAP inventory path. */
+export function getHiapInventoryPath(
+  lng: string,
+  cityId: string,
+  inventoryId: string,
+): string {
+  return `/${lng}/cities/${cityId}/HIAP/${inventoryId}`;
+}
+
+/**
+ * Build an absolute HIAP inventory URL for emails and other external links.
+ * Strips a trailing slash from HOST so we never produce `//en/...`.
+ */
+export function buildHiapInventoryUrl(
+  cityId: string,
+  inventoryId: string,
+  language: string = "en",
+): string {
+  const baseUrl = (process.env.HOST || "http://localhost:3000").replace(
+    /\/$/,
+    "",
+  );
+  return `${baseUrl}${getHiapInventoryPath(language, cityId, inventoryId)}`;
+}

--- a/app/tests/api/action-plan-generation.jest.ts
+++ b/app/tests/api/action-plan-generation.jest.ts
@@ -22,6 +22,7 @@ import {
 } from "../helpers/testDataCreationHelper";
 import { hiapApiWrapper } from "@/backend/hiap/HiapApiService";
 import { hiapServiceWrapper } from "@/backend/hiap/HiapService";
+import ActionPlanService from "@/backend/hiap/ActionPlanService";
 import ActionPlanEmailService from "@/backend/ActionPlanEmailService";
 import {
   ACTION_TYPES,
@@ -320,6 +321,12 @@ describe("Action Plan Generation", () => {
     });
 
     it("sends correct payload to start_plan_creation", async () => {
+      // Locode mismatch would fail DB validation; this test only covers HIAP payload.
+      jest.spyOn(ActionPlanService, "upsertActionPlan").mockResolvedValueOnce({
+        actionPlan: { id: randomUUID() } as any,
+        created: false,
+      });
+
       await hiapApiWrapper.startActionPlanJob({
         action: makeMockAction(rankedActionId, rankingId),
         cityId: testData.cityId,
@@ -497,6 +504,27 @@ describe("Action Plan Generation", () => {
 
       globalThis.fetch = mockFetch as typeof fetch;
     });
+
+    it("throws on DB save failure and does not send email", async () => {
+      jest
+        .spyOn(ActionPlanService, "upsertActionPlan")
+        .mockRejectedValueOnce(new Error("Ranked HIAP action not found"));
+
+      await expect(
+        hiapApiWrapper.startActionPlanJob({
+          action: makeMockAction(rankedActionId, rankingId),
+          cityId: testData.cityId,
+          cityLocode: "XX APT",
+          lng: LANGUAGES.en,
+          inventoryId,
+          createdBy: testData.userId,
+        }),
+      ).rejects.toThrow(/Failed to generate plan|Ranked HIAP action not found/);
+
+      expect(
+        ActionPlanEmailService.sendActionPlanReadyEmailWithUrl,
+      ).not.toHaveBeenCalled();
+    });
   });
 
   describe("startActionPlanJob - data flow", () => {
@@ -515,6 +543,12 @@ describe("Action Plan Generation", () => {
     });
 
     it("extracts country code from locode (first 2 chars)", async () => {
+      // Locode mismatch would fail DB validation; this test only covers countryCode.
+      jest.spyOn(ActionPlanService, "upsertActionPlan").mockResolvedValueOnce({
+        actionPlan: { id: randomUUID() } as any,
+        created: false,
+      });
+
       await hiapApiWrapper.startActionPlanJob({
         action: makeMockAction(rankedActionId, rankingId),
         cityId: testData.cityId,

--- a/app/tests/api/action-plan-generation.jest.ts
+++ b/app/tests/api/action-plan-generation.jest.ts
@@ -60,16 +60,20 @@ const MOCK_PLAN_RESPONSE = {
   },
 };
 
-const makeMockAction = (rankedActionId: string): AdaptationAction => ({
+const makeMockAction = (
+  rankedActionId: string,
+  rankingId: string,
+): AdaptationAction => ({
   actionId: "test-action-123",
   name: "Solar Rooftop",
-  hiaRankingId: rankedActionId,
+  // Match production HIAction shape from ActionService / HIAP status.
+  id: rankedActionId,
+  hiaRankingId: rankingId,
   type: ACTION_TYPES.Adaptation,
   lang: "en",
   GHGReductionPotential: null,
   adaptationEffectiveness: "",
 
-  id: randomUUID(),
   hazards: [],
   sectors: [],
   subsectors: [],
@@ -273,7 +277,7 @@ describe("Action Plan Generation", () => {
   describe("startActionPlanJob - success flow", () => {
     it("calls HIAP API in correct order: start, check_progress, get_plan", async () => {
       await hiapApiWrapper.startActionPlanJob({
-        action: makeMockAction(rankedActionId),
+        action: makeMockAction(rankedActionId, rankingId),
         cityId: testData.cityId,
         cityLocode: "XX APT",
         lng: LANGUAGES.en,
@@ -317,7 +321,7 @@ describe("Action Plan Generation", () => {
 
     it("sends correct payload to start_plan_creation", async () => {
       await hiapApiWrapper.startActionPlanJob({
-        action: makeMockAction(rankedActionId),
+        action: makeMockAction(rankedActionId, rankingId),
         cityId: testData.cityId,
         cityLocode: "BR SAO",
         lng: LANGUAGES.es,
@@ -342,7 +346,7 @@ describe("Action Plan Generation", () => {
 
     it("saves action plan to database", async () => {
       await hiapApiWrapper.startActionPlanJob({
-        action: makeMockAction(rankedActionId),
+        action: makeMockAction(rankedActionId, rankingId),
         cityId: testData.cityId,
         cityLocode: "XX APT",
         lng: LANGUAGES.en,
@@ -365,7 +369,7 @@ describe("Action Plan Generation", () => {
       });
 
       await hiapApiWrapper.startActionPlanJob({
-        action: makeMockAction(rankedActionId),
+        action: makeMockAction(rankedActionId, rankingId),
         cityId: testData.cityId,
         cityLocode: "XX APT",
         lng: LANGUAGES.en,
@@ -380,7 +384,7 @@ describe("Action Plan Generation", () => {
 
     it("returns plan, timestamp, and actionName", async () => {
       const result = await hiapApiWrapper.startActionPlanJob({
-        action: makeMockAction(rankedActionId),
+        action: makeMockAction(rankedActionId, rankingId),
         cityId: testData.cityId,
         cityLocode: "XX APT",
         lng: LANGUAGES.en,
@@ -405,7 +409,7 @@ describe("Action Plan Generation", () => {
 
       await expect(
         hiapApiWrapper.startActionPlanJob({
-          action: makeMockAction(rankedActionId),
+          action: makeMockAction(rankedActionId, rankingId),
           cityId: testData.cityId,
           cityLocode: "XX APT",
           lng: LANGUAGES.en,
@@ -426,7 +430,7 @@ describe("Action Plan Generation", () => {
 
       await expect(
         hiapApiWrapper.startActionPlanJob({
-          action: makeMockAction(rankedActionId),
+          action: makeMockAction(rankedActionId, rankingId),
           cityId: testData.cityId,
           cityLocode: "XX APT",
           lng: LANGUAGES.en,
@@ -447,7 +451,7 @@ describe("Action Plan Generation", () => {
 
       await expect(
         hiapApiWrapper.startActionPlanJob({
-          action: makeMockAction(rankedActionId),
+          action: makeMockAction(rankedActionId, rankingId),
           cityId: testData.cityId,
           cityLocode: "XX APT",
           lng: LANGUAGES.en,
@@ -465,7 +469,7 @@ describe("Action Plan Generation", () => {
 
       await expect(
         hiapApiWrapper.startActionPlanJob({
-          action: makeMockAction(rankedActionId),
+          action: makeMockAction(rankedActionId, rankingId),
           cityId: testData.cityId,
           cityLocode: "XX APT",
           lng: LANGUAGES.en,
@@ -483,7 +487,7 @@ describe("Action Plan Generation", () => {
 
       await expect(
         hiapApiWrapper.startActionPlanJob({
-          action: makeMockAction(rankedActionId),
+          action: makeMockAction(rankedActionId, rankingId),
           cityId: testData.cityId,
           cityLocode: "XX APT",
           lng: LANGUAGES.en,
@@ -498,7 +502,7 @@ describe("Action Plan Generation", () => {
   describe("startActionPlanJob - data flow", () => {
     it("uses getCityContextAndEmissionsData for payload", async () => {
       await hiapApiWrapper.startActionPlanJob({
-        action: makeMockAction(rankedActionId),
+        action: makeMockAction(rankedActionId, rankingId),
         cityId: testData.cityId,
         cityLocode: "XX APT",
         lng: LANGUAGES.en,
@@ -512,7 +516,7 @@ describe("Action Plan Generation", () => {
 
     it("extracts country code from locode (first 2 chars)", async () => {
       await hiapApiWrapper.startActionPlanJob({
-        action: makeMockAction(rankedActionId),
+        action: makeMockAction(rankedActionId, rankingId),
         cityId: testData.cityId,
         cityLocode: "CR SJ",
         lng: LANGUAGES.en,

--- a/app/tests/api/city-hiap-action_plan.jest.ts
+++ b/app/tests/api/city-hiap-action_plan.jest.ts
@@ -690,9 +690,10 @@ describe("City HIAP Prioritization API", () => {
 
       const requestBody = {
         action: {
+          id: rankedAction.id,
           actionId: rankedAction.actionId,
           name: "Generate Action",
-          hiaRankingId: rankedAction.id,
+          hiaRankingId: ranking.id,
         },
         inventoryId,
         cityLocode: "XX-APT",

--- a/app/tests/hiap-routes.jest.ts
+++ b/app/tests/hiap-routes.jest.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for city-scoped HIAP URL helpers used by notification emails.
+ */
+import { afterEach, describe, expect, it } from "@jest/globals";
+import {
+  buildHiapInventoryUrl,
+  getHiapInventoryPath,
+} from "@/util/hiap-routes";
+
+describe("hiap-routes", () => {
+  const originalHost = process.env.HOST;
+
+  afterEach(() => {
+    if (originalHost === undefined) {
+      delete process.env.HOST;
+    } else {
+      process.env.HOST = originalHost;
+    }
+  });
+
+  it("builds the city-scoped HIAP path", () => {
+    expect(
+      getHiapInventoryPath(
+        "en",
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+      ),
+    ).toBe(
+      "/en/cities/11111111-1111-1111-1111-111111111111/HIAP/22222222-2222-2222-2222-222222222222",
+    );
+  });
+
+  it("builds an absolute email URL from HOST", () => {
+    process.env.HOST = "https://citycatalyst.openearth.dev";
+
+    expect(
+      buildHiapInventoryUrl(
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+        "es",
+      ),
+    ).toBe(
+      "https://citycatalyst.openearth.dev/es/cities/11111111-1111-1111-1111-111111111111/HIAP/22222222-2222-2222-2222-222222222222",
+    );
+  });
+
+  it("strips a trailing slash from HOST", () => {
+    process.env.HOST = "https://citycatalyst.io/";
+
+    expect(
+      buildHiapInventoryUrl(
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+      ),
+    ).toBe(
+      "https://citycatalyst.io/en/cities/11111111-1111-1111-1111-111111111111/HIAP/22222222-2222-2222-2222-222222222222",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Hotpatch `1.25.1` to `main` with HIAP action-plan fixes from CC-746 and CC-748: correct ranked-action ID on save, surface generation/save failures with an error toast (email only on successful create), and fix ranking-ready email links that 404'd on `/hiap/`.

## Changes

- Pass `action.id` as `highImpactActionRankedId` for ranked actions; skip ranked validation for unranked plans
- Propagate DB save failures; await generation in UI and show error toast on failure
- Point HIAP ranking-ready email CTA at `/{lng}/cities/{cityId}/HIAP/{inventoryId}`
- Bump app version `1.25.0-rc.0` → `1.25.1`

## How to test

1. Generate a HIAP action plan for a ranked action and confirm it persists and appears under View Generated Plan.
2. Confirm the ready email is sent only after a successful first-time save; on failure, confirm an error toast (no email).
3. Trigger prioritization until the ranking-ready email arrives; confirm the CTA opens the city-scoped HIAP page (not `/hiap/`).

## Ticket

- [CC-746](https://linear.app/openearth/issue/CC-746/hiap-action-plan-email-redirects-to-404-error)
- [CC-748](https://linear.app/openearth/issue/CC-748/hiap-action-plan-is-not-generated-after-confirmation-email)
