### PR TITLE
feat(api): implement remaining MEED service API routes in CC

### DIFF
--- a/app/src/app/api/v1/city/[city]/meed/actions/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/actions/route.ts
@@ -1,4 +1,5 @@
 import MeedApiService from "@/backend/MeedApiService";
+import { PermissionService } from "@/backend/permissions/PermissionService";
 import { apiHandler } from "@/util/api";
 import { NextResponse } from "next/server";
 
@@ -102,7 +103,10 @@ import { NextResponse } from "next/server";
  *                              methodology:
  *                                type: string
  */
-export const GET = apiHandler(async (_req) => {
+export const GET = apiHandler(async (_req, { session, params }) => {
+  const { city: cityId } = params;
+  await PermissionService.canAccessCity(session, cityId);
+
   const result = await MeedApiService.getActions();
   return NextResponse.json({ data: result });
 });

--- a/app/src/app/api/v1/city/[city]/meed/actions/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/actions/route.ts
@@ -1,0 +1,108 @@
+import MeedApiService from "@/backend/MeedApiService";
+import { apiHandler } from "@/util/api";
+import { NextResponse } from "next/server";
+
+/**
+ * @swagger
+ * /api/v1/city/{city}/meed/actions:
+ *   get:
+ *     tags:
+ *       - meed
+ *       - city
+ *     operationId: getMeedActions
+ *     summary: Fetches MEED+ action pathways
+ *     description: Fetches MEED+ action pathways via the MEED service from the global API
+ *     parameters:
+ *       - in: path
+ *         name: city
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Actions retrieved
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     actions:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           action_id:
+ *                             type: string
+ *                           inventoryId:
+ *                             type: string
+ *                             format: uuid
+ *                           action_name:
+ *                             type: string
+ *                           action_type:
+ *                             type: string
+ *                           description:
+ *                             type: string
+ *                           name_i18n:
+ *                             type: object
+ *                             properties:
+ *                               en:
+ *                                 type: string
+ *                               es:
+ *                                 type: string
+ *                               pt:
+ *                                 type: string
+ *                           description_i18n:
+ *                             type: object
+ *                             properties:
+ *                               en:
+ *                                 type: string
+ *                               es:
+ *                                 type: string
+ *                               pt:
+ *                                 type: string
+ *
+ *                           investment_cost:
+ *                             type: string
+ *                           implementation_timeline:
+ *                             type: string
+ *                           co_benefits:
+ *                             type: object
+ *                             additionalProperties:
+ *                               type: object
+ *                               properties:
+ *                                 impact_relationship:
+ *                                   type: string
+ *                                 impact_text:
+ *                                   type: string
+ *                                 impact_numeric:
+ *                                   type: number
+ *                                 methodology:
+ *                                   type: string
+ *                          emissions:
+ *                            type: object
+ *                            properties:
+ *                              sector_number:
+ *                                type: string
+ *                              subsector_number:
+ *                                type: number
+ *                              gpc_reference_number:
+ *                                type: array
+ *                                items:
+ *                                  type: string
+ *                              impact_relationship:
+ *                                type: string
+ *                              impact_text:
+ *                                type: string
+ *                              impact_numeric:
+ *                                type: number
+ *                              methodology:
+ *                                type: string
+ */
+export const GET = apiHandler(async (_req) => {
+  const result = await MeedApiService.getActions();
+  return NextResponse.json({ data: result });
+});

--- a/app/src/app/api/v1/city/[city]/meed/city-attributes/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/city-attributes/route.ts
@@ -1,0 +1,74 @@
+import MeedApiService from "@/backend/MeedApiService";
+import { PermissionService } from "@/backend/permissions";
+import { apiHandler } from "@/util/api";
+import { NextResponse } from "next/server";
+import z from "zod";
+
+/**
+ * @swagger
+ * /api/v1/city/{city}/meed/city-attributes:
+ *   get:
+ *     tags:
+ *       - meed
+ *       - city
+ *     operationId: getMeedCityAttributes
+ *     summary: Fetches MEED+ city attributes
+ *     description: Fetches MEED+ city attributes for the given city via the MEED service from the global API
+ *     parameters:
+ *       - in: path
+ *         name: city
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: City attributes retrieved
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     city:
+ *                       type: object
+ *                       properties:
+ *                         locode:
+ *                           type: string
+ *                         city_name:
+ *                           type: string
+ *                         country_code:
+ *                           type: string
+ *                         region_name:
+ *                           type: string
+ *                         population_size:
+ *                           type: number
+ *                         area_km2:
+ *                           type: number
+ *                         population_density:
+ *                           type: number
+ *                         indicators:
+ *                           type: array
+ *                           items:
+ *                             type: object
+ *                             properties:
+ *                               key:
+ *                                 type: string
+ *                               value:
+ *                                 type: number
+ *                               unit:
+ *                                 type: string
+ *                               category:
+ *                                 type: string
+ */
+const getCityAttributesParams = z.object({
+  city: z.string().uuid(),
+});
+export const GET = apiHandler(async (_req, { session, params }) => {
+  const { city: cityId } = getCityAttributesParams.parse(params);
+  await PermissionService.canAccessCity(session, cityId);
+  const result = await MeedApiService.getCityAttributes(cityId);
+  return NextResponse.json({ data: result });
+});

--- a/app/src/app/api/v1/city/[city]/meed/finance/feasibility/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/finance/feasibility/route.ts
@@ -1,0 +1,92 @@
+import MeedApiService from "@/backend/MeedApiService";
+import { PermissionService } from "@/backend/permissions";
+import { apiHandler } from "@/util/api";
+import { NextResponse } from "next/server";
+import z from "zod";
+
+/**
+ * @swagger
+ * /api/v1/city/{city}/meed/finance/feasibility:
+ *   get:
+ *     tags:
+ *       - meed
+ *       - city
+ *     operationId: getMeedFinanceFeasibility
+ *     summary: Fetches MEED+ finance feasibility data
+ *     description: Fetches MEED+ finance feasibility data for the given city via the MEED service from the global API
+ *     parameters:
+ *       - in: path
+ *         name: city
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Finance feasibility data retrieved
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     locode:
+ *                       type: string
+ *                     country_code:
+ *                       type: string
+ *                     data:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           action_id:
+ *                             type: string
+ *                           action_name:
+ *                             type: string
+ *                           sector:
+ *                             type: string
+ *                           financial_feasibility:
+ *                             type: number
+ *                           route:
+ *                             type: string
+ *                           reason:
+ *                             type: string
+ *                           inputs:
+ *                             type: object
+ *                             properties:
+ *                               action:
+ *                                 type: object
+ *                                 properties:
+ *                                   capital_intensity:
+ *                                     type: number
+ *                                   preparation_complexity:
+ *                                     type: number
+ *                               city:
+ *                                 type: object
+ *                                 properties:
+ *                                   profile:
+ *                                     type: string
+ *                               finance:
+ *                                 type: object
+ *                                 properties:
+ *                                   fund_access:
+ *                                     type: string
+ *                                   n_reachable_opportunities:
+ *                                     type: number
+ *                               evidence:
+ *                                 type: object
+ *                                 properties:
+ *                                   n_existing_projects:
+ *                                     type: number
+ */
+const getFinanceFeasibilityParams = z.object({
+  city: z.string().uuid(),
+});
+export const GET = apiHandler(async (_req, { session, params }) => {
+  const { city: cityId } = getFinanceFeasibilityParams.parse(params);
+  await PermissionService.canAccessCity(session, cityId);
+  const result = await MeedApiService.getFinanceFeasibility(cityId);
+  return NextResponse.json({ data: result });
+});

--- a/app/src/app/api/v1/city/[city]/meed/finance/opportunities/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/finance/opportunities/route.ts
@@ -1,0 +1,89 @@
+import MeedApiService from "@/backend/MeedApiService";
+import { PermissionService } from "@/backend/permissions";
+import { apiHandler } from "@/util/api";
+import { NextResponse } from "next/server";
+import z from "zod";
+
+/**
+ * @swagger
+ * /api/v1/city/{city}/meed/finance/opportunities:
+ *   get:
+ *     tags:
+ *       - meed
+ *       - city
+ *     operationId: getMeedFinanceOpportunities
+ *     summary: Fetches MEED+ finance opportunities data
+ *     description: Fetches MEED+ finance opportunities data for the given city via the MEED service from the global API
+ *     parameters:
+ *       - in: path
+ *         name: city
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Finance opportunities data retrieved
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     current:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           opportunity_name:
+ *                             type: string
+ *                           funder_name:
+ *                             type: string
+ *                           instrument:
+ *                             type: string
+ *                           status:
+ *                             type: string
+ *                           source_url:
+ *                             type: string
+ *                     monitor:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           opportunity_name:
+ *                             type: string
+ *                           funder_name:
+ *                             type: string
+ *                           instrument:
+ *                             type: string
+ *                           status:
+ *                             type: string
+ *                           source_url:
+ *                             type: string
+ *                           recurrence:
+ *                             type: string
+ */
+const getFinanceOpportunitiesParams = z.object({
+  city: z.string().uuid(),
+});
+const getFinanceOpportunitiesQueryParams = z.object({
+  sector: z.string().min(1),
+  financeRoute: z.string().min(1),
+});
+export const GET = apiHandler(
+  async (_req, { session, params, searchParams }) => {
+    const { city: cityId } = getFinanceOpportunitiesParams.parse(params);
+    const { sector, financeRoute } =
+      getFinanceOpportunitiesQueryParams.parse(searchParams);
+    await PermissionService.canAccessCity(session, cityId);
+
+    const result = await MeedApiService.getFinanceOpportunities(
+      cityId,
+      sector,
+      financeRoute,
+    );
+    return NextResponse.json({ data: result });
+  },
+);

--- a/app/src/app/api/v1/city/[city]/meed/finance/projects/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/finance/projects/route.ts
@@ -1,0 +1,105 @@
+import MeedApiService from "@/backend/MeedApiService";
+import { PermissionService } from "@/backend/permissions";
+import { apiHandler } from "@/util/api";
+import { NextResponse } from "next/server";
+import z from "zod";
+
+/**
+ * @swagger
+ * /api/v1/city/{city}/meed/finance/projects:
+ *   get:
+ *     tags:
+ *       - meed
+ *       - city
+ *     operationId: getMeedFinanceProjects
+ *     summary: Fetches MEED+ finance projects data
+ *     description: Fetches MEED+ finance projects data for the given city via the MEED service from the global API
+ *     parameters:
+ *       - in: path
+ *         name: city
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Finance projects data retrieved
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     locode:
+ *                       type: string
+ *                     country_code:
+ *                       type: string
+ *                     projects:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           project_name:
+ *                             type: string
+ *                           project_name_i18n:
+ *                             type: object
+ *                             properties:
+ *                               en:
+ *                                 type: string
+ *                               es:
+ *                                 type: string
+ *                               pt:
+ *                                 type: string
+ *                           sector:
+ *                             type: string
+ *                           jurisdiction:
+ *                             type: number
+ *                           lifecycle_stage:
+ *                             type: string
+ *                           funding_channel:
+ *                             type: string
+ *                           cost_total:
+ *                             type: number
+ *                           amount_unit:
+ *                             type: string
+ *                           funding_sources:
+ *                             type: array
+ *                             items:
+ *                               type: object
+ *                               properties:
+ *                                 cycle:
+ *                                   type: string
+ *                                 amount:
+ *                                   type: number
+ *                                 amount_unit:
+ *                                   type: string
+ *                                 funder_name:
+ *                                   type: string
+ *                           action_matches:
+ *                             type: array
+ *                             items:
+ *                               type: object
+ *                               properties:
+ *                                 action_id:
+ *                                   type: string
+ *                                 confidence:
+ *                                   type: string
+ */
+const getFinanceProjectsParams = z.object({
+  city: z.string().uuid(),
+});
+const getFinanceProjectsQueryParams = z.object({
+  actionId: z.string().min(1),
+});
+export const GET = apiHandler(
+  async (_req, { session, params, searchParams }) => {
+    const { city: cityId } = getFinanceProjectsParams.parse(params);
+    const { actionId } = getFinanceProjectsQueryParams.parse(searchParams);
+    await PermissionService.canAccessCity(session, cityId);
+
+    const result = await MeedApiService.getFinanceProjects(cityId, actionId);
+    return NextResponse.json({ data: result });
+  },
+);

--- a/app/src/app/api/v1/city/[city]/meed/policy-scores/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/policy-scores/route.ts
@@ -1,0 +1,82 @@
+import MeedApiService from "@/backend/MeedApiService";
+import { PermissionService } from "@/backend/permissions";
+import { apiHandler } from "@/util/api";
+import { NextResponse } from "next/server";
+import z from "zod";
+
+/**
+ * @swagger
+ * /api/v1/city/{city}/meed/policy-scores:
+ *   get:
+ *     tags:
+ *       - meed
+ *       - city
+ *     operationId: getMeedPolicyScores
+ *     summary: Fetches MEED+ policy scores
+ *     description: Fetches MEED+ policy scores for the given city via the MEED service from the global API
+ *     parameters:
+ *       - in: path
+ *         name: city
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Policy scores retrieved
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     locode:
+ *                       type: string
+ *                     scores:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           action_id:
+ *                             type: string
+ *                           policy_support_score:
+ *                             type: number
+ *                           policy_support_category:
+ *                             type: string
+ *                           finding_count:
+ *                             type: number
+ *                           document_count:
+ *                             type: number
+ *                           policy_evidence:
+ *                             type: array
+ *                             items:
+ *                               type: object
+ *                               properties:
+ *                                 document_type:
+ *                                   type: string
+ *                                 scope:
+ *                                   type: string
+ *                                 document_name:
+ *                                   type: string
+ *                                 signal_type:
+ *                                   type: string
+ *                                 signal_relation:
+ *                                   type: string
+ *                                 signal_strength:
+ *                                   type: string
+ *                                 doc_relevance:
+ *                                   type: string
+ *                                 evidence_strength:
+ *                                   type: number
+ */
+const getPolicyScoresParams = z.object({
+  city: z.string().uuid(),
+});
+export const GET = apiHandler(async (_req, { session, params }) => {
+  const { city: cityId } = getPolicyScoresParams.parse(params);
+  await PermissionService.canAccessCity(session, cityId);
+  const result = await MeedApiService.getPolicyScores(cityId);
+  return NextResponse.json({ data: result });
+});

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -284,6 +284,18 @@ export default class MeedApiService {
     return result;
   }
 
+  public static async getPolicyScores(cityId: string) {
+    const city = await db.models.City.findOne({ where: { cityId } });
+    if (!city) {
+      throw new createHttpError.NotFound("City not found");
+    }
+    const locode = city.locode;
+    const result = await this.makeRequest(
+      `cities/${locode}/action-policy-scores`,
+    );
+    return result;
+  }
+
   private static async makeRequest(route: string, data: object | null = null) {
     const method = data == null ? "GET" : "POST";
     const body =

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -309,6 +309,34 @@ export default class MeedApiService {
     return result;
   }
 
+  public static async getFinanceOpportunities(
+    cityId: string,
+    sector: string,
+    financeRoute: string,
+  ) {
+    const city = await db.models.City.findOne({ where: { cityId } });
+    if (!city) {
+      throw new createHttpError.NotFound("City not found");
+    }
+    const countryLocode = city.countryLocode;
+    const result = await this.makeRequest(
+      `climate-finance/opportunities?country_code=${countryLocode}&sector=${sector}&route=${financeRoute}`,
+    );
+    return result;
+  }
+
+  public static async getFinanceProjects(cityId: string, actionId: string) {
+    const city = await db.models.City.findOne({ where: { cityId } });
+    if (!city) {
+      throw new createHttpError.NotFound("City not found");
+    }
+    const countryLocode = city.countryLocode;
+    const result = await this.makeRequest(
+      `climate-finance/projects?country_code=${countryLocode}&action_id=${actionId}`,
+    );
+    return result;
+  }
+
   private static async makeRequest(route: string, data: object | null = null) {
     const method = data == null ? "GET" : "POST";
     const body =

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -274,6 +274,16 @@ export default class MeedApiService {
     return result;
   }
 
+  public static async getCityAttributes(cityId: string) {
+    const city = await db.models.City.findOne({ where: { cityId } });
+    if (!city) {
+      throw new createHttpError.NotFound("City not found");
+    }
+    const locode = city.locode;
+    const result = await this.makeRequest(`cities/${locode}/attributes`);
+    return result;
+  }
+
   private static async makeRequest(route: string, data: object | null = null) {
     const method = data == null ? "GET" : "POST";
     const body =

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -44,6 +44,14 @@ type GpcActivity = {
   notationKey?: string;
 };
 
+type MeedRankResponse = {
+  results: {
+    ranked_actions: MeedResponseActionRanked[];
+    removed_actions: MeedResponseActionRemoved[];
+    metadata: { weights: Record<string, number> };
+  }[];
+};
+
 type MeedResponseActionRanked = {
   action_id: string;
   rank: number;
@@ -181,25 +189,10 @@ export default class MeedApiService {
     });
 
     // make API request to MEED API
-    const response = await fetch(MEED_API_URL + "prioritize", {
-      method: "POST",
-      body: JSON.stringify({
-        requestData: fullRequest,
-        meta: {
-          requestId: randomUUID(),
-        },
-      }),
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
-
-    const result = await response.json();
-    const resultString = JSON.stringify(result, null, 2);
-
-    if (response.status != 200 || result.detail) {
-      throw new createHttpError.BadRequest("MEED API error: " + resultString);
-    }
+    const result: MeedRankResponse = await this.makeRequest(
+      "rank",
+      fullRequest,
+    );
 
     const rankedActionsRaw: MeedResponseActionRanked[] =
       result.results[0].ranked_actions;
@@ -274,5 +267,39 @@ export default class MeedApiService {
     });
 
     return { rankedActions, removedActions };
+  }
+
+  public static async getActions() {
+    const result = await this.makeRequest("action-pathways");
+    return result;
+  }
+
+  private static async makeRequest(route: string, data: object | null = null) {
+    const method = data == null ? "GET" : "POST";
+    const body =
+      data == null
+        ? undefined
+        : JSON.stringify({
+            requestData: data,
+            meta: {
+              requestId: randomUUID(),
+            },
+          });
+    const response = await fetch(MEED_API_URL + route, {
+      method,
+      body,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const result = await response.json();
+
+    if (response.status != 200 || result.detail) {
+      const resultString = JSON.stringify(result, null, 2);
+      throw new createHttpError.BadRequest("MEED API error: " + resultString);
+    }
+
+    return result;
   }
 }

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -296,6 +296,19 @@ export default class MeedApiService {
     return result;
   }
 
+  public static async getFinanceFeasibility(cityId: string) {
+    const city = await db.models.City.findOne({ where: { cityId } });
+    if (!city) {
+      throw new createHttpError.NotFound("City not found");
+    }
+    const locode = city.locode;
+    const countryLocode = city.countryLocode;
+    const result = await this.makeRequest(
+      `cities/${locode}/climate-finance/feasibility?country_code=${countryLocode}`,
+    );
+    return result;
+  }
+
   private static async makeRequest(route: string, data: object | null = null) {
     const method = data == null ? "GET" : "POST";
     const body =


### PR DESCRIPTION
## Summary

Implements the following API routes:

Method | Path | Purpose
-- | -- | --
GET | city/{cityId}/meed/actions | Action catalog (102 mitigation actions)
GET | city/{cityId}/meed/city-attributes | Socioeconomic context
GET | city/{cityId}/meed/policy-scores | Policy-alignment scores per action
GET | city/{cityId}/meed/finance/feasibility | Climate-finance feasibility
GET | city/{cityId}/meed/finance/opportunities | Climate-finance opportunities
GET | city/{cityId}/meed/finance/projects | Climate-finance projects

## Ticket
CC-754