### PR TITLE
CC-717: Remove population step from city onboarding

### DIFF
--- a/app/e2e/city-onboarding.spec.ts
+++ b/app/e2e/city-onboarding.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { dismissCookieConsent, pickE2EOnboardingInventoryYear } from "./helpers";
+import { dismissCookieConsent } from "./helpers";
 
 test("City Onboarding", async ({ page }) => {
   test.setTimeout(120000);
@@ -57,45 +57,7 @@ test("City Onboarding", async ({ page }) => {
     await continueButton.click();
   }
 
-  /** "Step 2 – Population data is pre-populated" */
-  {
-    await expect(page.getByTestId("add-population-data-heading")).toBeVisible({
-      timeout: 15000,
-    });
-
-    const cityPopulationInput = page.getByPlaceholder("City population number");
-    try {
-      await expect(cityPopulationInput).toHaveValue(/^\d{1,3}(,\d{3})*$/, {
-        timeout: 15000,
-      });
-    } catch {
-      // OpenClimate pre-fill didn't return in time — fill manually so the
-      // wizard can still be exercised end-to-end.
-      const inventoryYear = pickE2EOnboardingInventoryYear();
-      await cityPopulationInput.fill("1000000");
-      await page
-        .locator('select[name="cityPopulationYear"]')
-        .selectOption(inventoryYear);
-      await page
-        .getByPlaceholder("Region or province population number")
-        .fill("5000000");
-      await page
-        .locator('select[name="regionPopulationYear"]')
-        .selectOption(inventoryYear);
-      await page.getByPlaceholder("Country population number").fill("10000000");
-      await page
-        .locator('select[name="countryPopulationYear"]')
-        .selectOption(inventoryYear);
-    }
-
-    const continueButton = page
-      .getByRole("button", { name: /^Continue$/ })
-      .last();
-    await expect(continueButton).toBeEnabled({ timeout: 30000 });
-    await continueButton.click();
-  }
-
-  /** "Step 3 – Invite collaborators (skip) completes onboarding" */
+  /** "Step 2 – Invite collaborators (skip) completes onboarding" */
   {
     await expect(page.getByTestId("invite-collaborators-step")).toBeVisible({
       timeout: 15000,

--- a/app/e2e/helpers.ts
+++ b/app/e2e/helpers.ts
@@ -152,9 +152,9 @@ export function pickE2EOnboardingInventoryYear(): string {
 }
 
 /**
- * Walks the city onboarding wizard (city select + population + invite
- * collaborators). Creating a city no longer creates an inventory as part of
- * this flow -- the wizard ends on `/cities/onboarding/done`. See
+ * Walks the city onboarding wizard (city select + invite collaborators).
+ * Creating a city no longer creates an inventory as part of this flow --
+ * the wizard ends on `/cities/onboarding/done`. See
  * createCityAndInventoryThroughOnboarding to also create the first
  * inventory via the separate GHGI onboarding flow.
  *
@@ -163,7 +163,6 @@ export function pickE2EOnboardingInventoryYear(): string {
 async function walkCitiesOnboardingWizard(
   page: Page,
 ): Promise<{ cityId: string }> {
-  const inventoryYear = pickE2EOnboardingInventoryYear();
   // Step 0: welcome page → click "Get Started"
   await page.goto("/en/cities/onboarding/");
 
@@ -192,7 +191,7 @@ async function walkCitiesOnboardingWizard(
   await expect(citySearchResults.first()).toBeVisible({ timeout: 30000 });
   await citySearchResults.first().click();
 
-  // Continue (creates the city, advances to population)
+  // Continue (creates the city, advances to invite collaborators)
   {
     const continueButton = page
       .getByRole("button", { name: /^Continue$/ })
@@ -201,46 +200,7 @@ async function walkCitiesOnboardingWizard(
     await continueButton.click();
   }
 
-  // Step 1: population — pre-filled by OpenClimate query
-  await expect(page.getByTestId("add-population-data-heading")).toBeVisible({
-    timeout: 15000,
-  });
-
-  const cityPopulationInput = page.getByPlaceholder("City population number");
-  try {
-    await expect(cityPopulationInput).toHaveValue(/^\d{1,3}(,\d{3})*$/, {
-      timeout: 10000,
-    });
-  } catch {
-    // OpenClimate pre-fill failed — fill manually
-    await cityPopulationInput.fill("1000000");
-    await page
-      .locator('select[name="cityPopulationYear"]')
-      .selectOption(inventoryYear);
-    await page
-      .getByPlaceholder("Region or province population number")
-      .fill("5000000");
-    await page
-      .locator('select[name="regionPopulationYear"]')
-      .selectOption(inventoryYear);
-    await page.getByPlaceholder("Country population number").fill("10000000");
-    await page
-      .locator('select[name="countryPopulationYear"]')
-      .selectOption(inventoryYear);
-  }
-
-  {
-    // Dismiss any toast notifications that may block the Continue button
-    await dismissToasts(page);
-
-    const continueButton = page
-      .getByRole("button", { name: /^Continue$/ })
-      .last();
-    await expect(continueButton).toBeEnabled({ timeout: 30000 });
-    await continueButton.click();
-  }
-
-  // Step 2: invite collaborators — skip for speed/determinism
+  // Step 1: invite collaborators — skip for speed/determinism
   await expect(page.getByTestId("invite-collaborators-step")).toBeVisible({
     timeout: 15000,
   });

--- a/app/src/app/[lng]/cities/onboarding/page.tsx
+++ b/app/src/app/[lng]/cities/onboarding/page.tsx
@@ -49,7 +49,7 @@ export default function Onboarding(props: {
       });
   }, [searchParams, acceptOrgInvite, status, pathname, router]);
 
-  const steps = [1, 2, 3];
+  const steps = [1, 2];
   const projectId = searchParams.get("project");
   const setupHref = projectId
     ? `${pathname}/setup?project=${projectId}`

--- a/app/src/app/[lng]/cities/onboarding/setup/page.tsx
+++ b/app/src/app/[lng]/cities/onboarding/setup/page.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import { useTranslation } from "@/i18n/client";
-import {
-  api,
-  useAddCityMutation,
-  useAddCityPopulationMutation,
-} from "@/services/api";
+import { api, useAddCityMutation } from "@/services/api";
 
 import { OCCityAttributes } from "@/util/types";
 import { GHGIFormInputs, GHGIOnboardingData } from "@/util/GHGI/types";
@@ -14,15 +10,9 @@ import { Box, Icon, Text, useSteps } from "@chakra-ui/react";
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { use, useEffect, useRef, useState } from "react";
-import type {
-  Control,
-  FieldErrors,
-  SubmitHandler,
-  UseFormSetValue,
-} from "react-hook-form";
+import type { SubmitHandler } from "react-hook-form";
 import { useForm } from "react-hook-form";
 import SelectCityStep from "@/components/steps/select-city-steps";
-import SetPopulationDataStep from "@/components/steps/GHGI/set-population-data-step";
 import InviteCollaboratorsStep, {
   type InviteCollaboratorsStepRef,
 } from "@/components/steps/GHGI/invite-collaborators-step";
@@ -38,6 +28,10 @@ import ProjectLimitModal from "@/components/project-limit";
 type Inputs = { city: string } & GHGIFormInputs;
 type OnboardingData = GHGIOnboardingData;
 
+/**
+ * City onboarding (no city yet): select city → invite collaborators.
+ * Population is collected later during GHGI inventory onboarding.
+ */
 export default function OnboardingSetup(props: {
   params: Promise<{ lng: string }>;
 }) {
@@ -64,8 +58,6 @@ export default function OnboardingSetup(props: {
     { skip: !EnterpriseMode },
   );
 
-  const { data: userInfo } = api.useGetUserInfoQuery();
-
   useEffect(() => {
     if (projectsList && projectsList.length > 0) {
       setSelectedProject([projectsList[0].projectId]);
@@ -74,11 +66,10 @@ export default function OnboardingSetup(props: {
 
   const steps = [
     { title: t("setup-step") },
-    { title: t("set-population-step") },
     { title: t("invite-collaborators-step") },
   ];
 
-  const inviteCollaboratorsStepIndex = 2;
+  const inviteCollaboratorsStepIndex = 1;
 
   const {
     value: activeStep,
@@ -90,7 +81,6 @@ export default function OnboardingSetup(props: {
   });
 
   const [addCity] = useAddCityMutation();
-  const [addCityPopulation] = useAddCityPopulationMutation();
 
   const [data, setData] = useState<OnboardingData>({
     name: "",
@@ -122,32 +112,6 @@ export default function OnboardingSetup(props: {
     { skip: !ocCityData?.actor_id },
   );
 
-  // Watched form fields used for per-step validation and population payload
-  const cityPopulation = watch("cityPopulation");
-  const regionPopulation = watch("regionPopulation");
-  const countryPopulation = watch("countryPopulation");
-  const cityPopulationYear = watch("cityPopulationYear");
-  const regionPopulationYear = watch("regionPopulationYear");
-  const countryPopulationYear = watch("countryPopulationYear");
-
-  // A field is "filled" if it is not undefined/null/empty string
-  const hasValue = (v: unknown) => v !== undefined && v !== null && v !== "";
-  const isPopulationValid = [
-    cityPopulation,
-    cityPopulationYear,
-    regionPopulation,
-    regionPopulationYear,
-    countryPopulation,
-    countryPopulationYear,
-  ].every(hasValue);
-
-  const currentYear = new Date().getFullYear();
-  const numberOfYearsDisplayed = 20;
-  const years = Array.from(
-    { length: numberOfYearsDisplayed },
-    (_x, i) => currentYear - i,
-  );
-
   // Final step: send invites (if any) and finish onboarding. The user's
   // default city is already set server-side when the city is created.
   // Inventory creation happens separately, outside onboarding.
@@ -160,98 +124,72 @@ export default function OnboardingSetup(props: {
     setIsFinishing(false);
   };
 
-  // Step 0: validate project limit, create city, then advance.
-  // Step 1: persist population data, then advance.
+  // Step 0: validate project limit, create city, then advance to invite.
   const onSubmit: SubmitHandler<Inputs> = async (formData) => {
-    if (activeStep === 0) {
-      // Guaranteed by the disabled state of the submit button, which requires ocCityData.
-      if (!ocCityData) return;
+    if (activeStep !== 0) return;
 
-      const selectedProjectId =
-        selectedProject.length > 0 ? selectedProject[0] : undefined;
-      if (EnterpriseMode && selectedProjectId) {
-        const project = projectsList?.find(
-          (proj) => proj.projectId === selectedProjectId,
-        );
-        const isCityAlreadyAdded = project?.cities.some(
-          (city) =>
-            city.name === formData.city && city.locode === ocCityData?.actor_id,
-        );
-        if (
-          Number(project?.cities.length) >=
-            Number(project?.cityCountLimit as unknown as string) &&
-          !isCityAlreadyAdded
-        ) {
-          setIsProjectLimitModalOpen(true);
-          return;
-        }
+    // Guaranteed by the disabled state of the submit button, which requires ocCityData.
+    if (!ocCityData) return;
+
+    const selectedProjectId =
+      selectedProject.length > 0 ? selectedProject[0] : undefined;
+    if (EnterpriseMode && selectedProjectId) {
+      const project = projectsList?.find(
+        (proj) => proj.projectId === selectedProjectId,
+      );
+      const isCityAlreadyAdded = project?.cities.some(
+        (city) =>
+          city.name === formData.city && city.locode === ocCityData?.actor_id,
+      );
+      if (
+        Number(project?.cities.length) >=
+          Number(project?.cityCountLimit as unknown as string) &&
+        !isCityAlreadyAdded
+      ) {
+        setIsProjectLimitModalOpen(true);
+        return;
       }
+    }
 
-      const nextData: OnboardingData = {
-        ...data,
-        ...formData,
-        locode: ocCityData.actor_id,
-        name: ocCityData.name,
-      };
-      setData(nextData);
+    const nextData: OnboardingData = {
+      ...data,
+      ...formData,
+      locode: ocCityData.actor_id,
+      name: ocCityData.name,
+    };
+    setData(nextData);
 
-      // Create city now (was previously done in the removed confirm step)
-      if (!createdCityId) {
-        setIsSubmittingStep(true);
-        const area = cityArea?.area ?? ocCityData?.area ?? undefined;
-        const region = ocCityData?.root_path_geo.filter(
-          (item) => item.type === "adm1",
-        )[0];
-        const country = ocCityData?.root_path_geo.filter(
-          (item) => item.type === "country",
-        )[0];
-
-        try {
-          const city = await addCity({
-            name: nextData.name,
-            locode: nextData.locode!,
-            area: area ? Math.round(area) : undefined,
-            region: region?.name ?? undefined,
-            country: country?.name ?? undefined,
-            regionLocode: region?.actor_id ?? undefined,
-            countryLocode: country?.actor_id ?? undefined,
-            projectId: EnterpriseMode ? selectedProjectId : undefined,
-          }).unwrap();
-          setCreatedCityId(city?.cityId ?? null);
-          setCreatedProjectId(city?.projectId ?? null);
-        } catch (err: unknown) {
-          logger.error({ err }, "Onboarding - Failed to add city");
-          const errorData = isFetchBaseQueryError(err)
-            ? (err.data as { error?: { message?: string } })
-            : undefined;
-          makeErrorToast(
-            t("failed-to-add-city"),
-            t(errorData?.error?.message ?? ""),
-          );
-          setIsSubmittingStep(false);
-          return;
-        }
-        setIsSubmittingStep(false);
-      }
-    } else if (activeStep === 1) {
-      if (!createdCityId) return;
+    if (!createdCityId) {
       setIsSubmittingStep(true);
+      const area = cityArea?.area ?? ocCityData?.area ?? undefined;
+      const region = ocCityData?.root_path_geo.filter(
+        (item) => item.type === "adm1",
+      )[0];
+      const country = ocCityData?.root_path_geo.filter(
+        (item) => item.type === "country",
+      )[0];
+
       try {
-        await addCityPopulation({
-          cityId: createdCityId,
-          cityPopulation: cityPopulation!,
-          cityPopulationYear: cityPopulationYear!,
-          regionPopulation: regionPopulation!,
-          regionPopulationYear: regionPopulationYear!,
-          countryPopulation: countryPopulation!,
-          countryPopulationYear: countryPopulationYear!,
+        const city = await addCity({
+          name: nextData.name,
+          locode: nextData.locode!,
+          area: area ? Math.round(area) : undefined,
+          region: region?.name ?? undefined,
+          country: country?.name ?? undefined,
+          regionLocode: region?.actor_id ?? undefined,
+          countryLocode: country?.actor_id ?? undefined,
+          projectId: EnterpriseMode ? selectedProjectId : undefined,
         }).unwrap();
-        setData({ ...data, ...formData });
-      } catch (err: any) {
-        logger.error({ err }, "Onboarding - Failed to add population");
+        setCreatedCityId(city?.cityId ?? null);
+        setCreatedProjectId(city?.projectId ?? null);
+      } catch (err: unknown) {
+        logger.error({ err }, "Onboarding - Failed to add city");
+        const errorData = isFetchBaseQueryError(err)
+          ? (err.data as { error?: { message?: string } })
+          : undefined;
         makeErrorToast(
           t("failed-to-add-city"),
-          t(err.data?.error?.message ?? ""),
+          t(errorData?.error?.message ?? ""),
         );
         setIsSubmittingStep(false);
         return;
@@ -317,20 +255,6 @@ export default function OnboardingSetup(props: {
               t={t}
             />
           )}
-          {activeStep === 1 && (
-            <SetPopulationDataStep
-              t={t}
-              control={control as unknown as Control<GHGIFormInputs>}
-              errors={errors as unknown as FieldErrors<GHGIFormInputs>}
-              years={years}
-              numberOfYearsDisplayed={numberOfYearsDisplayed}
-              setData={setData}
-              setValue={setValue as unknown as UseFormSetValue<GHGIFormInputs>}
-              watch={watch}
-              ocCityData={ocCityData}
-              numberFormat={userInfo?.numberFormat}
-            />
-          )}
           {activeStep === inviteCollaboratorsStepIndex && (
             <InviteCollaboratorsStep
               ref={inviteStepRef}
@@ -356,7 +280,7 @@ export default function OnboardingSetup(props: {
               <ProgressSteps steps={steps} currentStep={activeStep} />
             </Box>
             <Box w="full" display="flex" justifyContent="end" px="135px">
-              {(activeStep === 0 || activeStep === 1) && (
+              {activeStep === 0 && (
                 <Button
                   w="auto"
                   gap="8px"
@@ -366,11 +290,7 @@ export default function OnboardingSetup(props: {
                   h="64px"
                   type="submit"
                   loading={isSubmittingStep}
-                  disabled={
-                    isSubmittingStep ||
-                    (activeStep === 0 && !ocCityData) ||
-                    (activeStep === 1 && !isPopulationValid)
-                  }
+                  disabled={isSubmittingStep || !ocCityData}
                 >
                   <Text
                     fontFamily="button.md"


### PR DESCRIPTION
## Summary

City onboarding (no city yet) no longer asks for population. Flow is select city → invite collaborators; population remains in GHGI inventory onboarding.

## Changes

- Dropped population step and `addCityPopulation` from `cities/onboarding/setup`
- Welcome placeholder steppers reduced from 3 to 2
- Updated city onboarding Playwright coverage and helper wizard walk

## How to test

1. Open /en/cities/onboarding/ and complete setup for a new city.
2. Confirm there is no population step between city select and invite collaborators.
3. Confirm GHGI onboarding for an existing city still includes the population step.

## Ticket

CC-717