### PR TITLE
 Fix HIAP action plan generate timeouts with 202 Accepted

### DIFF
--- a/app/src/app/api/v1/city/[city]/hiap/action-plan/generate/route.ts
+++ b/app/src/app/api/v1/city/[city]/hiap/action-plan/generate/route.ts
@@ -5,6 +5,7 @@ import { languages } from "@/i18n/settings";
 import { PermissionService } from "@/backend/permissions/PermissionService";
 import { hiapApiWrapper } from "@/backend/hiap/HiapApiService";
 import { HIAction, LANGUAGES } from "@/util/types";
+import { logger } from "@/services/logger";
 
 const generateRankingRequest = z.object({
   action: z.any(), // HIAction object - using z.any() for flexibility
@@ -12,6 +13,9 @@ const generateRankingRequest = z.object({
   cityLocode: z.string().min(1, "City is required"),
   lng: z.enum([languages[0], ...languages.slice(1)]).optional(), // workaround for required first element in Zod type
 });
+
+/** Quick response so ingress does not 504; HIAP poll/save/email runs in background. */
+export const maxDuration = 30;
 
 /**
  * @swagger
@@ -21,8 +25,11 @@ const generateRankingRequest = z.object({
  *       - city
  *       - hiap
  *     operationId: postCityHiapActionPlanGenerate
- *     summary: Generate action plan for a specific ranking
- *     description: Generate a new action plan based on the provided action. The city ID is extracted from the route parameter.
+ *     summary: Start action plan generation for a specific action
+ *     description: |
+ *       Accepts generation and returns 202 immediately. HIAP polling, DB save, and
+ *       the ready email run in the background. Clients should rely on email (not this
+ *       response) for completion notification.
  *     parameters:
  *       - in: path
  *         name: city
@@ -53,8 +60,8 @@ const generateRankingRequest = z.object({
  *                 type: string
  *                 description: Language code
  *     responses:
- *       200:
- *         description: Action plan generation started
+ *       202:
+ *         description: Action plan generation accepted; completion notified by email
  *         content:
  *           application/json:
  *             schema:
@@ -62,6 +69,11 @@ const generateRankingRequest = z.object({
  *               properties:
  *                 data:
  *                   type: object
+ *                   properties:
+ *                     accepted:
+ *                       type: boolean
+ *                     message:
+ *                       type: string
  */
 export const POST = apiHandler(
   async (req: NextRequest, { params, session }) => {
@@ -69,16 +81,39 @@ export const POST = apiHandler(
     await PermissionService.canAccessInventory(session, body.inventoryId);
 
     const lng = body.lng || languages[0];
+    const cityId = params.city;
+    const createdBy = session?.user?.id;
 
-    const result = await hiapApiWrapper.startActionPlanJob({
-      action: body.action as HIAction,
-      cityId: params.city,
-      cityLocode: body.cityLocode,
-      lng: lng as LANGUAGES,
-      inventoryId: body.inventoryId,
-      createdBy: session?.user?.id,
-    });
+    hiapApiWrapper
+      .startActionPlanJob({
+        action: body.action as HIAction,
+        cityId,
+        cityLocode: body.cityLocode,
+        lng: lng as LANGUAGES,
+        inventoryId: body.inventoryId,
+        createdBy,
+      })
+      .catch((err) =>
+        logger.error(
+          {
+            err,
+            cityId,
+            inventoryId: body.inventoryId,
+            actionId: (body.action as HIAction)?.actionId,
+          },
+          "Action plan generation background failed",
+        ),
+      );
 
-    return NextResponse.json({ data: result });
+    return NextResponse.json(
+      {
+        data: {
+          accepted: true,
+          message:
+            "Action plan generation started; you will receive an email when it is ready.",
+        },
+      },
+      { status: 202 },
+    );
   },
 );

--- a/app/src/backend/hiap/HiapApiService.ts
+++ b/app/src/backend/hiap/HiapApiService.ts
@@ -183,7 +183,11 @@ const getPrioritizationResultImpl = async (
   return json;
 };
 
-/** This Service works with the AI API. In development, run kubectl port-forward svc/hiap-service-dev 8080:80 to access it. */
+/**
+ * Poll HIAP for plan completion, persist the plan, and email on first create.
+ * Intended to run in the background after the generate route returns 202.
+ * In development, run: kubectl port-forward svc/hiap-service-dev 8080:80
+ */
 const startActionPlanJobImpl = async ({
   action,
   cityId,

--- a/app/src/components/HIAP/GeneratePlanDrawer.tsx
+++ b/app/src/components/HIAP/GeneratePlanDrawer.tsx
@@ -56,7 +56,7 @@ export const GeneratePlanDrawer = ({
       return;
     }
 
-    // Inform the user immediately; success is confirmed by email after save.
+    // API returns 202 immediately; completion is notified by email after save.
     const startedToastId = toaster.create({
       title: t("plan-generation-started"),
       description: t("plan-generation-started-description"),
@@ -65,7 +65,7 @@ export const GeneratePlanDrawer = ({
     });
 
     try {
-      // Await so generation/save failures surface as an error toast (no email).
+      // Await only acceptance (202). Background poll/save/email failures are logged server-side.
       await generateActionPlan({
         action: action,
         cityId: cityData.cityId,
@@ -74,7 +74,7 @@ export const GeneratePlanDrawer = ({
         lng: action.lang,
       }).unwrap();
     } catch (error) {
-      console.error("Failed to generate action plan:", error);
+      console.error("Failed to start action plan generation:", error);
       toaster.remove(startedToastId);
       toaster.create({
         title: t("plan-generation-failed"),

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -1493,7 +1493,7 @@ export const api = createApi({
         invalidatesTags: ["Hiap", "VersionHistory"],
       }),
       generateActionPlan: builder.mutation<
-        { plan: string; timestamp: string; actionName: string },
+        { accepted: boolean; message: string },
         {
           action: HIAction;
           inventoryId: string;
@@ -1520,11 +1520,11 @@ export const api = createApi({
           body: { action, inventoryId, cityLocode, lng },
         }),
         transformResponse: (response: {
-          data: { plan: string; timestamp: string; actionName: string };
+          data: { accepted: boolean; message: string };
         }) => {
           return response.data;
         },
-        invalidatesTags: ["ActionPlan"],
+        // Plan is not ready yet (202); cache refresh happens when the user returns after email.
       }),
       getActionPlans: builder.query<
         { actionPlans: ActionPlanAttributes[] },

--- a/app/tests/api/city-hiap-action_plan.jest.ts
+++ b/app/tests/api/city-hiap-action_plan.jest.ts
@@ -707,12 +707,15 @@ describe("City HIAP Prioritization API", () => {
         }),
       });
 
-      await expectStatusCode(res, 200);
+      // Generation is accepted immediately; HIAP work continues in the background.
+      await expectStatusCode(res, 202);
       const body = await res.json();
-      expect(body.data).toBeTruthy();
-      expect(body.data.actionName).toBe("Mock Action");
+      expect(body.data).toEqual({
+        accepted: true,
+        message:
+          "Action plan generation started; you will receive an email when it is ready.",
+      });
 
-      // Verify the mock was called
       expect(
         HiapApiService.hiapApiWrapper.startActionPlanJob,
       ).toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Action plan generation no longer holds the HTTP request open while polling HIAP (which caused ingress 504s in prod). The API returns 202 immediately and finishes poll/save/email in the background; users are notified by email when the plan is ready.

## Changes

- `POST .../action-plan/generate` returns 202 and fire-and-forgets `startActionPlanJob` (same pattern as inventory import approve)
- Frontend treats acceptance as success; relies on the existing started toast + ready email
- RTK mutation typed for the 202 payload; tests updated for 202

## How to test

1. Generate an action plan from HIAP and confirm the request returns quickly with 202 (no long hang / 504).
2. Confirm the info toast still appears on start.
3. Confirm the plan is saved and the ready email is sent after HIAP finishes.
4. Confirm validation/auth failures still return 4xx and show the error toast.

## Notes

No client-side polling in this PR — completion is email-only by design.
