### PR TITLE
CC-585: Re-enable signup e2e test suite

### DIFF
--- a/app/e2e/signup.spec.ts
+++ b/app/e2e/signup.spec.ts
@@ -20,86 +20,90 @@ test.setTimeout(60000);
  * Using this URL in tests avoids having to `fill()` the email input, which
  * Playwright can't reliably do once the field is rendered as `readOnly`.
  */
-function signupUrlWithEmail(email: string): string {
-  const callbackUrl = encodeURIComponent(`/en/cities?email=${email}`);
+function signupUrlWithEmail(email: string, destination = "/en/cities") {
+  const callbackUrl = encodeURIComponent(`${destination}?email=${email}`);
   return `/en/auth/signup?callbackUrl=${callbackUrl}`;
 }
 
-test.describe("Signup", () => {
-  test.skip("should navigate to signup from login", async ({ page }) => {
-    await page.goto("/");
-    const link = page.getByText("Sign up");
-    await expect(link).toBeVisible();
-    await link.click();
-    await expect(
-      page.getByRole("heading", { name: "Create your account" }),
-    ).toBeVisible();
-  });
+/** Shared checkbox control selector (Chakra v3 / Ark overlays the native input). */
+async function acceptPrivacyPolicy(page: import("@playwright/test").Page) {
+  await page.locator('[data-scope="checkbox"][data-part="control"]').click();
+}
 
-  test.skip("should redirect to dashboard after entering correct data", async ({
+test.describe("Signup", () => {
+  test("should navigate to signup from login (invite flow)", async ({
     page,
   }) => {
-    const email = `e2e-test+${randomUUID()}@example.com`;
-    await page.goto(signupUrlWithEmail(email));
+    // Sign-up CTA on login is only shown when callbackUrl carries an invite token.
+    const inviteCallback = encodeURIComponent(
+      "/en/user/invites?token=e2e-invite-token",
+    );
+    await page.goto(`/en/auth/login?callbackUrl=${inviteCallback}`);
+    await dismissCookieConsent(page);
+
+    const link = page.getByRole("link", { name: /sign.?up/i });
+    await expect(link).toBeVisible();
+    await link.click();
 
     await expect(
       page.getByRole("heading", { name: "Create your account" }),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 15000 });
+    await expect(page).toHaveURL(/\/en\/auth\/signup/);
+  });
+
+  test("should redirect after successful signup", async ({ page }) => {
+    const email = `e2e-test+${randomUUID()}@example.com`;
+    const destination = "/en/cities";
+    await page.goto(signupUrlWithEmail(email, destination));
+    await dismissCookieConsent(page);
+
+    await expect(
+      page.getByRole("heading", { name: "Create your account" }),
+    ).toBeVisible({ timeout: 15000 });
+    await waitForAuthFormReady(page, { expectEnabled: true });
 
     await page.getByPlaceholder("Your full name").fill("Test User");
     await page.getByLabel("Password", { exact: true }).fill("Test123!");
     await page.getByLabel("Confirm Password").fill("Test123!");
-    await page
-      .locator('input[name="acceptTerms"] + .chakra-checkbox__control')
-      .click();
+    await acceptPrivacyPolicy(page);
     await page.getByRole("button", { name: "Create Account" }).click();
 
-    await page.waitForLoadState("load");
-
-    await expect(page).toHaveURL(
-      `/en/auth/check-email/?email=${email.replace("@", "%40")}`,
-      {
-        timeout: 30000,
-      },
-    );
+    // Successful signup signs the user in and navigates to callbackUrl (or home).
+    await expect(page).toHaveURL(new RegExp(`${destination}`), {
+      timeout: 30000,
+    });
   });
 
-  test.skip("should show errors when entering invalid data", async ({ page }) => {
-    // Prefill the email field with an invalid value via the invitation URL
-    // pattern so the pattern-validation message fires on submit.
+  test("should show errors when entering invalid data", async ({ page }) => {
+    // Prefill email with an invalid value via the invitation URL pattern so
+    // pattern validation fires on submit.
     await page.goto(signupUrlWithEmail("testopenearthorg"));
+    await dismissCookieConsent(page);
 
     await expect(
       page.getByRole("heading", { name: "Create your account" }),
-    ).toBeVisible();
-    // Button starts disabled until all fields are valid (new UX)
-    await waitForAuthFormReady(page, { expectEnabled: false });
+    ).toBeVisible({ timeout: 15000 });
+    // Validation runs on submit; the button stays enabled so the user can trigger it.
+    await waitForAuthFormReady(page, { expectEnabled: true });
 
-    // Fill invalid name (too short) — use clear + pressSequentially to fire
-    // individual keystroke events so react-hook-form's onChange validation
-    // processes each character reliably.
-    const nameInput = page.getByPlaceholder("Your full name");
-    await nameInput.click();
-    await nameInput.fill("");
-    await nameInput.pressSequentially("asd");
-    // Tab to next field to trigger blur validation
-    await page.keyboard.press("Tab");
+    await page.getByPlaceholder("Your full name").fill("asd");
+    await page.getByLabel("Password", { exact: true }).fill("Pas");
+    await page.getByLabel("Confirm Password").fill("Pas");
+    await acceptPrivacyPolicy(page);
 
-    // Fill short password using same approach
-    const passwordInput = page.getByLabel("Password", { exact: true });
-    await passwordInput.click();
-    await passwordInput.fill("");
-    await passwordInput.pressSequentially("Pas");
-    // Tab away to trigger blur
-    await page.keyboard.press("Tab");
-
-    // Button must remain disabled when inputs are invalid
     const submitButton = page.getByRole("button", { name: "Create Account" });
-    await expect(submitButton).toBeDisabled();
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
 
-    // Field-level errors should appear via onChange validation
+    // Stay on signup; field-level errors surface after the submit attempt.
+    await expect(page).toHaveURL(/\/en\/auth\/signup/);
     await expectFieldInvalid(page, "name");
-    await expectFieldInvalid(page, "password");
+    await expectFieldInvalid(page, "email");
+    // Password pattern is guidance-only (not an RHF rule); short passwords
+    // still leave the pattern hint in the error state after submit.
+    await expect(
+      page.getByText(/password must be at least 8 characters/i),
+    ).toBeVisible();
   });
 
   test("should require matching passwords", async ({ page }) => {
@@ -110,25 +114,42 @@ test.describe("Signup", () => {
 
     await expect(
       page.getByRole("heading", { name: "Create your account" }),
-    ).toBeVisible();
-    // Validation only fires on submit — the button stays enabled beforehand
-    // so the user can trigger it.
+    ).toBeVisible({ timeout: 15000 });
     await waitForAuthFormReady(page, { expectEnabled: true });
 
     await page.getByPlaceholder("Your full name").fill("Test Account");
     await page.getByLabel("Password", { exact: true }).fill("Password1");
     await page.getByLabel("Confirm Password").fill("Password2");
-    // The visible checkbox control overlays the native (accessible) input;
-    // click the control directly rather than the input it decorates.
-    await page.locator('[data-scope="checkbox"][data-part="control"]').click();
+    await acceptPrivacyPolicy(page);
 
     const submitButton = page.getByRole("button", { name: "Create Account" });
     await expect(submitButton).toBeEnabled();
     await submitButton.click();
 
-    // Mismatch message only appears after the submit attempt
     await expectText(page, "Passwords do not match");
   });
 
-  test.skip("should correctly handle and pass callbackUrl", () => {});
+  test("should correctly handle and pass callbackUrl", async ({ page }) => {
+    const email = `e2e-callback+${randomUUID()}@example.com`;
+    // Use a dedicated destination so we can assert callbackUrl is honored
+    // (not just the default post-signup home path).
+    const destination = "/en/cities/onboarding";
+    await page.goto(signupUrlWithEmail(email, destination));
+    await dismissCookieConsent(page);
+
+    await expect(
+      page.getByRole("heading", { name: "Create your account" }),
+    ).toBeVisible({ timeout: 15000 });
+    await waitForAuthFormReady(page, { expectEnabled: true });
+
+    await page.getByPlaceholder("Your full name").fill("Callback User");
+    await page.getByLabel("Password", { exact: true }).fill("Test123!");
+    await page.getByLabel("Confirm Password").fill("Test123!");
+    await acceptPrivacyPolicy(page);
+    await page.getByRole("button", { name: "Create Account" }).click();
+
+    await expect(page).toHaveURL(/\/en\/cities\/onboarding/, {
+      timeout: 30000,
+    });
+  });
 });

--- a/app/src/i18n/locales/en/auth.json
+++ b/app/src/i18n/locales/en/auth.json
@@ -10,6 +10,7 @@
   "min-length": "Minimum length should be {{length}}",
   "forgot-password": "Forgot password",
   "no-account": "Don't have an account?",
+  "sign-up": "Sign up",
   "verified-toast-title": "Account validated!",
   "verified-toast-description": "You can now login into your account.",
   "invalid-email-password": "Invalid email or password",


### PR DESCRIPTION
## Summary

Re-enables the skipped Playwright signup suite and aligns assertions with the current submit-on-validate UX and post-signup auto-login redirect.

## Changes

- Unskipped navigation, happy-path, invalid-data, and callbackUrl tests in `signup.spec.ts`
- Updated expectations for invite-flow Sign up CTA, submit-triggered validation, and callbackUrl navigation
- Added missing `sign-up` string to `en/auth.json`

## How to test

1. Run `npx playwright test e2e/signup.spec.ts --project=chromium` from `app/` (with CityCatalyst on port 3000).
2. Confirm all five Signup tests pass.

## Ticket

CC-585

## Notes

Local runs can reuse the wrong process if another app is already on port 3000 (`reuseExistingServer`).

