### PR TITLE
CC-655: Redirect multi-project users to All Projects view on login

### DIFF
--- a/app/src/app/[lng]/page.tsx
+++ b/app/src/app/[lng]/page.tsx
@@ -8,7 +8,6 @@ import { useRouter } from "next/navigation";
 import { api } from "@/services/api";
 import ProgressLoader from "@/components/ProgressLoader";
 
-/** @deprecated has been replaced with GHGI module home page */
 export default function PrivateHome(props: {
   params: Promise<{ lng: string }>;
 }) {
@@ -22,19 +21,43 @@ export default function PrivateHome(props: {
     isError,
   } = api.useGetUserInfoQuery();
 
+  // Get the user's projects to decide between the Journey Navigator and the
+  // All Projects view for multi-project users
+  const { data: projects, isLoading: projectsLoading } =
+    api.useGetUserProjectsQuery({});
+
   // Handle routing based on user's default city/inventory status
   useEffect(() => {
-    if (userInfoLoading) return; // Wait for user info to load
+    if (userInfoLoading || projectsLoading) return; // Wait for user info and projects to load
+    // RTK Query reports isLoading: false for a not-yet-initiated query on the
+    // first render, before its fetch has actually been dispatched, so also
+    // wait for the projects data itself to arrive before deciding.
+    if (!projects) return;
 
     // Don't redirect to onboarding if there was an API error (e.g., rate limiting)
     // The user should stay on the current page and retry
     if (isError) return;
 
-    router.replace(`/${lng}/cities/`);
-  }, [lng, router, userInfo, userInfoLoading, isError]);
+    if (projects.length > 1) {
+      const organizationId = projects.find(
+        (project) => project.organizationId,
+      )?.organizationId;
+      if (organizationId) {
+        router.replace(`/${lng}/organization/${organizationId}/project`);
+        return;
+      }
+    }
 
-  // Show loading state while determining where to redirect
-  if (userInfoLoading) {
+    router.replace(`/${lng}/cities/`);
+  }, [lng, router, userInfo, userInfoLoading, isError, projects, projectsLoading]);
+
+  // Only render the (deprecated) fallback home page when there was an error
+  // fetching user info, so the user has something to retry from. In every
+  // other case a redirect is either pending or about to be dispatched by the
+  // effect above, so keep showing the loading state — otherwise this page
+  // briefly mounts, and its own onboarding-redirect effects race the
+  // redirect above.
+  if (!userInfoLoading && !projectsLoading && isError) {
     return (
       <Box
         h="full"
@@ -43,7 +66,7 @@ export default function PrivateHome(props: {
         bg="background.backgroundLight"
       >
         <NavigationBar showMenu lng={lng} />
-        <ProgressLoader />
+        <HomePage lng={lng} isPublic={false} />
       </Box>
     );
   }
@@ -56,7 +79,7 @@ export default function PrivateHome(props: {
       bg="background.backgroundLight"
     >
       <NavigationBar showMenu lng={lng} />
-      <HomePage lng={lng} isPublic={false} />
+      <ProgressLoader />
     </Box>
   );
 }

--- a/app/src/proxy.ts
+++ b/app/src/proxy.ts
@@ -122,10 +122,6 @@ export async function proxy(req: NextRequestWithAuth) {
     lng = fallbackLng;
   }
 
-  if ([`/${lng}`, `/${lng}/`].includes(req.nextUrl.pathname)) {
-    return NextResponse.redirect(new URL(`/${lng}/cities/`, req.url));
-  }
-
   const legacyInventoryRedirect = await maybeRedirectLegacyInventoryUrl(req);
   if (legacyInventoryRedirect) {
     return legacyInventoryRedirect;


### PR DESCRIPTION
## Summary

Users with access to multiple projects previously always landed on the Journey Navigator (`/cities`) after login, requiring extra navigation to see their other projects. They now land on the existing "All Projects" view instead. Single/zero-project users keep the existing behavior.

## Changes

- `app/[lng]/page.tsx`: fetch the user's projects alongside user info; redirect to `/organization/{orgId}/project` when the user has more than one project, otherwise `/cities/` as before. Also stopped rendering the deprecated `GHGIHomePage` fallback except on error, since it has its own onboarding-redirect effects that raced the new redirect.
- `proxy.ts` (Next 16's `middleware.ts` equivalent): removed an unconditional server-side redirect that sent every request to `/{lng}` or `/{lng}/` straight to `/{lng}/cities/`, which made the landing-page redirect logic dead code before this change.

## How to test

1. Log in as a user who is an OrganizationAdmin (or otherwise has access to) more than one project — confirm you land on `/{lng}/organization/{orgId}/project` ("All Projects").
2. Log in as a user with a single project (or none) — confirm you still land on `/{lng}/cities/` as before.

## Ticket

CC-655