### PR TITLE
CC-752: Promote HIAP cron heap fix to test

### DIFF
--- a/.github/workflows/web-test.yml
+++ b/.github/workflows/web-test.yml
@@ -14,6 +14,7 @@ on:
       - k8s/test/cc-test-ca-smoke-fixture.yml
       - k8s/test/cc-test-web-deploy.yml
       - k8s/test/cc-test-web.yml
+      - k8s/test/cc-test-check-hiap-jobs.yml
       - k8s/test/cc-test-process-pdf-ocr-jobs.yml
       - .github/scripts/cc-ca-post-deploy-smoke.sh
       - .github/workflows/web-test.yml
@@ -276,9 +277,9 @@ jobs:
           CDP_API_KEY=${{secrets.CDP_API_KEY_TEST}} \
             "CC_CRON_JOB_API_KEY=${{secrets.CC_CRON_JOB_API_KEY}}"
           kubectl create -f k8s/test/cc-test-create-admin.yml -n default
+          kubectl apply -f k8s/test/cc-test-check-hiap-jobs.yml -n default
           kubectl set env cronjob/citycatalyst-test-check-hiap-jobs \
             "CC_CRON_JOB_API_KEY=${{secrets.CC_CRON_JOB_API_KEY}}"
-          kubectl apply -f k8s/cc-check-hiap-jobs.yml -n default
           kubectl apply -f k8s/test/cc-test-process-pdf-ocr-jobs.yml -n default
           kubectl set env cronjob/citycatalyst-test-process-pdf-ocr-jobs \
             "CC_CRON_JOB_API_KEY=${{secrets.CC_CRON_JOB_API_KEY}}"

--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,6 @@ demo-recording/
 
 # Codex
 .codex/
+
+# Local load-test evidence generated during runs
+load-test/results/

--- a/app/migrations/20260824120000-create-hiap-catalog-backfill-checkpoint.cjs
+++ b/app/migrations/20260824120000-create-hiap-catalog-backfill-checkpoint.cjs
@@ -1,0 +1,49 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable("HiapCatalogBackfillCheckpoint", {
+      job_key: {
+        type: Sequelize.STRING(128),
+        allowNull: false,
+        primaryKey: true,
+      },
+      rankings_cursor_created: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+      rankings_cursor_id: {
+        type: Sequelize.STRING(255),
+        allowNull: true,
+      },
+      rankings_completed: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
+      action_plans_cursor_created: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+      action_plans_cursor_id: {
+        type: Sequelize.STRING(255),
+        allowNull: true,
+      },
+      action_plans_completed: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
+      last_updated: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn("NOW"),
+      },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable("HiapCatalogBackfillCheckpoint");
+  },
+};

--- a/app/package.json
+++ b/app/package.json
@@ -28,6 +28,8 @@
     "db:gen-migration": "sequelize-cli migration:generate --name",
     "db:gen-seed": "sequelize-cli seed:generate --name",
     "sync-catalogue": "tsx scripts/catalogue-sync.ts",
+    "hiap-catalog-backfill": "tsx scripts/hiap-catalog-backfill.ts",
+    "seed-hiap-load-test": "tsx scripts/seed-hiap-load-test.ts",
     "sync-emissions-factors": "tsx scripts/emissions-factors-sync.ts",
     "sync-formula-values": "tsx scripts/formula-values-sync.ts",
     "ci:test": "npx jest --coverage",

--- a/app/scripts/hiap-catalog-backfill.ts
+++ b/app/scripts/hiap-catalog-backfill.ts
@@ -1,0 +1,40 @@
+/**
+ * Repairs missing HIAP native-input catalog entries in bounded, resumable pages.
+ *
+ * Run from `app/` with `npm run hiap-catalog-backfill`. The command reads
+ * `HIAP_CATALOG_BACKFILL_BATCH_SIZE`, `HIAP_CATALOG_BACKFILL_MAX_BATCHES`, and
+ * `HIAP_CATALOG_BACKFILL_DRY_RUN` from the environment. The maximum batch count
+ * applies independently to rankings and action plans. Non-dry runs persist both
+ * cursors in `HiapCatalogBackfillCheckpoint`; dry runs do not read or write them.
+ * It writes repair statistics to the structured logger and updates the database.
+ */
+import env from "@next/env";
+
+import { db } from "@/models";
+import {
+  parseHIAPCatalogBackfillConfig,
+  runHIAPCatalogBackfill,
+} from "@/backend/hiap/HiapCatalogBackfillRunner";
+import { logger } from "@/services/logger";
+
+async function main(): Promise<void> {
+  env.loadEnvConfig(process.cwd());
+
+  if (!db.initialized) {
+    await db.initialize();
+  }
+
+  try {
+    const result = await runHIAPCatalogBackfill(
+      parseHIAPCatalogBackfillConfig(),
+    );
+    logger.info(result, "HIAP catalog backfill command finished");
+  } finally {
+    await db.sequelize?.close();
+  }
+}
+
+main().catch((error) => {
+  logger.error({ err: error }, "HIAP catalog backfill command failed");
+  process.exitCode = 1;
+});

--- a/app/scripts/seed-hiap-load-test.ts
+++ b/app/scripts/seed-hiap-load-test.ts
@@ -1,0 +1,216 @@
+import env from "@next/env";
+import { randomUUID } from "node:crypto";
+import type { Transaction } from "sequelize";
+import { db } from "@/models";
+import { ACTION_TYPES, HighImpactActionRankingStatus } from "@/util/types";
+import { OrganizationPlanType } from "@/util/enums";
+
+const FIXTURE_PREFIX = "ZZ-CC752-LOAD";
+const ORGANIZATION_ID = "00000000-0000-4000-8000-000000000752";
+const PROJECT_ID = "00000000-0000-4000-8000-000000000753";
+const CITY_ID = "00000000-0000-4000-8000-000000000754";
+const INVENTORY_ID = "00000000-0000-4000-8000-000000000755";
+
+function positiveInteger(name: string, fallback: number): number {
+  const value = Number(process.env[name] || fallback);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function jsonPayload(bytes: number, index: number): Record<string, unknown> {
+  return {
+    fixture: "cc-752-hiap-load-test",
+    index,
+    content: "x".repeat(bytes),
+  };
+}
+
+async function resetFixture(transaction: Transaction): Promise<void> {
+  await db.sequelize!.query(
+    `DELETE FROM "NativeInputCatalog" WHERE inventory_id = '${INVENTORY_ID}'`,
+    { transaction },
+  );
+  await db.sequelize!.query(
+    `DELETE FROM "ActionPlan" WHERE city_locode LIKE '${FIXTURE_PREFIX}-%'`,
+    { transaction },
+  );
+  await db.sequelize!.query(
+    `DELETE FROM "HighImpactActionRanked" WHERE hia_ranking_id IN (
+      SELECT id FROM "HighImpactActionRanking" WHERE locode LIKE '${FIXTURE_PREFIX}-%'
+    )`,
+    { transaction },
+  );
+  await db.sequelize!.query(
+    `DELETE FROM "HighImpactActionRanking" WHERE locode LIKE '${FIXTURE_PREFIX}-%'`,
+    { transaction },
+  );
+}
+
+async function seed(): Promise<void> {
+  const rankingCount = positiveInteger("HIAP_LOAD_TEST_RANKINGS", 1000);
+  const planCount = positiveInteger("HIAP_LOAD_TEST_PLANS", rankingCount);
+  const jsonBytes = positiveInteger("HIAP_LOAD_TEST_JSON_BYTES", 32768);
+  const shouldReset = process.env.HIAP_LOAD_TEST_RESET !== "false";
+
+  if (!db.initialized) await db.initialize();
+  if (!db.sequelize) throw new Error("Database not initialized");
+
+  await db.sequelize.transaction(async (transaction) => {
+    if (shouldReset) await resetFixture(transaction);
+
+    const organization = await db.models.Organization.findByPk(
+      ORGANIZATION_ID,
+      { transaction },
+    );
+    if (!organization) {
+      await db.models.Organization.create(
+        {
+          organizationId: ORGANIZATION_ID,
+          name: "CC-752 load-test organization",
+          contactEmail: "load-test@example.invalid",
+          active: true,
+          planType: OrganizationPlanType.FULL,
+        },
+        { transaction },
+      );
+    }
+
+    const project = await db.models.Project.findByPk(PROJECT_ID, {
+      transaction,
+    });
+    if (!project) {
+      await db.models.Project.create(
+        {
+          projectId: PROJECT_ID,
+          name: "CC-752 load-test project",
+          cityCountLimit: Math.max(rankingCount, planCount),
+          organizationId: ORGANIZATION_ID,
+          description: "Synthetic project for the CC-752 local load test",
+        },
+        { transaction },
+      );
+    }
+
+    const city = await db.models.City.findByPk(CITY_ID, { transaction });
+    if (!city) {
+      await db.models.City.create(
+        {
+          cityId: CITY_ID,
+          locode: `${FIXTURE_PREFIX}-CITY`,
+          name: "CC-752 Load-Test City",
+          country: "Testland",
+          projectId: PROJECT_ID,
+        },
+        { transaction },
+      );
+    }
+
+    const inventory = await db.models.Inventory.findByPk(INVENTORY_ID, {
+      transaction,
+    });
+    if (!inventory) {
+      await db.models.Inventory.create(
+        {
+          inventoryId: INVENTORY_ID,
+          inventoryName: "CC-752 Load-Test Inventory",
+          year: 2024,
+          cityId: CITY_ID,
+          isPublic: false,
+        },
+        { transaction },
+      );
+    }
+
+    const createdAt = new Date("2026-01-01T00:00:00.000Z");
+    const rankings = Array.from({ length: rankingCount }, (_, index) => ({
+      id: randomUUID(),
+      locode: `${FIXTURE_PREFIX}-${String(index).padStart(6, "0")}`,
+      inventoryId: INVENTORY_ID,
+      type: ACTION_TYPES.Mitigation,
+      langs: ["en", "pt"],
+      status: HighImpactActionRankingStatus.SUCCESS,
+      isBulk: true,
+      jobId: `cc-752-load-${index}`,
+      created: new Date(createdAt.getTime() + index * 1000),
+      lastUpdated: new Date(createdAt.getTime() + index * 1000),
+    }));
+    await db.models.HighImpactActionRanking.bulkCreate(rankings, {
+      transaction,
+    });
+
+    const rankedActions = rankings.flatMap((ranking, rankingIndex) =>
+      [0, 1, 2].map((actionIndex) => ({
+        id: randomUUID(),
+        hiaRankingId: ranking.id,
+        type: ACTION_TYPES.Mitigation,
+        name: `Synthetic action ${rankingIndex}-${actionIndex}`,
+        description: "d".repeat(Math.max(1024, Math.floor(jsonBytes / 4))),
+        actionId: `cc-752-action-${rankingIndex}-${actionIndex}`,
+        rank: actionIndex + 1,
+        explanation: {
+          explanations: { en: `Synthetic explanation ${rankingIndex}` },
+        },
+        lang: actionIndex === 1 ? "pt" : "en",
+        isSelected: actionIndex === 0,
+      })),
+    );
+    await db.models.HighImpactActionRanked.bulkCreate(rankedActions, {
+      transaction,
+    });
+
+    const plans = Array.from({ length: planCount }, (_, index) => {
+      const ranked = rankedActions[(index % rankingCount) * 3];
+      return {
+        id: randomUUID(),
+        actionId: ranked.actionId,
+        highImpactActionRankedId: ranked.id,
+        cityLocode: `${FIXTURE_PREFIX}-${String(index).padStart(6, "0")}`,
+        cityId: CITY_ID,
+        inventoryId: INVENTORY_ID,
+        actionName: `Synthetic action plan ${index}`,
+        language: "en",
+        cityName: "CC-752 Load-Test City",
+        createdAtTimestamp: new Date(
+          createdAt.getTime() + index * 1000,
+        ).toISOString(),
+        cityDescription: "Synthetic city description",
+        actionDescription: "Synthetic action description",
+        nationalStrategyExplanation: "Synthetic strategy explanation",
+        subactions: jsonPayload(jsonBytes, index),
+        institutions: { fixture: true },
+        milestones: { fixture: true },
+        timeline: { fixture: true },
+        costBudget: { fixture: true },
+        merIndicators: { fixture: true },
+        mitigations: { fixture: true },
+        adaptations: { fixture: true },
+        sdgs: { fixture: true },
+        created: new Date(createdAt.getTime() + index * 1000),
+        lastUpdated: new Date(createdAt.getTime() + index * 1000),
+      };
+    });
+    await db.models.ActionPlan.bulkCreate(plans, { transaction });
+
+    console.log(
+      JSON.stringify({
+        fixturePrefix: FIXTURE_PREFIX,
+        rankings: rankingCount,
+        rankedActions: rankedActions.length,
+        actionPlans: planCount,
+        jsonBytesPerPlan: jsonBytes,
+      }),
+    );
+  });
+}
+
+env.loadEnvConfig(process.cwd());
+seed()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await db.sequelize?.close();
+  });

--- a/app/src/app/api/v1/admin/bulk-hiap-prioritization/route.md
+++ b/app/src/app/api/v1/admin/bulk-hiap-prioritization/route.md
@@ -154,6 +154,17 @@ WHERE har.job_id IN (
 - If 2+ cities share the same `job_id` → Bulk job (`is_bulk = true`)
 - If only 1 city has the `job_id` → Single job (`is_bulk = false`)
 
+### Catalog Backfill Checkpoints
+
+The standalone `npm run hiap-catalog-backfill` command repairs missing HIAP
+catalog entries in pages. Non-dry runs persist independent cursors and
+completion flags for rankings and action plans in
+`HiapCatalogBackfillCheckpoint`, after each page, so a later run resumes from
+the last successful page. A page with failures remains resumable at its current
+cursor. `HIAP_CATALOG_BACKFILL_MAX_BATCHES` limits each catalog type
+independently, and `HIAP_CATALOG_BACKFILL_DRY_RUN=true` disables checkpoint
+reads and writes.
+
 ### Implementation Notes
 
 **Cron Job** (`/api/v1/cron/check-hiap-jobs`):

--- a/app/src/app/api/v1/cron/check-hiap-jobs/README.md
+++ b/app/src/app/api/v1/cron/check-hiap-jobs/README.md
@@ -2,7 +2,9 @@
 
 This cron job endpoint checks the status of pending HIAP prioritization jobs and starts new batches when ready.
 
-**Schedule:** Runs every minute (configured in `k8s/cc-check-hiap-jobs.yml`)
+**Schedule:** Runs every five minutes. Development and production use
+`k8s/cc-check-hiap-jobs.yml`; the test deployment uses
+`k8s/test/cc-test-check-hiap-jobs.yml` so it targets the `cc-test-web` service.
 
 ---
 
@@ -19,11 +21,15 @@ This cron job endpoint checks the status of pending HIAP prioritization jobs and
 
 ## Overview
 
-**Purpose:** 
+**Purpose:**
+
 - Check PENDING jobs for completion
 - Save results when jobs finish
-- Backfill successful rankings and persisted action plans that are missing their NativeInputCatalog entry
 - Start the next batch when no PENDING jobs exist
+
+NativeInputCatalog reconciliation is intentionally handled by the isolated
+`hiap-catalog-backfill` command and manual Kubernetes Job. It is not part of
+this polling endpoint.
 
 **Critical Constraint:** HIAP API can only handle **1 bulk job at a time, system-wide**. This cron enforces that limit.
 
@@ -31,40 +37,26 @@ This cron job endpoint checks the status of pending HIAP prioritization jobs and
 
 ## How It Works
 
-Every minute, this cron does 2 main steps:
+Every five minutes, this cron does 2 main steps:
 
 ### Step 1: Check PENDING Jobs
+
 ```
 Query database for rankings with status = PENDING
 For each unique jobId:
   → Call HIAP API: /check_progress/{taskId}
-  → If "pending": Do nothing, check again next minute
+  → If "pending": Do nothing, check again on the next run
   → If "completed": Save results → PENDING → SUCCESS
   → If "failed": Mark as FAILURE with error message
   → If error (404, timeout, etc): Mark as FAILURE to unblock queue
 ```
 
-**Critical:** When HIAP API throws an error (404 Task Not Found, timeout, etc.), 
-the cron job marks all PENDING rankings with that jobId as FAILURE. This prevents 
+**Critical:** When HIAP API throws an error (404 Task Not Found, timeout, etc.),
+the cron job marks all PENDING rankings with that jobId as FAILURE. This prevents
 stuck jobs from blocking the entire queue indefinitely.
 
-### Step 2: Backfill Missing HIAP Catalog Entries
+### Step 2: Start Next Batch (if idle)
 
-```
-Query successful rankings with an inventory
-For each ranking without an active hiap_ranking catalog entry:
-  → Retry NativeInputCatalog registration
-  → Keep the ranking SUCCESS even if this attempt fails
-
-Query persisted action plans with an inventory and ranked action
-For each action plan without a catalog entry for its current content version:
-  → Retry NativeInputCatalog registration
-  → Keep the action plan persisted even if this attempt fails
-```
-
-This makes catalog registration recoverable after a transient database or service failure. The next cron execution retries any ranking or action plan that is still missing its current active catalog entry.
-
-### Step 3: Start Next Batch (if idle)
 ```
 If NO PENDING jobs exist anywhere:
   → Find ONE project with TO_DO rankings (oldest first, FIFO)
@@ -77,12 +69,11 @@ If ANY PENDING jobs exist:
 ```
 
 ### Response Metrics
+
 ```json
 {
   "checkedJobs": 2,
   "completedJobs": 1,
-  "catalogBackfilled": 1,
-  "actionPlansBackfilled": 1,
   "startedBatches": 1,
   "durationMs": 1250
 }
@@ -107,6 +98,7 @@ Every successful run produces these logs:
 ```
 
 **Key markers:**
+
 - ✅ `🔄 Cron job STARTED` - Job execution began
 - ✅ `✅ Cron job FINISHED successfully` - Job completed normally
 - ✅ `durationMs: 1245` - Execution time (1-10 seconds is normal)
@@ -134,17 +126,18 @@ Every successful run produces these logs:
 ### Quick Health Check (30 seconds)
 
 ```bash
-# 1. Is cron running? (LAST SCHEDULE should be < 1 minute ago)
+# 1. Is cron running? (LAST SCHEDULE should be < 5 minutes ago)
 kubectl get cronjob citycatalyst-check-hiap-jobs
 
 # 2. Recent jobs succeeding? (COMPLETIONS should be 1/1)
 kubectl get jobs | grep check-hiap | head -5
 
-# 3. Logs showing START/FINISH? (should see pairs every minute)
+# 3. Logs showing START/FINISH? (should see pairs every five minutes)
 kubectl logs -l job-name=citycatalyst-check-hiap-jobs --tail=20 | grep -E "STARTED|FINISHED"
 ```
 
 **Expected output:**
+
 ```
 ... "🔄 Cron job STARTED: Checking HIAP jobs"
 ... "✅ Cron job FINISHED successfully"
@@ -152,7 +145,7 @@ kubectl logs -l job-name=citycatalyst-check-hiap-jobs --tail=20 | grep -E "START
 ... "✅ Cron job FINISHED successfully"
 ```
 
-You should see pairs of START/FINISH logs every ~1 minute.
+You should see pairs of START/FINISH logs every ~5 minutes.
 
 ---
 
@@ -165,17 +158,19 @@ kubectl get cronjobs citycatalyst-check-hiap-jobs
 ```
 
 **Expected output:**
+
 ```
 NAME                          SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE
-citycatalyst-check-hiap-jobs  */1 * * * *   False     0        42s             5d
+citycatalyst-check-hiap-jobs  */5 * * * *   False     0        42s             5d
 ```
 
 **What to check:**
+
 - ✅ `SUSPEND: False` - CronJob is active
-- ✅ `LAST SCHEDULE: <1 minute ago` - Recently executed
+- ✅ `LAST SCHEDULE: <5 minutes ago` - Recently executed
 - ❌ `SUSPEND: True` - CronJob is paused!
 - ❌ `LAST SCHEDULE: -` - Never ran!
-- ❌ `LAST SCHEDULE: 10m ago` - Hasn't run in 10 minutes!
+- ❌ `LAST SCHEDULE: 15m ago` - Hasn't run in 15 minutes!
 
 #### 2. Recent Executions
 
@@ -188,6 +183,7 @@ kubectl get jobs -l job=check-hiap-jobs --sort-by=.metadata.creationTimestamp | 
 ```
 
 **Expected output:**
+
 ```
 NAME                                    COMPLETIONS   DURATION   AGE
 citycatalyst-check-hiap-jobs-28934710   1/1          5s         2m
@@ -195,6 +191,7 @@ citycatalyst-check-hiap-jobs-28934709   1/1          4s         3m
 ```
 
 **What to check:**
+
 - ✅ `COMPLETIONS: 1/1` - Job succeeded
 - ✅ `DURATION: 4-10s` - Normal execution time
 - ❌ `COMPLETIONS: 0/1` - Job failed or still running
@@ -207,7 +204,7 @@ citycatalyst-check-hiap-jobs-28934709   1/1          4s         3m
 ### 30-Second Health Check
 
 ```bash
-# 1. Cron running? (LAST SCHEDULE < 1 minute ago)
+# 1. Cron running? (LAST SCHEDULE < 5 minutes ago)
 kubectl get cronjob citycatalyst-check-hiap-jobs
 
 # 2. Recent jobs succeeding? (COMPLETIONS: 1/1)
@@ -227,5 +224,6 @@ kubectl logs -l job-name=citycatalyst-check-hiap-jobs --tail=20 | grep -E "START
 
 - **API Documentation**: [../../v1/admin/bulk-hiap-prioritization/README.md](../../v1/admin/bulk-hiap-prioritization/README.md) - Full system documentation
 - **Kubernetes Config**: `k8s/cc-check-hiap-jobs.yml` - CronJob definition
+- **Test Kubernetes Config**: `k8s/test/cc-test-check-hiap-jobs.yml` - Test CronJob targeting `cc-test-web`
 - **Ingress Security**: `k8s/cc-ingress.yml` - Network-level protection
 - **Tests**: `app/tests/api/bulk-hiap-prioritization.jest.ts` - Integration tests

--- a/app/src/app/api/v1/cron/check-hiap-jobs/route.ts
+++ b/app/src/app/api/v1/cron/check-hiap-jobs/route.ts
@@ -8,10 +8,6 @@ import {
 } from "@/util/types";
 import { checkBulkActionRankingJob } from "@/backend/hiap/HiapService";
 import { BulkHiapPrioritizationService } from "@/backend/hiap/BulkHiapPrioritizationService";
-import {
-  backfillMissingHIAPActionPlans,
-  backfillMissingHIAPRankings,
-} from "@/backend/hiap/HiapNativeInputCatalogService";
 import { QueryTypes } from "sequelize";
 import { checkSingleActionRankingJob } from "@/backend/hiap/HiapService";
 import type { HighImpactActionRanking } from "@/models/HighImpactActionRanking";
@@ -232,22 +228,7 @@ export async function GET(req: NextRequest) {
       }
     }
 
-    const catalogBackfilled = await backfillMissingHIAPRankings();
-    const actionPlansBackfilled = await backfillMissingHIAPActionPlans();
-    if (catalogBackfilled > 0) {
-      logger.info(
-        { catalogBackfilled },
-        "Backfilled missing HIAP catalog entries",
-      );
-    }
-    if (actionPlansBackfilled > 0) {
-      logger.info(
-        { actionPlansBackfilled },
-        "Backfilled missing HIAP action-plan catalog entries",
-      );
-    }
-
-    // Step 3: Start ONE batch if no PENDING jobs exist system-wide
+    // Step 2: Start ONE batch if no PENDING jobs exist system-wide
     if (pendingJobs.length === 0) {
       logger.info(
         "No PENDING jobs system-wide. Checking for TO_DO rankings to start next batch.",
@@ -318,7 +299,7 @@ export async function GET(req: NextRequest) {
         {
           pendingJobCount: pendingJobs.length,
         },
-        "PENDING jobs exist. Skipping Step 3 (enforce 1 batch at a time globally).",
+        "PENDING jobs exist. Skipping Step 2 (enforce 1 batch at a time globally).",
       );
     }
 
@@ -328,8 +309,6 @@ export async function GET(req: NextRequest) {
       {
         checkedJobs: pendingJobs.length,
         completedJobs,
-        catalogBackfilled,
-        actionPlansBackfilled,
         startedBatches,
         durationMs: duration,
       },
@@ -339,8 +318,6 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({
       checkedJobs: pendingJobs.length,
       completedJobs,
-      catalogBackfilled,
-      actionPlansBackfilled,
       startedBatches,
       durationMs: duration,
     });

--- a/app/src/backend/hiap/HiapCatalogBackfillRunner.ts
+++ b/app/src/backend/hiap/HiapCatalogBackfillRunner.ts
@@ -1,0 +1,386 @@
+import { QueryTypes, type Sequelize } from "sequelize";
+
+import { db } from "@/models";
+import {
+  backfillMissingHIAPActionPlansPage,
+  backfillMissingHIAPRankingsPage,
+  type HIAPCatalogBackfillCursor,
+  type HIAPCatalogBackfillPage,
+  type HIAPCatalogBackfillPageOptions,
+} from "@/backend/hiap/HiapNativeInputCatalogService";
+import { logger } from "@/services/logger";
+
+const LOCK_KEY = "citycatalyst:hiap-catalog-backfill";
+const CHECKPOINT_KEY = LOCK_KEY;
+const DEFAULT_BATCH_SIZE = 25;
+const MAX_BATCH_SIZE = 1000;
+
+export type HIAPCatalogBackfillConfig = {
+  batchSize: number;
+  maxBatchesPerType?: number;
+  dryRun: boolean;
+};
+
+export type HIAPCatalogBackfillProgress = {
+  cursor: HIAPCatalogBackfillCursor | null;
+  completed: boolean;
+};
+
+export type HIAPCatalogBackfillCheckpoint = {
+  rankings: HIAPCatalogBackfillProgress;
+  actionPlans: HIAPCatalogBackfillProgress;
+};
+
+export type HIAPCatalogBackfillPooledConnection = Awaited<
+  ReturnType<Sequelize["connectionManager"]["getConnection"]>
+> & {
+  query: (
+    sql: string,
+    values?: readonly unknown[],
+  ) => Promise<{ rows: Array<Record<string, unknown>> }>;
+};
+
+export type HIAPCatalogBackfillLock = {
+  sequelize: Sequelize;
+  connection: HIAPCatalogBackfillPooledConnection;
+};
+
+type BackfillTotals = {
+  scanned: number;
+  repaired: number;
+  failed: number;
+};
+
+export type HIAPCatalogBackfillResult = {
+  skipped: boolean;
+  pages: number;
+  rankings?: BackfillTotals;
+  actionPlans?: BackfillTotals;
+};
+
+export type HIAPCatalogBackfillRunnerDeps = {
+  acquireLock: () => Promise<HIAPCatalogBackfillLock | null>;
+  releaseLock: (lock: HIAPCatalogBackfillLock) => Promise<void>;
+  loadCheckpoint: () => Promise<HIAPCatalogBackfillCheckpoint>;
+  saveCheckpoint: (checkpoint: HIAPCatalogBackfillCheckpoint) => Promise<void>;
+  processRankingsPage: (
+    options: HIAPCatalogBackfillPageOptions,
+  ) => Promise<HIAPCatalogBackfillPage>;
+  processActionPlansPage: (
+    options: HIAPCatalogBackfillPageOptions,
+  ) => Promise<HIAPCatalogBackfillPage>;
+};
+
+function parsePositiveInteger(
+  env: NodeJS.ProcessEnv,
+  name: string,
+  fallback: number,
+  maximum?: number,
+): number {
+  const raw = env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+
+  const value = Number(raw);
+  if (
+    !Number.isInteger(value) ||
+    value < 1 ||
+    (maximum !== undefined && value > maximum)
+  ) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+export function parseHIAPCatalogBackfillConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): HIAPCatalogBackfillConfig {
+  const maxBatchesRaw = env.HIAP_CATALOG_BACKFILL_MAX_BATCHES;
+  const maxBatchesPerType =
+    maxBatchesRaw === undefined || maxBatchesRaw.trim() === ""
+      ? undefined
+      : parsePositiveInteger(env, "HIAP_CATALOG_BACKFILL_MAX_BATCHES", 1);
+
+  return {
+    batchSize: parsePositiveInteger(
+      env,
+      "HIAP_CATALOG_BACKFILL_BATCH_SIZE",
+      DEFAULT_BATCH_SIZE,
+      MAX_BATCH_SIZE,
+    ),
+    maxBatchesPerType,
+    dryRun: env.HIAP_CATALOG_BACKFILL_DRY_RUN?.toLowerCase() === "true",
+  };
+}
+
+export async function acquireHIAPCatalogBackfillLock(
+  sequelize: Sequelize | null | undefined = db.sequelize,
+): Promise<HIAPCatalogBackfillLock | null> {
+  if (!sequelize) throw new Error("Database not initialized");
+
+  const connection = (await sequelize.connectionManager.getConnection({
+    type: "write",
+  })) as HIAPCatalogBackfillPooledConnection;
+
+  try {
+    const result = await connection.query(
+      "SELECT pg_try_advisory_lock(hashtext($1)) AS locked",
+      [LOCK_KEY],
+    );
+    if (result.rows[0]?.locked !== true) {
+      sequelize.connectionManager.releaseConnection(connection);
+      return null;
+    }
+
+    return { sequelize, connection };
+  } catch (error) {
+    sequelize.connectionManager.releaseConnection(connection);
+    throw error;
+  }
+}
+
+export async function releaseHIAPCatalogBackfillLock(
+  lock: HIAPCatalogBackfillLock,
+): Promise<void> {
+  try {
+    await lock.connection.query("SELECT pg_advisory_unlock(hashtext($1))", [
+      LOCK_KEY,
+    ]);
+  } finally {
+    lock.sequelize.connectionManager.releaseConnection(lock.connection);
+  }
+}
+
+function emptyCheckpoint(): HIAPCatalogBackfillCheckpoint {
+  return {
+    rankings: { cursor: null, completed: false },
+    actionPlans: { cursor: null, completed: false },
+  };
+}
+
+type HIAPCatalogBackfillCheckpointRow = {
+  rankings_cursor_created: Date | string | null;
+  rankings_cursor_id: string | null;
+  rankings_completed: boolean;
+  action_plans_cursor_created: Date | string | null;
+  action_plans_cursor_id: string | null;
+  action_plans_completed: boolean;
+};
+
+function rowCursor(
+  created: Date | string | null,
+  id: string | null,
+): HIAPCatalogBackfillCursor | null {
+  if (created === null || id === null) return null;
+
+  const date = created instanceof Date ? created : new Date(created);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error("HIAP catalog backfill checkpoint has an invalid cursor");
+  }
+
+  return { created: date.toISOString(), id };
+}
+
+async function loadHIAPCatalogBackfillCheckpoint(): Promise<HIAPCatalogBackfillCheckpoint> {
+  if (!db.sequelize) throw new Error("Database not initialized");
+
+  const rows = await db.sequelize.query<HIAPCatalogBackfillCheckpointRow>(
+    `
+      SELECT
+        rankings_cursor_created,
+        rankings_cursor_id,
+        rankings_completed,
+        action_plans_cursor_created,
+        action_plans_cursor_id,
+        action_plans_completed
+      FROM "HiapCatalogBackfillCheckpoint"
+      WHERE job_key = :jobKey
+    `,
+    {
+      replacements: { jobKey: CHECKPOINT_KEY },
+      type: QueryTypes.SELECT,
+    },
+  );
+  const row = rows[0];
+  if (!row) return emptyCheckpoint();
+
+  return {
+    rankings: {
+      cursor: rowCursor(row.rankings_cursor_created, row.rankings_cursor_id),
+      completed: row.rankings_completed,
+    },
+    actionPlans: {
+      cursor: rowCursor(
+        row.action_plans_cursor_created,
+        row.action_plans_cursor_id,
+      ),
+      completed: row.action_plans_completed,
+    },
+  };
+}
+
+async function saveHIAPCatalogBackfillCheckpoint(
+  checkpoint: HIAPCatalogBackfillCheckpoint,
+): Promise<void> {
+  if (!db.sequelize) throw new Error("Database not initialized");
+
+  await db.sequelize.query(
+    `
+      INSERT INTO "HiapCatalogBackfillCheckpoint" (
+        job_key,
+        rankings_cursor_created,
+        rankings_cursor_id,
+        rankings_completed,
+        action_plans_cursor_created,
+        action_plans_cursor_id,
+        action_plans_completed
+      ) VALUES (
+        :jobKey,
+        :rankingsCursorCreated,
+        :rankingsCursorId,
+        :rankingsCompleted,
+        :actionPlansCursorCreated,
+        :actionPlansCursorId,
+        :actionPlansCompleted
+      )
+      ON CONFLICT (job_key) DO UPDATE SET
+        rankings_cursor_created = EXCLUDED.rankings_cursor_created,
+        rankings_cursor_id = EXCLUDED.rankings_cursor_id,
+        rankings_completed = EXCLUDED.rankings_completed,
+        action_plans_cursor_created = EXCLUDED.action_plans_cursor_created,
+        action_plans_cursor_id = EXCLUDED.action_plans_cursor_id,
+        action_plans_completed = EXCLUDED.action_plans_completed,
+        last_updated = NOW()
+    `,
+    {
+      replacements: {
+        jobKey: CHECKPOINT_KEY,
+        rankingsCursorCreated: checkpoint.rankings.cursor?.created ?? null,
+        rankingsCursorId: checkpoint.rankings.cursor?.id ?? null,
+        rankingsCompleted: checkpoint.rankings.completed,
+        actionPlansCursorCreated:
+          checkpoint.actionPlans.cursor?.created ?? null,
+        actionPlansCursorId: checkpoint.actionPlans.cursor?.id ?? null,
+        actionPlansCompleted: checkpoint.actionPlans.completed,
+      },
+      type: QueryTypes.INSERT,
+    },
+  );
+}
+
+const defaultDeps: HIAPCatalogBackfillRunnerDeps = {
+  acquireLock: acquireHIAPCatalogBackfillLock,
+  releaseLock: releaseHIAPCatalogBackfillLock,
+  loadCheckpoint: loadHIAPCatalogBackfillCheckpoint,
+  saveCheckpoint: saveHIAPCatalogBackfillCheckpoint,
+  processRankingsPage: backfillMissingHIAPRankingsPage,
+  processActionPlansPage: backfillMissingHIAPActionPlansPage,
+};
+
+function emptyTotals(): BackfillTotals {
+  return { scanned: 0, repaired: 0, failed: 0 };
+}
+
+function addPage(totals: BackfillTotals, page: HIAPCatalogBackfillPage): void {
+  totals.scanned += page.scanned;
+  totals.repaired += page.repaired;
+  totals.failed += page.failed;
+}
+
+async function processPages(
+  kind: "rankings" | "actionPlans",
+  processPage: HIAPCatalogBackfillRunnerDeps["processRankingsPage"],
+  config: HIAPCatalogBackfillConfig,
+  checkpoint: HIAPCatalogBackfillCheckpoint,
+  saveCheckpoint: HIAPCatalogBackfillRunnerDeps["saveCheckpoint"],
+): Promise<{
+  totals: BackfillTotals;
+  checkpoint: HIAPCatalogBackfillCheckpoint;
+  pages: number;
+}> {
+  const totals = emptyTotals();
+  let progress = checkpoint[kind];
+  let pages = 0;
+
+  if (progress.completed) return { totals, checkpoint, pages };
+
+  while (
+    config.maxBatchesPerType === undefined ||
+    pages < config.maxBatchesPerType
+  ) {
+    const page = await processPage({
+      limit: config.batchSize,
+      cursor: progress.cursor ?? undefined,
+      dryRun: config.dryRun,
+    });
+    pages++;
+    addPage(totals, page);
+
+    if (page.hasMore && !page.nextCursor) {
+      throw new Error("HIAP catalog backfill page hasMore without nextCursor");
+    }
+
+    progress = {
+      cursor:
+        page.failed > 0
+          ? progress.cursor
+          : page.hasMore
+            ? page.nextCursor
+            : null,
+      completed: page.failed === 0 && !page.hasMore,
+    };
+    checkpoint =
+      kind === "rankings"
+        ? { ...checkpoint, rankings: progress }
+        : { ...checkpoint, actionPlans: progress };
+    await saveCheckpoint(checkpoint);
+
+    if (page.failed > 0 || !page.hasMore) break;
+  }
+
+  return { totals, checkpoint, pages };
+}
+
+export async function runHIAPCatalogBackfill(
+  config: HIAPCatalogBackfillConfig,
+  deps: HIAPCatalogBackfillRunnerDeps = defaultDeps,
+): Promise<HIAPCatalogBackfillResult> {
+  const lock = await deps.acquireLock();
+  if (!lock) {
+    logger.info("HIAP catalog backfill skipped because another run is active");
+    return { skipped: true, pages: 0 };
+  }
+
+  try {
+    const saveCheckpoint: HIAPCatalogBackfillRunnerDeps["saveCheckpoint"] =
+      config.dryRun ? async () => undefined : deps.saveCheckpoint;
+    let checkpoint = config.dryRun
+      ? emptyCheckpoint()
+      : await deps.loadCheckpoint();
+    const rankingsRun = await processPages(
+      "rankings",
+      deps.processRankingsPage,
+      config,
+      checkpoint,
+      saveCheckpoint,
+    );
+    checkpoint = rankingsRun.checkpoint;
+    const actionPlansRun = await processPages(
+      "actionPlans",
+      deps.processActionPlansPage,
+      config,
+      checkpoint,
+      saveCheckpoint,
+    );
+
+    const result = {
+      skipped: false,
+      pages: rankingsRun.pages + actionPlansRun.pages,
+      rankings: rankingsRun.totals,
+      actionPlans: actionPlansRun.totals,
+    } satisfies HIAPCatalogBackfillResult;
+    logger.info(result, "HIAP catalog backfill completed");
+    return result;
+  } finally {
+    await deps.releaseLock(lock);
+  }
+}

--- a/app/src/backend/hiap/HiapNativeInputCatalogService.ts
+++ b/app/src/backend/hiap/HiapNativeInputCatalogService.ts
@@ -8,6 +8,7 @@ import {
   registerNativeInput,
   supersedeNativeInput,
   withdrawNativeInput,
+  type NativeInputCatalogRegistration,
   type RegisterNativeInputInput,
 } from "@/backend/NativeInputCatalogService";
 import { HighImpactActionRankingStatus, type ACTION_TYPES } from "@/util/types";
@@ -35,6 +36,25 @@ type SelectionRegistration = {
 
 type SelectionSourceType =
   typeof RANKED_SELECTION_SOURCE_TYPE | typeof UNRANKED_SELECTION_SOURCE_TYPE;
+
+export type HIAPCatalogBackfillCursor = {
+  created: string;
+  id: string;
+};
+
+export type HIAPCatalogBackfillPageOptions = {
+  limit: number;
+  cursor?: HIAPCatalogBackfillCursor;
+  dryRun?: boolean;
+};
+
+export type HIAPCatalogBackfillPage = {
+  scanned: number;
+  repaired: number;
+  failed: number;
+  nextCursor: HIAPCatalogBackfillCursor | null;
+  hasMore: boolean;
+};
 
 function digest(value: unknown): string {
   return createHash("sha256")
@@ -227,50 +247,134 @@ export async function registerHIAPRanking(ranking: HighImpactActionRanking) {
   return registration;
 }
 
-export async function backfillMissingHIAPRankings(): Promise<number> {
-  const successfulRankings = await db.models.HighImpactActionRanking.findAll({
-    where: { status: HighImpactActionRankingStatus.SUCCESS },
-    include: [
+function validateBackfillLimit(limit: number): void {
+  if (!Number.isInteger(limit) || limit < 1 || limit > 1000) {
+    throw new Error(
+      "HIAP catalog backfill limit must be an integer from 1 to 1000",
+    );
+  }
+}
+
+function cursorWhere(cursor?: HIAPCatalogBackfillCursor) {
+  if (!cursor) return {};
+
+  return {
+    [Op.or]: [
+      { created: { [Op.gt]: new Date(cursor.created) } },
       {
-        model: db.models.Inventory,
-        as: "inventory",
-        required: true,
-      },
-      {
-        model: db.models.HighImpactActionRanked,
-        as: "highImpactActionRanked",
-        attributes: ["id"],
-        required: true,
+        created: new Date(cursor.created),
+        id: { [Op.gt]: cursor.id },
       },
     ],
-    order: [["created", "ASC"]],
-  });
+  };
+}
 
-  let backfilledCount = 0;
+function cursorFor(record: {
+  id: string;
+  created?: Date;
+}): HIAPCatalogBackfillCursor {
+  if (!record.created) {
+    throw new Error(
+      `HIAP catalog backfill record ${record.id} has no created timestamp`,
+    );
+  }
 
-  for (const ranking of successfulRankings) {
-    const existingCatalogEntry = await db.models.NativeInputCatalog.findOne({
-      where: {
-        owningModule: HIAP_MODULE,
-        sourceType: RANKING_SOURCE_TYPE,
-        sourceId: { [Op.like]: `${ranking.id}:%` },
-        availability: "active",
-      },
-    });
+  return { created: record.created.toISOString(), id: record.id };
+}
 
-    if (existingCatalogEntry) continue;
+async function processBackfillRecords<T extends { id: string }>(
+  records: T[],
+  options: Pick<HIAPCatalogBackfillPageOptions, "dryRun">,
+  build: (record: T) => Promise<RegisterNativeInputInput>,
+  sync: (record: T) => Promise<NativeInputCatalogRegistration | null>,
+): Promise<Pick<HIAPCatalogBackfillPage, "repaired" | "failed">> {
+  let repaired = 0;
+  let failed = 0;
 
-    const registration = await syncHIAPRanking(ranking);
-    if (registration) {
-      backfilledCount++;
-      logger.info(
-        { rankingId: ranking.id, inventoryId: ranking.inventoryId },
-        "Backfilled missing HIAP ranking catalog entry",
+  for (const record of records) {
+    try {
+      if (options.dryRun) {
+        await build(record);
+        repaired++;
+      } else if (await sync(record)) {
+        repaired++;
+      } else {
+        failed++;
+      }
+    } catch (error) {
+      failed++;
+      logger.error(
+        {
+          recordId: record.id,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "HIAP NativeInputCatalog backfill record failed",
       );
     }
   }
 
-  return backfilledCount;
+  return { repaired, failed };
+}
+
+function pageResult(
+  records: Array<{ id: string; created?: Date }>,
+  limit: number,
+  outcome: Pick<HIAPCatalogBackfillPage, "repaired" | "failed">,
+): HIAPCatalogBackfillPage {
+  const hasMore = records.length === limit;
+  return {
+    scanned: records.length,
+    ...outcome,
+    hasMore,
+    nextCursor:
+      hasMore && records.length > 0
+        ? cursorFor(records[records.length - 1])
+        : null,
+  };
+}
+
+export async function backfillMissingHIAPRankingsPage(
+  options: HIAPCatalogBackfillPageOptions,
+): Promise<HIAPCatalogBackfillPage> {
+  validateBackfillLimit(options.limit);
+
+  const successfulRankings = await db.models.HighImpactActionRanking.findAll({
+    where: {
+      status: HighImpactActionRankingStatus.SUCCESS,
+      ...cursorWhere(options.cursor),
+    },
+    attributes: [
+      "id",
+      "inventoryId",
+      "userId",
+      "locode",
+      "type",
+      "langs",
+      "status",
+      "created",
+    ],
+    include: [
+      {
+        model: db.models.HighImpactActionRanked,
+        as: "highImpactActionRanked",
+        attributes: [],
+        required: true,
+      },
+    ],
+    order: [
+      ["created", "ASC"],
+      ["id", "ASC"],
+    ],
+    limit: options.limit,
+  });
+
+  const outcome = await processBackfillRecords(
+    successfulRankings,
+    options,
+    buildHIAPRankingInput,
+    syncHIAPRanking,
+  );
+  return pageResult(successfulRankings, options.limit, outcome);
 }
 
 function planContent(plan: ActionPlan): Record<string, unknown> {
@@ -337,7 +441,6 @@ export async function buildHIAPActionPlanInput(
 
 export async function registerHIAPActionPlan(plan: ActionPlan) {
   const input = await buildHIAPActionPlanInput(plan);
-
   const registration = await registerNativeInput(input);
   await supersedePreviousVersions(
     ACTION_PLAN_SOURCE_TYPE,
@@ -348,40 +451,57 @@ export async function registerHIAPActionPlan(plan: ActionPlan) {
   return registration;
 }
 
-export async function backfillMissingHIAPActionPlans(): Promise<number> {
+export async function backfillMissingHIAPActionPlansPage(
+  options: HIAPCatalogBackfillPageOptions,
+): Promise<HIAPCatalogBackfillPage> {
+  validateBackfillLimit(options.limit);
+
   const actionPlans = await db.models.ActionPlan.findAll({
     where: {
       inventoryId: { [Op.ne]: null },
       highImpactActionRankedId: { [Op.ne]: null },
+      ...cursorWhere(options.cursor),
     },
-    order: [["created", "ASC"]],
+    attributes: [
+      "id",
+      "actionId",
+      "highImpactActionRankedId",
+      "cityLocode",
+      "cityId",
+      "inventoryId",
+      "actionName",
+      "language",
+      "cityName",
+      "createdAtTimestamp",
+      "cityDescription",
+      "actionDescription",
+      "nationalStrategyExplanation",
+      "subactions",
+      "institutions",
+      "milestones",
+      "timeline",
+      "costBudget",
+      "merIndicators",
+      "mitigations",
+      "adaptations",
+      "sdgs",
+      "createdBy",
+      "created",
+    ],
+    order: [
+      ["created", "ASC"],
+      ["id", "ASC"],
+    ],
+    limit: options.limit,
   });
 
-  let backfilledCount = 0;
-
-  for (const actionPlan of actionPlans) {
-    const existingCatalogEntry = await db.models.NativeInputCatalog.findOne({
-      where: {
-        owningModule: HIAP_MODULE,
-        sourceType: ACTION_PLAN_SOURCE_TYPE,
-        sourceId: actionPlanSourceId(actionPlan),
-        availability: "active",
-      },
-    });
-
-    if (existingCatalogEntry) continue;
-
-    const registration = await syncHIAPActionPlan(actionPlan);
-    if (registration) {
-      backfilledCount++;
-      logger.info(
-        { actionPlanId: actionPlan.id, inventoryId: actionPlan.inventoryId },
-        "Backfilled missing HIAP action-plan catalog entry",
-      );
-    }
-  }
-
-  return backfilledCount;
+  const outcome = await processBackfillRecords(
+    actionPlans,
+    options,
+    buildHIAPActionPlanInput,
+    syncHIAPActionPlan,
+  );
+  return pageResult(actionPlans, options.limit, outcome);
 }
 
 function selectionSourceId(

--- a/app/tests/api/check-hiap-jobs-route.jest.ts
+++ b/app/tests/api/check-hiap-jobs-route.jest.ts
@@ -1,0 +1,100 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import { NextRequest } from "next/server";
+
+const query = jest.fn();
+const backfillMissingHIAPRankings = jest.fn();
+const backfillMissingHIAPActionPlans = jest.fn();
+
+jest.unstable_mockModule("@/models", () => ({
+  db: {
+    initialized: true,
+    sequelize: { query },
+    models: {
+      HighImpactActionRanking: { update: jest.fn(), findOne: jest.fn() },
+    },
+  },
+}));
+jest.mock("@/models", () => ({
+  db: {
+    initialized: true,
+    sequelize: { query },
+    models: {
+      HighImpactActionRanking: { update: jest.fn(), findOne: jest.fn() },
+    },
+  },
+}));
+jest.unstable_mockModule("@/services/logger", () => ({
+  logger: { info: jest.fn(), error: jest.fn() },
+}));
+jest.mock("@/services/logger", () => ({
+  logger: { info: jest.fn(), error: jest.fn() },
+}));
+jest.unstable_mockModule("@/backend/hiap/HiapService", () => ({
+  checkBulkActionRankingJob: jest.fn(),
+  checkSingleActionRankingJob: jest.fn(),
+}));
+jest.mock("@/backend/hiap/HiapService", () => ({
+  checkBulkActionRankingJob: jest.fn(),
+  checkSingleActionRankingJob: jest.fn(),
+}));
+jest.unstable_mockModule(
+  "@/backend/hiap/BulkHiapPrioritizationService",
+  () => ({
+    BulkHiapPrioritizationService: { startNextBatch: jest.fn() },
+  }),
+);
+jest.mock("@/backend/hiap/BulkHiapPrioritizationService", () => ({
+  BulkHiapPrioritizationService: { startNextBatch: jest.fn() },
+}));
+jest.unstable_mockModule(
+  "@/backend/hiap/HiapNativeInputCatalogService",
+  () => ({
+    backfillMissingHIAPRankings,
+    backfillMissingHIAPActionPlans,
+  }),
+);
+jest.mock("@/backend/hiap/HiapNativeInputCatalogService", () => ({
+  backfillMissingHIAPRankings,
+  backfillMissingHIAPActionPlans,
+}));
+
+let GET: typeof import("@/app/api/v1/cron/check-hiap-jobs/route").GET;
+
+beforeAll(async () => {
+  ({ GET } = await import("@/app/api/v1/cron/check-hiap-jobs/route"));
+});
+
+beforeEach(() => {
+  process.env.CC_CRON_JOB_API_KEY = "test-cron-key";
+  query.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("check-hiap-jobs route", () => {
+  it("keeps NativeInputCatalog backfills out of the Web polling request", async () => {
+    const request = new NextRequest(
+      "http://localhost/api/v1/cron/check-hiap-jobs",
+      { headers: { Authorization: "Bearer test-cron-key" } },
+    );
+
+    const response = await GET(request);
+    const responseBody = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(backfillMissingHIAPRankings).not.toHaveBeenCalled();
+    expect(backfillMissingHIAPActionPlans).not.toHaveBeenCalled();
+    expect(responseBody).not.toHaveProperty("catalogBackfilled");
+    expect(responseBody).not.toHaveProperty("actionPlansBackfilled");
+  });
+});

--- a/app/tests/hiap-catalog-backfill-runner.jest.ts
+++ b/app/tests/hiap-catalog-backfill-runner.jest.ts
@@ -1,0 +1,214 @@
+import type { Sequelize } from "sequelize";
+import { describe, expect, it, jest } from "@jest/globals";
+
+import type {
+  HIAPCatalogBackfillPage,
+  HIAPCatalogBackfillPageOptions,
+} from "@/backend/hiap/HiapNativeInputCatalogService";
+
+import {
+  acquireHIAPCatalogBackfillLock,
+  parseHIAPCatalogBackfillConfig,
+  releaseHIAPCatalogBackfillLock,
+  runHIAPCatalogBackfill,
+  type HIAPCatalogBackfillCheckpoint,
+  type HIAPCatalogBackfillRunnerDeps,
+} from "@/backend/hiap/HiapCatalogBackfillRunner";
+
+const page = (
+  overrides: Partial<HIAPCatalogBackfillPage> = {},
+): HIAPCatalogBackfillPage => ({
+  scanned: 1,
+  repaired: 1,
+  failed: 0,
+  hasMore: false,
+  nextCursor: null,
+  ...overrides,
+});
+
+describe("HIAP catalog backfill runner", () => {
+  it("parses bounded batch settings and dry-run mode", () => {
+    expect(
+      parseHIAPCatalogBackfillConfig({
+        HIAP_CATALOG_BACKFILL_BATCH_SIZE: "40",
+        HIAP_CATALOG_BACKFILL_MAX_BATCHES: "3",
+        HIAP_CATALOG_BACKFILL_DRY_RUN: "true",
+      }),
+    ).toEqual({ batchSize: 40, maxBatchesPerType: 3, dryRun: true });
+  });
+
+  it("resumes each catalog type from its checkpoint and persists completion", async () => {
+    const rankingPages: HIAPCatalogBackfillPageOptions[] = [];
+    const actionPlanPages: HIAPCatalogBackfillPageOptions[] = [];
+    const savedCheckpoints: HIAPCatalogBackfillCheckpoint[] = [];
+    const initialCheckpoint: HIAPCatalogBackfillCheckpoint = {
+      rankings: {
+        cursor: { created: "2026-01-01T00:00:00.000Z", id: "r-0" },
+        completed: false,
+      },
+      actionPlans: { cursor: null, completed: false },
+    };
+    const deps: HIAPCatalogBackfillRunnerDeps = {
+      acquireLock: jest.fn().mockResolvedValue({ connectionId: "lock-1" }),
+      releaseLock: jest.fn().mockResolvedValue(undefined),
+      loadCheckpoint: jest.fn().mockResolvedValue(initialCheckpoint),
+      saveCheckpoint: jest.fn(async (checkpoint) => {
+        savedCheckpoints.push(checkpoint);
+      }),
+      processRankingsPage: jest.fn(async (options) => {
+        rankingPages.push(options);
+        return page({ scanned: 2, repaired: 2 });
+      }),
+      processActionPlansPage: jest.fn(async (options) => {
+        actionPlanPages.push(options);
+        return page({ scanned: 3, repaired: 3 });
+      }),
+    };
+
+    await expect(
+      runHIAPCatalogBackfill(
+        { batchSize: 10, maxBatchesPerType: 1, dryRun: false },
+        deps,
+      ),
+    ).resolves.toEqual({
+      skipped: false,
+      pages: 2,
+      rankings: { scanned: 2, repaired: 2, failed: 0 },
+      actionPlans: { scanned: 3, repaired: 3, failed: 0 },
+    });
+    expect(rankingPages).toEqual([
+      {
+        limit: 10,
+        dryRun: false,
+        cursor: { created: "2026-01-01T00:00:00.000Z", id: "r-0" },
+      },
+    ]);
+    expect(actionPlanPages).toEqual([
+      { limit: 10, dryRun: false, cursor: undefined },
+    ]);
+    expect(savedCheckpoints.at(-1)).toEqual({
+      rankings: { cursor: null, completed: true },
+      actionPlans: { cursor: null, completed: true },
+    });
+  });
+
+  it("does not persist checkpoints during a dry run", async () => {
+    const deps: HIAPCatalogBackfillRunnerDeps = {
+      acquireLock: jest.fn().mockResolvedValue({ connectionId: "lock-1" }),
+      releaseLock: jest.fn().mockResolvedValue(undefined),
+      loadCheckpoint: jest.fn(),
+      saveCheckpoint: jest.fn(),
+      processRankingsPage: jest.fn().mockResolvedValue(page()),
+      processActionPlansPage: jest.fn().mockResolvedValue(page()),
+    };
+
+    await expect(
+      runHIAPCatalogBackfill(
+        { batchSize: 10, maxBatchesPerType: 1, dryRun: true },
+        deps,
+      ),
+    ).resolves.toMatchObject({ skipped: false, pages: 2 });
+
+    expect(deps.loadCheckpoint).not.toHaveBeenCalled();
+    expect(deps.saveCheckpoint).not.toHaveBeenCalled();
+  });
+
+  it("keeps a failed page resumable instead of advancing past it", async () => {
+    const savedCheckpoints: HIAPCatalogBackfillCheckpoint[] = [];
+    const deps: HIAPCatalogBackfillRunnerDeps = {
+      acquireLock: jest.fn().mockResolvedValue({ connectionId: "lock-1" }),
+      releaseLock: jest.fn().mockResolvedValue(undefined),
+      loadCheckpoint: jest.fn().mockResolvedValue({
+        rankings: { cursor: null, completed: false },
+        actionPlans: { cursor: null, completed: true },
+      }),
+      saveCheckpoint: jest.fn(async (checkpoint) => {
+        savedCheckpoints.push(checkpoint);
+      }),
+      processRankingsPage: jest.fn().mockResolvedValue(
+        page({
+          failed: 1,
+          hasMore: true,
+          nextCursor: { created: "2026-01-01T00:00:00.000Z", id: "r-1" },
+        }),
+      ),
+      processActionPlansPage: jest.fn(),
+    };
+
+    await expect(
+      runHIAPCatalogBackfill(
+        { batchSize: 10, maxBatchesPerType: 1, dryRun: false },
+        deps,
+      ),
+    ).resolves.toMatchObject({
+      skipped: false,
+      rankings: { failed: 1 },
+      actionPlans: { scanned: 0, repaired: 0, failed: 0 },
+    });
+    expect(savedCheckpoints.at(-1)).toEqual({
+      rankings: { cursor: null, completed: false },
+      actionPlans: { cursor: null, completed: true },
+    });
+  });
+
+  it("uses one dedicated connection for lock acquisition and release", async () => {
+    const firstConnection = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ locked: true }] })
+        .mockResolvedValueOnce({ rows: [{ unlocked: true }] }),
+    };
+    const secondConnection = {
+      query: jest.fn().mockResolvedValue({ rows: [{ locked: false }] }),
+    };
+    const connectionManager = {
+      getConnection: jest
+        .fn()
+        .mockResolvedValueOnce(firstConnection)
+        .mockResolvedValueOnce(secondConnection),
+      releaseConnection: jest.fn(),
+    };
+    const sequelize = { connectionManager } as unknown as Sequelize;
+
+    const firstLease = await acquireHIAPCatalogBackfillLock(sequelize);
+    const secondLease = await acquireHIAPCatalogBackfillLock(sequelize);
+
+    expect(firstLease?.connection).toBe(firstConnection);
+    expect(secondLease).toBeNull();
+    expect(connectionManager.releaseConnection).toHaveBeenCalledWith(
+      secondConnection,
+    );
+
+    await releaseHIAPCatalogBackfillLock(firstLease!);
+
+    expect(firstConnection.query).toHaveBeenLastCalledWith(
+      "SELECT pg_advisory_unlock(hashtext($1))",
+      ["citycatalyst:hiap-catalog-backfill"],
+    );
+    expect(connectionManager.releaseConnection).toHaveBeenLastCalledWith(
+      firstConnection,
+    );
+  });
+
+  it("does not process or release a lock it did not acquire", async () => {
+    const deps: HIAPCatalogBackfillRunnerDeps = {
+      acquireLock: jest.fn().mockResolvedValue(null),
+      releaseLock: jest.fn().mockResolvedValue(undefined),
+      loadCheckpoint: jest.fn(),
+      saveCheckpoint: jest.fn(),
+      processRankingsPage: jest.fn(),
+      processActionPlansPage: jest.fn(),
+    };
+
+    await expect(
+      runHIAPCatalogBackfill(
+        { batchSize: 10, maxBatchesPerType: 1, dryRun: false },
+        deps,
+      ),
+    ).resolves.toEqual({ skipped: true, pages: 0 });
+    expect(deps.loadCheckpoint).not.toHaveBeenCalled();
+    expect(deps.processRankingsPage).not.toHaveBeenCalled();
+    expect(deps.processActionPlansPage).not.toHaveBeenCalled();
+    expect(deps.releaseLock).not.toHaveBeenCalled();
+  });
+});

--- a/app/tests/hiap-native-input-catalog-service.jest.ts
+++ b/app/tests/hiap-native-input-catalog-service.jest.ts
@@ -67,8 +67,12 @@ jest.unstable_mockModule("@/services/logger", () => ({
 }));
 
 let registerHIAPRanking: typeof import("@/backend/hiap/HiapNativeInputCatalogService").registerHIAPRanking;
-let backfillMissingHIAPRankings: typeof import("@/backend/hiap/HiapNativeInputCatalogService").backfillMissingHIAPRankings;
-let backfillMissingHIAPActionPlans: typeof import("@/backend/hiap/HiapNativeInputCatalogService").backfillMissingHIAPActionPlans;
+let resolveHIAPCatalogScope: typeof import("@/backend/hiap/HiapNativeInputCatalogService").resolveHIAPCatalogScope;
+let buildHIAPRankingInput: typeof import("@/backend/hiap/HiapNativeInputCatalogService").buildHIAPRankingInput;
+let buildHIAPActionPlanInput: typeof import("@/backend/hiap/HiapNativeInputCatalogService").buildHIAPActionPlanInput;
+let buildHIAPSelectionInput: typeof import("@/backend/hiap/HiapNativeInputCatalogService").buildHIAPSelectionInput;
+let backfillMissingHIAPRankingsPage: typeof import("@/backend/hiap/HiapNativeInputCatalogService").backfillMissingHIAPRankingsPage;
+let backfillMissingHIAPActionPlansPage: typeof import("@/backend/hiap/HiapNativeInputCatalogService").backfillMissingHIAPActionPlansPage;
 let registerHIAPSelections: typeof import("@/backend/hiap/HiapNativeInputCatalogService").registerHIAPSelections;
 let registerHIAPActionPlan: typeof import("@/backend/hiap/HiapNativeInputCatalogService").registerHIAPActionPlan;
 let withdrawHIAPActionPlanCatalog: typeof import("@/backend/hiap/HiapNativeInputCatalogService").withdrawHIAPActionPlanCatalog;
@@ -77,8 +81,12 @@ let withdrawHIAPCatalogForCity: typeof import("@/backend/hiap/HiapNativeInputCat
 beforeAll(async () => {
   ({
     registerHIAPRanking,
-    backfillMissingHIAPRankings,
-    backfillMissingHIAPActionPlans,
+    resolveHIAPCatalogScope,
+    buildHIAPRankingInput,
+    buildHIAPActionPlanInput,
+    buildHIAPSelectionInput,
+    backfillMissingHIAPRankingsPage,
+    backfillMissingHIAPActionPlansPage,
     registerHIAPSelections,
     registerHIAPActionPlan,
     withdrawHIAPActionPlanCatalog,
@@ -128,6 +136,177 @@ const ranking = {
 } as never;
 
 describe("HiapNativeInputCatalogService", () => {
+  it("keeps the public HIAP input builders available", async () => {
+    rankedModel.findAll.mockResolvedValue([
+      {
+        actionId: "action-1",
+        rank: 1,
+        lang: "en",
+        type: "mitigation",
+        isSelected: false,
+      },
+    ]);
+    const scope = await resolveHIAPCatalogScope({
+      inventoryId: "inventory-1",
+      userId: "user-1",
+    });
+
+    await expect(buildHIAPRankingInput(ranking)).resolves.toEqual(
+      expect.objectContaining({
+        kind: "hiap_ranking",
+        sourceType: "hiap_ranking",
+      }),
+    );
+    await expect(
+      buildHIAPActionPlanInput({
+        id: "plan-1",
+        actionId: "action-1",
+        highImpactActionRankedId: "ranked-1",
+        inventoryId: "inventory-1",
+        createdBy: "user-1",
+      } as never),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        kind: "hiap_action_plan",
+        sourceType: "action_plan",
+      }),
+    );
+    expect(
+      buildHIAPSelectionInput(
+        "hiap_ranked_selection",
+        "inventory-1",
+        "mitigation" as never,
+        "action-1",
+        scope,
+        "ranking-1",
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        kind: "hiap_selection",
+        sourceType: "hiap_ranked_selection",
+        sourceId: "ranking-1:action-1",
+      }),
+    );
+  });
+
+  it("processes rankings in a bounded keyset-paginated page", async () => {
+    const first = {
+      ...ranking,
+      id: "ranking-1",
+      created: new Date("2026-01-01T00:00:00.000Z"),
+    };
+    const second = {
+      ...ranking,
+      id: "ranking-2",
+      created: new Date("2026-01-02T00:00:00.000Z"),
+    };
+    rankingModel.findAll.mockResolvedValue([first, second]);
+    rankedModel.findAll.mockResolvedValue([
+      {
+        actionId: "action-1",
+        rank: 1,
+        lang: "en",
+        type: "mitigation",
+        isSelected: false,
+      },
+    ]);
+
+    const page = await backfillMissingHIAPRankingsPage({ limit: 2 });
+
+    expect(page).toEqual({
+      scanned: 2,
+      repaired: 2,
+      failed: 0,
+      hasMore: true,
+      nextCursor: {
+        created: "2026-01-02T00:00:00.000Z",
+        id: "ranking-2",
+      },
+    });
+    expect(rankingModel.findAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 2,
+        order: [
+          ["created", "ASC"],
+          ["id", "ASC"],
+        ],
+      }),
+    );
+  });
+
+  it("continues a ranking page after an individual catalog sync fails", async () => {
+    rankingModel.findAll.mockResolvedValue([
+      {
+        ...ranking,
+        id: "ranking-failed",
+        created: new Date("2026-01-01T00:00:00.000Z"),
+      },
+      {
+        ...ranking,
+        id: "ranking-recovered",
+        created: new Date("2026-01-02T00:00:00.000Z"),
+      },
+    ]);
+    rankedModel.findAll.mockResolvedValue([
+      {
+        actionId: "action-1",
+        rank: 1,
+        lang: "en",
+        type: "mitigation",
+        isSelected: false,
+      },
+    ]);
+    registerNativeInput
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValueOnce({
+        catalog: { id: "catalog-recovered" },
+        created: true,
+      });
+
+    const page = await backfillMissingHIAPRankingsPage({ limit: 2 });
+
+    expect(page.scanned).toBe(2);
+    expect(page.repaired).toBe(1);
+    expect(page.failed).toBe(1);
+    expect(registerNativeInput).toHaveBeenCalledTimes(2);
+  });
+
+  it("processes action plans with a bounded page and dry-run mode", async () => {
+    actionPlanModel.findAll.mockResolvedValue([
+      {
+        id: "plan-1",
+        actionId: "action-1",
+        highImpactActionRankedId: "ranked-1",
+        cityLocode: "BR-SAO",
+        cityId: "city-1",
+        inventoryId: "inventory-1",
+        actionName: "Action plan",
+        language: "en",
+        createdBy: "user-1",
+        created: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    ]);
+
+    const page = await backfillMissingHIAPActionPlansPage({
+      limit: 2,
+      dryRun: true,
+    });
+
+    expect(page.scanned).toBe(1);
+    expect(page.repaired).toBe(1);
+    expect(page.failed).toBe(0);
+    expect(registerNativeInput).not.toHaveBeenCalled();
+    expect(actionPlanModel.findAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 2,
+        order: [
+          ["created", "ASC"],
+          ["id", "ASC"],
+        ],
+      }),
+    );
+  });
+
   it("registers only a successful persisted ranking and keeps content out of labels", async () => {
     rankedModel.findAll.mockResolvedValue([
       {
@@ -170,103 +349,6 @@ describe("HiapNativeInputCatalogService", () => {
       "Only persisted HIAP rankings",
     );
     expect(registerNativeInput).not.toHaveBeenCalled();
-  });
-
-  it("backfills successful rankings that are missing an active catalog entry", async () => {
-    rankingModel.findAll.mockResolvedValue([ranking]);
-    catalogModel.findOne.mockResolvedValue(null);
-    rankedModel.findAll.mockResolvedValue([
-      {
-        actionId: "action-1",
-        rank: 1,
-        lang: "en",
-        type: "mitigation",
-        isSelected: false,
-      },
-    ]);
-
-    await expect(backfillMissingHIAPRankings()).resolves.toBe(1);
-    expect(registerNativeInput).toHaveBeenCalledWith(
-      expect.objectContaining({
-        kind: "hiap_ranking",
-        sourceType: "hiap_ranking",
-      }),
-    );
-  });
-
-  it("retries a failed backfill on a later run", async () => {
-    rankingModel.findAll.mockResolvedValue([ranking]);
-    catalogModel.findOne.mockResolvedValue(null);
-    rankedModel.findAll.mockResolvedValue([
-      {
-        actionId: "action-1",
-        rank: 1,
-        lang: "en",
-        type: "mitigation",
-        isSelected: false,
-      },
-    ]);
-    registerNativeInput.mockRejectedValueOnce(new Error("temporary failure"));
-
-    await expect(backfillMissingHIAPRankings()).resolves.toBe(0);
-
-    registerNativeInput.mockResolvedValue({
-      catalog: { id: "catalog-recovered" },
-      created: true,
-    });
-    await expect(backfillMissingHIAPRankings()).resolves.toBe(1);
-    expect(registerNativeInput).toHaveBeenCalledTimes(2);
-  });
-
-  it("backfills generated action plans that are missing the current catalog entry", async () => {
-    const actionPlan = {
-      id: "plan-1",
-      actionId: "action-1",
-      highImpactActionRankedId: "ranked-1",
-      cityLocode: "BR-SAO",
-      cityId: "city-1",
-      inventoryId: "inventory-1",
-      actionName: "Action plan",
-      language: "en",
-      createdBy: "user-1",
-    };
-    actionPlanModel.findAll.mockResolvedValue([actionPlan]);
-    catalogModel.findOne.mockResolvedValue(null);
-
-    await expect(backfillMissingHIAPActionPlans()).resolves.toBe(1);
-    expect(registerNativeInput).toHaveBeenCalledWith(
-      expect.objectContaining({
-        kind: "hiap_action_plan",
-        sourceType: "action_plan",
-        sourceId: expect.stringMatching(/^plan-1:/),
-      }),
-    );
-  });
-
-  it("retries a failed action-plan backfill on a later run", async () => {
-    const actionPlan = {
-      id: "plan-1",
-      actionId: "action-1",
-      highImpactActionRankedId: "ranked-1",
-      cityLocode: "BR-SAO",
-      cityId: "city-1",
-      inventoryId: "inventory-1",
-      actionName: "Action plan",
-      language: "en",
-      createdBy: "user-1",
-    };
-    actionPlanModel.findAll.mockResolvedValue([actionPlan]);
-    catalogModel.findOne.mockResolvedValue(null);
-    registerNativeInput.mockRejectedValueOnce(new Error("temporary failure"));
-
-    await expect(backfillMissingHIAPActionPlans()).resolves.toBe(0);
-
-    registerNativeInput.mockResolvedValue({
-      catalog: { id: "catalog-recovered" },
-      created: true,
-    });
-    await expect(backfillMissingHIAPActionPlans()).resolves.toBe(1);
-    expect(registerNativeInput).toHaveBeenCalledTimes(2);
   });
 
   it("creates separate ranked and unranked selection artifacts and withdraws stale rows", async () => {

--- a/k8s/prod/cc-hiap-catalog-backfill-manual.yml
+++ b/k8s/prod/cc-hiap-catalog-backfill-manual.yml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: cc-hiap-catalog-backfill-manual-
+spec:
+  ttlSecondsAfterFinished: 86400
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: citycatalyst-manual
+        job: hiap-catalog-backfill
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: hiap-catalog-backfill
+          image: ghcr.io/open-earth-foundation/citycatalyst:stable
+          imagePullPolicy: Always
+          envFrom:
+            - configMapRef:
+                name: cc-db-configmap
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: HIAP_CATALOG_BACKFILL_BATCH_SIZE
+              value: "25"
+            # Keep the default manual invocation read-only; set to "false" for repair.
+            - name: HIAP_CATALOG_BACKFILL_DRY_RUN
+              value: "true"
+          command: ["npm"]
+          args: ["run", "hiap-catalog-backfill"]
+          resources:
+            limits:
+              memory: "1024Mi"
+              cpu: "1000m"

--- a/k8s/test/cc-test-check-hiap-jobs.yml
+++ b/k8s/test/cc-test-check-hiap-jobs.yml
@@ -4,34 +4,31 @@ metadata:
   name: citycatalyst-test-check-hiap-jobs
   namespace: default
 spec:
-  # Run every minute
-  schedule: "* * * * *"
+  schedule: "*/5 * * * *"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
-  concurrencyPolicy: Forbid # Prevent overlapping runs
+  concurrencyPolicy: Forbid
   jobTemplate:
     spec:
-      backoffLimit: 2 # Retry twice on failure
+      backoffLimit: 2
+      activeDeadlineSeconds: 180
       template:
         metadata:
           labels:
             app: citycatalyst-test-cron
-            job: test-check-hiap-jobs
+            job: check-hiap-jobs
         spec:
-          restartPolicy: OnFailure
+          restartPolicy: Never
           containers:
-            - name: test-check-hiap-jobs
+            - name: check-hiap-jobs
               image: curlimages/curl:latest
               command:
                 - /bin/sh
-                - -c
+                - -ec
                 - |
-                  echo "Checking HIAP jobs at $(date)"
-                  curl -f -L -X GET http://cc-test-web:3000/api/cron/check-hiap-jobs
-                  EXIT_CODE=$?
-                  if [ $EXIT_CODE -eq 0 ]; then
-                    echo "Cron job completed successfully"
-                  else
-                    echo "Cron job failed with exit code $EXIT_CODE"
-                    exit $EXIT_CODE
-                  fi
+                  test -n "$CC_CRON_JOB_API_KEY"
+                  echo "Checking test HIAP jobs at $(date)"
+                  curl --fail --location --max-time 60 \
+                    --request GET \
+                    --header "Authorization: Bearer $CC_CRON_JOB_API_KEY" \
+                    http://cc-test-web:3000/api/v1/cron/check-hiap-jobs

--- a/load-test/README.md
+++ b/load-test/README.md
@@ -14,3 +14,63 @@ _OR_ (for manual parameter selection)
 ```bash
 k6 run --vus 30 --duration 10s city_catalyst.ts
 ```
+
+## HIAP cron regression load test
+
+### Local Docker dataset
+
+Start an isolated PostgreSQL instance and apply the application's migrations:
+
+```powershell
+docker compose -f .\docker-compose.hiap.yml up -d
+cd ..\app
+$env:NODE_ENV = "development"
+$env:DATABASE_HOST = "127.0.0.1"
+$env:DATABASE_NAME = "citycatalyst_loadtest"
+$env:DATABASE_USER = "citycatalyst"
+$env:DATABASE_PASSWORD = "local-loadtest"
+$env:CC_CRON_JOB_API_KEY = "local-loadtest-key"
+npm run db:migrate
+$env:HIAP_LOAD_TEST_RANKINGS = "1000"
+$env:HIAP_LOAD_TEST_PLANS = "1000"
+$env:HIAP_LOAD_TEST_JSON_BYTES = "32768"
+npm run seed-hiap-load-test
+```
+
+The fixture is synthetic and deterministic. It creates successful rankings,
+ranked actions, and action plans with controlled JSONB payloads. It uses a
+reserved `ZZ-CC752-LOAD` prefix and can be safely reset and regenerated with
+the same command.
+
+`hiap_cron.js` exercises the internal `GET /api/v1/cron/check-hiap-jobs`
+endpoint at a constant arrival rate. It verifies the polling-only response
+contract and records latency, HTTP errors, 5xx responses, and unexpected
+backfill fields.
+
+Run it only against a disposable local or approved staging/prod-like target.
+The endpoint can advance HIAP work, so prepare the target dataset first and do
+not point this test at production without an explicit change approval.
+
+```powershell
+$env:BASE_URL = "https://citycatalyst-test.openearth.dev"
+$env:CRON_API_KEY = "<internal-cron-key>"
+$env:RUN_ID = "cc-752-fixed-2026-08-21"
+k6 run --summary-export .\results\cc-752-fixed-summary.json .\hiap_cron.js
+```
+
+Defaults are five minutes at one request per second, with a maximum of 20
+virtual users. Override `RATE`, `DURATION`, `PRE_ALLOCATED_VUS`, or `MAX_VUS`
+only when the target's capacity and test objective justify it.
+
+The expected fixed-build evidence is:
+
+- `http_req_failed < 1%` and `hiap_cron_5xx == 0`;
+- p95 request and route duration below 2 seconds;
+- zero unexpected backfill fields in the response;
+- no increase in Web pod restarts during the run;
+- stable pod memory, collected alongside k6 with
+  `collect-hiap-cron-evidence.ps1` when Kubernetes metrics are available.
+
+Use `cc-752-evidence-table.template.md` to turn the run artifacts into a
+card-ready comparison without claiming incident data was a controlled
+baseline.

--- a/load-test/cc-752-evidence-table.template.md
+++ b/load-test/cc-752-evidence-table.template.md
@@ -1,0 +1,25 @@
+# CC-752 load-test evidence
+
+Fill the fixed-build column from the generated `evidence.json`, k6 summary,
+and pod memory samples after an approved staging/prod-like run. Do not present
+the incident observations as a controlled baseline: the Slack report provides
+the failure symptoms, not a repeatable benchmark.
+
+| Metric | v1.25.2 incident observation | Fixed build measured result | Acceptance signal | Evidence |
+|---|---|---|---|---|
+| HIAP cron HTTP 5xx | Intermittent `502` responses during cron execution | `TBD` | `hiap_cron_5xx = 0` | k6 summary |
+| Request error rate | Not measured as a controlled rate | `TBD` | `< 1%` | k6 summary |
+| p95 cron duration | Not available from incident | `TBD` | `< 2 s` | k6 summary |
+| V8 heap failure | Both Web replicas reached the ~1 GB V8 heap limit | `TBD` | No fatal heap error | Web logs |
+| Web pod restart delta | Both replicas repeatedly restarted | `TBD` | `0` during run | `pods-before.json` / `pods-after.json` |
+| Web pod memory | Not available as a controlled time series | `TBD` | Stable; no upward runaway | `pod-memory-samples.txt` |
+| Polling response contract | Backfill counters were present before the fix | `TBD` | No `catalogBackfilled` or `actionPlansBackfilled` fields | k6 checks |
+| Backfill execution path | Ran inside the Web process | Isolated command/Job | No `cc-web` request from the backfill Job | Job manifest/logs |
+
+## Card-ready conclusion
+
+> On `[target]`, commit `[sha]` sustained `[duration]` at `[rate]` requests/s
+> with `[requests]` requests, `[error rate]` errors, p95 latency of `[p95]`,
+> `[restart delta]` Web pod restarts, and peak Web memory of `[peak memory]`.
+> No V8 heap failure or 5xx response was observed. The result is `[pass/fail]`
+> against the CC-752 acceptance signals above.

--- a/load-test/cc-752-local-evidence.md
+++ b/load-test/cc-752-local-evidence.md
@@ -1,0 +1,34 @@
+# CC-752 Local Load-Test Evidence
+
+Date: 2026-08-21
+
+## Test setup
+
+- Target: local CityCatalyst production build, backed by PostgreSQL 16 in Docker.
+- Dataset: synthetic deterministic fixture with 1,000 successful HIAP rankings, 3,000 ranked actions, and 1,000 action plans.
+- Payload profile: 32 KiB JSONB `subactions` payload per action plan.
+- Load: constant arrival rate of 2 GET requests/second for 60 seconds, executed by `grafana/k6:0.54.0`.
+- Baseline: `origin/develop` at `c5d3a091d`.
+- Fixed: CC-752 implementation at `4afe89e13`.
+- Memory: local Node process working set and private bytes sampled every five seconds.
+
+## Comparison
+
+| Evidence                       |                          Baseline (`origin/develop`) |               Fixed (`4afe89e13`) | Result                                                                   |
+| ------------------------------ | ---------------------------------------------------: | --------------------------------: | ------------------------------------------------------------------------ |
+| Completed requests             |                                                   12 |                               120 | Fixed sustained the target rate.                                         |
+| Dropped iterations             |                                                  101 |                                 0 | Fixed did not exhaust the VU budget.                                     |
+| HTTP/request failures          |                                         100% (12/12) |                        0% (0/120) | Fixed stayed within the error budget.                                    |
+| 5xx responses                  |                                            0% (0/12) |                        0% (0/120) | No server 5xx in either run; baseline requests timed out.                |
+| p95 request latency            |                                          59,995.7 ms |                           11.1 ms | Fixed removed the synchronous backfill cost from the cron path.          |
+| Polling-only response contract |                               0% of completed checks |             100% (240/240 checks) | Fixed returned no `catalogBackfilled` or `actionPlansBackfilled` fields. |
+| First cold request             | 24,771 ms; backfilled 1,000 rankings and 1,000 plans | 238 ms smoke request; no backfill | Backfill is no longer part of the web request.                           |
+| Node working-set peak          |                                         1,040.68 MiB |                        162.25 MiB | Fixed peak was 84.4% lower in this local run.                            |
+| Node private-memory peak       |                                         1,058.28 MiB |                        157.21 MiB | Fixed peak was 85.1% lower in this local run.                            |
+| Process restarts               |                               Not applicable locally |            Not applicable locally | Kubernetes restart evidence still requires staging.                      |
+
+## Interpretation
+
+The local comparison reproduces the failure mode: the old cron endpoint performs the catalog backfills synchronously, becomes saturated, and grows to approximately 1 GiB of process memory. The fixed endpoint only polls HIAP jobs and remains responsive under the same synthetic load and database profile.
+
+This is controlled local evidence, not production or Kubernetes evidence. The next validation step is the same k6 profile against an approved staging target while collecting pod restarts and `kubectl top` memory samples.

--- a/load-test/collect-hiap-cron-evidence.ps1
+++ b/load-test/collect-hiap-cron-evidence.ps1
@@ -1,0 +1,111 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$BaseUrl,
+
+  [Parameter(Mandatory = $true)]
+  [string]$CronApiKey,
+
+  [string]$TargetName = "staging",
+  [string]$Namespace = "default",
+  [string]$PodSelector = "app=citycatalyst",
+  [int]$SampleSeconds = 5,
+  [switch]$AllowRemoteTarget,
+  [string]$RunId = "cc-752-$((Get-Date).ToUniversalTime().ToString('yyyyMMddTHHmmssZ'))",
+  [string]$ResultsRoot = (Join-Path $PSScriptRoot "results")
+)
+
+$uri = [Uri]$BaseUrl
+$localHosts = @("localhost", "127.0.0.1", "::1")
+if ($uri.Host -notin $localHosts -and -not $AllowRemoteTarget) {
+  throw "Refusing remote target '$BaseUrl'. Re-run with -AllowRemoteTarget after explicit approval."
+}
+
+if (-not (Get-Command k6 -ErrorAction SilentlyContinue)) {
+  throw "k6 is required. Install it from https://grafana.com/docs/k6/latest/set-up/install-k6/"
+}
+
+if (-not (Get-Command kubectl -ErrorAction SilentlyContinue)) {
+  throw "kubectl is required to collect pod restarts and memory samples."
+}
+
+$resultsDir = Join-Path $ResultsRoot $RunId
+New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+
+$beforePath = Join-Path $resultsDir "pods-before.json"
+$afterPath = Join-Path $resultsDir "pods-after.json"
+$topPath = Join-Path $resultsDir "pod-memory-samples.txt"
+$summaryPath = Join-Path $resultsDir "k6-summary.json"
+$k6StdoutPath = Join-Path $resultsDir "k6.stdout.log"
+$k6StderrPath = Join-Path $resultsDir "k6.stderr.log"
+$evidencePath = Join-Path $resultsDir "evidence.json"
+
+function Save-PodSnapshot([string]$Path) {
+  $json = kubectl get pods -n $Namespace -l $PodSelector -o json
+  if ($LASTEXITCODE -ne 0) {
+    throw "kubectl could not read pods using selector '$PodSelector' in namespace '$Namespace'."
+  }
+  Set-Content -Path $Path -Value $json -NoNewline
+}
+
+function Get-RestartTotal([string]$Path) {
+  if (-not (Test-Path $Path)) { return 0 }
+  $snapshot = Get-Content -Raw -Path $Path | ConvertFrom-Json
+  $total = 0
+  foreach ($pod in @($snapshot.items)) {
+    foreach ($container in @($pod.status.containerStatuses)) {
+      $total += [int]$container.restartCount
+    }
+  }
+  return $total
+}
+
+Save-PodSnapshot $beforePath
+
+$env:BASE_URL = $BaseUrl.TrimEnd("/")
+$env:CRON_API_KEY = $CronApiKey
+$env:RUN_ID = $RunId
+
+$scriptPath = Join-Path $PSScriptRoot "hiap_cron.js"
+$process = Start-Process `
+  -FilePath "k6" `
+  -ArgumentList @("run", $scriptPath, "--summary-export", $summaryPath) `
+  -RedirectStandardOutput $k6StdoutPath `
+  -RedirectStandardError $k6StderrPath `
+  -NoNewWindow `
+  -PassThru
+
+$startedAt = (Get-Date).ToUniversalTime()
+while (-not $process.HasExited) {
+  $sampleTime = (Get-Date).ToUniversalTime().ToString("o")
+  $top = kubectl top pods -n $Namespace -l $PodSelector --no-headers 2>&1
+  Add-Content -Path $topPath -Value ("{0}`t{1}" -f $sampleTime, ($top -join " | "))
+  Start-Sleep -Seconds $SampleSeconds
+}
+$process.WaitForExit()
+$finishedAt = (Get-Date).ToUniversalTime()
+
+Save-PodSnapshot $afterPath
+
+$evidence = [ordered]@{
+  runId = $RunId
+  targetName = $TargetName
+  baseUrl = $BaseUrl
+  startedAt = $startedAt.ToString("o")
+  finishedAt = $finishedAt.ToString("o")
+  durationSeconds = [Math]::Round(($finishedAt - $startedAt).TotalSeconds, 2)
+  k6ExitCode = $process.ExitCode
+  podRestartsBefore = Get-RestartTotal $beforePath
+  podRestartsAfter = Get-RestartTotal $afterPath
+  podRestartDelta = (Get-RestartTotal $afterPath) - (Get-RestartTotal $beforePath)
+  summaryFile = (Resolve-Path $summaryPath).Path
+  podMemorySamplesFile = (Resolve-Path $topPath).Path
+  stdoutFile = (Resolve-Path $k6StdoutPath).Path
+  stderrFile = (Resolve-Path $k6StderrPath).Path
+}
+$evidence | ConvertTo-Json -Depth 5 | Set-Content -Path $evidencePath
+
+Write-Output "Evidence written to $evidencePath"
+if ($process.ExitCode -ne 0) {
+  throw "k6 exited with code $($process.ExitCode). Review $k6StdoutPath and $k6StderrPath."
+}

--- a/load-test/docker-compose.hiap.yml
+++ b/load-test/docker-compose.hiap.yml
@@ -1,0 +1,20 @@
+services:
+  hiap-loadtest-db:
+    image: postgres:16-alpine
+    container_name: cc-752-hiap-loadtest-db
+    environment:
+      POSTGRES_DB: citycatalyst_loadtest
+      POSTGRES_USER: citycatalyst
+      POSTGRES_PASSWORD: local-loadtest
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U citycatalyst -d citycatalyst_loadtest"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+    volumes:
+      - hiap-loadtest-db-data:/var/lib/postgresql/data
+
+volumes:
+  hiap-loadtest-db-data:

--- a/load-test/hiap_cron.js
+++ b/load-test/hiap_cron.js
@@ -1,0 +1,82 @@
+import http from "k6/http";
+import { check } from "k6";
+import { Counter, Rate, Trend } from "k6/metrics";
+
+const cronDuration = new Trend("hiap_cron_duration", true);
+const cronErrors = new Rate("hiap_cron_errors");
+const cron5xx = new Rate("hiap_cron_5xx");
+const unexpectedPayload = new Counter("hiap_cron_unexpected_payload");
+
+const BASE_URL = (__ENV.BASE_URL || "http://localhost:3000").replace(/\/$/, "");
+const CRON_API_KEY = __ENV.CRON_API_KEY;
+const RATE = Number(__ENV.RATE || 1);
+const DURATION = __ENV.DURATION || "5m";
+const PRE_ALLOCATED_VUS = Number(__ENV.PRE_ALLOCATED_VUS || 5);
+const MAX_VUS = Number(__ENV.MAX_VUS || 20);
+
+if (!CRON_API_KEY) {
+  throw new Error(
+    "CRON_API_KEY is required; refusing to run unauthenticated load",
+  );
+}
+
+export const options = {
+  scenarios: {
+    hiap_cron_polling: {
+      executor: "constant-arrival-rate",
+      rate: RATE,
+      timeUnit: "1s",
+      duration: DURATION,
+      preAllocatedVUs: PRE_ALLOCATED_VUS,
+      maxVUs: MAX_VUS,
+      gracefulStop: "10s",
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.01"],
+    http_req_duration: ["p(95)<2000", "p(99)<5000"],
+    hiap_cron_errors: ["rate<0.01"],
+    hiap_cron_5xx: ["rate==0"],
+    hiap_cron_duration: ["p(95)<2000"],
+    hiap_cron_unexpected_payload: ["count==0"],
+  },
+};
+
+export default function () {
+  const response = http.get(`${BASE_URL}/api/v1/cron/check-hiap-jobs/`, {
+    headers: {
+      Authorization: `Bearer ${CRON_API_KEY}`,
+      "X-Load-Test-Run": __ENV.RUN_ID || "hiap-cron-load-test",
+    },
+    tags: {
+      endpoint: "check-hiap-jobs",
+    },
+  });
+
+  const payload = (() => {
+    try {
+      return response.json();
+    } catch {
+      return null;
+    }
+  })();
+  const hasExpectedShape =
+    response.status === 200 &&
+    payload !== null &&
+    typeof payload.checkedJobs === "number" &&
+    typeof payload.completedJobs === "number" &&
+    typeof payload.startedBatches === "number" &&
+    typeof payload.durationMs === "number" &&
+    !Object.prototype.hasOwnProperty.call(payload, "catalogBackfilled") &&
+    !Object.prototype.hasOwnProperty.call(payload, "actionPlansBackfilled");
+
+  check(response, {
+    "HIAP cron returns HTTP 200": (res) => res.status === 200,
+    "HIAP cron response has polling-only contract": () => hasExpectedShape,
+  });
+
+  cronDuration.add(response.timings.duration);
+  cronErrors.add(response.status >= 400 || !hasExpectedShape);
+  cron5xx.add(response.status >= 500);
+  if (!hasExpectedShape) unexpectedPayload.add(1);
+}


### PR DESCRIPTION
## Summary

Promote the merged CC-752 fix from #3044 to `main` for deployment and validation in the test environment ahead of the v1.25.3 production hotfix.

## Changes

- Remove catalog backfills from the recurring HIAP polling request
- Add bounded, resumable catalog backfill processing with locking and checkpoints
- Align the test CronJob with the authenticated `cc-test-web` v1 endpoint
- Include repeatable load-test fixtures and validation documentation

## Verification

- Source PR #3044 build, Jest, and Playwright workflow passed
- Hotfix diff and whitespace checks passed
- Test CronJob manifest passed Kubernetes client-side validation
- Require this PR's GitHub checks and test-environment CronJob/memory validation before production promotion

Source: #3044
Linear: CC-752