### PR TITLE
CC-756: Pre-select project so onboarding city shows in invite step

### DIFF
--- a/app/src/app/[lng]/cities/onboarding/setup/page.tsx
+++ b/app/src/app/[lng]/cities/onboarding/setup/page.tsx
@@ -102,6 +102,9 @@ export default function OnboardingSetup(props: {
   const [ocCityData, setOcCityData] = useState<OCCityAttributes>();
   const [isProjectLimitModalOpen, setIsProjectLimitModalOpen] = useState(false);
   const [createdCityId, setCreatedCityId] = useState<string | null>(null);
+  const [createdProjectId, setCreatedProjectId] = useState<string | null>(
+    null,
+  );
   const [isSubmittingStep, setIsSubmittingStep] = useState(false);
   const [isFinishing, setIsFinishing] = useState(false);
   // Continue on the invite step requires project + email(s) + city (CC-652).
@@ -215,6 +218,7 @@ export default function OnboardingSetup(props: {
             projectId: EnterpriseMode ? selectedProjectId : undefined,
           }).unwrap();
           setCreatedCityId(city?.cityId ?? null);
+          setCreatedProjectId(city?.projectId ?? null);
         } catch (err: unknown) {
           logger.error({ err }, "Onboarding - Failed to add city");
           const errorData = isFetchBaseQueryError(err)
@@ -332,6 +336,7 @@ export default function OnboardingSetup(props: {
               ref={inviteStepRef}
               lng={lng}
               onValidityChange={setCanSubmitInvite}
+              createdProjectId={createdProjectId}
             />
           )}
         </Box>

--- a/app/src/components/steps/GHGI/invite-collaborators-step.tsx
+++ b/app/src/components/steps/GHGI/invite-collaborators-step.tsx
@@ -52,8 +52,12 @@ export interface InviteCollaboratorsStepRef {
 
 const InviteCollaboratorsStep = forwardRef<
   InviteCollaboratorsStepRef,
-  { lng: string; onValidityChange?: (canSubmit: boolean) => void }
->(({ lng, onValidityChange }, ref) => {
+  {
+    lng: string;
+    onValidityChange?: (canSubmit: boolean) => void;
+    createdProjectId?: string | null;
+  }
+>(({ lng, onValidityChange, createdProjectId }, ref) => {
   const { t } = useTranslation(lng, "onboarding");
   const { t: tSettings } = useTranslation(lng, "settings");
   const [emailInput, setEmailInput] = useState("");
@@ -87,6 +91,16 @@ const InviteCollaboratorsStep = forwardRef<
   const { data: projectsData } = useGetUserProjectsQuery({});
   const { data: accessStatus } = useGetUserAccessStatusQuery({});
   const [inviteUsers] = useInviteUsersMutation();
+
+  useEffect(() => {
+    if (
+      createdProjectId &&
+      selectedProject.length === 0 &&
+      projectsData?.some((p) => p.projectId === createdProjectId)
+    ) {
+      setSelectedProject([createdProjectId]);
+    }
+  }, [createdProjectId, projectsData, selectedProject.length]);
 
   const isCollaborator =
     accessStatus?.isCollaborator &&


### PR DESCRIPTION
## Summary

Fixes a bug where a city created during project onboarding never appeared as a selectable checkbox on the "invite collaborators" step, because that step tracked its own independent project selection with nothing to seed it.

## Changes

- `setup/page.tsx`: capture the `projectId` returned by the `addCity` mutation and pass it to `InviteCollaboratorsStep` as `createdProjectId`.
- `invite-collaborators-step.tsx`: accept `createdProjectId` and auto-select it once it's present in the fetched project list (only if the user hasn't already picked a project manually), so the new city's checkbox renders without requiring a manual dropdown guess.

## How to test

1. Run through `/cities/onboarding/setup`: create a new city (step 0), fill population data (step 1).
2. On the invite-collaborators step, confirm the project dropdown is pre-selected and the newly created city appears in the checkbox grid.
3. Manually switch the project dropdown to confirm selection still updates the checkbox list correctly.

## Ticket

CC-756