### PR TITLE
 CC-714: Normalize notation-key encoding via shared mapper

### DIFF
--- a/app/src/app/api/v1/inventory/[inventory]/download/route.ts
+++ b/app/src/app/api/v1/inventory/[inventory]/download/route.ts
@@ -41,19 +41,13 @@ import InventoryDownloadService from "@/backend/InventoryDownloadService";
 import { db } from "@/models";
 import { logger } from "@/services/logger";
 import { getTranslationFromDictionary, keyBy } from "@/util/helpers";
+import { toShort } from "@/util/notation-keys";
 import type {
   InventoryDownloadResponse,
   InventoryWithInventoryValuesAndActivityValues,
 } from "@/util/types";
 
 const CIRIS_TEMPLATE_PATH = "./templates/CIRIS_template.xlsm";
-
-const notationKeyMapping: { [key: string]: string } = {
-  "no-occurrance": "NO",
-  "not-estimated": "NE",
-  "confidential-information": "C",
-  "included-elsewhere": "IE",
-};
 
 // converts sector GPC reference number to index of sheet in CIRIS file
 const sectorSheetMapping: { [key: string]: number } = {
@@ -191,8 +185,7 @@ async function inventoryXLS(
       }
 
       if (inventoryValue.unavailableReason) {
-        row.getCell("AM").value =
-          notationKeyMapping[inventoryValue.unavailableReason];
+        row.getCell("AM").value = toShort(inventoryValue.unavailableReason);
         row.getCell("AQ").value = inventoryValue.unavailableExplanation;
       } else {
         row.getCell("AO").value = inventoryValue.dataSource?.notes;

--- a/app/src/backend/CSVDownloadService.ts
+++ b/app/src/backend/CSVDownloadService.ts
@@ -7,6 +7,7 @@ import { db } from "@/models";
 import { MANUAL_INPUT_HIERARCHY } from "@/util/form-schema";
 import createHttpError from "http-errors";
 import { logger } from "@/services/logger";
+import { toShort } from "@/util/notation-keys";
 
 type InventoryLine = (string | number | null | undefined)[];
 
@@ -300,10 +301,7 @@ export default class CSVDownloadService {
         inventory_reference: inventoryValue.subCategoryId,
         gpc_reference_number: inventoryValue.gpcReferenceNumber,
         subsector_name: inventoryValue.subSector.subsectorName,
-        notation_key: inventoryValue.unavailableReason
-          ?.split("-")
-          .map((word) => word.charAt(0).toUpperCase())
-          .join(""),
+        notation_key: toShort(inventoryValue.unavailableReason) ?? undefined,
         activityValues: finalActivityValues,
       };
 

--- a/app/src/backend/DataSourceConnectService.ts
+++ b/app/src/backend/DataSourceConnectService.ts
@@ -282,7 +282,7 @@ export default class DataSourceConnectService {
             sectorId,
             subSectorId,
             subCategoryId,
-            "reason-NE",
+            "not-estimated",
           );
         }
       } else if (addNotationKeysForEmptyRefnos) {
@@ -292,7 +292,7 @@ export default class DataSourceConnectService {
           sectorId,
           subSectorId,
           subCategoryId,
-          "reason-NE",
+          "not-estimated",
         );
       }
     }

--- a/app/src/backend/ECRFDownloadService.ts
+++ b/app/src/backend/ECRFDownloadService.ts
@@ -15,6 +15,7 @@ import CityBoundaryService, {
   CityBoundary,
 } from "@/backend/CityBoundaryService";
 import { logger } from "@/services/logger";
+import { toShort } from "@/util/notation-keys";
 import fs from "fs";
 import path from "path";
 
@@ -325,7 +326,8 @@ export default class ECRFDownloadService {
 
     output.inventoryValues.map((inventoryValue) => {
       dataDictionary[inventoryValue.gpcReferenceNumber as string] = {
-        "notation-key": inventoryValue.unavailableReason?.split("-")[1],
+        "notation-key":
+          toShort(inventoryValue.unavailableReason) ?? undefined,
         explanation: inventoryValue.unavailableExplanation ?? undefined,
         total: inventoryValue.unavailableReason
           ? 0n
@@ -353,7 +355,8 @@ export default class ECRFDownloadService {
         dataDictionary[gpcRefNo as string] = {
           inventory_year: inventoryYear,
           gpc_reference_number: inventoryValue.gpcReferenceNumber,
-          notation_key: inventoryValue.unavailableReason ?? undefined,
+          notation_key:
+            toShort(inventoryValue.unavailableReason) ?? undefined,
           activityValues: [
             {
               activity_type: null,
@@ -384,7 +387,8 @@ export default class ECRFDownloadService {
           // InventoryValue fields
           inventory_year: inventoryYear,
           gpc_reference_number: inventoryValue.gpcReferenceNumber,
-          notation_key: inventoryValue.unavailableReason ?? undefined,
+          notation_key:
+            toShort(inventoryValue.unavailableReason) ?? undefined,
           input_methodology: t(inventoryValue.inputMethodology ?? ""),
           activityValues: activityValues.map((activityValue) => {
             const activityTitleKey =
@@ -471,10 +475,7 @@ export default class ECRFDownloadService {
     }
 
     if (dataSection.notation_key) {
-      this.markRowAsNotEstimated(
-        row,
-        dataSection["notation_key"].split("-")[1],
-      );
+      this.markRowAsNotEstimated(row, dataSection.notation_key);
       return;
     }
 
@@ -507,8 +508,7 @@ export default class ECRFDownloadService {
             const replacementValue = dataSection[fieldName];
 
             if (fieldName === "no_key" && dataSection["notation_key"]) {
-              // the stored value looks like "reason_NO", "reason_NE", etc.
-              cell.value = dataSection["notation_key"].split("-")[1];
+              cell.value = dataSection["notation_key"];
               return;
             } else if (replacementValue !== undefined) {
               cell.value = replacementValue as Excel.CellValue;

--- a/app/src/backend/InventoryImportService.ts
+++ b/app/src/backend/InventoryImportService.ts
@@ -11,23 +11,12 @@ import {
   type ExtraField,
 } from "@/util/form-schema";
 import manageSubsectorsEn from "@/i18n/locales/en/manage-subsectors.json";
+import { toCanonical } from "@/util/notation-keys";
 
 /** Options for import (e.g. PDF): default data source from file name. */
 export type ImportECRFDataOptions = {
   /** When set (e.g. file name), used as activity data source when row does not provide one. */
   defaultActivityDataSource?: string;
-};
-
-/**
- * Maps eCRF notation keys to unavailableReason enum values
- * eCRF uses: NO, NE, C, IE
- * Database uses: no-occurrance, not-estimated, confidential-information, included-elsewhere
- */
-const notationKeyMapping: Record<string, string> = {
-  NO: "no-occurrance",
-  NE: "not-estimated",
-  C: "confidential-information",
-  IE: "included-elsewhere",
 };
 
 /**
@@ -715,13 +704,12 @@ export default class InventoryImportService {
           }
         } else if (row.notationKey) {
           console.log(
-            `[Import] GPC ${row.gpcRefNo} - Processing notation key: "${row.notationKey}" (normalized: "${row.notationKey.toUpperCase()}")`,
+            `[Import] GPC ${row.gpcRefNo} - Processing notation key: "${row.notationKey}"`,
           );
-          // Handle notation keys only if there are NO emission values
-          const unavailableReason =
-            notationKeyMapping[row.notationKey.toUpperCase()];
+          // Accept short, kebab, or legacy reason-* spellings → canonical kebab
+          const unavailableReason = toCanonical(row.notationKey);
           console.log(
-            `[Import] GPC ${row.gpcRefNo} - Mapped notation key "${row.notationKey.toUpperCase()}" -> "${unavailableReason}"`,
+            `[Import] GPC ${row.gpcRefNo} - Mapped notation key "${row.notationKey}" -> "${unavailableReason}"`,
           );
 
           if (!unavailableReason) {

--- a/app/src/backend/InventoryProgressService.ts
+++ b/app/src/backend/InventoryProgressService.ts
@@ -11,6 +11,7 @@ import {
   SECTORS,
 } from "@/util/constants";
 import { InventoryTypeEnum } from "@/util/enums";
+import { isNotEstimated, isNotOccurring } from "@/util/notation-keys";
 
 const romanTable: Record<string, number> = {
   I: 1,
@@ -144,9 +145,9 @@ export default class InventoryProgressService {
           (acc, inventoryValue) => {
             if (inventoryValue.dataSource) {
               acc.thirdParty++;
-            } else if (inventoryValue.unavailableReason === "reason-NE") {
+            } else if (isNotEstimated(inventoryValue.unavailableReason)) {
               acc.reasonNE++;
-            } else if (inventoryValue.unavailableReason === "reason-NO") {
+            } else if (isNotOccurring(inventoryValue.unavailableReason)) {
               acc.reasonNO++;
             } else {
               acc.uploaded++;

--- a/app/src/backend/agentic/ghgi/stationary-energy/context.ts
+++ b/app/src/backend/agentic/ghgi/stationary-energy/context.ts
@@ -13,6 +13,7 @@ import {
 } from "@/util/helpers";
 import { STATIONARY_ENERGY } from "@/util/methodologies/stationary-energy";
 import { LANGUAGES } from "@/util/types";
+import { isNotEstimated } from "@/util/notation-keys";
 
 type StationaryEnergyLocale = `${LANGUAGES}`;
 
@@ -433,11 +434,7 @@ function hasCommittedCurrentValue(value: Record<string, unknown>): boolean {
   }
 
   const unavailableReason = stringField(value["unavailable_reason"]);
-  return Boolean(
-    unavailableReason &&
-      unavailableReason !== "reason-NE" &&
-      unavailableReason !== "not-estimated",
-  );
+  return Boolean(unavailableReason && !isNotEstimated(unavailableReason));
 }
 
 async function buildSourceCandidates(

--- a/app/src/backend/agentic/ghgi/stationary-energy/notation-keys.ts
+++ b/app/src/backend/agentic/ghgi/stationary-energy/notation-keys.ts
@@ -8,6 +8,7 @@ import { db } from "@/models";
 import type { Inventory } from "@/models/Inventory";
 import type { InventoryValue } from "@/models/InventoryValue";
 import { InventoryTypeEnum } from "@/util/constants";
+import { toCanonical } from "@/util/notation-keys";
 
 const STATIONARY_ENERGY_SECTOR_REFERENCE = "I";
 
@@ -70,13 +71,6 @@ type NotationKeyCandidateEntry = {
   subCategory: Record<string, unknown>;
 };
 
-const notationKeyByCode = new Map(
-  ALLOWED_STATIONARY_ENERGY_NOTATION_KEYS.map((entry) => [
-    entry.notation_key,
-    entry,
-  ]),
-);
-
 const notationKeyByUnavailableReason = new Map(
   ALLOWED_STATIONARY_ENERGY_NOTATION_KEYS.map((entry) => [
     entry.unavailable_reason,
@@ -87,8 +81,7 @@ const notationKeyByUnavailableReason = new Map(
 export function unavailableReasonForNotationKey(
   notationKey: string,
 ): StationaryEnergyUnavailableReason | null {
-  return notationKeyByCode.get(notationKey as StationaryEnergyNotationKey)
-    ?.unavailable_reason ?? null;
+  return toCanonical(notationKey) as StationaryEnergyUnavailableReason | null;
 }
 
 export async function listNotationKeyCandidateGroups(params: {
@@ -421,9 +414,10 @@ function toStationaryEnergyNotationTarget(
   entry: NotationKeyCandidateEntry,
 ): Record<string, unknown> {
   const unavailableReason = entry.inventoryValue?.unavailableReason ?? null;
-  const notation = unavailableReason
+  const canonical = toCanonical(unavailableReason);
+  const notation = canonical
     ? notationKeyByUnavailableReason.get(
-        unavailableReason as StationaryEnergyUnavailableReason,
+        canonical as StationaryEnergyUnavailableReason,
       )
     : null;
   const targetRef = targetRefFromEntry(entry);

--- a/app/src/components/Tabs/Activity/activity-tab.tsx
+++ b/app/src/components/Tabs/Activity/activity-tab.tsx
@@ -37,6 +37,10 @@ import SelectMethodology from "@/components/Tabs/Activity/select-methodology";
 import ExternalDataSection from "@/components/Tabs/Activity/external-data-section";
 import { api } from "@/services/api";
 import {
+  toI18nReasonKey,
+  toNotationKeyLabelKey,
+} from "@/util/notation-keys";
+import {
   MdModeEditOutline,
   MdCheckCircleOutline,
   MdInfoOutline,
@@ -424,16 +428,7 @@ const ActivityTab: FC<ActivityTabProps> = ({
   }, [showUnavailableForm, inventoryValue]);
 
   const notationKey = useMemo(() => {
-    switch (inventoryValue?.unavailableReason) {
-      case "reason-NE":
-        return "notation-key-NE";
-      case "reason-C":
-        return "notation-key-C";
-      case "reason-IE":
-        return "notation-key-IE";
-      default:
-        return "notation-key-NO";
-    }
+    return toNotationKeyLabelKey(inventoryValue?.unavailableReason);
   }, [inventoryValue]);
 
   const { isFrozenCheck } = useOrganizationContext();
@@ -516,7 +511,10 @@ const ActivityTab: FC<ActivityTabProps> = ({
               >
                 <Text fontSize="body.md" fontFamily="body">
                   <strong> {t("reason")}: </strong>
-                  {t(inventoryValue?.unavailableReason as string)}
+                  {t(
+                    (toI18nReasonKey(inventoryValue?.unavailableReason) ??
+                      "") as string,
+                  )}
                 </Text>
               </Text>
               <Text

--- a/app/src/components/Tabs/Activity/scope-unavailable.tsx
+++ b/app/src/components/Tabs/Activity/scope-unavailable.tsx
@@ -14,6 +14,10 @@ import { useController, useForm } from "react-hook-form";
 import { api } from "@/services/api";
 import { Radio, RadioGroup } from "@/components/ui/radio";
 import { MdWarning } from "react-icons/md";
+import {
+  toCanonical,
+  type NotationKeyCanonical,
+} from "@/util/notation-keys";
 
 interface ScopeUnavailableProps {
   t: TFunction;
@@ -45,7 +49,7 @@ const ScopeUnavailable: FC<ScopeUnavailableProps> = ({
     justification: string;
   }>({
     defaultValues: {
-      reason: reason,
+      reason: reason ? (toCanonical(reason) ?? reason) : reason,
       justification: justification,
     },
   });
@@ -64,8 +68,9 @@ const ScopeUnavailable: FC<ScopeUnavailableProps> = ({
 
   useEffect(() => {
     if (reason) {
-      setSelectedReason(reason);
-      setValue("reason", reason);
+      const canonical = toCanonical(reason) ?? reason;
+      setSelectedReason(canonical);
+      setValue("reason", canonical);
     }
   }, [reason, setSelectedReason, setValue]);
 
@@ -78,11 +83,13 @@ const ScopeUnavailable: FC<ScopeUnavailableProps> = ({
     reason: string;
     justification: string;
   }) => {
+    const unavailableReason =
+      toCanonical(data.reason) ?? (data.reason as NotationKeyCanonical);
     await markAsUnavailable({
       inventoryId: inventoryId,
       subSectorId: subSectorId,
       data: {
-        unavailableReason: data.reason,
+        unavailableReason,
         unavailableExplanation: data.justification,
         gpcReferenceNumber: gpcReferenceNumber,
       },
@@ -124,34 +131,22 @@ const ScopeUnavailable: FC<ScopeUnavailableProps> = ({
             colorPalette="interactive.secondary"
           >
             <Stack direction="column">
-              <Radio
-                value="reason-NO"
-                key={"reason-NO"}
-                color="content.secondary"
-              >
-                {t("reason-NO")}
-              </Radio>
-              <Radio
-                value="reason-NE"
-                key={"reason-NE"}
-                color="content.secondary"
-              >
-                {t("reason-NE")}
-              </Radio>
-              <Radio
-                value="reason-C"
-                key={"reason-C"}
-                color="content.secondary"
-              >
-                {t("reason-C")}
-              </Radio>
-              <Radio
-                value="reason-IE"
-                key={"reason-IE"}
-                color="content.secondary"
-              >
-                {t("reason-IE")}
-              </Radio>
+              {(
+                [
+                  ["no-occurrance", "reason-NO"],
+                  ["not-estimated", "reason-NE"],
+                  ["confidential-information", "reason-C"],
+                  ["included-elsewhere", "reason-IE"],
+                ] as const
+              ).map(([value, labelKey]) => (
+                <Radio
+                  value={value}
+                  key={value}
+                  color="content.secondary"
+                >
+                  {t(labelKey)}
+                </Radio>
+              ))}
 
               {errors?.reason ? (
                 <Box display="flex" gap="6px" alignItems="center" mt="6px">

--- a/app/src/util/notation-keys.ts
+++ b/app/src/util/notation-keys.ts
@@ -1,0 +1,110 @@
+/**
+ * Shared GPC notation-key encoding for CityCatalyst.
+ *
+ * CityCatalyst historically stored `unavailableReason` in three spellings:
+ * - GPC short codes: NO | NE | C | IE
+ * - Canonical kebab (DB/API): no-occurrance | not-estimated | …
+ * - Legacy activity/auto-connect: reason-NO | reason-NE | …
+ *
+ * Writers should persist kebab via `toCanonical`. Exporters emit short codes via
+ * `toShort`. Readers dual-accept all three forms through these helpers.
+ *
+ * Note: `no-occurrance` keeps the existing typo for backwards compatibility.
+ */
+
+export const NOTATION_KEY_CANONICAL = [
+  "no-occurrance",
+  "not-estimated",
+  "confidential-information",
+  "included-elsewhere",
+] as const;
+
+export type NotationKeyCanonical = (typeof NOTATION_KEY_CANONICAL)[number];
+
+export const NOTATION_KEY_SHORT = ["NO", "NE", "C", "IE"] as const;
+
+export type NotationKeyShort = (typeof NOTATION_KEY_SHORT)[number];
+
+const SHORT_TO_CANONICAL: Record<NotationKeyShort, NotationKeyCanonical> = {
+  NO: "no-occurrance",
+  NE: "not-estimated",
+  C: "confidential-information",
+  IE: "included-elsewhere",
+};
+
+const CANONICAL_TO_SHORT: Record<NotationKeyCanonical, NotationKeyShort> = {
+  "no-occurrance": "NO",
+  "not-estimated": "NE",
+  "confidential-information": "C",
+  "included-elsewhere": "IE",
+};
+
+const LEGACY_REASON_TO_CANONICAL: Record<string, NotationKeyCanonical> = {
+  "reason-NO": "no-occurrance",
+  "reason-NE": "not-estimated",
+  "reason-C": "confidential-information",
+  "reason-IE": "included-elsewhere",
+};
+
+/** Normalize any known spelling to the canonical kebab DB/API form. */
+export function toCanonical(
+  input?: string | null,
+): NotationKeyCanonical | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  const upper = trimmed.toUpperCase();
+  if (upper in SHORT_TO_CANONICAL) {
+    return SHORT_TO_CANONICAL[upper as NotationKeyShort];
+  }
+
+  const lower = trimmed.toLowerCase();
+  if ((NOTATION_KEY_CANONICAL as readonly string[]).includes(lower)) {
+    return lower as NotationKeyCanonical;
+  }
+
+  // Legacy reason-* (case-insensitive)
+  const reasonMatch = Object.entries(LEGACY_REASON_TO_CANONICAL).find(
+    ([key]) => key.toLowerCase() === lower,
+  );
+  if (reasonMatch) {
+    return reasonMatch[1];
+  }
+
+  return null;
+}
+
+/** Convert any known spelling to the GPC short code for exports. */
+export function toShort(input?: string | null): NotationKeyShort | null {
+  const canonical = toCanonical(input);
+  return canonical ? CANONICAL_TO_SHORT[canonical] : null;
+}
+
+export function isNotationKey(input?: string | null): boolean {
+  return toCanonical(input) != null;
+}
+
+export function isNotEstimated(input?: string | null): boolean {
+  return toCanonical(input) === "not-estimated";
+}
+
+export function isNotOccurring(input?: string | null): boolean {
+  return toCanonical(input) === "no-occurrance";
+}
+
+/**
+ * i18n key for activity/manage-sectors copy. Prefers canonical kebab keys that
+ * exist in locale files; falls back to the original string when unknown.
+ */
+export function toI18nReasonKey(input?: string | null): string | null {
+  return toCanonical(input) ?? (input ? input : null);
+}
+
+/** Badge / label keys like notation-key-NE used in the activity tab. */
+export function toNotationKeyLabelKey(
+  input?: string | null,
+): `notation-key-${NotationKeyShort}` {
+  const short = toShort(input) ?? "NO";
+  return `notation-key-${short}`;
+}

--- a/app/tests/notation-keys.jest.ts
+++ b/app/tests/notation-keys.jest.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for shared GPC notation-key encoding helpers.
+ */
+import { describe, expect, it } from "@jest/globals";
+import {
+  isNotEstimated,
+  isNotOccurring,
+  isNotationKey,
+  toCanonical,
+  toNotationKeyLabelKey,
+  toShort,
+} from "@/util/notation-keys";
+
+describe("notation-keys", () => {
+  describe("toCanonical", () => {
+    it.each([
+      ["NO", "no-occurrance"],
+      ["ne", "not-estimated"],
+      ["C", "confidential-information"],
+      ["IE", "included-elsewhere"],
+      ["no-occurrance", "no-occurrance"],
+      ["not-estimated", "not-estimated"],
+      ["confidential-information", "confidential-information"],
+      ["included-elsewhere", "included-elsewhere"],
+      ["reason-NO", "no-occurrance"],
+      ["reason-NE", "not-estimated"],
+      ["reason-C", "confidential-information"],
+      ["reason-IE", "included-elsewhere"],
+      ["REASON-NE", "not-estimated"],
+    ] as const)("maps %s → %s", (input, expected) => {
+      expect(toCanonical(input)).toBe(expected);
+    });
+
+    it("returns null for unknown or empty input", () => {
+      expect(toCanonical(null)).toBeNull();
+      expect(toCanonical(undefined)).toBeNull();
+      expect(toCanonical("")).toBeNull();
+      expect(toCanonical("unknown")).toBeNull();
+      expect(toCanonical("presented-elsewhere")).toBeNull();
+    });
+  });
+
+  describe("toShort", () => {
+    it("emits GPC letters for kebab and legacy spellings", () => {
+      expect(toShort("not-estimated")).toBe("NE");
+      expect(toShort("reason-NE")).toBe("NE");
+      expect(toShort("confidential-information")).toBe("C");
+      expect(toShort("reason-C")).toBe("C");
+      expect(toShort("no-occurrance")).toBe("NO");
+      expect(toShort("included-elsewhere")).toBe("IE");
+    });
+
+    it("does not turn confidential into CI", () => {
+      expect(toShort("confidential-information")).toBe("C");
+    });
+  });
+
+  describe("predicates", () => {
+    it("detects NE/NO across spellings", () => {
+      expect(isNotEstimated("reason-NE")).toBe(true);
+      expect(isNotEstimated("not-estimated")).toBe(true);
+      expect(isNotEstimated("NE")).toBe(true);
+      expect(isNotOccurring("reason-NO")).toBe(true);
+      expect(isNotOccurring("no-occurrance")).toBe(true);
+      expect(isNotationKey("IE")).toBe(true);
+      expect(isNotationKey("nope")).toBe(false);
+    });
+  });
+
+  describe("label helpers", () => {
+    it("builds activity-tab notation-key label keys", () => {
+      expect(toNotationKeyLabelKey("reason-NE")).toBe("notation-key-NE");
+      expect(toNotationKeyLabelKey("not-estimated")).toBe("notation-key-NE");
+      expect(toNotationKeyLabelKey(undefined)).toBe("notation-key-NO");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Normalizes GPC notation-key encoding through a shared mapper so exporters, progress, import, and the activity UI agree on one canonical form (kebab-case), while still reading legacy `reason-*` and short codes (`NO`/`NE`/`C`/`IE`).

<img width="1123" height="952" alt="image" src="https://github.com/user-attachments/assets/bbafc99b-9c21-4a3f-9745-86266ce6cf9a" />


## Changes

- Add `app/src/util/notation-keys.ts` (`toCanonical` / `toShort` / dual-read helpers) + unit tests
- Progress counts NE/NO via dual-read (kebab + `reason-*`)
- CSV / eCRF / CIRIS exports emit GPC short letters through `toShort`
- Import and auto-connect persist kebab; activity UI writes kebab and labels dual-read
- Agentic stationary-energy notation listing uses the shared mapper

## How to test

1. Unit: `npm run jest:windows -- --testPathPatterns=notation-keys`
2. Mark a scope unavailable in activity data → DB/`unavailableReason` should be kebab (e.g. `not-estimated`)
3. Confirm progress NE/NO badges count both kebab (manage-sectors) and legacy `reason-*` rows
4. Export CSV/eCRF/CIRIS and confirm notation letters are `NO`/`NE`/`C`/`IE` (not `CI` / mangled splits)
5. Import a CRF row with `Notation key = NE` → stored as `not-estimated`

## Ticket

[CC-714](https://linear.app/openearth/issue/CC-714/normalize-notation-key-encoding-via-shared-mapper-fix-exports-and)

## Notes

- Keeps existing `no-occurrance` typo as canonical (no rename migration).
- Fuel-level CRF NE rows that share a GPC subcategory with emission rows can still be overwritten by emissions on import; that is separate from this encoding fix.
