### PR TITLE
CC-582: Re-enable login e2e test suite

### DIFF
--- a/app/e2e/helpers.ts
+++ b/app/e2e/helpers.ts
@@ -106,7 +106,7 @@ export async function signup(
   name: string = "Test Account",
   acceptTerms: boolean = true,
 ) {
-  const result = await request.post("/api/v1/auth/register", {
+  const result = await request.post("/api/v1/auth/register/", {
     data: {
       email,
       password,

--- a/app/e2e/login.spec.ts
+++ b/app/e2e/login.spec.ts
@@ -4,47 +4,53 @@ import {
   expectFieldInvalid,
   signup,
   waitForAuthFormReady,
+  dismissCookieConsent,
 } from "./helpers";
 import { randomUUID } from "node:crypto";
+
+test.setTimeout(120000);
 
 test.beforeEach(async ({ page, context }) => {
   // make sure user is logged out to prevent order of execution issues
   await context.clearCookies();
   await page.goto("/en/auth/login");
+  await dismissCookieConsent(page);
+  // Wait until client handlers are attached so submit is not a native GET.
+  await expect(page.getByTestId("login-form")).toHaveAttribute(
+    "data-ready",
+    "true",
+    { timeout: 30000 },
+  );
+  await waitForAuthFormReady(page, { expectEnabled: true });
 });
 
 test.describe("Login page", () => {
-  test.skip("redirects to onboarding after entering correct data", async ({
+  test("redirects away from login after entering correct data", async ({
     page,
     request,
   }) => {
     const email = `login-test+${randomUUID()}@openearth.org`;
     const password = "Test123!";
     await signup(request, email, password, password);
-    // await page.route("/api/auth/session", (route) => {
-    //   route.fulfill({ body: JSON.stringify({ ok: true }) });
-    // });
 
     await expectText(page, "Log In");
+
     await page.locator('input[name="email"]').fill(email);
     await page.locator('input[name="password"]').fill(password);
-    await page.getByRole("button", { name: "LOG IN" }).click();
+    await page.getByRole("button", { name: /log in/i }).click();
 
-    // TODO how to ensure that session route was called?
-    await page.waitForResponse("/api/auth/session");
-
-    await expect(page).not.toHaveURL("/en/auth/login/");
+    // Successful login uses a full-page redirect to callbackUrl (default `/`).
+    await expect(page).not.toHaveURL(/\/en\/auth\/login/, { timeout: 30000 });
   });
 
   test("shows errors when entering invalid data", async ({ page }) => {
     await expectText(page, "Log In");
-    await waitForAuthFormReady(page);
 
     await page.locator('input[name="email"]').fill("testopenearthorg");
     await page.locator('input[name="password"]').fill("pas");
-    await page.getByRole("button", { name: "LOG IN" }).click();
+    await page.getByRole("button", { name: /log in/i }).click();
 
-    await expect(page).toHaveURL(/\/en\/auth\/login/);
+    await expect(page).toHaveURL(/\/en\/auth\/login\/?$/);
     await expectFieldInvalid(page, "email");
     await expectFieldInvalid(page, "password");
   });

--- a/app/src/app/[lng]/auth/login/page.tsx
+++ b/app/src/app/[lng]/auth/login/page.tsx
@@ -7,7 +7,7 @@ import { Box, Heading, Link, Text } from "@chakra-ui/react";
 import { TFunction } from "i18next";
 import { useSession } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, use } from "react";
+import { Suspense, useEffect, use, useState } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { Toaster } from "@/components/ui/toaster";
 import { Button } from "@/components/ui/button";
@@ -48,6 +48,11 @@ export default function Login(props: { params: Promise<{ lng: string }> }) {
     register,
     formState: { errors },
   } = useForm<LoginInputs>();
+  // Gates native form submit until the client handlers are attached (E2E/hydration).
+  const [isFormReady, setIsFormReady] = useState(false);
+  useEffect(() => {
+    setIsFormReady(true);
+  }, []);
 
   const searchParams = useSearchParams();
   const queryParams = Object.fromEntries(searchParams.entries());
@@ -110,7 +115,12 @@ export default function Login(props: { params: Promise<{ lng: string }> }) {
       <Text my={4} color="content.tertiary">
         {t("login-details")}
       </Text>
-      <form noValidate onSubmit={handleSubmit(onSubmit)}>
+      <form
+        noValidate
+        data-testid="login-form"
+        data-ready={isFormReady ? "true" : "false"}
+        onSubmit={handleSubmit(onSubmit)}
+      >
         <Box display="flex" flexDirection="column" gap="16px">
           <EmailInput register={register} error={errors.email} t={t} />
           <PasswordInput
@@ -131,6 +141,7 @@ export default function Login(props: { params: Promise<{ lng: string }> }) {
             type="submit"
             formNoValidate
             loading={isLoading}
+            disabled={!isFormReady || isLoading}
             h={16}
             width="full"
             bgColor="interactive.secondary"

--- a/app/src/i18n/locales/en/auth.json
+++ b/app/src/i18n/locales/en/auth.json
@@ -10,6 +10,7 @@
   "min-length": "Minimum length should be {{length}}",
   "forgot-password": "Forgot password",
   "no-account": "Don't have an account?",
+  "log-in": "Log In",
   "verified-toast-title": "Account validated!",
   "verified-toast-description": "You can now login into your account.",
   "invalid-email-password": "Invalid email or password",


### PR DESCRIPTION
## Summary

Re-enables the skipped Playwright login happy-path test and stabilizes form submit so client handlers run before the button is clickable.

## Changes

- Unskipped login redirect test; assert navigation away from `/auth/login`
- Gate login submit with `data-ready` until after mount (avoids native GET with credentials in the query string)
- Post `/api/v1/auth/register/` with trailing slash in the e2e signup helper
- Added missing `log-in` string to `en/auth.json`

## How to test

1. From `app/`, run `npx playwright test e2e/login.spec.ts --project=chromium` (CityCatalyst on the Playwright base URL).
2. Confirm both Login page tests pass.

## Ticket

CC-582
