### PR TITLE
perf(hiap): add indexes for catalog backfill

### DIFF
--- a/app/migrations/20260825120000-add-hiap-catalog-backfill-indexes.cjs
+++ b/app/migrations/20260825120000-add-hiap-catalog-backfill-indexes.cjs
@@ -1,0 +1,30 @@
+"use strict";
+
+const RANKED_ACTIONS_INDEX = "idx_hiap_ranked_hia_ranking_id";
+const SUCCESS_RANKINGS_INDEX = "idx_hiap_ranking_success_created_id";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    // These indexes are created concurrently because the tables are populated
+    // in production and the backfill is not allowed to block live requests.
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS ${RANKED_ACTIONS_INDEX}
+      ON "HighImpactActionRanked" (hia_ranking_id);
+    `);
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS ${SUCCESS_RANKINGS_INDEX}
+      ON "HighImpactActionRanking" (status, created, id)
+      WHERE status = 'SUCCESS';
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS ${SUCCESS_RANKINGS_INDEX};`,
+    );
+    await queryInterface.sequelize.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS ${RANKED_ACTIONS_INDEX};`,
+    );
+  },
+};

--- a/app/migrations/20260825120000-add-hiap-catalog-backfill-indexes.cjs
+++ b/app/migrations/20260825120000-add-hiap-catalog-backfill-indexes.cjs
@@ -9,11 +9,11 @@ module.exports = {
     // These indexes are created concurrently because the tables are populated
     // in production and the backfill is not allowed to block live requests.
     await queryInterface.sequelize.query(`
-      CREATE INDEX CONCURRENTLY IF NOT EXISTS ${RANKED_ACTIONS_INDEX}
+      CREATE INDEX CONCURRENTLY ${RANKED_ACTIONS_INDEX}
       ON "HighImpactActionRanked" (hia_ranking_id);
     `);
     await queryInterface.sequelize.query(`
-      CREATE INDEX CONCURRENTLY IF NOT EXISTS ${SUCCESS_RANKINGS_INDEX}
+      CREATE INDEX CONCURRENTLY ${SUCCESS_RANKINGS_INDEX}
       ON "HighImpactActionRanking" (status, created, id)
       WHERE status = 'SUCCESS';
     `);

--- a/app/tests/hiap-catalog-backfill-indexes-migration.jest.ts
+++ b/app/tests/hiap-catalog-backfill-indexes-migration.jest.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "@jest/globals";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+
+const loadCjs = createRequire(import.meta.url);
+const migrationPath = resolve(
+  process.cwd(),
+  "migrations/20260825120000-add-hiap-catalog-backfill-indexes.cjs",
+);
+
+describe("HIAP catalog backfill indexes migration", () => {
+  it("creates concurrent indexes for the ranking page join and keyset order", async () => {
+    expect(existsSync(migrationPath)).toBe(true);
+    if (!existsSync(migrationPath)) return;
+
+    const migration = loadCjs(migrationPath) as {
+      up: (queryInterface: {
+        sequelize: { query: (sql: string) => Promise<void> };
+      }) => Promise<void>;
+      down: (queryInterface: {
+        sequelize: { query: (sql: string) => Promise<void> };
+      }) => Promise<void>;
+    };
+    const queries: string[] = [];
+    const queryInterface = {
+      sequelize: {
+        query: async (sql: string) => {
+          queries.push(sql);
+        },
+      },
+    };
+
+    await migration.up(queryInterface);
+
+    expect(queries).toHaveLength(2);
+    expect(queries[0]).toContain("CREATE INDEX CONCURRENTLY IF NOT EXISTS");
+    expect(queries[0]).toContain("idx_hiap_ranked_hia_ranking_id");
+    expect(queries[0]).toContain('"HighImpactActionRanked" (hia_ranking_id)');
+    expect(queries[1]).toContain("CREATE INDEX CONCURRENTLY IF NOT EXISTS");
+    expect(queries[1]).toContain("idx_hiap_ranking_success_created_id");
+    expect(queries[1]).toContain(
+      '"HighImpactActionRanking" (status, created, id)',
+    );
+    expect(queries[1]).toContain("WHERE status = 'SUCCESS'");
+
+    queries.length = 0;
+    await migration.down(queryInterface);
+
+    expect(queries).toEqual([
+      expect.stringContaining(
+        "DROP INDEX CONCURRENTLY IF EXISTS idx_hiap_ranking_success_created_id",
+      ),
+      expect.stringContaining(
+        "DROP INDEX CONCURRENTLY IF EXISTS idx_hiap_ranked_hia_ranking_id",
+      ),
+    ]);
+  });
+});

--- a/app/tests/hiap-catalog-backfill-indexes-migration.jest.ts
+++ b/app/tests/hiap-catalog-backfill-indexes-migration.jest.ts
@@ -34,10 +34,12 @@ describe("HIAP catalog backfill indexes migration", () => {
     await migration.up(queryInterface);
 
     expect(queries).toHaveLength(2);
-    expect(queries[0]).toContain("CREATE INDEX CONCURRENTLY IF NOT EXISTS");
+    expect(queries[0]).toContain("CREATE INDEX CONCURRENTLY");
+    expect(queries[0]).not.toContain("IF NOT EXISTS");
     expect(queries[0]).toContain("idx_hiap_ranked_hia_ranking_id");
     expect(queries[0]).toContain('"HighImpactActionRanked" (hia_ranking_id)');
-    expect(queries[1]).toContain("CREATE INDEX CONCURRENTLY IF NOT EXISTS");
+    expect(queries[1]).toContain("CREATE INDEX CONCURRENTLY");
+    expect(queries[1]).not.toContain("IF NOT EXISTS");
     expect(queries[1]).toContain("idx_hiap_ranking_success_created_id");
     expect(queries[1]).toContain(
       '"HighImpactActionRanking" (status, created, id)',


### PR DESCRIPTION
## Summary

Add the PostgreSQL indexes identified during the production-like synthetic test of the HIAP catalog backfill.

- Add a concurrent index on `HighImpactActionRanked.hia_ranking_id` for the ranking join.
- Add a partial concurrent index on successful rankings ordered by `created, id`.
- Add migration coverage for creation and rollback.

## Validation

With 11,747 synthetic rankings and 469,880 ranked-action rows, the equivalent page query changed from a parallel sequential scan/hash join to index-only scans/nested loop:

- Before: ~103 ms locally
- After: ~0.065 ms locally

The migration was also executed against a temporary PostgreSQL instance and rolled back successfully. Focused tests pass 18/18, plus TypeScript, ESLint, Prettier, and diff checks.

Related to #3044.