### PR TITLE
[1/2] CC-605: Add chapter validation in Climate Advisor

### DIFF
--- a/climate-advisor/.env.example
+++ b/climate-advisor/.env.example
@@ -38,8 +38,9 @@ CC_BASE_URL=http://localhost:3000
 # Maximum CC-owned Markdown artifact size CA will verify through authenticated CC.
 # This is independent from CC's source-PDF upload limit.
 CNB_MARKDOWN_REQUEST_MAX_BYTES=20971520
-# Independent CNB workspace/reference database used by the reviewed-reference
+# Independent CNB workspace/reference database required by the Concept Note
+# Builder workspace and validation flow, as well as the reviewed-reference
 # importer, similar-project reader, and runtime funding-reference validation.
 # The repository owns its schema through cnb-alembic.ini; infrastructure and
 # curated data remain external.
-CNB_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/cnb
+CNB_DATABASE_URL=postgresql://climateadvisor:climateadvisor@localhost:5433/cnb

--- a/climate-advisor/README.md
+++ b/climate-advisor/README.md
@@ -53,6 +53,26 @@ Climate Advisor runs three chat modes through the same `/v1/messages` endpoint:
    - Uses the detailed contract in
      [`ConceptNoteBuilderArchitecture.md`](../docs/ConceptNoteBuilderArchitecture.md#context-bundle)
 
+### Concept Note chapter validation
+
+Chapter validation is triggered from CityCatalyst's **Review & export** button,
+not from chat. The guided review calls
+`POST /v1/concept-notes/{run_id}/chapters/{chapter_id}/validation` for every
+active chapter. Each call runs two structured passes in strict order:
+completeness/template/evidence first, then internal and target-involved
+cross-chapter consistency. The second call receives the first result and every
+active chapter; large documents are batched without truncating the target or
+comparisons.
+
+`llm_config.yaml` configures `cnb_chapter_validator` as GPT-5.6 Terra with
+medium reasoning and a 50,000-token validation prompt budget. The service uses
+temperature zero. Model or parse failures persist nothing. Successful results
+store actionable findings, never reasoning, and are guarded
+by a transactional fingerprint covering active chapter metadata and revisions,
+target gaps and evidence links, and every application-template field. See
+[`ConceptNoteBuilderArchitecture.md`](../docs/ConceptNoteBuilderArchitecture.md#chapter-validation)
+for status aggregation, staleness, persistence, API, and the guided export UI.
+
 At runtime:
 
 - `ThreadService` and `ThreadResolver` own chat-thread lifecycle.
@@ -420,11 +440,9 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 # CityCatalyst Postgres on localhost:5432)
 CA_DATABASE_URL=postgresql://climateadvisor:climateadvisor@localhost:5433/climateadvisor
 
-# Optional unless CNB schema, importer, or matching access is needed.
-CNB_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/cnb
+# Required for the Concept Note Builder workspace and validation flow.
+CNB_DATABASE_URL=postgresql://climateadvisor:climateadvisor@localhost:5433/cnb
 
-# Optional
-CA_PORT=8080
 CA_LOG_LEVEL=info
 CA_CORS_ORIGINS=*
 OPENAI_API_KEY=your-openai-api-key
@@ -444,7 +462,13 @@ docker compose up -d postgres
 ```
 
 Make sure Docker Desktop (or another Docker daemon) is running before invoking
-`docker compose`.
+`docker compose`. A fresh Compose volume creates both the `climateadvisor` and
+`cnb` databases. If the volume predates Concept Note Builder support and does
+not yet contain `cnb`, create it once with:
+
+```bash
+docker compose exec postgres createdb -U climateadvisor cnb
+```
 
 If you use this compose-based PostgreSQL setup and run the CA service on your
 host (not in Docker), use:
@@ -467,6 +491,7 @@ docker run --name ca-postgres \
   -d pgvector/pgvector:pg15
 
 docker exec ca-postgres psql -U climateadvisor -d climateadvisor -c "CREATE EXTENSION IF NOT EXISTS vector;"
+docker exec ca-postgres createdb -U climateadvisor cnb
 ```
 
 ### 4. Install Dependencies And Setup Database
@@ -484,16 +509,16 @@ uv run --directory service alembic -c cnb-alembic.ini upgrade head
 
 ```bash
 cd climate-advisor
-uv run --directory service uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
+uv run --directory service uvicorn app.main:app --host 0.0.0.0 --port 8081 --reload
 ```
 
 ### 6. Verify Setup
 
-- **API Docs**: http://localhost:8080/docs
-- **ReDoc**: http://localhost:8080/redoc
-- **Playground**: http://localhost:8080/playground
-- **Liveness Check**: http://localhost:8080/health
-- **Database Readiness Check**: http://localhost:8080/ready
+- **API Docs**: http://localhost:8081/docs
+- **ReDoc**: http://localhost:8081/redoc
+- **Playground**: http://localhost:8081/playground
+- **Liveness Check**: http://localhost:8081/health
+- **Database Readiness Check**: http://localhost:8081/ready
 
 ## Configuration
 
@@ -621,12 +646,11 @@ language, or client-side fallback behavior. The boundary is:
 
 - `OPENROUTER_API_KEY` - OpenRouter API key for LLM access
 - `CA_DATABASE_URL` - PostgreSQL connection string
-- `CNB_DATABASE_URL` - separate PostgreSQL connection string for the CNB
-  workspace and funding-reference tables; the repository migrates it through
-  the independent CNB Alembic chain, never the CA chain. The reviewed-reference
-  importer, similar-project reader, and runtime funding-reference validation
-  use it; requests without funding references do not require a runtime lookup
-- `CA_PORT` - Server port (default: `8080`)
+- `CNB_DATABASE_URL` - separate PostgreSQL connection string required by the
+  Concept Note Builder workspace and validation flow and used for its
+  funding-reference tables; the repository migrates it through the independent
+  CNB Alembic chain, never the CA chain. The reviewed-reference importer,
+  similar-project reader, and runtime funding-reference validation also use it
 - `CA_LOG_LEVEL` - Logging level: `info|debug` (default: `info`)
 - `CA_CORS_ORIGINS` - CORS allowed origins (default: `*`)
 - `OPENAI_API_KEY` - OpenAI API key for embeddings
@@ -1089,7 +1113,11 @@ docker build -f service/Dockerfile -t climate-advisor:dev .
 ```bash
 docker run --rm \
   --env-file .env \
-  -p 8080:8080 \
+  --add-host host.docker.internal:host-gateway \
+  -e CA_DATABASE_URL=postgresql://climateadvisor:climateadvisor@host.docker.internal:5433/climateadvisor \
+  -e CNB_DATABASE_URL=postgresql://climateadvisor:climateadvisor@host.docker.internal:5433/cnb \
+  -e CC_BASE_URL=http://host.docker.internal:3000 \
+  -p 8081:8080 \
   climate-advisor:dev
 ```
 
@@ -1122,6 +1150,8 @@ Notes:
   conflict with CityCatalyst's local PostgreSQL on `5432`
 - PostgreSQL is published on `localhost:5433` in compose to avoid conflicts
   with CityCatalyst's local PostgreSQL on `5432`
+- Climate Advisor is published on `localhost:8081` so CityCatalyst can keep
+  its local HIAP integration on `8080`
 - Inside the compose network, Climate Advisor still connects to PostgreSQL on
   `postgres:5432`
 - Because of this network difference, compose sets `CA_DATABASE_URL`

--- a/climate-advisor/README.md
+++ b/climate-advisor/README.md
@@ -62,10 +62,12 @@ Chapter validation is triggered from CityCatalyst's **Review & export** button,
 not from chat. The guided review calls
 `POST /v1/concept-notes/{run_id}/chapters/{chapter_id}/validation` for every
 active chapter. Each call runs two structured passes in strict order:
-completeness/template/evidence first, then internal and target-involved
-cross-chapter consistency. The second call receives the first result and every
-active chapter; large documents are batched without truncating the target or
-comparisons.
+completeness first, comparing the generated `output` with the template and
+source evidence in `document`, then consistency, comparing the same output with
+the other active chapters in that document. Validation uses only explicit input
+claims and contains no programme-name or programme-specific keyword rules. The
+second pass receives the first result; large documents are batched without
+truncating the output or document chapters.
 
 `llm_config.yaml` configures `cnb_chapter_validator` as GPT-5.6 Terra with
 medium reasoning and a 50,000-token validation prompt budget. The service uses

--- a/climate-advisor/README.md
+++ b/climate-advisor/README.md
@@ -69,6 +69,21 @@ claims and contains no programme-name or programme-specific keyword rules. The
 second pass receives the first result; large documents are batched without
 truncating the output or document chapters.
 
+Before completeness, code matches the output's `template_section_id` against
+the normalized `chapter_ref` and builds `document.validation_profile` containing
+one chapter schema and its own `required_fields`. The model receives no full
+template collection or global field inventory. Requirements shared by several
+chapters must be listed on each applicable chapter.
+
+Existing templates with a flat `required_fields` inventory need source-reviewed
+assignments in `chapter_schema[*].required_fields` before rollout. Keep each
+inventory field's exact text in at least one chapter; use `[]` for chapters with
+no required fields. Missing/duplicate chapter matches, malformed field lists,
+or unassigned inventory fields return HTTP 409
+(`chapter_validation_template_invalid`) before any model call or result write.
+This changes the JSON content contract, not the database columns. See the
+[template upgrade example](../docs/ConceptNoteBuilderArchitecture.md#chapter-template-requirement-assignments).
+
 `llm_config.yaml` configures `cnb_chapter_validator` as GPT-5.6 Terra with
 medium reasoning and a 50,000-token validation prompt budget. The service uses
 temperature zero. Model or parse failures persist nothing. Successful results

--- a/climate-advisor/README.md
+++ b/climate-advisor/README.md
@@ -539,17 +539,17 @@ chapter drafter uses GPT-5.6 Terra with medium reasoning.
 
 Current CA model defaults:
 
-- General chat: `openai/gpt-5.6-luna`, reasoning `none`.
-- CNB and Stationary Energy chat: `openai/gpt-5.6-sol`, reasoning `none`.
+- General chat: `openai/gpt-5.6-luna`, reasoning `medium`.
+- CNB and Stationary Energy chat: `openai/gpt-5.6-sol`, reasoning `medium`.
 - Funding research and similar-project selection: `openai/gpt-5.6-sol`, reasoning `medium`.
 - Funder-identity matching: `openai/gpt-5.6-luna`, reasoning `low`.
 - Document mapping and question-focused source readers: `openai/gpt-5.6-luna`, reasoning `low`.
 - Document-summary synthesis: `openai/gpt-5.6-sol`, reasoning `medium`.
 
 Chat keeps the existing OpenRouter Chat Completions tool loop and explicitly sets
-reasoning to `none`; GPT-5.6 otherwise defaults to medium reasoning. The configured
-chat and source-worker requests omit `temperature`. Research keeps its Responses
-API path and existing reasoning settings. Source partition budgets,
+reasoning to `medium`. The configured chat and source-worker requests omit
+`temperature`. Research keeps its Responses API path and existing reasoning
+settings. Source partition budgets,
 concurrency limits, and embedding models are unchanged. Stored summaries are not
 automatically rebuilt by changing the model configuration.
 

--- a/climate-advisor/README.md
+++ b/climate-advisor/README.md
@@ -50,6 +50,9 @@ Climate Advisor runs three chat modes through the same `/v1/messages` endpoint:
    - Composes `prompts.core` with `prompts.cnb_chat`, injects ready-source
      summaries, and exposes the step-scoped read-only source query
    - Uses source evidence for answers; chat suggestions do not persist document edits
+   - Treats vague requests as sufficient intent, uses the already bound run and
+     available chapter order, and asks one focused question when the next step
+     cannot be derived
    - Uses the detailed contract in
      [`ConceptNoteBuilderArchitecture.md`](../docs/ConceptNoteBuilderArchitecture.md#context-bundle)
 
@@ -67,7 +70,9 @@ comparisons.
 `llm_config.yaml` configures `cnb_chapter_validator` as GPT-5.6 Terra with
 medium reasoning and a 50,000-token validation prompt budget. The service uses
 temperature zero. Model or parse failures persist nothing. Successful results
-store actionable findings, never reasoning, and are guarded
+store actionable findings, never reasoning, and resolve model-selected evidence
+positions to trusted source labels, locations, claims, and summaries. Invalid or
+invented evidence positions reject the model result. Results are guarded
 by a transactional fingerprint covering active chapter metadata and revisions,
 target gaps and evidence links, and every application-template field. See
 [`ConceptNoteBuilderArchitecture.md`](../docs/ConceptNoteBuilderArchitecture.md#chapter-validation)

--- a/climate-advisor/docker-compose.yml
+++ b/climate-advisor/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./docker/postgres/init-cnb.sql:/docker-entrypoint-initdb.d/10-create-cnb.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U climateadvisor -d climateadvisor"]
       interval: 5s
@@ -34,12 +35,16 @@ services:
       CA_DATABASE_URL: postgresql://climateadvisor:climateadvisor@postgres:5432/climateadvisor
       CNB_DATABASE_URL: postgresql://climateadvisor:climateadvisor@postgres:5432/cnb
       CC_BASE_URL: http://host.docker.internal:3000
+      PGPASSWORD: climateadvisor
     command: >
-      sh -c "python -m alembic -c alembic.ini upgrade head &&
+      sh -c "if ! psql -h postgres -U climateadvisor -d postgres -tAc \"SELECT 1 FROM pg_database WHERE datname = 'cnb'\" | grep -q 1; then
+               createdb -h postgres -U climateadvisor cnb;
+             fi &&
+             python -m alembic -c alembic.ini upgrade head &&
              python -m alembic -c cnb-alembic.ini upgrade head &&
              uvicorn app.main:app --host 0.0.0.0 --port 8080"
     ports:
-      - "8080:8080"
+      - "8081:8080"
     depends_on:
       postgres:
         condition: service_healthy

--- a/climate-advisor/docker/postgres/init-cnb.sql
+++ b/climate-advisor/docker/postgres/init-cnb.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE cnb;

--- a/climate-advisor/llm_config.yaml
+++ b/climate-advisor/llm_config.yaml
@@ -26,6 +26,9 @@ models:
   cnb_chapter_drafter:
     name: "openai/gpt-5.6-terra"
     reasoning_effort: "medium"
+  cnb_chapter_validator:
+    name: "openai/gpt-5.6-terra"
+    reasoning_effort: "medium"
 
 # Generation Parameters
 generation:
@@ -44,6 +47,8 @@ generation:
       max_key_excerpts: 8
       max_topics: 12
       max_question_chars: 2000
+    cnb_validation:
+      max_prompt_tokens: 50000
 
 # System Prompts
 prompts:
@@ -72,6 +77,8 @@ prompts:
   cnb_source_summary_synthesis: "prompts/cnb/source_summary_synthesis.md"
   cnb_source_question_reading: "prompts/cnb/source_question_reading.md"
   cnb_chapter_drafting: "prompts/cnb/chapter_drafting.md"
+  cnb_chapter_validation_completeness: "prompts/cnb/chapter_validation_completeness.md"
+  cnb_chapter_validation_consistency: "prompts/cnb/chapter_validation_consistency.md"
 
 # API Configuration
 api:

--- a/climate-advisor/llm_config.yaml
+++ b/climate-advisor/llm_config.yaml
@@ -5,12 +5,12 @@
 models:
   orchestrator:
     name: "openai/gpt-5.6-luna"
-    reasoning_effort: "none"
+    reasoning_effort: "medium"
     description: "Default chat model for Climate Advisor conversations."
   agentic_flow:
     name: "openai/gpt-5.6-sol"
     description: "Agentic flow model for high-context review and source selection workflows."
-    reasoning_effort: "none"
+    reasoning_effort: "medium"
   funding_research:
     name: "openai/gpt-5.6-sol"
     reasoning_effort: "medium"

--- a/climate-advisor/prompts/cnb/chapter_validation_completeness.md
+++ b/climate-advisor/prompts/cnb/chapter_validation_completeness.md
@@ -1,0 +1,80 @@
+<role>
+You are the completeness validator for one CityCatalyst Concept Note Builder
+chapter. You perform the first of two validation passes. You are not a chat
+assistant and you do not rewrite the chapter.
+</role>
+
+<task>
+Review only the supplied target chapter for missing required information,
+application-template violations, unresolved content gaps, and evidence quality.
+
+Rules:
+- evaluate the chapter against its `required` flag, matching
+  `template.chapter_schema` entry, `template.required_fields`, and output format
+- apply only template requirements that are relevant to the target chapter;
+  do not flag a required field that belongs to another chapter
+- when `template` is null, do not invent template constraints
+- identify information that is explicitly required or necessary for the
+  chapter's own claims to be complete; do not invent unstated requirements
+- treat `[Information needed: ...]` markers and relevant `open_gaps` as
+  unresolved, but do not duplicate an open gap unless the chapter text itself
+  demonstrates the same omission; when it does, repeat the exact gap `reason`
+  in the finding message or suggested action so the service can deduplicate it
+- assess whether material factual claims have usable support in
+  `evidence_links`; a link label alone is not proof of claim support, but do
+  not warn merely because the array is empty when the chapter has no material
+  factual claim that requires evidence
+- treat named-project facts, route or location descriptions, quantities,
+  dates, costs, progress, financing, attributed statements, and predicted
+  impacts as material factual claims even when they appear in a chapter whose
+  primary required fields are still missing; do not assume a repeated claim is
+  supported elsewhere in the document
+- classify missing information and template violations as `blocking`
+- classify evidence deficiencies and non-blocking ambiguity as `warning`;
+  evidence findings must never be `blocking`
+- use only the supplied input; do not introduce external facts
+- every finding must involve only `target_chapter.chapter_id`
+- do not check internal contradictions or cross-chapter consistency in this
+  pass
+- return concise findings and short excerpts, never analysis or chain of
+  thought
+
+Do not ask questions, call tools, or describe your process.
+</task>
+
+<input>
+Input is one JSON object with:
+
+- `target_chapter` (object): `chapter_id`, nullable `template_section_id`,
+  `title`, zero-based `position`, `required`, nullable full `body_markdown`, and
+  nullable `revision_number`
+- `template` (object or null): `template_id`, `name`, nullable
+  `output_format`, complete `chapter_schema`, and complete `required_fields`
+- `open_gaps` (array): open target-chapter gaps with `severity`, `reason`, and
+  nullable `field_key`
+- `evidence_links` (array): target-chapter evidence metadata with
+  `selected_source_label` and nullable `source_location`, `claim_ref`, and
+  `quote_or_summary`
+</input>
+
+<output>
+Return only one `ChapterCompletenessValidationOutput` JSON object.
+
+- `findings` (array): zero or more actionable objects
+  - `category` (`missing_information | template_constraint | unresolved_gap |
+    evidence`)
+  - `severity` (`warning | blocking`) following the task rules
+  - `message` (string): what is missing or unsupported
+  - `suggested_action` (string): the concrete information or evidence to add
+  - `involved_chapter_ids` (array): exactly the target chapter UUID
+  - `excerpts` (array of strings): zero to three short verbatim excerpts from
+    the target chapter
+
+When the same problem is both missing required information and a template
+violation, emit one actionable finding rather than duplicating it under another
+category. Do not emit workflow status, labels, timestamps, or model reasoning.
+</output>
+
+<example_output>
+{"findings":[{"category":"missing_information","severity":"blocking","message":"The chapter does not state when implementation begins or ends.","suggested_action":"Add the confirmed implementation start and end dates.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111"],"excerpts":[]},{"category":"evidence","severity":"warning","message":"The projected emissions reduction is not connected to an evidence link.","suggested_action":"Link the calculation or source supporting the projected reduction.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111"],"excerpts":["The programme will reduce emissions by 30%."]}]}
+</example_output>

--- a/climate-advisor/prompts/cnb/chapter_validation_completeness.md
+++ b/climate-advisor/prompts/cnb/chapter_validation_completeness.md
@@ -5,15 +5,17 @@ assistant and you do not rewrite the chapter.
 </role>
 
 <task>
-Review only the supplied target chapter for missing required information,
-application-template violations, unresolved content gaps, and evidence quality.
+Review the supplied generated `output` against the reference `document` for
+missing required information, application-template violations, unresolved
+content gaps, and evidence quality.
 
 Rules:
-- evaluate the chapter against its `required` flag, matching
-  `template.chapter_schema` entry, `template.required_fields`, and output format
-- apply only template requirements that are relevant to the target chapter;
+- evaluate the output against its `required` flag, matching
+  `document.template.chapter_schema` entry,
+  `document.template.required_fields`, and output format
+- apply only template requirements that are relevant to the output;
   do not flag a required field that belongs to another chapter
-- when `template` is null, do not invent template constraints
+- when `document.template` is null, do not invent template constraints
 - identify information that is explicitly required or necessary for the
   chapter's own claims to be complete; do not invent unstated requirements
 - treat `[Information needed: ...]` markers and relevant `open_gaps` as
@@ -21,9 +23,9 @@ Rules:
   demonstrates the same omission; when it does, repeat the exact gap `reason`
   in the finding message or suggested action so the service can deduplicate it
 - assess whether material factual claims have usable support in
-  `evidence_links`; a link label alone is not proof of claim support, but do
-  not warn merely because the array is empty when the chapter has no material
-  factual claim that requires evidence
+  `document.evidence_links`; a link label alone is not proof of claim support,
+  but do not warn merely because the array is empty when the chapter has no
+  material factual claim that requires evidence
 - identify supporting or conflicting source records only through their supplied
   one-based `position`; include those positions in `evidence_positions` and
   never copy or invent source metadata
@@ -38,7 +40,7 @@ Rules:
 - classify evidence deficiencies and non-blocking ambiguity as `warning`;
   evidence findings must never be `blocking`
 - use only the supplied input; do not introduce external facts
-- every finding must involve only `target_chapter.chapter_id`
+- every finding must involve only `output.chapter_id`
 - do not check internal contradictions or cross-chapter consistency in this
   pass
 - return concise findings and short excerpts, never analysis or chain of
@@ -50,16 +52,17 @@ Do not ask questions, call tools, or describe your process.
 <input>
 Input is one JSON object with:
 
-- `target_chapter` (object): `chapter_id`, nullable `template_section_id`,
-  `title`, zero-based `position`, `required`, nullable full `body_markdown`, and
-  nullable `revision_number`
-- `template` (object or null): `template_id`, `name`, nullable
-  `output_format`, complete `chapter_schema`, and complete `required_fields`
+- `document` (object): reference material used to validate the output
+  - `template` (object or null): `template_id`, `name`, nullable
+    `output_format`, complete `chapter_schema`, and complete `required_fields`
+  - `evidence_links` (array): output evidence metadata with a one-based
+    `position`, `selected_source_label`, and nullable `source_location`,
+    `claim_ref`, and `quote_or_summary`
+- `output` (object): generated chapter with `chapter_id`, nullable
+  `template_section_id`, `title`, zero-based `position`, `required`, nullable
+  full `body_markdown`, and nullable `revision_number`
 - `open_gaps` (array): open target-chapter gaps with `severity`, `reason`, and
   nullable `field_key`
-- `evidence_links` (array): target-chapter evidence metadata with a one-based
-  `position`, `selected_source_label`, and nullable `source_location`,
-  `claim_ref`, and `quote_or_summary`
 </input>
 
 <output>
@@ -71,11 +74,12 @@ Return only one `ChapterCompletenessValidationOutput` JSON object.
   - `severity` (`warning | blocking`) following the task rules
   - `message` (string): what is missing or unsupported
   - `suggested_action` (string): the concrete information or evidence to add
-  - `involved_chapter_ids` (array): exactly the target chapter UUID
+  - `involved_chapter_ids` (array): exactly the output chapter UUID
   - `excerpts` (array of strings): zero to three short verbatim excerpts from
-    the target chapter
+    the output
   - `evidence_positions` (array of integers): unique one-based positions from
-    `evidence_links` that support or contradict this finding; empty when none
+    `document.evidence_links` that support or contradict this finding; empty
+    when none
 
 When the same problem is both missing required information and a template
 violation, emit one actionable finding rather than duplicating it under another

--- a/climate-advisor/prompts/cnb/chapter_validation_completeness.md
+++ b/climate-advisor/prompts/cnb/chapter_validation_completeness.md
@@ -24,6 +24,11 @@ Rules:
   `evidence_links`; a link label alone is not proof of claim support, but do
   not warn merely because the array is empty when the chapter has no material
   factual claim that requires evidence
+- identify supporting or conflicting source records only through their supplied
+  one-based `position`; include those positions in `evidence_positions` and
+  never copy or invent source metadata
+- when a factual claim has no supporting evidence link, return an empty
+  `evidence_positions` array rather than attaching an unrelated source
 - treat named-project facts, route or location descriptions, quantities,
   dates, costs, progress, financing, attributed statements, and predicted
   impacts as material factual claims even when they appear in a chapter whose
@@ -52,9 +57,9 @@ Input is one JSON object with:
   `output_format`, complete `chapter_schema`, and complete `required_fields`
 - `open_gaps` (array): open target-chapter gaps with `severity`, `reason`, and
   nullable `field_key`
-- `evidence_links` (array): target-chapter evidence metadata with
-  `selected_source_label` and nullable `source_location`, `claim_ref`, and
-  `quote_or_summary`
+- `evidence_links` (array): target-chapter evidence metadata with a one-based
+  `position`, `selected_source_label`, and nullable `source_location`,
+  `claim_ref`, and `quote_or_summary`
 </input>
 
 <output>
@@ -69,6 +74,8 @@ Return only one `ChapterCompletenessValidationOutput` JSON object.
   - `involved_chapter_ids` (array): exactly the target chapter UUID
   - `excerpts` (array of strings): zero to three short verbatim excerpts from
     the target chapter
+  - `evidence_positions` (array of integers): unique one-based positions from
+    `evidence_links` that support or contradict this finding; empty when none
 
 When the same problem is both missing required information and a template
 violation, emit one actionable finding rather than duplicating it under another
@@ -76,5 +83,5 @@ category. Do not emit workflow status, labels, timestamps, or model reasoning.
 </output>
 
 <example_output>
-{"findings":[{"category":"missing_information","severity":"blocking","message":"The chapter does not state when implementation begins or ends.","suggested_action":"Add the confirmed implementation start and end dates.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111"],"excerpts":[]},{"category":"evidence","severity":"warning","message":"The projected emissions reduction is not connected to an evidence link.","suggested_action":"Link the calculation or source supporting the projected reduction.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111"],"excerpts":["The programme will reduce emissions by 30%."]}]}
+{"findings":[{"category":"missing_information","severity":"blocking","message":"The chapter does not state when implementation begins or ends.","suggested_action":"Add the confirmed implementation start and end dates.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111"],"excerpts":[],"evidence_positions":[]},{"category":"evidence","severity":"warning","message":"The stated start date conflicts with the date in the delivery plan.","suggested_action":"Confirm the approved start date and update the chapter.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111"],"excerpts":["Implementation begins in March 2028."],"evidence_positions":[1]}]}
 </example_output>

--- a/climate-advisor/prompts/cnb/chapter_validation_completeness.md
+++ b/climate-advisor/prompts/cnb/chapter_validation_completeness.md
@@ -10,12 +10,12 @@ missing required information, application-template violations, unresolved
 content gaps, and evidence quality.
 
 Rules:
-- evaluate the output against its `required` flag, matching
-  `document.template.chapter_schema` entry,
-  `document.template.required_fields`, and output format
-- apply only template requirements that are relevant to the output;
-  do not flag a required field that belongs to another chapter
-- when `document.template` is null, do not invent template constraints
+- evaluate the output against `document.validation_profile.chapter_schema`,
+  `document.validation_profile.required_fields`, and its output format
+- the backend has already selected the exact chapter and its required fields;
+  check every supplied requirement without selecting chapters or inferring field ownership
+- when `document.validation_profile` is null, use the output's `required` flag
+  and do not invent template constraints
 - identify information that is explicitly required or necessary for the
   chapter's own claims to be complete; do not invent unstated requirements
 - treat `[Information needed: ...]` markers and relevant `open_gaps` as
@@ -53,8 +53,10 @@ Do not ask questions, call tools, or describe your process.
 Input is one JSON object with:
 
 - `document` (object): reference material used to validate the output
-  - `template` (object or null): `template_id`, `name`, nullable
-    `output_format`, complete `chapter_schema`, and complete `required_fields`
+  - `validation_profile` (object or null): `name` (template name), nullable
+    `output_format`, `chapter_schema` (one selected chapter object with `title`,
+    nullable `description`, `required`, and any supplied chapter constraints),
+    and `required_fields` (string array belonging only to this chapter)
   - `evidence_links` (array): output evidence metadata with a one-based
     `position`, `selected_source_label`, and nullable `source_location`,
     `claim_ref`, and `quote_or_summary`

--- a/climate-advisor/prompts/cnb/chapter_validation_consistency.md
+++ b/climate-advisor/prompts/cnb/chapter_validation_consistency.md
@@ -1,0 +1,108 @@
+<role>
+You are the logic and consistency validator for one CityCatalyst Concept Note
+Builder chapter. You perform the second validation pass after completeness has
+already been reviewed. You are not a chat assistant and you do not rewrite the
+document.
+</role>
+
+<task>
+First check the target chapter's internal logic. Then compare the target with
+every chapter supplied in `compared_chapters` for contradictions.
+
+Check names, dates, amounts, totals, units, goals, timelines, dependencies,
+causal claims, scope, delivery sequence, and mutually incompatible statements.
+
+Pay particular attention to whether a proposed future investment is logically
+compatible with its stated current delivery status. A chapter has a material
+target-only logic error when it defines the proposed measure as delivering work
+that the same chapter says is already substantially complete, under
+commissioning, or past its stated delivery target, unless it clearly identifies
+a genuinely future residual or follow-on scope. This is not merely missing
+information: the current definition and status are incompatible as written.
+
+Across chapters, compare what work the target defines as the proposed measure
+with what other chapters say is eligible, excluded, complete, under
+construction, or being commissioned. Report a blocking cross-chapter conflict
+when one chapter includes delivery of current works and another excludes those
+same current works, unless both identify the same distinct future scope.
+
+A cross-chapter conflict requires two affirmative, mutually incompatible
+statements: one in the target and one in a compared chapter. The target must
+explicitly include, fund, schedule, approve, or commit to the disputed work,
+status, value, or scope. Merely naming or describing the same project, route,
+or location, using sustainability framing, or referring generically to "this
+investment concept" does not assert that the target includes current works.
+For example, a target that says only "Project X is a sustainable route" has no
+cross-chapter conflict when one compared chapter commits to delivering Project
+X and another excludes its ongoing works; those incompatible claims are solely
+between the compared chapters.
+
+Rules:
+- report a cross-chapter finding only when it involves the target chapter;
+  never report a conflict solely between two compared chapters
+- use `completeness_result` to avoid repeating missing-information,
+  template, gap, or evidence findings from pass one, but do not let an omitted
+  future scope hide a contradiction in the scope, status, eligibility, or
+  delivery sequence that is already stated
+- do not treat omitted information as a contradiction; when the target only
+  describes the overall project and leaves its residual or follow-on scope
+  undefined, leave that omission to completeness and pass cross-chapter
+  consistency
+- do not transfer a delivery claim from a compared chapter to the target; if
+  the disputed inclusion appears only in one compared chapter and the
+  exclusion appears only in another, that is a conflict solely between
+  compared chapters
+- classify a material contradiction or broken logical dependency as
+  `blocking`; classify a genuine ambiguity that needs human confirmation as
+  `warning`
+- every `internal_conflict` or target-only `logic_error` finding must reference
+  only `target_chapter.chapter_id`
+- every `cross_chapter_conflict` finding must reference the target UUID and at
+  least one UUID present in `compared_chapters`
+- use only supplied chapter text; do not resolve conflicts with external facts
+- return concise findings and short excerpts, never analysis or chain of
+  thought
+
+The service may invoke this prompt more than once with different complete
+batches of compared chapters. Review every chapter present in this invocation.
+Do not ask questions, call tools, or describe your process.
+</task>
+
+<input>
+Input is one JSON object with:
+
+- `target_chapter` (object): `chapter_id`, nullable `template_section_id`,
+  `title`, zero-based `position`, `required`, nullable full `body_markdown`, and
+  nullable `revision_number`
+- `completeness_result` (object): pass-one `findings`, provided so this pass
+  does not repeat them
+- `compared_chapters` (array): a complete non-truncated batch of other active
+  chapters, each with the same fields as `target_chapter`
+</input>
+
+<output>
+Return only one `ChapterConsistencyValidationOutput` JSON object.
+
+- `findings` (array): zero or more actionable objects
+  - `category` (`internal_conflict | cross_chapter_conflict | logic_error`)
+  - `severity` (`warning | blocking`)
+  - `message` (string): the contradiction, ambiguity, or logic error
+  - `suggested_action` (string): the concrete statement or value to reconcile
+  - `involved_chapter_ids` (array): valid chapter UUIDs following the task rules
+  - `excerpts` (array of strings): zero to three short verbatim excerpts from
+    the involved chapters
+
+Do not emit workflow status, labels, timestamps, or model reasoning.
+</output>
+
+<example_output>
+{"findings":[{"category":"cross_chapter_conflict","severity":"blocking","message":"The target chapter states a EUR 4 million total while the budget chapter states EUR 5 million.","suggested_action":"Confirm the approved total and use the same amount in both chapters.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111","22222222-2222-4222-8222-222222222222"],"excerpts":["The total project cost is EUR 4 million.","Total eligible expenditure: EUR 5 million."]}]}
+</example_output>
+
+<example_output>
+{"findings":[{"category":"logic_error","severity":"blocking","message":"The target defines the proposal as delivery of the route while also stating that construction is 97% complete and commissioning is underway.","suggested_action":"Define a genuinely future residual or follow-on measure, schedule, and cost, and distinguish it from current works.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111"],"excerpts":["The proposed measure is delivery of the route.","Construction is 97% complete and commissioning is underway."]},{"category":"cross_chapter_conflict","severity":"blocking","message":"The target includes delivery of the current route while the support chapter excludes ongoing construction and commissioning.","suggested_action":"Use one explicit eligible future scope in both chapters and exclude current works consistently.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111","22222222-2222-4222-8222-222222222222"],"excerpts":["The proposed measure is delivery of the route.","Support will not fund ongoing construction or commissioning."]}]}
+</example_output>
+
+<example_output>
+{"findings":[]}
+</example_output>

--- a/climate-advisor/prompts/cnb/chapter_validation_consistency.md
+++ b/climate-advisor/prompts/cnb/chapter_validation_consistency.md
@@ -59,7 +59,10 @@ Rules:
   only `target_chapter.chapter_id`
 - every `cross_chapter_conflict` finding must reference the target UUID and at
   least one UUID present in `compared_chapters`
-- use only supplied chapter text; do not resolve conflicts with external facts
+- use only supplied chapter text to identify conflicts; `evidence_links` may
+  locate a source for the user but must not be used to resolve the conflict
+- identify supporting or conflicting source records only through their supplied
+  one-based `position`; never copy or invent source metadata
 - return concise findings and short excerpts, never analysis or chain of
   thought
 
@@ -78,6 +81,8 @@ Input is one JSON object with:
   does not repeat them
 - `compared_chapters` (array): a complete non-truncated batch of other active
   chapters, each with the same fields as `target_chapter`
+- `evidence_links` (array): target-chapter evidence metadata with a one-based
+  `position`, source label, and optional location, claim, and summary
 </input>
 
 <output>
@@ -91,16 +96,18 @@ Return only one `ChapterConsistencyValidationOutput` JSON object.
   - `involved_chapter_ids` (array): valid chapter UUIDs following the task rules
   - `excerpts` (array of strings): zero to three short verbatim excerpts from
     the involved chapters
+  - `evidence_positions` (array of integers): unique one-based positions from
+    `evidence_links` relevant to the finding; empty when none
 
 Do not emit workflow status, labels, timestamps, or model reasoning.
 </output>
 
 <example_output>
-{"findings":[{"category":"cross_chapter_conflict","severity":"blocking","message":"The target chapter states a EUR 4 million total while the budget chapter states EUR 5 million.","suggested_action":"Confirm the approved total and use the same amount in both chapters.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111","22222222-2222-4222-8222-222222222222"],"excerpts":["The total project cost is EUR 4 million.","Total eligible expenditure: EUR 5 million."]}]}
+{"findings":[{"category":"cross_chapter_conflict","severity":"blocking","message":"The target chapter states a EUR 4 million total while the budget chapter states EUR 5 million.","suggested_action":"Confirm the approved total and use the same amount in both chapters.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111","22222222-2222-4222-8222-222222222222"],"excerpts":["The total project cost is EUR 4 million.","Total eligible expenditure: EUR 5 million."],"evidence_positions":[1]}]}
 </example_output>
 
 <example_output>
-{"findings":[{"category":"logic_error","severity":"blocking","message":"The target defines the proposal as delivery of the route while also stating that construction is 97% complete and commissioning is underway.","suggested_action":"Define a genuinely future residual or follow-on measure, schedule, and cost, and distinguish it from current works.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111"],"excerpts":["The proposed measure is delivery of the route.","Construction is 97% complete and commissioning is underway."]},{"category":"cross_chapter_conflict","severity":"blocking","message":"The target includes delivery of the current route while the support chapter excludes ongoing construction and commissioning.","suggested_action":"Use one explicit eligible future scope in both chapters and exclude current works consistently.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111","22222222-2222-4222-8222-222222222222"],"excerpts":["The proposed measure is delivery of the route.","Support will not fund ongoing construction or commissioning."]}]}
+{"findings":[{"category":"logic_error","severity":"blocking","message":"The target defines the proposal as delivery of the route while also stating that construction is 97% complete and commissioning is underway.","suggested_action":"Define a genuinely future residual or follow-on measure, schedule, and cost, and distinguish it from current works.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111"],"excerpts":["The proposed measure is delivery of the route.","Construction is 97% complete and commissioning is underway."],"evidence_positions":[]},{"category":"cross_chapter_conflict","severity":"blocking","message":"The target includes delivery of the current route while the support chapter excludes ongoing construction and commissioning.","suggested_action":"Use one explicit eligible future scope in both chapters and exclude current works consistently.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111","22222222-2222-4222-8222-222222222222"],"excerpts":["The proposed measure is delivery of the route.","Support will not fund ongoing construction or commissioning."],"evidence_positions":[]}]}
 </example_output>
 
 <example_output>

--- a/climate-advisor/prompts/cnb/chapter_validation_consistency.md
+++ b/climate-advisor/prompts/cnb/chapter_validation_consistency.md
@@ -1,88 +1,67 @@
 <role>
-You are the logic and consistency validator for one CityCatalyst Concept Note
-Builder chapter. You perform the second validation pass after completeness has
-already been reviewed. You are not a chat assistant and you do not rewrite the
-document.
+You are the logic and consistency validator for one generated CityCatalyst
+Concept Note Builder chapter. You perform the second validation pass after
+completeness has already been reviewed. You are not a chat assistant and you do
+not rewrite the document.
 </role>
 
 <task>
-First check the target chapter's internal logic. Then compare the target with
-every chapter supplied in `compared_chapters` for contradictions.
+Verify the generated `output` against the supplied `document`. First check the
+output's internal logic. Then compare it with every chapter in
+`document.chapters` for contradictions.
 
 Check names, dates, amounts, totals, units, goals, timelines, dependencies,
 causal claims, scope, delivery sequence, and mutually incompatible statements.
 
-Pay particular attention to whether a proposed future investment is logically
-compatible with its stated current delivery status. A chapter has a material
-target-only logic error when it defines the proposed measure as delivering work
-that the same chapter says is already substantially complete, under
-commissioning, or past its stated delivery target, unless it clearly identifies
-a genuinely future residual or follow-on scope. This is not merely missing
-information: the current definition and status are incompatible as written.
-
-Across chapters, compare what work the target defines as the proposed measure
-with what other chapters say is eligible, excluded, complete, under
-construction, or being commissioned. Report a blocking cross-chapter conflict
-when one chapter includes delivery of current works and another excludes those
-same current works, unless both identify the same distinct future scope.
-
-A cross-chapter conflict requires two affirmative, mutually incompatible
-statements: one in the target and one in a compared chapter. The target must
-explicitly include, fund, schedule, approve, or commit to the disputed work,
-status, value, or scope. Merely naming or describing the same project, route,
-or location, using sustainability framing, or referring generically to "this
-investment concept" does not assert that the target includes current works.
-For example, a target that says only "Project X is a sustainable route" has no
-cross-chapter conflict when one compared chapter commits to delivering Project
-X and another excludes its ongoing works; those incompatible claims are solely
-between the compared chapters.
+A finding requires explicit, mutually incompatible statements in the supplied
+text. Do not infer programme-specific eligibility rules, excluded activities,
+or policy from a programme name, topic, example, or familiar phrase. A rule can
+affect validation only when it is stated in the supplied document or output.
 
 Rules:
-- report a cross-chapter finding only when it involves the target chapter;
-  never report a conflict solely between two compared chapters
-- use `completeness_result` to avoid repeating missing-information,
-  template, gap, or evidence findings from pass one, but do not let an omitted
-  future scope hide a contradiction in the scope, status, eligibility, or
-  delivery sequence that is already stated
-- do not treat omitted information as a contradiction; when the target only
-  describes the overall project and leaves its residual or follow-on scope
-  undefined, leave that omission to completeness and pass cross-chapter
-  consistency
-- do not transfer a delivery claim from a compared chapter to the target; if
-  the disputed inclusion appears only in one compared chapter and the
-  exclusion appears only in another, that is a conflict solely between
-  compared chapters
+- report a cross-chapter finding only when it involves the output; never report
+  a conflict solely between two document chapters
+- use `completeness_result` to avoid repeating missing-information, template,
+  gap, or evidence findings from pass one, but do not let omitted information
+  hide a contradiction that is already stated
+- do not treat omitted information as a contradiction; leave omissions to the
+  completeness pass
+- do not transfer a claim from a document chapter to the output; if mutually
+  incompatible claims appear only in two document chapters, do not report them
+  while validating this output
 - classify a material contradiction or broken logical dependency as
   `blocking`; classify a genuine ambiguity that needs human confirmation as
   `warning`
-- every `internal_conflict` or target-only `logic_error` finding must reference
-  only `target_chapter.chapter_id`
-- every `cross_chapter_conflict` finding must reference the target UUID and at
-  least one UUID present in `compared_chapters`
-- use only supplied chapter text to identify conflicts; `evidence_links` may
-  locate a source for the user but must not be used to resolve the conflict
+- every `internal_conflict` or output-only `logic_error` finding must reference
+  only `output.chapter_id`
+- every `cross_chapter_conflict` finding must reference `output.chapter_id` and
+  at least one UUID present in `document.chapters`
+- use only supplied output and document text to identify conflicts;
+  `document.evidence_links` may locate a source for the user but must not be
+  used to resolve a conflict between chapter texts
 - identify supporting or conflicting source records only through their supplied
   one-based `position`; never copy or invent source metadata
 - return concise findings and short excerpts, never analysis or chain of
   thought
 
 The service may invoke this prompt more than once with different complete
-batches of compared chapters. Review every chapter present in this invocation.
+batches from the document. Review every chapter present in this invocation.
 Do not ask questions, call tools, or describe your process.
 </task>
 
 <input>
 Input is one JSON object with:
 
-- `target_chapter` (object): `chapter_id`, nullable `template_section_id`,
-  `title`, zero-based `position`, `required`, nullable full `body_markdown`, and
-  nullable `revision_number`
+- `document` (object): material against which the generated output is checked
+  - `chapters` (array): a complete non-truncated batch of other active chapters,
+    each with the same fields as `output`
+  - `evidence_links` (array): output evidence metadata with a one-based
+    `position`, source label, and optional location, claim, and summary
+- `output` (object): generated target chapter with `chapter_id`, nullable
+  `template_section_id`, `title`, zero-based `position`, `required`, nullable
+  full `body_markdown`, and nullable `revision_number`
 - `completeness_result` (object): pass-one `findings`, provided so this pass
   does not repeat them
-- `compared_chapters` (array): a complete non-truncated batch of other active
-  chapters, each with the same fields as `target_chapter`
-- `evidence_links` (array): target-chapter evidence metadata with a one-based
-  `position`, source label, and optional location, claim, and summary
 </input>
 
 <output>
@@ -97,17 +76,13 @@ Return only one `ChapterConsistencyValidationOutput` JSON object.
   - `excerpts` (array of strings): zero to three short verbatim excerpts from
     the involved chapters
   - `evidence_positions` (array of integers): unique one-based positions from
-    `evidence_links` relevant to the finding; empty when none
+    `document.evidence_links` relevant to the finding; empty when none
 
 Do not emit workflow status, labels, timestamps, or model reasoning.
 </output>
 
 <example_output>
-{"findings":[{"category":"cross_chapter_conflict","severity":"blocking","message":"The target chapter states a EUR 4 million total while the budget chapter states EUR 5 million.","suggested_action":"Confirm the approved total and use the same amount in both chapters.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111","22222222-2222-4222-8222-222222222222"],"excerpts":["The total project cost is EUR 4 million.","Total eligible expenditure: EUR 5 million."],"evidence_positions":[1]}]}
-</example_output>
-
-<example_output>
-{"findings":[{"category":"logic_error","severity":"blocking","message":"The target defines the proposal as delivery of the route while also stating that construction is 97% complete and commissioning is underway.","suggested_action":"Define a genuinely future residual or follow-on measure, schedule, and cost, and distinguish it from current works.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111"],"excerpts":["The proposed measure is delivery of the route.","Construction is 97% complete and commissioning is underway."],"evidence_positions":[]},{"category":"cross_chapter_conflict","severity":"blocking","message":"The target includes delivery of the current route while the support chapter excludes ongoing construction and commissioning.","suggested_action":"Use one explicit eligible future scope in both chapters and exclude current works consistently.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111","22222222-2222-4222-8222-222222222222"],"excerpts":["The proposed measure is delivery of the route.","Support will not fund ongoing construction or commissioning."],"evidence_positions":[]}]}
+{"findings":[{"category":"cross_chapter_conflict","severity":"blocking","message":"The output states a EUR 4 million total while the document budget states EUR 5 million.","suggested_action":"Confirm the approved total and use the same amount in both chapters.","involved_chapter_ids":["11111111-1111-4111-8111-111111111111","22222222-2222-4222-8222-222222222222"],"excerpts":["The total project cost is EUR 4 million.","Total eligible expenditure: EUR 5 million."],"evidence_positions":[1]}]}
 </example_output>
 
 <example_output>

--- a/climate-advisor/prompts/cnb/chat.md
+++ b/climate-advisor/prompts/cnb/chat.md
@@ -8,6 +8,16 @@ similar projects, and current concept-note content. Ground factual answers in th
 authorized run context and source-query results. This chat does not persist
 document edits or resolve missing-information records: clearly label proposed
 wording as an unsaved suggestion and never claim to have applied a change.
+
+Assume the user has no knowledge of internal run context, workflow stages, or
+chapter orchestration. A short or vague request such as "Help me", "What should I
+do next?", or "Work on my concept note" is enough to ask for guidance. Infer the
+next useful action from the supplied `workflow_step` and available context. Never
+require the user to say "use only this", identify a run, or instruct you to visit
+template chapters in order. Treat the concept note as one guided workflow and use
+the available template or document order automatically. When the next chapter or
+required detail is unavailable, say what is missing and ask one focused question
+instead of inventing workflow state.
 </task>
 
 <input>
@@ -22,7 +32,8 @@ CONCEPT_NOTE_CONTEXT_BUNDLE_JSON, followed by a JSON object containing:
   sections may be null.
 - `funder_context` (object or null): available funding context.
 - `similar_projects` (array of objects): available comparable projects.
-- `document_context` (object or null): available concept-note document context.
+- `document_context` (object or null): available concept-note document and
+  chapter state, including order when supplied.
 - `context_bundle_status` (object): bundle readiness, not project evidence.
 
 If CONCEPT_NOTE_CONTEXT_BUNDLE_UNAVAILABLE is supplied, or a section is missing,

--- a/climate-advisor/prompts/cnb/funding_opportunity_research.md
+++ b/climate-advisor/prompts/cnb/funding_opportunity_research.md
@@ -50,6 +50,15 @@ For each sparse project retain evidence at
 its funded relationship to this program. Add field-level evidence for optional
 values. Retain disagreements in `conflicts`; never infer awards, rules, weights,
 hard gates, dates, projects, or statuses.
+
+For application templates, assign each source-backed required field to the
+applicable chapter's `required_fields`. Preserve the exact field text from the
+template-level inventory. Requirements applying to several chapters must appear
+on each applicable chapter; use an empty array when no fields are required there.
+Keep template-level `required_fields` as the complete inventory. If the source
+does not establish field ownership, retain the inventory field and record a gap
+for its chapter assignment rather than guessing. Such a template needs review
+before chapter validation can run.
 </task>
 
 <input>
@@ -108,8 +117,9 @@ Required top-level fields:
   `award_year`, `status`, `summary`, and string arrays `hazards` and
   `interventions`
 - `funder_templates`: rows with `template_name`, nullable `output_format`, a
-  `chapter_schema` of `title`, nullable `description` and
-  `required`, and `required_fields`
+  `chapter_schema` array of objects with `title`, nullable `description` and
+  `required`, and chapter-specific `required_fields` (string array); the template
+  also has `required_fields` (string array inventory across chapters)
 - `funder_criteria`: rows with `criterion_type`, `label`, `requirement_text`,
   nullable `weight`, `hard_gate`, and `normalized_rule`
 - `source_assessments`: rows with captured `source_url`, `source_type`, nullable ISO

--- a/climate-advisor/service/app/config/settings.py
+++ b/climate-advisor/service/app/config/settings.py
@@ -137,6 +137,7 @@ class ModelsConfig(BaseModel):
     cnb_source_reader: ResearchModelConfig
     cnb_source_synthesizer: ResearchModelConfig
     cnb_chapter_drafter: ResearchModelConfig | None = None
+    cnb_chapter_validator: ResearchModelConfig
 
 
 class StationaryEnergyPromptBudgetFlowConfig(BaseModel):
@@ -161,6 +162,12 @@ class CnbSourcePromptBudgetConfig(BaseModel):
     max_question_chars: int = Field(default=2000, ge=1, le=10000)
 
 
+class CnbValidationPromptBudgetConfig(BaseModel):
+    """Full-prompt limit for non-truncating chapter validation batches."""
+
+    max_prompt_tokens: int = Field(default=50000, ge=1000)
+
+
 class PromptBudgetConfig(BaseModel):
     tokenizer_encoding: str = "o200k_base"
     stationary_energy: StationaryEnergyPromptBudgetConfig = Field(
@@ -168,6 +175,9 @@ class PromptBudgetConfig(BaseModel):
     )
     cnb_sources: CnbSourcePromptBudgetConfig = Field(
         default_factory=CnbSourcePromptBudgetConfig,
+    )
+    cnb_validation: CnbValidationPromptBudgetConfig = Field(
+        default_factory=CnbValidationPromptBudgetConfig,
     )
 
 
@@ -191,6 +201,12 @@ class PromptsConfig(BaseModel):
     cnb_source_summary_synthesis: str = "prompts/cnb/source_summary_synthesis.md"
     cnb_source_question_reading: str = "prompts/cnb/source_question_reading.md"
     cnb_chapter_drafting: str = "prompts/cnb/chapter_drafting.md"
+    cnb_chapter_validation_completeness: str = (
+        "prompts/cnb/chapter_validation_completeness.md"
+    )
+    cnb_chapter_validation_consistency: str = (
+        "prompts/cnb/chapter_validation_consistency.md"
+    )
 
     def get_prompt(self, prompt_type: str) -> str:
         """Load prompt content from file."""

--- a/climate-advisor/service/app/main.py
+++ b/climate-advisor/service/app/main.py
@@ -8,6 +8,9 @@ from app.middleware.request_context import RequestContextMiddleware, get_request
 from app.routes.concept_note_city_context import (
     router as concept_note_city_context_router,
 )
+from app.routes.concept_note_chapter_validation import (
+    router as concept_note_chapter_validation_router,
+)
 from app.routes.concept_note_context_bundle import (
     router as concept_note_context_bundle_router,
 )
@@ -117,6 +120,7 @@ def get_app() -> FastAPI:
     app.include_router(stationary_energy_drafts_router, prefix="/v1")
     app.include_router(concept_note_markdown_router, prefix="/v1")
     app.include_router(concept_note_city_context_router, prefix="/v1")
+    app.include_router(concept_note_chapter_validation_router, prefix="/v1")
     app.include_router(concept_note_context_bundle_router, prefix="/v1")
     app.include_router(concept_note_runs_router, prefix="/v1")
 

--- a/climate-advisor/service/app/models/cnb/concept_note_chapter_validation.py
+++ b/climate-advisor/service/app/models/cnb/concept_note_chapter_validation.py
@@ -1,0 +1,171 @@
+"""Contracts for two-pass Concept Note chapter validation."""
+
+from __future__ import annotations
+
+from typing import Annotated, ClassVar, Literal, Self
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+ChapterValidationStatus = Literal["ready", "needs_review", "incomplete"]
+ChapterValidationPhase = Literal["completeness", "consistency", "evidence"]
+ChapterValidationSeverity = Literal["warning", "blocking"]
+ChapterValidationFindingCategory = Literal[
+    "missing_information",
+    "template_constraint",
+    "unresolved_gap",
+    "evidence",
+    "internal_conflict",
+    "cross_chapter_conflict",
+    "logic_error",
+]
+
+ConciseText = Annotated[str, Field(min_length=1, max_length=1_000)]
+ExcerptText = Annotated[str, Field(min_length=1, max_length=500)]
+
+
+class ChapterValidationChapter(BaseModel):
+    """One active chapter supplied by the workspace repository."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    chapter_id: UUID
+    template_section_id: str | None = None
+    title: str = Field(min_length=1, max_length=500)
+    position: int = Field(ge=0)
+    required: bool
+    body_markdown: str | None = None
+    revision_number: int | None = Field(default=None, ge=1)
+
+
+class ChapterValidationTemplate(BaseModel):
+    """Application-template context used by the completeness pass."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    template_id: UUID
+    name: str = Field(min_length=1, max_length=500)
+    output_format: str | None = None
+    chapter_schema: list[dict[str, object]] = Field(default_factory=list)
+    required_fields: list[str] = Field(default_factory=list)
+
+
+class ChapterValidationGap(BaseModel):
+    """One open workspace gap relevant to the target chapter."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    severity: str = Field(min_length=1, max_length=100)
+    reason: str = Field(min_length=1, max_length=2_000)
+    field_key: str | None = Field(default=None, max_length=255)
+
+
+class ChapterValidationEvidenceLink(BaseModel):
+    """Persisted evidence metadata available for target-chapter claims."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    selected_source_label: str = Field(min_length=1, max_length=1_000)
+    source_location: str | None = Field(default=None, max_length=2_000)
+    claim_ref: str | None = Field(default=None, max_length=1_000)
+    quote_or_summary: str | None = Field(default=None, max_length=4_000)
+
+
+class ChapterValidationRequest(BaseModel):
+    """Repository-facing immutable inputs for one explicit validation attempt."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    target_chapter_id: UUID
+    validation_input_fingerprint: str = Field(pattern=r"^[0-9a-f]{64}$")
+    chapters: list[ChapterValidationChapter] = Field(min_length=1)
+    template: ChapterValidationTemplate | None = None
+    open_gaps: list[ChapterValidationGap] = Field(default_factory=list)
+    evidence_links: list[ChapterValidationEvidenceLink] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_chapter_identity(self) -> Self:
+        """Require one unique target inside the active document snapshot."""
+        chapter_ids = [chapter.chapter_id for chapter in self.chapters]
+        if len(chapter_ids) != len(set(chapter_ids)):
+            raise ValueError("chapters must contain unique chapter_id values")
+        if self.target_chapter_id not in chapter_ids:
+            raise ValueError("target_chapter_id must identify an active chapter")
+        return self
+
+
+class ChapterValidationFindingDraft(BaseModel):
+    """Concise actionable finding returned by a validation pass."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    category: ChapterValidationFindingCategory
+    severity: ChapterValidationSeverity
+    message: ConciseText
+    suggested_action: ConciseText
+    involved_chapter_ids: list[UUID] = Field(min_length=1, max_length=10)
+    excerpts: list[ExcerptText] = Field(default_factory=list, max_length=3)
+
+
+class _ChapterValidationOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    allowed_categories: ClassVar[set[ChapterValidationFindingCategory]]
+    findings: list[ChapterValidationFindingDraft] = Field(
+        default_factory=list,
+        max_length=50,
+    )
+
+    @model_validator(mode="after")
+    def validate_categories(self) -> Self:
+        if any(
+            finding.category not in self.allowed_categories for finding in self.findings
+        ):
+            raise ValueError("validation output contains an out-of-scope finding")
+        return self
+
+
+class ChapterCompletenessValidationOutput(_ChapterValidationOutput):
+    """Missing-information and evidence findings from the first pass."""
+
+    allowed_categories = {
+        "missing_information",
+        "template_constraint",
+        "unresolved_gap",
+        "evidence",
+    }
+
+
+class ChapterConsistencyValidationOutput(_ChapterValidationOutput):
+    """Logic and contradiction findings from the second pass."""
+
+    allowed_categories = {
+        "internal_conflict",
+        "cross_chapter_conflict",
+        "logic_error",
+    }
+
+
+class ChapterValidationFinding(BaseModel):
+    """Stable public finding contract persisted and exposed to the frontend."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    phase: ChapterValidationPhase
+    category: ChapterValidationFindingCategory
+    severity: ChapterValidationSeverity
+    message: ConciseText
+    suggested_action: ConciseText
+    involved_chapter_ids: list[UUID] = Field(min_length=1, max_length=10)
+    excerpts: list[ExcerptText] = Field(default_factory=list, max_length=3)
+
+
+class ChapterValidationDecision(BaseModel):
+    """Persistence-ready result produced only after both validation passes."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    target_chapter_id: UUID
+    validated_revision_number: int | None = Field(default=None, ge=1)
+    validation_input_fingerprint: str = Field(pattern=r"^[0-9a-f]{64}$")
+    status: ChapterValidationStatus
+    findings: list[ChapterValidationFinding] = Field(default_factory=list)

--- a/climate-advisor/service/app/models/cnb/concept_note_chapter_validation.py
+++ b/climate-advisor/service/app/models/cnb/concept_note_chapter_validation.py
@@ -40,7 +40,7 @@ class ChapterValidationChapter(BaseModel):
 
 
 class ChapterValidationTemplate(BaseModel):
-    """Application-template context used by the completeness pass."""
+    """Full template retained in code for deterministic chapter selection."""
 
     model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
@@ -49,6 +49,15 @@ class ChapterValidationTemplate(BaseModel):
     output_format: str | None = None
     chapter_schema: list[dict[str, object]] = Field(default_factory=list)
     required_fields: list[str] = Field(default_factory=list)
+
+
+class ChapterValidationProfile(BaseModel):
+    """Only the selected chapter's template requirements sent to the model."""
+
+    name: str
+    output_format: str | None = None
+    chapter_schema: dict[str, object]
+    required_fields: list[str]
 
 
 class ChapterValidationGap(BaseModel):

--- a/climate-advisor/service/app/models/cnb/concept_note_chapter_validation.py
+++ b/climate-advisor/service/app/models/cnb/concept_note_chapter_validation.py
@@ -22,6 +22,7 @@ ChapterValidationFindingCategory = Literal[
 
 ConciseText = Annotated[str, Field(min_length=1, max_length=1_000)]
 ExcerptText = Annotated[str, Field(min_length=1, max_length=500)]
+EvidencePosition = Annotated[int, Field(ge=1)]
 
 
 class ChapterValidationChapter(BaseModel):
@@ -105,6 +106,9 @@ class ChapterValidationFindingDraft(BaseModel):
     suggested_action: ConciseText
     involved_chapter_ids: list[UUID] = Field(min_length=1, max_length=10)
     excerpts: list[ExcerptText] = Field(default_factory=list, max_length=3)
+    evidence_positions: list[EvidencePosition] = Field(
+        default_factory=list, max_length=10
+    )
 
 
 class _ChapterValidationOutput(BaseModel):
@@ -157,6 +161,10 @@ class ChapterValidationFinding(BaseModel):
     suggested_action: ConciseText
     involved_chapter_ids: list[UUID] = Field(min_length=1, max_length=10)
     excerpts: list[ExcerptText] = Field(default_factory=list, max_length=3)
+    evidence: list[ChapterValidationEvidenceLink] = Field(
+        default_factory=list,
+        max_length=10,
+    )
 
 
 class ChapterValidationDecision(BaseModel):

--- a/climate-advisor/service/app/models/cnb/concept_note_draft.py
+++ b/climate-advisor/service/app/models/cnb/concept_note_draft.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
@@ -14,6 +15,9 @@ ConceptNoteChapterStatus = Literal[
     "needs_review",
     "ready",
 ]
+ConceptNoteValidationStatus = Literal["ready", "needs_review", "incomplete"]
+ConceptNoteValidationCheckStatus = Literal["pass", "warning", "fail"]
+ConceptNoteValidationFindingSeverity = Literal["warning", "blocking"]
 
 
 class ConceptNoteChapterDraftOutput(BaseModel):
@@ -23,6 +27,46 @@ class ConceptNoteChapterDraftOutput(BaseModel):
 
     body_markdown: str = Field(min_length=1, max_length=50_000)
     missing_information: list[str] = Field(default_factory=list, max_length=30)
+
+
+class ConceptNoteValidationCheckResponse(BaseModel):
+    """One derived readiness area in the public validation response."""
+
+    key: str
+    label: str
+    status: ConceptNoteValidationCheckStatus
+    message: str | None = None
+
+
+class ConceptNoteValidationFindingResponse(BaseModel):
+    """One actionable issue found by a validation pass or deterministic gate."""
+
+    phase: str
+    category: str
+    severity: ConceptNoteValidationFindingSeverity
+    message: str
+    suggested_action: str
+    involved_chapter_ids: list[UUID] = Field(default_factory=list)
+    excerpts: list[str] = Field(default_factory=list)
+
+
+class ConceptNoteChapterValidationResponse(BaseModel):
+    """Latest persisted chapter validation with server-derived staleness."""
+
+    status: ConceptNoteValidationStatus
+    is_stale: bool
+    validated_revision_number: int | None = Field(default=None, ge=1)
+    validated_at: datetime
+    checks: list[ConceptNoteValidationCheckResponse] = Field(default_factory=list)
+    findings: list[ConceptNoteValidationFindingResponse] = Field(default_factory=list)
+
+
+class ConceptNoteChapterValidationActionResponse(
+    ConceptNoteChapterValidationResponse
+):
+    """Explicit mark-ready response identifying the validated chapter."""
+
+    chapter_id: UUID
 
 
 class ConceptNoteDraftChapterResponse(BaseModel):
@@ -38,6 +82,7 @@ class ConceptNoteDraftChapterResponse(BaseModel):
     body_markdown: str | None = None
     missing_information: list[str] = Field(default_factory=list)
     revision_number: int | None = Field(default=None, ge=1)
+    validation: ConceptNoteChapterValidationResponse | None = None
 
 
 class ConceptNoteDraftResponse(BaseModel):

--- a/climate-advisor/service/app/models/cnb/concept_note_draft.py
+++ b/climate-advisor/service/app/models/cnb/concept_note_draft.py
@@ -6,6 +6,9 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
+from app.models.cnb.concept_note_chapter_validation import (
+    ChapterValidationEvidenceLink,
+)
 from pydantic import BaseModel, ConfigDict, Field
 
 ConceptNoteDraftStatus = Literal["not_started", "running", "failed", "complete"]
@@ -48,6 +51,10 @@ class ConceptNoteValidationFindingResponse(BaseModel):
     suggested_action: str
     involved_chapter_ids: list[UUID] = Field(default_factory=list)
     excerpts: list[str] = Field(default_factory=list)
+    evidence: list[ChapterValidationEvidenceLink] = Field(
+        default_factory=list,
+        max_length=10,
+    )
 
 
 class ConceptNoteChapterValidationResponse(BaseModel):
@@ -61,9 +68,7 @@ class ConceptNoteChapterValidationResponse(BaseModel):
     findings: list[ConceptNoteValidationFindingResponse] = Field(default_factory=list)
 
 
-class ConceptNoteChapterValidationActionResponse(
-    ConceptNoteChapterValidationResponse
-):
+class ConceptNoteChapterValidationActionResponse(ConceptNoteChapterValidationResponse):
     """Explicit mark-ready response identifying the validated chapter."""
 
     chapter_id: UUID

--- a/climate-advisor/service/app/models/cnb/concept_note_runs.py
+++ b/climate-advisor/service/app/models/cnb/concept_note_runs.py
@@ -6,6 +6,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from app.models.cnb.concept_note_markdown import ConceptNoteUploadStatusResponse
+
 
 class ConceptNoteStartRequest(BaseModel):
     """Authenticated request to create one Concept Note Builder run."""
@@ -95,6 +97,7 @@ class ConceptNoteRunResponse(ConceptNoteRunListItemResponse):
     """Persisted concept-note run returned by start and detail endpoints."""
 
     user_id: str
+    uploads: list[ConceptNoteUploadStatusResponse] = Field(default_factory=list)
     next_action: Literal["load_context"] = "load_context"
     created: bool
     trace_id: str | None = None

--- a/climate-advisor/service/app/models/cnb/research.py
+++ b/climate-advisor/service/app/models/cnb/research.py
@@ -7,9 +7,8 @@ from decimal import Decimal
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl, JsonValue, model_validator
-
 from app.models.cnb.similar_projects import CnbSimilarProjectSearchRequest
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, JsonValue, model_validator
 
 
 def _ensure_unique(values: list[str], field_name: str) -> None:
@@ -43,7 +42,7 @@ class FieldEvidence(ResearchModel):
     quote_or_summary: str
 
     @model_validator(mode="after")
-    def validate_exactly_one_parent(self) -> "FieldEvidence":
+    def validate_exactly_one_parent(self) -> FieldEvidence:
         """Require evidence to identify exactly one funding parent."""
         has_opportunity = self.funding_opportunity_ref is not None
         has_project = self.funded_project_ref is not None
@@ -181,6 +180,10 @@ class TemplateChapterDraft(ResearchModel):
     title: str
     description: str | None = None
     required: bool | None = None
+    required_fields: list[str] = Field(
+        default_factory=list,
+        description="Source-backed required fields belonging to this chapter only.",
+    )
 
 
 class FunderTemplateDraft(ResearchModel):
@@ -244,7 +247,7 @@ class FunderProfileResearchResult(ResearchModel):
     derived: list[FunderProfileFact] = Field(default_factory=list)
 
     @model_validator(mode="after")
-    def validate_unique_keys(self) -> "FunderProfileResearchResult":
+    def validate_unique_keys(self) -> FunderProfileResearchResult:
         """Prevent dictionary conversion from silently replacing profile facts."""
         _ensure_unique([item.key for item in self.stated], "profile.stated.key")
         _ensure_unique([item.key for item in self.derived], "profile.derived.key")
@@ -320,7 +323,7 @@ class FunderTemplateResearchResult(ResearchModel):
     required_fields: list[str] = Field(default_factory=list)
 
     @model_validator(mode="after")
-    def validate_unique_chapter_refs(self) -> "FunderTemplateResearchResult":
+    def validate_unique_chapter_refs(self) -> FunderTemplateResearchResult:
         """Keep application-template chapter paths unambiguous for review."""
         _ensure_unique(
             [item.chapter_ref for item in self.chapter_schema],
@@ -365,7 +368,7 @@ class FundingOpportunityResearchResult(ResearchModel):
     conflicts: list[ResearchConflictResult] = Field(default_factory=list)
 
     @model_validator(mode="after")
-    def validate_result_references(self) -> "FundingOpportunityResearchResult":
+    def validate_result_references(self) -> FundingOpportunityResearchResult:
         """Require one opportunity and valid project, evidence, and conflict links."""
         reference_lists = (
             (

--- a/climate-advisor/service/app/models/db/cnb_workspace.py
+++ b/climate-advisor/service/app/models/db/cnb_workspace.py
@@ -116,6 +116,58 @@ class ConceptNoteChapterRevision(CnbBase):
     )
 
 
+class ConceptNoteChapterValidation(CnbBase):
+    """Latest structured readiness validation for a concept-note chapter."""
+
+    __tablename__ = "concept_note_chapter_validations"
+
+    validation_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    chapter_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey(
+            "concept_note_chapters.chapter_id",
+            name="fk_cnb_chapter_validations_chapter",
+            ondelete="CASCADE",
+        ),
+        nullable=False,
+    )
+    validated_revision_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey(
+            "concept_note_chapter_revisions.revision_id",
+            name="fk_cnb_chapter_validations_revision",
+            ondelete="SET NULL",
+        ),
+    )
+    validation_input_fingerprint: Mapped[str] = mapped_column(
+        String(64), nullable=False
+    )
+    status: Mapped[str] = mapped_column(String(32), nullable=False)
+    findings: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSONBCompat(), nullable=False, default=list, server_default=text("'[]'::jsonb")
+    )
+    validated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "chapter_id",
+            name="uq_concept_note_chapter_validations_chapter",
+        ),
+        CheckConstraint(
+            "status IN ('ready', 'needs_review', 'incomplete')",
+            name="status_valid",
+        ),
+        CheckConstraint(
+            "length(validation_input_fingerprint) = 64",
+            name="fingerprint_length",
+        ),
+    )
+
+
 class ConceptNoteEvidenceLink(CnbBase):
     """Workspace citation from a chapter claim to selected run context."""
 

--- a/climate-advisor/service/app/persistence/concept_notes/runs.py
+++ b/climate-advisor/service/app/persistence/concept_notes/runs.py
@@ -6,7 +6,7 @@ from app.models.cnb.context_bundle import ConceptNoteContextBundle
 from app.models.db.concept_note import (
     ConceptNoteContextBundle as ConceptNoteContextBundleRow,
 )
-from app.models.db.concept_note import ConceptNoteRun
+from app.models.db.concept_note import ConceptNoteRun, ConceptNoteUpload
 from app.models.db.thread import Thread
 from app.utils.chat_workflow_context import (
     CONCEPT_NOTE_RUN_ID_KEY,
@@ -146,6 +146,26 @@ class ConceptNoteRunRepository:
             )
         )
         result = await self.session.execute(query)
+        return list(result.scalars().all())
+
+    async def list_uploads_for_run(
+        self,
+        *,
+        run_id: UUID,
+        user_id: str,
+    ) -> list[ConceptNoteUpload]:
+        """Return a run's owned uploads in deterministic newest-first order."""
+        result = await self.session.execute(
+            select(ConceptNoteUpload)
+            .where(
+                ConceptNoteUpload.run_id == run_id,
+                ConceptNoteUpload.uploaded_by_user_id == user_id,
+            )
+            .order_by(
+                ConceptNoteUpload.received_at.desc(),
+                ConceptNoteUpload.upload_id.desc(),
+            )
+        )
         return list(result.scalars().all())
 
     async def bind_thread_context(

--- a/climate-advisor/service/app/persistence/concept_notes/workspace.py
+++ b/climate-advisor/service/app/persistence/concept_notes/workspace.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+import json
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from hashlib import sha256
 from typing import Any
 from uuid import UUID
 
 from app.models.db.cnb_workspace import (
     ConceptNoteChapter,
     ConceptNoteChapterRevision,
+    ConceptNoteChapterValidation,
     ConceptNoteEvidenceLink,
     ConceptNoteExport,
     ConceptNoteGap,
@@ -44,6 +47,69 @@ class WorkspaceChapterSnapshot:
     body_markdown: str | None
     missing_information: list[str]
     revision_number: int | None
+    revision_id: UUID | None = None
+    validation: WorkspaceValidationSnapshot | None = None
+
+
+@dataclass(frozen=True)
+class WorkspaceValidationSnapshot:
+    """Detached latest validation plus its derived freshness state."""
+
+    validation_id: UUID
+    status: str
+    is_stale: bool
+    validated_revision_id: UUID | None
+    validated_revision_number: int | None
+    validation_input_fingerprint: str
+    validated_at: datetime
+    findings: list[dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class WorkspaceValidationChapter:
+    """One active chapter and the immutable revision supplied to validation."""
+
+    chapter_id: UUID
+    chapter_ref: str | None
+    title: str
+    position: int
+    status: str
+    required: bool
+    body_markdown: str | None
+    revision_id: UUID | None
+    revision_number: int | None
+
+
+@dataclass(frozen=True)
+class WorkspaceValidationGap:
+    """One open target-chapter gap included in the validation fingerprint."""
+
+    gap_id: UUID
+    field_key: str | None
+    severity: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class WorkspaceValidationEvidence:
+    """One target-chapter evidence link included in validation input."""
+
+    evidence_link_id: UUID
+    selected_source_label: str
+    source_location: str | None
+    claim_ref: str | None
+    quote_or_summary: str
+
+
+@dataclass(frozen=True)
+class WorkspaceValidationContext:
+    """Consistent database input for both chapter-validation passes."""
+
+    target: WorkspaceValidationChapter
+    chapters: list[WorkspaceValidationChapter]
+    open_gaps: list[WorkspaceValidationGap]
+    evidence_links: list[WorkspaceValidationEvidence]
+    fingerprint: str
 
 
 @dataclass(frozen=True)
@@ -52,6 +118,10 @@ class WorkspaceCopyResult:
 
     completed_chapters: int
     total_chapters: int
+
+
+class WorkspaceValidationInputChangedError(Exception):
+    """The persisted validation input changed after LLM evaluation started."""
 
 
 class ConceptNoteWorkspaceRepository:
@@ -150,25 +220,105 @@ class ConceptNoteWorkspaceRepository:
         self,
         *,
         run_id: UUID,
+        template_fingerprint: str | None = None,
     ) -> list[WorkspaceChapterSnapshot]:
         """Return active chapters in document order with latest Markdown."""
         async with self._session_factory() as session:
-            chapters = list(
-                (
-                    await session.scalars(
-                        select(ConceptNoteChapter)
-                        .where(
-                            ConceptNoteChapter.run_id == run_id,
-                            ConceptNoteChapter.status != "deleted",
-                        )
-                        .order_by(
-                            ConceptNoteChapter.position.asc(),
-                            ConceptNoteChapter.chapter_id.asc(),
-                        )
-                    )
-                ).all()
+            return await _snapshot_chapters(
+                session,
+                run_id,
+                template_fingerprint=template_fingerprint,
             )
-            return [await _snapshot_chapter(session, chapter) for chapter in chapters]
+
+    async def load_validation_context(
+        self,
+        *,
+        run_id: UUID,
+        chapter_id: UUID,
+        template_fingerprint: str,
+    ) -> WorkspaceValidationContext:
+        """Load the target, full document, gaps, evidence, and input fingerprint."""
+        async with self._session_factory() as session:
+            return await _load_validation_context(
+                session,
+                run_id=run_id,
+                chapter_id=chapter_id,
+                template_fingerprint=template_fingerprint,
+            )
+
+    async def upsert_validation(
+        self,
+        *,
+        run_id: UUID,
+        chapter_id: UUID,
+        template_fingerprint: str,
+        expected_fingerprint: str,
+        status: str,
+        findings: list[dict[str, Any]],
+    ) -> WorkspaceValidationSnapshot:
+        """Atomically replace a validation if its complete input remains current.
+
+        Raises:
+            WorkspaceValidationInputChangedError: If any fingerprinted input changed.
+            ValueError: If the chapter or validation status is invalid.
+        """
+        if status not in {"ready", "needs_review", "incomplete"}:
+            raise ValueError(f"Unsupported chapter validation status: {status}")
+
+        async with self._session_factory() as session, session.begin():
+            # Lock the active document before checking the post-LLM fingerprint.
+            context = await _load_validation_context(
+                session,
+                run_id=run_id,
+                chapter_id=chapter_id,
+                template_fingerprint=template_fingerprint,
+                lock=True,
+            )
+            if context.fingerprint != expected_fingerprint:
+                raise WorkspaceValidationInputChangedError(
+                    "Concept Note validation input changed during evaluation"
+                )
+
+            # Replace the one latest result and lifecycle state together.
+            stored = await session.scalar(
+                select(ConceptNoteChapterValidation)
+                .where(ConceptNoteChapterValidation.chapter_id == chapter_id)
+                .with_for_update()
+            )
+            validated_at = datetime.now(UTC)
+            if stored is None:
+                stored = ConceptNoteChapterValidation(chapter_id=chapter_id)
+                session.add(stored)
+            stored.validated_revision_id = context.target.revision_id
+            stored.validation_input_fingerprint = context.fingerprint
+            stored.status = status
+            stored.findings = deepcopy(findings)
+            stored.validated_at = validated_at
+
+            chapter = await session.get(ConceptNoteChapter, chapter_id)
+            if chapter is None:
+                raise ValueError(f"Concept Note chapter {chapter_id} was not found")
+            if status == "ready":
+                chapter.status = "ready"
+            elif status == "needs_review":
+                chapter.status = "needs_review"
+            else:
+                chapter.status = (
+                    "draft" if context.target.revision_id is not None else "empty"
+                )
+            chapter.updated_at = validated_at
+            await session.flush()
+
+            return WorkspaceValidationSnapshot(
+                validation_id=stored.validation_id,
+                status=stored.status,
+                is_stale=False,
+                validated_revision_id=stored.validated_revision_id,
+                validated_revision_number=context.target.revision_number,
+                validation_input_fingerprint=stored.validation_input_fingerprint,
+                validated_at=stored.validated_at,
+                findings=deepcopy(stored.findings),
+            )
 
     async def copy_working_copy(
         self,
@@ -178,126 +328,28 @@ class ConceptNoteWorkspaceRepository:
     ) -> WorkspaceCopyResult:
         """Replace a destination with an independent copy of current workspace state."""
         async with self._session_factory() as session, session.begin():
-            # Make retries deterministic after any earlier transaction failure.
+            # Step 1: make retries deterministic and load the source in bulk.
             await _delete_workspace_rows(session, destination_run_id)
-            source_chapters = list(
-                (
-                    await session.scalars(
-                        select(ConceptNoteChapter)
-                        .where(
-                            ConceptNoteChapter.run_id == source_run_id,
-                            ConceptNoteChapter.status != "deleted",
-                        )
-                        .order_by(
-                            ConceptNoteChapter.position.asc(),
-                            ConceptNoteChapter.chapter_id.asc(),
-                        )
-                    )
-                ).all()
+            source_chapters = await _active_chapters(session, source_run_id)
+            chapter_ids = [chapter.chapter_id for chapter in source_chapters]
+            revisions = await _latest_revisions(session, chapter_ids)
+            evidence_by_chapter = await _evidence_by_chapter(session, chapter_ids)
+            gaps = await _run_gaps(session, source_run_id)
+            matches = await _run_matches(session, source_run_id)
+
+            # Step 2: clone chapters first so dependent rows can be remapped.
+            chapter_map, completed_chapters = await _copy_chapters(
+                session,
+                destination_run_id=destination_run_id,
+                source_chapters=source_chapters,
+                revisions=revisions,
+                evidence_by_chapter=evidence_by_chapter,
+                gaps=gaps,
             )
-            chapter_map: dict[UUID, UUID] = {}
-            completed_chapters = 0
 
-            # Copy chapter metadata and only the latest body as revision one.
-            for source_chapter in source_chapters:
-                destination_chapter = ConceptNoteChapter(
-                    run_id=destination_run_id,
-                    template_section_id=source_chapter.template_section_id,
-                    title=source_chapter.title,
-                    position=source_chapter.position,
-                    status=source_chapter.status,
-                    required=source_chapter.required,
-                    user_locked=source_chapter.user_locked,
-                )
-                session.add(destination_chapter)
-                await session.flush()
-                chapter_map[source_chapter.chapter_id] = destination_chapter.chapter_id
-
-                latest = await _latest_revision(session, source_chapter.chapter_id)
-                if latest is not None:
-                    session.add(
-                        ConceptNoteChapterRevision(
-                            chapter_id=destination_chapter.chapter_id,
-                            revision_number=1,
-                            author_type="system",
-                            change_type="draft",
-                            body_markdown=latest.body_markdown,
-                            patch_summary={
-                                "duplicated_from_revision_id": str(latest.revision_id)
-                            },
-                        )
-                    )
-                    completed_chapters += 1
-
-                evidence_links = list(
-                    (
-                        await session.scalars(
-                            select(ConceptNoteEvidenceLink).where(
-                                ConceptNoteEvidenceLink.chapter_id
-                                == source_chapter.chapter_id
-                            )
-                        )
-                    ).all()
-                )
-                for evidence in evidence_links:
-                    session.add(
-                        ConceptNoteEvidenceLink(
-                            chapter_id=destination_chapter.chapter_id,
-                            selected_source_label=evidence.selected_source_label,
-                            source_location=evidence.source_location,
-                            claim_ref=evidence.claim_ref,
-                            quote_or_summary=evidence.quote_or_summary,
-                        )
-                    )
-
-            # Copy run-scoped gaps and remap any chapter relationship.
-            gaps = list(
-                (
-                    await session.scalars(
-                        select(ConceptNoteGap).where(
-                            ConceptNoteGap.run_id == source_run_id
-                        )
-                    )
-                ).all()
-            )
-            for gap in gaps:
-                session.add(
-                    ConceptNoteGap(
-                        run_id=destination_run_id,
-                        chapter_id=(
-                            chapter_map.get(gap.chapter_id)
-                            if gap.chapter_id is not None
-                            else None
-                        ),
-                        field_key=gap.field_key,
-                        severity=gap.severity,
-                        reason=gap.reason,
-                        status=gap.status,
-                    )
-                )
-
-            # Copy selected project matches as independent mutable rows.
-            matches = list(
-                (
-                    await session.scalars(
-                        select(ConceptNoteMatchedProject).where(
-                            ConceptNoteMatchedProject.run_id == source_run_id
-                        )
-                    )
-                ).all()
-            )
-            for match in matches:
-                session.add(
-                    ConceptNoteMatchedProject(
-                        run_id=destination_run_id,
-                        funded_project_id=match.funded_project_id,
-                        decision=match.decision,
-                        fit_rationale=match.fit_rationale,
-                        matched_tags=deepcopy(match.matched_tags),
-                        evidence=deepcopy(match.evidence),
-                        caveats=deepcopy(match.caveats),
-                    )
-                )
+            # Step 3: clone run-scoped rows after chapter identities are known.
+            _copy_gaps(session, destination_run_id, gaps, chapter_map)
+            _copy_matches(session, destination_run_id, matches)
 
             return WorkspaceCopyResult(
                 completed_chapters=completed_chapters,
@@ -308,6 +360,150 @@ class ConceptNoteWorkspaceRepository:
         """Delete every managed workspace row owned by one CA run."""
         async with self._session_factory() as session, session.begin():
             await _delete_workspace_rows(session, run_id)
+
+
+async def _run_gaps(
+    session: AsyncSession,
+    run_id: UUID,
+) -> list[ConceptNoteGap]:
+    """Load every run-scoped gap copied into a duplicated workspace."""
+    return list(
+        (
+            await session.scalars(
+                select(ConceptNoteGap).where(ConceptNoteGap.run_id == run_id)
+            )
+        ).all()
+    )
+
+
+async def _run_matches(
+    session: AsyncSession,
+    run_id: UUID,
+) -> list[ConceptNoteMatchedProject]:
+    """Load selected project matches copied into a duplicated workspace."""
+    return list(
+        (
+            await session.scalars(
+                select(ConceptNoteMatchedProject).where(
+                    ConceptNoteMatchedProject.run_id == run_id
+                )
+            )
+        ).all()
+    )
+
+
+async def _copy_chapters(
+    session: AsyncSession,
+    *,
+    destination_run_id: UUID,
+    source_chapters: list[ConceptNoteChapter],
+    revisions: dict[UUID, ConceptNoteChapterRevision],
+    evidence_by_chapter: dict[UUID, list[ConceptNoteEvidenceLink]],
+    gaps: list[ConceptNoteGap],
+) -> tuple[dict[UUID, UUID], int]:
+    """Clone active chapters, latest bodies, and evidence with new identities."""
+    # Open gaps determine the destination chapter's initial review state.
+    chapters_with_open_gaps = {
+        gap.chapter_id
+        for gap in gaps
+        if gap.chapter_id is not None and gap.status == "open"
+    }
+    chapter_map: dict[UUID, UUID] = {}
+    completed_chapters = 0
+
+    # Persist each chapter before cloning rows that require its new identity.
+    for source in source_chapters:
+        latest = revisions.get(source.chapter_id)
+        if latest is None:
+            status = "empty"
+        elif source.chapter_id in chapters_with_open_gaps:
+            status = "needs_review"
+        else:
+            status = "draft"
+        destination = ConceptNoteChapter(
+            run_id=destination_run_id,
+            template_section_id=source.template_section_id,
+            title=source.title,
+            position=source.position,
+            status=status,
+            required=source.required,
+            user_locked=source.user_locked,
+        )
+        session.add(destination)
+        await session.flush()
+        chapter_map[source.chapter_id] = destination.chapter_id
+
+        if latest is not None:
+            session.add(
+                ConceptNoteChapterRevision(
+                    chapter_id=destination.chapter_id,
+                    revision_number=1,
+                    author_type="system",
+                    change_type="draft",
+                    body_markdown=latest.body_markdown,
+                    patch_summary={
+                        "duplicated_from_revision_id": str(latest.revision_id)
+                    },
+                )
+            )
+            completed_chapters += 1
+
+        for evidence in evidence_by_chapter[source.chapter_id]:
+            session.add(
+                ConceptNoteEvidenceLink(
+                    chapter_id=destination.chapter_id,
+                    selected_source_label=evidence.selected_source_label,
+                    source_location=evidence.source_location,
+                    claim_ref=evidence.claim_ref,
+                    quote_or_summary=evidence.quote_or_summary,
+                )
+            )
+
+    return chapter_map, completed_chapters
+
+
+def _copy_gaps(
+    session: AsyncSession,
+    destination_run_id: UUID,
+    gaps: list[ConceptNoteGap],
+    chapter_map: dict[UUID, UUID],
+) -> None:
+    """Clone gaps while remapping optional chapter relationships."""
+    for gap in gaps:
+        session.add(
+            ConceptNoteGap(
+                run_id=destination_run_id,
+                chapter_id=(
+                    chapter_map.get(gap.chapter_id)
+                    if gap.chapter_id is not None
+                    else None
+                ),
+                field_key=gap.field_key,
+                severity=gap.severity,
+                reason=gap.reason,
+                status=gap.status,
+            )
+        )
+
+
+def _copy_matches(
+    session: AsyncSession,
+    destination_run_id: UUID,
+    matches: list[ConceptNoteMatchedProject],
+) -> None:
+    """Clone selected project matches as independent mutable rows."""
+    for match in matches:
+        session.add(
+            ConceptNoteMatchedProject(
+                run_id=destination_run_id,
+                funded_project_id=match.funded_project_id,
+                decision=match.decision,
+                fit_rationale=match.fit_rationale,
+                matched_tags=deepcopy(match.matched_tags),
+                evidence=deepcopy(match.evidence),
+                caveats=deepcopy(match.caveats),
+            )
+        )
 
 
 async def _latest_revision(
@@ -323,34 +519,399 @@ async def _latest_revision(
     )
 
 
-async def _snapshot_chapter(
+async def _active_chapters(
     session: AsyncSession,
-    chapter: ConceptNoteChapter,
-) -> WorkspaceChapterSnapshot:
-    latest = await _latest_revision(session, chapter.chapter_id)
-    gaps = list(
+    run_id: UUID,
+    *,
+    lock: bool = False,
+) -> list[ConceptNoteChapter]:
+    """Load one run's active chapters in canonical document order."""
+    statement = (
+        select(ConceptNoteChapter)
+        .where(
+            ConceptNoteChapter.run_id == run_id,
+            ConceptNoteChapter.status != "deleted",
+        )
+        .order_by(
+            ConceptNoteChapter.position.asc(),
+            ConceptNoteChapter.chapter_id.asc(),
+        )
+    )
+    if lock:
+        statement = statement.with_for_update()
+    return list((await session.scalars(statement)).all())
+
+
+async def _latest_revisions(
+    session: AsyncSession,
+    chapter_ids: list[UUID],
+) -> dict[UUID, ConceptNoteChapterRevision]:
+    """Load the latest immutable revision for each supplied chapter."""
+    if not chapter_ids:
+        return {}
+    revisions = list(
         (
             await session.scalars(
-                select(ConceptNoteGap.reason)
-                .where(
-                    ConceptNoteGap.chapter_id == chapter.chapter_id,
-                    ConceptNoteGap.status == "open",
+                select(ConceptNoteChapterRevision)
+                .where(ConceptNoteChapterRevision.chapter_id.in_(chapter_ids))
+                .order_by(
+                    ConceptNoteChapterRevision.chapter_id.asc(),
+                    ConceptNoteChapterRevision.revision_number.desc(),
                 )
-                .order_by(ConceptNoteGap.created_at.asc(), ConceptNoteGap.gap_id.asc())
             )
         ).all()
     )
+    latest: dict[UUID, ConceptNoteChapterRevision] = {}
+    for revision in revisions:
+        latest.setdefault(revision.chapter_id, revision)
+    return latest
+
+
+async def _open_gaps_by_chapter(
+    session: AsyncSession,
+    chapter_ids: list[UUID],
+    *,
+    lock: bool = False,
+) -> dict[UUID, list[ConceptNoteGap]]:
+    """Group open gaps for fingerprinting and draft-state presentation."""
+    grouped = {chapter_id: [] for chapter_id in chapter_ids}
+    if not chapter_ids:
+        return grouped
+    statement = (
+        select(ConceptNoteGap)
+        .where(
+            ConceptNoteGap.chapter_id.in_(chapter_ids),
+            ConceptNoteGap.status == "open",
+        )
+        .order_by(ConceptNoteGap.created_at.asc(), ConceptNoteGap.gap_id.asc())
+    )
+    if lock:
+        statement = statement.with_for_update()
+    gaps = list((await session.scalars(statement)).all())
+    for gap in gaps:
+        if gap.chapter_id is not None:
+            grouped[gap.chapter_id].append(gap)
+    return grouped
+
+
+async def _evidence_by_chapter(
+    session: AsyncSession,
+    chapter_ids: list[UUID],
+    *,
+    lock: bool = False,
+) -> dict[UUID, list[ConceptNoteEvidenceLink]]:
+    """Group evidence links in stable identifier order."""
+    grouped = {chapter_id: [] for chapter_id in chapter_ids}
+    if not chapter_ids:
+        return grouped
+    statement = (
+        select(ConceptNoteEvidenceLink)
+        .where(ConceptNoteEvidenceLink.chapter_id.in_(chapter_ids))
+        .order_by(ConceptNoteEvidenceLink.evidence_link_id.asc())
+    )
+    if lock:
+        statement = statement.with_for_update()
+    evidence_links = list((await session.scalars(statement)).all())
+    for evidence in evidence_links:
+        grouped[evidence.chapter_id].append(evidence)
+    return grouped
+
+
+def _validation_chapters(
+    chapters: list[ConceptNoteChapter],
+    revisions: dict[UUID, ConceptNoteChapterRevision],
+) -> list[WorkspaceValidationChapter]:
+    """Detach active chapter state for the validator and fingerprint builder."""
+    detached: list[WorkspaceValidationChapter] = []
+    for chapter in chapters:
+        revision = revisions.get(chapter.chapter_id)
+        detached.append(
+            WorkspaceValidationChapter(
+                chapter_id=chapter.chapter_id,
+                chapter_ref=chapter.template_section_id,
+                title=chapter.title,
+                position=chapter.position,
+                status=chapter.status,
+                required=chapter.required,
+                body_markdown=(
+                    revision.body_markdown if revision is not None else None
+                ),
+                revision_id=(revision.revision_id if revision is not None else None),
+                revision_number=(
+                    revision.revision_number if revision is not None else None
+                ),
+            )
+        )
+    return detached
+
+
+def _validation_gaps(gaps: list[ConceptNoteGap]) -> list[WorkspaceValidationGap]:
+    """Detach open gaps from their SQLAlchemy session."""
+    return [
+        WorkspaceValidationGap(
+            gap_id=gap.gap_id,
+            field_key=gap.field_key,
+            severity=gap.severity,
+            reason=gap.reason,
+        )
+        for gap in gaps
+    ]
+
+
+def _validation_evidence(
+    evidence_links: list[ConceptNoteEvidenceLink],
+) -> list[WorkspaceValidationEvidence]:
+    """Detach evidence links from their SQLAlchemy session."""
+    return [
+        WorkspaceValidationEvidence(
+            evidence_link_id=evidence.evidence_link_id,
+            selected_source_label=evidence.selected_source_label,
+            source_location=evidence.source_location,
+            claim_ref=evidence.claim_ref,
+            quote_or_summary=evidence.quote_or_summary,
+        )
+        for evidence in evidence_links
+    ]
+
+
+def calculate_validation_input_fingerprint(
+    *,
+    chapters: list[WorkspaceValidationChapter],
+    target_chapter_id: UUID,
+    open_gaps: list[WorkspaceValidationGap],
+    evidence_links: list[WorkspaceValidationEvidence],
+    template_fingerprint: str | None,
+) -> str:
+    """Hash all document, target, and template inputs supplied to validation."""
+    payload = {
+        "chapters": [
+            {
+                "chapter_id": str(chapter.chapter_id),
+                "chapter_ref": chapter.chapter_ref,
+                "title": chapter.title,
+                "position": chapter.position,
+                "required": chapter.required,
+                "revision_id": (
+                    str(chapter.revision_id)
+                    if chapter.revision_id is not None
+                    else None
+                ),
+            }
+            for chapter in chapters
+        ],
+        "target": {
+            "chapter_id": str(target_chapter_id),
+            "open_gaps": [
+                {
+                    "gap_id": str(gap.gap_id),
+                    "field_key": gap.field_key,
+                    "severity": gap.severity,
+                    "reason": gap.reason,
+                }
+                for gap in open_gaps
+            ],
+            "evidence_links": [
+                {
+                    "evidence_link_id": str(evidence.evidence_link_id),
+                    "selected_source_label": evidence.selected_source_label,
+                    "source_location": evidence.source_location,
+                    "claim_ref": evidence.claim_ref,
+                    "quote_or_summary": evidence.quote_or_summary,
+                }
+                for evidence in evidence_links
+            ],
+        },
+        "template_fingerprint": template_fingerprint,
+    }
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return sha256(canonical.encode("utf-8")).hexdigest()
+
+
+async def _load_validation_context(
+    session: AsyncSession,
+    *,
+    run_id: UUID,
+    chapter_id: UUID,
+    template_fingerprint: str,
+    lock: bool = False,
+) -> WorkspaceValidationContext:
+    """Build one validation input snapshot from the managed CNB database."""
+    # Load and optionally lock the whole active document for the final race check.
+    chapters = await _active_chapters(session, run_id, lock=lock)
+    target = next(
+        (chapter for chapter in chapters if chapter.chapter_id == chapter_id),
+        None,
+    )
+    if target is None:
+        raise ValueError(f"Concept Note chapter {chapter_id} was not found")
+
+    # Detach target-specific gaps and evidence alongside every current revision.
+    chapter_ids = [chapter.chapter_id for chapter in chapters]
+    revisions = await _latest_revisions(session, chapter_ids)
+    gap_rows = await _open_gaps_by_chapter(session, [chapter_id], lock=lock)
+    evidence_rows = await _evidence_by_chapter(session, [chapter_id], lock=lock)
+    validation_chapters = _validation_chapters(chapters, revisions)
+    open_gaps = _validation_gaps(gap_rows[chapter_id])
+    evidence_links = _validation_evidence(evidence_rows[chapter_id])
+    target_snapshot = next(
+        chapter for chapter in validation_chapters if chapter.chapter_id == chapter_id
+    )
+    fingerprint = calculate_validation_input_fingerprint(
+        chapters=validation_chapters,
+        target_chapter_id=chapter_id,
+        open_gaps=open_gaps,
+        evidence_links=evidence_links,
+        template_fingerprint=template_fingerprint,
+    )
+    return WorkspaceValidationContext(
+        target=target_snapshot,
+        chapters=validation_chapters,
+        open_gaps=open_gaps,
+        evidence_links=evidence_links,
+        fingerprint=fingerprint,
+    )
+
+
+async def _snapshot_chapters(
+    session: AsyncSession,
+    run_id: UUID,
+    *,
+    template_fingerprint: str | None = None,
+) -> list[WorkspaceChapterSnapshot]:
+    """Project active chapters with latest validations and derived staleness."""
+    # Fetch all current inputs once because draft state is polled frequently.
+    chapters = await _active_chapters(session, run_id)
+    if not chapters:
+        return []
+    chapter_ids = [chapter.chapter_id for chapter in chapters]
+    revisions = await _latest_revisions(session, chapter_ids)
+    gaps = await _open_gaps_by_chapter(session, chapter_ids)
+    evidence = await _evidence_by_chapter(session, chapter_ids)
+    validations = {
+        validation.chapter_id: validation
+        for validation in (
+            await session.scalars(
+                select(ConceptNoteChapterValidation).where(
+                    ConceptNoteChapterValidation.chapter_id.in_(chapter_ids)
+                )
+            )
+        ).all()
+    }
+    validation_chapters = _validation_chapters(chapters, revisions)
+    validated_revision_numbers = await _validated_revision_numbers(
+        session,
+        validations,
+        revisions,
+    )
+
+    # Compute every target's freshness against the same document snapshot.
+    return [
+        _chapter_snapshot(
+            chapter=chapter,
+            detached=detached,
+            validation_chapters=validation_chapters,
+            gaps=gaps[chapter.chapter_id],
+            evidence=evidence[chapter.chapter_id],
+            stored_validation=validations.get(chapter.chapter_id),
+            validated_revision_numbers=validated_revision_numbers,
+            template_fingerprint=template_fingerprint,
+        )
+        for chapter, detached in zip(chapters, validation_chapters, strict=True)
+    ]
+
+
+async def _validated_revision_numbers(
+    session: AsyncSession,
+    validations: dict[UUID, ConceptNoteChapterValidation],
+    current_revisions: dict[UUID, ConceptNoteChapterRevision],
+) -> dict[UUID, int]:
+    """Resolve revision numbers referenced by current and historical validations."""
+    revision_numbers = {
+        revision.revision_id: revision.revision_number
+        for revision in current_revisions.values()
+    }
+    historical_ids = {
+        validation.validated_revision_id
+        for validation in validations.values()
+        if validation.validated_revision_id is not None
+        and validation.validated_revision_id not in revision_numbers
+    }
+    if historical_ids:
+        historical_revisions = (
+            await session.execute(
+                select(
+                    ConceptNoteChapterRevision.revision_id,
+                    ConceptNoteChapterRevision.revision_number,
+                ).where(ConceptNoteChapterRevision.revision_id.in_(historical_ids))
+            )
+        ).all()
+        revision_numbers.update(dict(historical_revisions))
+    return revision_numbers
+
+
+def _chapter_snapshot(
+    *,
+    chapter: ConceptNoteChapter,
+    detached: WorkspaceValidationChapter,
+    validation_chapters: list[WorkspaceValidationChapter],
+    gaps: list[ConceptNoteGap],
+    evidence: list[ConceptNoteEvidenceLink],
+    stored_validation: ConceptNoteChapterValidation | None,
+    validated_revision_numbers: dict[UUID, int],
+    template_fingerprint: str | None,
+) -> WorkspaceChapterSnapshot:
+    """Project one chapter and derive validation freshness and display status."""
+    # Compare the stored validation with the chapter's complete current input.
+    current_fingerprint = calculate_validation_input_fingerprint(
+        chapters=validation_chapters,
+        target_chapter_id=chapter.chapter_id,
+        open_gaps=_validation_gaps(gaps),
+        evidence_links=_validation_evidence(evidence),
+        template_fingerprint=template_fingerprint,
+    )
+    validation_snapshot = None
+    if stored_validation is not None:
+        validation_snapshot = WorkspaceValidationSnapshot(
+            validation_id=stored_validation.validation_id,
+            status=stored_validation.status,
+            is_stale=(
+                stored_validation.validation_input_fingerprint != current_fingerprint
+            ),
+            validated_revision_id=stored_validation.validated_revision_id,
+            validated_revision_number=validated_revision_numbers.get(
+                stored_validation.validated_revision_id
+            ),
+            validation_input_fingerprint=stored_validation.validation_input_fingerprint,
+            validated_at=stored_validation.validated_at,
+            findings=deepcopy(stored_validation.findings),
+        )
+
+    # A stale ready result must return to review without deleting its details.
+    effective_status = chapter.status
+    if (
+        validation_snapshot is not None
+        and validation_snapshot.is_stale
+        and effective_status == "ready"
+    ):
+        effective_status = "needs_review"
     return WorkspaceChapterSnapshot(
         chapter_id=chapter.chapter_id,
         chapter_ref=chapter.template_section_id,
         title=chapter.title,
         position=chapter.position,
-        status=chapter.status,
+        status=effective_status,
         required=chapter.required,
         user_locked=chapter.user_locked,
-        body_markdown=latest.body_markdown if latest is not None else None,
-        missing_information=gaps,
-        revision_number=latest.revision_number if latest is not None else None,
+        body_markdown=detached.body_markdown,
+        missing_information=[gap.reason for gap in gaps],
+        revision_number=detached.revision_number,
+        revision_id=detached.revision_id,
+        validation=validation_snapshot,
     )
 
 
@@ -366,6 +927,11 @@ async def _delete_workspace_rows(session: AsyncSession, run_id: UUID) -> None:
         ).all()
     )
     if chapter_ids:
+        await session.execute(
+            delete(ConceptNoteChapterValidation).where(
+                ConceptNoteChapterValidation.chapter_id.in_(chapter_ids)
+            )
+        )
         await session.execute(
             delete(ConceptNoteEvidenceLink).where(
                 ConceptNoteEvidenceLink.chapter_id.in_(chapter_ids)

--- a/climate-advisor/service/app/routes/concept_note_chapter_validation.py
+++ b/climate-advisor/service/app/routes/concept_note_chapter_validation.py
@@ -1,0 +1,88 @@
+"""Authenticated Concept Note chapter-validation route."""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from app.db.session import get_session
+from app.models.cnb.concept_note_draft import (
+    ConceptNoteChapterValidationActionResponse,
+)
+from app.services.cnb.chapter_validation import ChapterValidationError
+from app.services.cnb.chapter_validation_workflow import (
+    ChapterValidationWorkflowError,
+    ConceptNoteChapterValidationWorkflowService,
+)
+from app.services.concept_note_runs import ConceptNoteRunService
+from fastapi import APIRouter, Depends, Header, Query
+from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+router = APIRouter()
+
+
+def get_chapter_validation_workflow_service(
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ConceptNoteChapterValidationWorkflowService | None:
+    """Build validation dependencies, returning unavailable when CNB DB is unset."""
+    try:
+        return ConceptNoteChapterValidationWorkflowService(workflow_session=session)
+    except RuntimeError:
+        return None
+
+
+@router.post(
+    "/concept-notes/{run_id}/chapters/{chapter_id}/validation",
+    response_model=ConceptNoteChapterValidationActionResponse,
+)
+async def validate_concept_note_chapter(
+    run_id: UUID,
+    chapter_id: UUID,
+    validation_service: Annotated[
+        ConceptNoteChapterValidationWorkflowService | None,
+        Depends(get_chapter_validation_workflow_service),
+    ],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    user_id: Annotated[str, Query(min_length=1)],
+    authorization: Annotated[str | None, Header()] = None,
+) -> ConceptNoteChapterValidationActionResponse | JSONResponse:
+    """Validate one authorized chapter and publish its effective ready state."""
+    run_service = ConceptNoteRunService(session)
+    run = await run_service.get_authorized_run(
+        run_id=run_id,
+        requested_user_id=user_id,
+        authorization=authorization,
+    )
+    if validation_service is None:
+        return _problem(
+            503,
+            "cnb_storage_unavailable",
+            "Concept Note validation storage is unavailable",
+        )
+
+    try:
+        validation = await validation_service.validate(
+            run=run,
+            chapter_id=chapter_id,
+        )
+    except (ChapterValidationWorkflowError, ChapterValidationError) as exc:
+        return _problem(
+            exc.status_code,
+            exc.code,
+            "Unable to validate the requested chapter",
+        )
+
+    return ConceptNoteChapterValidationActionResponse(
+        chapter_id=chapter_id,
+        **validation.model_dump(),
+    )
+
+
+def _problem(status_code: int, code: str, message: str) -> JSONResponse:
+    """Return one stable machine-readable validation failure."""
+    return JSONResponse(
+        status_code=status_code,
+        content={"code": code, "detail": message, "status": status_code},
+        media_type="application/problem+json",
+    )

--- a/climate-advisor/service/app/routes/concept_note_chapter_validation.py
+++ b/climate-advisor/service/app/routes/concept_note_chapter_validation.py
@@ -9,7 +9,10 @@ from app.db.session import get_session
 from app.models.cnb.concept_note_draft import (
     ConceptNoteChapterValidationActionResponse,
 )
-from app.services.cnb.chapter_validation import ChapterValidationError
+from app.services.cnb.chapter_validation import (
+    ChapterValidationError,
+    ChapterValidationTemplateError,
+)
 from app.services.cnb.chapter_validation_workflow import (
     ChapterValidationWorkflowError,
     ConceptNoteChapterValidationWorkflowService,
@@ -70,7 +73,9 @@ async def validate_concept_note_chapter(
         return _problem(
             exc.status_code,
             exc.code,
-            "Unable to validate the requested chapter",
+            ChapterValidationTemplateError.public_message
+            if isinstance(exc, ChapterValidationTemplateError)
+            else "Unable to validate the requested chapter",
         )
 
     return ConceptNoteChapterValidationActionResponse(

--- a/climate-advisor/service/app/services/cnb/application_context.py
+++ b/climate-advisor/service/app/services/cnb/application_context.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import json
+from hashlib import sha256
 from uuid import UUID
 
 from app.db.cnb_reference import get_cnb_reference_session_factory
-from app.models.cnb.context_bundle import ConceptNoteContextBundle
 from app.models.cnb.concept_note_application_context import (
     ApplicationContextFunder,
     ApplicationContextIncludedSources,
@@ -11,6 +12,7 @@ from app.models.cnb.concept_note_application_context import (
     ApplicationContextTemplate,
     ConceptNoteApplicationContextResponse,
 )
+from app.models.cnb.context_bundle import ConceptNoteContextBundle
 from app.models.db.cnb_reference import (
     CnbFunder,
     CnbFunderTemplate,
@@ -88,14 +90,37 @@ class ConceptNoteApplicationContextService:
                 name=opportunity.name,
             )
         if template is not None:
-            response.template = ApplicationContextTemplate(
-                id=template.template_id,
-                name=template.template_name,
-                output_format=template.output_format,
-                chapter_schema=template.chapter_schema,
-                required_fields=template.required_fields,
-            )
+            response.template = _template_response(template)
         return response
+
+    async def load_template_fingerprint_for_run(
+        self,
+        run: ConceptNoteRun,
+    ) -> str | None:
+        """Load the current template fingerprint with one reference query."""
+        if run.funder_id is None or run.selected_funding_opportunity_id is None:
+            return None
+
+        statement = (
+            select(CnbFunderTemplate)
+            .join(
+                CnbFundingOpportunity,
+                CnbFundingOpportunity.funding_opportunity_id
+                == CnbFunderTemplate.funding_opportunity_id,
+            )
+            .where(
+                CnbFunderTemplate.funding_opportunity_id
+                == run.selected_funding_opportunity_id,
+                CnbFundingOpportunity.funder_id == run.funder_id,
+            )
+        )
+        session_factory = self._session_factory or get_cnb_reference_session_factory()
+        async with session_factory() as session:
+            template = await session.scalar(statement)
+
+        if template is None:
+            return None
+        return calculate_application_template_fingerprint(_template_response(template))
 
     async def _load_included_sources(
         self,
@@ -168,3 +193,27 @@ def included_sources_from_bundle(
         ccra=context.ccra is not None,
         hiap=context.hiap is not None,
     )
+
+
+def _template_response(template: CnbFunderTemplate) -> ApplicationContextTemplate:
+    """Convert a managed template row to the stable public model."""
+    return ApplicationContextTemplate(
+        id=template.template_id,
+        name=template.template_name,
+        output_format=template.output_format,
+        chapter_schema=template.chapter_schema,
+        required_fields=template.required_fields,
+    )
+
+
+def calculate_application_template_fingerprint(
+    template: ApplicationContextTemplate,
+) -> str:
+    """Hash every application-template field supplied to chapter validation."""
+    canonical = json.dumps(
+        template.model_dump(mode="json"),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return sha256(canonical.encode("utf-8")).hexdigest()

--- a/climate-advisor/service/app/services/cnb/chapter_drafting.py
+++ b/climate-advisor/service/app/services/cnb/chapter_drafting.py
@@ -16,10 +16,12 @@ from app.db.cnb_reference import get_cnb_reference_session_factory
 from app.db.session import get_session_factory
 from app.models.cnb.concept_note_application_context import (
     ApplicationContextIncludedSources,
+    ApplicationContextTemplate,
     ConceptNoteApplicationContextResponse,
 )
 from app.models.cnb.concept_note_draft import (
     ConceptNoteChapterDraftOutput,
+    ConceptNoteChapterValidationResponse,
     ConceptNoteDraftChapterResponse,
     ConceptNoteDraftResponse,
 )
@@ -32,10 +34,12 @@ from app.persistence.concept_notes.workspace import (
     ConceptNoteWorkspaceRepository,
     WorkspaceChapterSnapshot,
     WorkspaceTemplateChapter,
+    WorkspaceValidationSnapshot,
     normalize_template_chapters,
 )
 from app.services.cnb.application_context import (
     ConceptNoteApplicationContextService,
+    calculate_application_template_fingerprint,
     included_sources_from_bundle,
 )
 from app.services.openrouter_client import build_openrouter_client_options
@@ -100,7 +104,13 @@ class ConceptNoteChapterDraftService:
 
     async def load_state(self, run: ConceptNoteRun) -> ConceptNoteDraftResponse:
         """Return persisted chapter state without starting generation."""
-        chapters = await self._workspace.list_chapters(run_id=run.run_id)
+        template_fingerprint = (
+            await self._application_context.load_template_fingerprint_for_run(run)
+        )
+        chapters = await self._workspace.list_chapters(
+            run_id=run.run_id,
+            template_fingerprint=template_fingerprint,
+        )
         return _build_state_response(
             run_id=run.run_id,
             progress=_draft_progress(run.context_summary),
@@ -117,12 +127,16 @@ class ConceptNoteChapterDraftService:
             run,
             included_sources=included_sources,
         )
-        template_chapters = _require_template(application_context)
+        template, template_chapters = _require_template(application_context)
+        template_fingerprint = calculate_application_template_fingerprint(template)
         await self._workspace.ensure_template_chapters(
             run_id=run.run_id,
             chapters=template_chapters,
         )
-        chapters = await self._workspace.list_chapters(run_id=run.run_id)
+        chapters = await self._workspace.list_chapters(
+            run_id=run.run_id,
+            template_fingerprint=template_fingerprint,
+        )
         build_id = await self._begin_draft(
             run_id=run.run_id,
             user_id=run.user_id,
@@ -156,12 +170,16 @@ class ConceptNoteChapterDraftService:
                 run,
                 included_sources=included_sources,
             )
-            template_chapters = _require_template(application_context)
+            template, template_chapters = _require_template(application_context)
+            template_fingerprint = calculate_application_template_fingerprint(template)
             template_by_ref = {
                 chapter.chapter_ref: chapter for chapter in template_chapters
             }
             while await self._lease_is_active(run_id, user_id, build_id):
-                chapters = await self._workspace.list_chapters(run_id=run_id)
+                chapters = await self._workspace.list_chapters(
+                    run_id=run_id,
+                    template_fingerprint=template_fingerprint,
+                )
                 current = next(
                     (chapter for chapter in chapters if chapter.body_markdown is None),
                     None,
@@ -203,7 +221,10 @@ class ConceptNoteChapterDraftService:
                         if item.strip()
                     ],
                 )
-                refreshed = await self._workspace.list_chapters(run_id=run_id)
+                refreshed = await self._workspace.list_chapters(
+                    run_id=run_id,
+                    template_fingerprint=template_fingerprint,
+                )
                 if not await self._record_completed_count(
                     run_id,
                     user_id,
@@ -589,20 +610,19 @@ async def _require_owned_run(
 
 def _require_template(
     application_context: ConceptNoteApplicationContextResponse,
-) -> list[WorkspaceTemplateChapter]:
-    if application_context.template is None:
+) -> tuple[ApplicationContextTemplate, list[WorkspaceTemplateChapter]]:
+    template = application_context.template
+    if template is None:
         raise ChapterDraftingTemplateError(
             "A selected application template is required"
         )
     try:
-        chapters = normalize_template_chapters(
-            application_context.template.chapter_schema
-        )
+        chapters = normalize_template_chapters(template.chapter_schema)
     except ValueError as exc:
         raise ChapterDraftingTemplateError("The selected template is invalid") from exc
     if not chapters:
         raise ChapterDraftingTemplateError("The selected template has no chapters")
-    return chapters
+    return template, chapters
 
 
 def _build_chapter_input(
@@ -688,6 +708,7 @@ def _build_state_response(
                 body_markdown=chapter.body_markdown,
                 missing_information=chapter.missing_information,
                 revision_number=chapter.revision_number,
+                validation=_validation_response(chapter.validation),
             )
             for chapter in chapters
         ],
@@ -696,6 +717,21 @@ def _build_state_response(
 
 def _completed_count(chapters: list[WorkspaceChapterSnapshot]) -> int:
     return sum(chapter.body_markdown is not None for chapter in chapters)
+
+
+def _validation_response(
+    validation: WorkspaceValidationSnapshot | None,
+) -> ConceptNoteChapterValidationResponse | None:
+    """Convert a detached persistence result into the public draft contract."""
+    if validation is None:
+        return None
+    return ConceptNoteChapterValidationResponse(
+        status=validation.status,
+        is_stale=validation.is_stale,
+        validated_revision_number=validation.validated_revision_number,
+        validated_at=validation.validated_at,
+        findings=validation.findings,
+    )
 
 
 def _draft_progress(summary: Any) -> dict[str, Any]:

--- a/climate-advisor/service/app/services/cnb/chapter_validation.py
+++ b/climate-advisor/service/app/services/cnb/chapter_validation.py
@@ -1,0 +1,824 @@
+"""Two-pass, non-truncating validation for one Concept Note chapter."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Awaitable, Callable
+from typing import Any, Literal, cast
+from uuid import UUID
+
+from agents import Agent, ModelSettings, OpenAIChatCompletionsModel, Runner
+from app.config import Settings, get_settings
+from app.models.cnb.concept_note_application_context import ApplicationContextTemplate
+from app.models.cnb.concept_note_chapter_validation import (
+    ChapterCompletenessValidationOutput,
+    ChapterConsistencyValidationOutput,
+    ChapterValidationChapter,
+    ChapterValidationDecision,
+    ChapterValidationEvidenceLink,
+    ChapterValidationFinding,
+    ChapterValidationFindingDraft,
+    ChapterValidationGap,
+    ChapterValidationRequest,
+    ChapterValidationTemplate,
+)
+from app.persistence.concept_notes.workspace import WorkspaceValidationContext
+from app.services.openrouter_client import build_openrouter_client_options
+from app.utils.prompt_budget import count_prompt_tokens
+from openai import AsyncOpenAI
+from pydantic import BaseModel, ValidationError
+
+logger = logging.getLogger(__name__)
+
+ValidationPass = Literal["completeness", "consistency"]
+ValidationPassOutput = (
+    ChapterCompletenessValidationOutput | ChapterConsistencyValidationOutput
+)
+ValidationPassRunner = Callable[
+    [ValidationPass, dict[str, Any]],
+    Awaitable[ValidationPassOutput],
+]
+
+
+_BLOCKING_GAP_SEVERITIES = {"missing_information", "critical", "blocking"}
+_SCOPE_CONFLICT_MESSAGE = (
+    "The target and related chapter define incompatible scope: one includes "
+    "delivery of current works while the other explicitly excludes completed or "
+    "current construction and commissioning works."
+)
+_SCOPE_CONFLICT_ACTION = (
+    "Align both chapters on one explicit future eligible scope and consistently "
+    "separate it from completed, construction, and commissioning works."
+)
+_INTERNAL_SCOPE_CONFLICT_MESSAGE = (
+    "The target defines the proposed measure as delivery of current works while "
+    "also stating that construction or commissioning is already at a late stage."
+)
+_INTERNAL_SCOPE_CONFLICT_ACTION = (
+    "Replace current works with a distinct future residual or follow-on scope, "
+    "schedule, and cost."
+)
+_SCOPE_PATTERNS = {
+    "include": re.compile(
+        r"\b(?:proposed measure|supported scope|funding scope|EUCF support)\b"
+        r".{0,160}\b(?:delivery|includes?|covers?|funds?)\b.{0,200}"
+        r"\b(?:route|construction|works?|infrastructure|building|installation)\b",
+        re.IGNORECASE,
+    ),
+    "exclude": re.compile(
+        r"\b(?:(?:must|will)\s+not\s+fund|exclud(?:e|es|ed|ing)|rather than)\b"
+        r".{0,260}\b(?:works?|construction|commissioning)\b",
+        re.IGNORECASE,
+    ),
+    "late": re.compile(
+        r"\b(?:late(?:-stage)?\s+construction\s+and\s+commissioning|"
+        r"construction\b.{0,120}(?:\d{1,3}\s*%\s+complete|almost complete|"
+        r"nearly complete).{0,160}\bcommissioning\b.{0,80}"
+        r"(?:underway|ongoing|continues?|continued|continuing|in progress))\b",
+        re.IGNORECASE,
+    ),
+}
+_NEGATED_SCOPE = re.compile(
+    r"\b(?:not|never)\s+(?:include|cover|fund)|\brather than\b|\bexclud(?:e|es|ed|ing)\b",
+    re.IGNORECASE,
+)
+
+
+class ChapterValidationError(Exception):
+    """Stable failure raised without producing a persistence-ready decision."""
+
+    code = "chapter_validation_failed"
+    status_code = 502
+
+
+class ChapterValidationInputTooLargeError(ChapterValidationError):
+    """A complete target or comparison chapter cannot fit without truncation."""
+
+    code = "chapter_validation_input_too_large"
+    status_code = 422
+
+
+class ChapterValidationModelOutputError(ChapterValidationError):
+    """The model returned invalid structured output or chapter references."""
+
+    code = "chapter_validation_model_output_invalid"
+    status_code = 502
+
+
+def build_chapter_validation_request(
+    context: WorkspaceValidationContext,
+    *,
+    template: ApplicationContextTemplate | None,
+) -> ChapterValidationRequest:
+    """Adapt one repository snapshot and application template to core inputs."""
+    template_context = None
+    if template is not None:
+        template_context = ChapterValidationTemplate(
+            template_id=template.id,
+            name=template.name,
+            output_format=template.output_format,
+            chapter_schema=template.chapter_schema,
+            required_fields=template.required_fields,
+        )
+    return ChapterValidationRequest(
+        target_chapter_id=context.target.chapter_id,
+        validation_input_fingerprint=context.fingerprint,
+        chapters=[
+            ChapterValidationChapter(
+                chapter_id=chapter.chapter_id,
+                template_section_id=chapter.chapter_ref,
+                title=chapter.title,
+                position=chapter.position,
+                required=chapter.required,
+                body_markdown=chapter.body_markdown,
+                revision_number=chapter.revision_number,
+            )
+            for chapter in context.chapters
+        ],
+        template=template_context,
+        open_gaps=[
+            ChapterValidationGap(
+                severity=gap.severity,
+                reason=gap.reason,
+                field_key=gap.field_key,
+            )
+            for gap in context.open_gaps
+        ],
+        evidence_links=[
+            ChapterValidationEvidenceLink(
+                selected_source_label=evidence.selected_source_label,
+                source_location=evidence.source_location,
+                claim_ref=evidence.claim_ref,
+                quote_or_summary=evidence.quote_or_summary,
+            )
+            for evidence in context.evidence_links
+        ],
+    )
+
+
+class ConceptNoteChapterValidationService:
+    """Run completeness first, then target-versus-document consistency checks."""
+
+    def __init__(
+        self,
+        *,
+        settings: Settings | None = None,
+        run_pass: ValidationPassRunner | None = None,
+        runner: Any = Runner,
+    ) -> None:
+        self._settings = settings or get_settings()
+        self._run_pass_override = run_pass
+        self._runner = runner
+
+    async def validate(
+        self,
+        request: ChapterValidationRequest,
+    ) -> ChapterValidationDecision:
+        """Return a persistence-ready decision without writing workspace state."""
+        target = next(
+            chapter
+            for chapter in request.chapters
+            if chapter.chapter_id == request.target_chapter_id
+        )
+        if not (target.body_markdown or "").strip():
+            return _empty_chapter_decision(request)
+
+        target_payload = target.model_dump(mode="json")
+        completeness_payload = {
+            "target_chapter": target_payload,
+            "template": (
+                request.template.model_dump(mode="json") if request.template else None
+            ),
+            "open_gaps": [gap.model_dump(mode="json") for gap in request.open_gaps],
+            "evidence_links": [
+                evidence.model_dump(mode="json") for evidence in request.evidence_links
+            ],
+        }
+        prompts = self._settings.llm.prompts
+        budget = self._settings.llm.generation.prompt_budget.cnb_validation
+        model_name = self._settings.llm.models.cnb_chapter_validator.name
+        fallback_encoding = (
+            self._settings.llm.generation.prompt_budget.tokenizer_encoding
+        )
+        _require_prompt_fit(
+            prompt=prompts.get_prompt("cnb_chapter_validation_completeness"),
+            payload=completeness_payload,
+            output_schema=ChapterCompletenessValidationOutput.model_json_schema(),
+            model=model_name,
+            fallback_encoding=fallback_encoding,
+            max_prompt_tokens=budget.max_prompt_tokens,
+            description="target chapter completeness input",
+        )
+
+        logger.info(
+            "Starting Concept Note chapter validation target_chapter_id=%s chapters=%s",
+            request.target_chapter_id,
+            len(request.chapters),
+        )
+
+        (
+            completeness,
+            consistency_outputs,
+            consistency_batch_count,
+        ) = await self._run_validation_passes(
+            request=request,
+            target_payload=target_payload,
+            completeness_payload=completeness_payload,
+            consistency_prompt=prompts.get_prompt("cnb_chapter_validation_consistency"),
+            model_name=model_name,
+            fallback_encoding=fallback_encoding,
+            max_prompt_tokens=budget.max_prompt_tokens,
+        )
+
+        findings = _merge_findings(
+            request=request,
+            completeness=completeness,
+            consistency_outputs=consistency_outputs,
+        )
+        status = _aggregate_status(findings)
+
+        logger.info(
+            "Completed Concept Note chapter validation target_chapter_id=%s "
+            "status=%s findings=%s consistency_batches=%s",
+            request.target_chapter_id,
+            status,
+            len(findings),
+            consistency_batch_count,
+        )
+        return ChapterValidationDecision(
+            target_chapter_id=request.target_chapter_id,
+            validated_revision_number=target.revision_number,
+            validation_input_fingerprint=request.validation_input_fingerprint,
+            status=status,
+            findings=findings,
+        )
+
+    async def _run_validation_passes(
+        self,
+        *,
+        request: ChapterValidationRequest,
+        target_payload: dict[str, Any],
+        completeness_payload: dict[str, Any],
+        consistency_prompt: str,
+        model_name: str,
+        fallback_encoding: str,
+        max_prompt_tokens: int,
+    ) -> tuple[
+        ChapterCompletenessValidationOutput,
+        list[ChapterConsistencyValidationOutput],
+        int,
+    ]:
+        """Execute completeness and every required consistency batch."""
+        client: AsyncOpenAI | None = None
+        run_pass = self._run_pass_override
+        if run_pass is None:
+            options = build_openrouter_client_options(
+                self._settings,
+                missing_api_key_message=(
+                    "OpenRouter API key is required for Concept Note validation"
+                ),
+                error_cls=ChapterValidationError,
+            )
+            client = AsyncOpenAI(**options.kwargs)
+
+            async def configured_runner(
+                phase: ValidationPass,
+                payload: dict[str, Any],
+            ) -> ValidationPassOutput:
+                return await self._run_configured_pass(
+                    client=cast(AsyncOpenAI, client),
+                    phase=phase,
+                    payload=payload,
+                )
+
+            run_pass = configured_runner
+
+        try:
+            completeness = await _invoke_pass(
+                run_pass,
+                "completeness",
+                completeness_payload,
+                ChapterCompletenessValidationOutput,
+            )
+            _validate_completeness_findings(
+                completeness,
+                target_chapter_id=request.target_chapter_id,
+            )
+            batches = _build_consistency_batches(
+                target=target_payload,
+                completeness=completeness.model_dump(mode="json"),
+                other_chapters=[
+                    chapter.model_dump(mode="json")
+                    for chapter in sorted(
+                        (
+                            chapter
+                            for chapter in request.chapters
+                            if chapter.chapter_id != request.target_chapter_id
+                        ),
+                        key=lambda chapter: (chapter.position, str(chapter.chapter_id)),
+                    )
+                ],
+                prompt=consistency_prompt,
+                model=model_name,
+                fallback_encoding=fallback_encoding,
+                max_prompt_tokens=max_prompt_tokens,
+            )
+            outputs: list[ChapterConsistencyValidationOutput] = []
+            for batch in batches:
+                output = await _invoke_pass(
+                    run_pass,
+                    "consistency",
+                    {
+                        "target_chapter": target_payload,
+                        "completeness_result": completeness.model_dump(mode="json"),
+                        "compared_chapters": batch,
+                    },
+                    ChapterConsistencyValidationOutput,
+                )
+                _validate_consistency_findings(
+                    output,
+                    target_chapter_id=request.target_chapter_id,
+                    compared_chapter_ids={
+                        UUID(chapter["chapter_id"]) for chapter in batch
+                    },
+                )
+                outputs.append(output)
+            return completeness, outputs, len(batches)
+        finally:
+            if client is not None:
+                await client.close()
+
+    async def _run_configured_pass(
+        self,
+        *,
+        client: AsyncOpenAI,
+        phase: ValidationPass,
+        payload: dict[str, Any],
+    ) -> ValidationPassOutput:
+        """Run one structured pass through the configured OpenRouter model."""
+        model_config = self._settings.llm.models.cnb_chapter_validator
+        if phase == "completeness":
+            prompt_name = "cnb_chapter_validation_completeness"
+            output_type: type[BaseModel] = ChapterCompletenessValidationOutput
+            agent_name = "Concept Note chapter completeness validator"
+        else:
+            prompt_name = "cnb_chapter_validation_consistency"
+            output_type = ChapterConsistencyValidationOutput
+            agent_name = "Concept Note chapter consistency validator"
+
+        agent = Agent(
+            name=agent_name,
+            instructions=self._settings.llm.prompts.get_prompt(prompt_name),
+            model=OpenAIChatCompletionsModel(
+                model=model_config.name,
+                openai_client=client,
+            ),
+            model_settings=ModelSettings(
+                temperature=0.0,
+                include_usage=True,
+                reasoning={"effort": model_config.reasoning_effort},
+            ),
+            output_type=output_type,
+            tools=[],
+        )
+        result = await self._runner.run(
+            agent,
+            json.dumps(payload, ensure_ascii=False),
+        )
+        return cast(
+            ValidationPassOutput,
+            output_type.model_validate(result.final_output),
+        )
+
+
+async def _invoke_pass(
+    run_pass: ValidationPassRunner,
+    phase: ValidationPass,
+    payload: dict[str, Any],
+    output_type: type[BaseModel],
+) -> ValidationPassOutput:
+    """Coerce callback output and keep provider/parsing failures typed."""
+    try:
+        raw_output = await run_pass(phase, payload)
+        return cast(ValidationPassOutput, output_type.model_validate(raw_output))
+    except ChapterValidationError:
+        raise
+    except (ValidationError, ValueError, TypeError) as exc:
+        raise ChapterValidationModelOutputError(
+            f"Invalid {phase} validation output"
+        ) from exc
+    except Exception as exc:
+        raise ChapterValidationError(f"{phase.title()} validation failed") from exc
+
+
+def _build_consistency_batches(
+    *,
+    target: dict[str, Any],
+    completeness: dict[str, Any],
+    other_chapters: list[dict[str, Any]],
+    prompt: str,
+    model: str,
+    fallback_encoding: str,
+    max_prompt_tokens: int,
+) -> list[list[dict[str, Any]]]:
+    """Batch complete chapters greedily while never truncating document text."""
+
+    def fits(chapters: list[dict[str, Any]]) -> bool:
+        payload = {
+            "target_chapter": target,
+            "completeness_result": completeness,
+            "compared_chapters": chapters,
+        }
+        token_count = count_prompt_tokens(
+            [
+                prompt,
+                payload,
+                ChapterConsistencyValidationOutput.model_json_schema(),
+            ],
+            model=model,
+            fallback_encoding=fallback_encoding,
+        )
+        return token_count.tokens <= max_prompt_tokens
+
+    # The target and first-pass output must fit even for an empty document.
+    if not fits([]):
+        raise ChapterValidationInputTooLargeError(
+            "Target chapter consistency input exceeds the configured prompt budget"
+        )
+    if not other_chapters:
+        return [[]]
+
+    batches: list[list[dict[str, Any]]] = []
+    current: list[dict[str, Any]] = []
+    for chapter in other_chapters:
+        candidate = [*current, chapter]
+        if fits(candidate):
+            current = candidate
+            continue
+        if not current:
+            raise ChapterValidationInputTooLargeError(
+                "A complete comparison chapter exceeds the configured prompt budget"
+            )
+        batches.append(current)
+        current = [chapter]
+        if not fits(current):
+            raise ChapterValidationInputTooLargeError(
+                "A complete comparison chapter exceeds the configured prompt budget"
+            )
+    if current:
+        batches.append(current)
+    return batches
+
+
+def _require_prompt_fit(
+    *,
+    prompt: str,
+    payload: dict[str, Any],
+    output_schema: dict[str, Any],
+    model: str,
+    fallback_encoding: str,
+    max_prompt_tokens: int,
+    description: str,
+) -> None:
+    """Reject an indivisible prompt instead of silently dropping content."""
+    token_count = count_prompt_tokens(
+        [prompt, payload, output_schema],
+        model=model,
+        fallback_encoding=fallback_encoding,
+    )
+    if token_count.tokens > max_prompt_tokens:
+        raise ChapterValidationInputTooLargeError(
+            f"{description.capitalize()} exceeds the configured prompt budget"
+        )
+
+
+def _validate_completeness_findings(
+    output: ChapterCompletenessValidationOutput,
+    *,
+    target_chapter_id: UUID,
+) -> None:
+    """Reject pass-one findings that reference anything beyond the target."""
+    for finding in output.findings:
+        involved_ids = set(finding.involved_chapter_ids)
+        if len(involved_ids) != len(finding.involved_chapter_ids) or involved_ids != {
+            target_chapter_id
+        }:
+            raise ChapterValidationModelOutputError(
+                "Completeness finding referenced an invalid chapter"
+            )
+
+
+def _validate_consistency_findings(
+    output: ChapterConsistencyValidationOutput,
+    *,
+    target_chapter_id: UUID,
+    compared_chapter_ids: set[UUID],
+) -> None:
+    """Reject hallucinated references and conflicts unrelated to the target."""
+    allowed_ids = {target_chapter_id} | compared_chapter_ids
+    for finding in output.findings:
+        involved_ids = set(finding.involved_chapter_ids)
+        if len(involved_ids) != len(finding.involved_chapter_ids):
+            raise ChapterValidationModelOutputError(
+                "Consistency finding contains duplicate chapter references"
+            )
+        if target_chapter_id not in involved_ids or not involved_ids <= allowed_ids:
+            raise ChapterValidationModelOutputError(
+                "Consistency finding referenced an invalid chapter"
+            )
+        if finding.category == "cross_chapter_conflict":
+            if not (involved_ids - {target_chapter_id}):
+                raise ChapterValidationModelOutputError(
+                    "Cross-chapter finding did not reference a compared chapter"
+                )
+        elif involved_ids != {target_chapter_id}:
+            raise ChapterValidationModelOutputError(
+                "Internal consistency finding referenced another chapter"
+            )
+
+
+def _merge_findings(
+    *,
+    request: ChapterValidationRequest,
+    completeness: ChapterCompletenessValidationOutput,
+    consistency_outputs: list[ChapterConsistencyValidationOutput],
+) -> list[ChapterValidationFinding]:
+    """Normalize policy-sensitive findings and remove batch duplicates."""
+    # Persisted gaps are authoritative and appear once even if the model also
+    # recognizes the same omission in chapter text.
+    merged = _deterministic_gap_findings(request)
+    for finding in completeness.findings:
+        severity = finding.severity
+        if finding.category in {"missing_information", "template_constraint"}:
+            severity = "blocking"
+        elif finding.category == "evidence":
+            severity = "warning"
+        public_finding = _public_finding(
+            finding,
+            phase="evidence" if finding.category == "evidence" else "completeness",
+            severity=severity,
+        )
+        if not _finding_is_covered_by_open_gaps(public_finding, request.open_gaps):
+            merged.append(public_finding)
+
+    merged.extend(_deterministic_scope_findings(request))
+    for output in consistency_outputs:
+        merged.extend(
+            _public_finding(finding, phase="consistency") for finding in output.findings
+        )
+
+    return _deduplicate_findings(merged)
+
+
+def _finding_is_covered_by_open_gaps(
+    finding: ChapterValidationFinding,
+    gaps: list[ChapterValidationGap],
+) -> bool:
+    """Use the prompt's required exact gap reason to remove duplicates."""
+    if finding.category not in {
+        "missing_information",
+        "template_constraint",
+        "unresolved_gap",
+    }:
+        return False
+    finding_text = _normalized_text(f"{finding.message} {finding.suggested_action}")
+    return any(
+        _normalized_text(gap.reason) in finding_text
+        for gap in gaps
+    )
+
+
+def _normalized_text(value: str) -> str:
+    """Normalize punctuation and whitespace for concise finding comparison."""
+    return " ".join(
+        "".join(character if character.isalnum() else " " for character in value)
+        .casefold()
+        .split()
+    )
+
+
+def _deterministic_gap_findings(
+    request: ChapterValidationRequest,
+) -> list[ChapterValidationFinding]:
+    """Convert every persisted open gap into a policy-owned finding."""
+    findings: list[ChapterValidationFinding] = []
+    for gap in request.open_gaps:
+        normalized_severity = gap.severity.strip().lower()
+        severity = (
+            "blocking" if normalized_severity in _BLOCKING_GAP_SEVERITIES else "warning"
+        )
+        category = (
+            "missing_information"
+            if normalized_severity == "missing_information"
+            else "unresolved_gap"
+        )
+        findings.append(
+            ChapterValidationFinding(
+                phase="completeness",
+                category=category,
+                severity=severity,
+                message=f"Open gap: {gap.reason}",
+                suggested_action=f"Resolve or confirm this gap: {gap.reason}",
+                involved_chapter_ids=[request.target_chapter_id],
+            )
+        )
+    return findings
+
+
+def _deterministic_scope_findings(
+    request: ChapterValidationRequest,
+) -> list[ChapterValidationFinding]:
+    """Find only explicit target-involved current-versus-future scope conflicts."""
+    target = next(
+        chapter
+        for chapter in request.chapters
+        if chapter.chapter_id == request.target_chapter_id
+    )
+    target_inclusion = _scope_excerpt(target.body_markdown, "include")
+    target_exclusion = _scope_excerpt(target.body_markdown, "exclude")
+    findings: list[ChapterValidationFinding] = []
+
+    late_works = _scope_excerpt(target.body_markdown, "late")
+    if target_inclusion is not None and late_works is not None:
+        findings.append(
+            _scope_finding(
+                category="internal_conflict",
+                chapter_ids=[target.chapter_id],
+                excerpts=[target_inclusion, late_works],
+            )
+        )
+
+    for chapter in request.chapters:
+        if chapter.chapter_id == target.chapter_id:
+            continue
+        target_excerpt, related_excerpt = (
+            (target_inclusion, _scope_excerpt(chapter.body_markdown, "exclude"))
+            if target_inclusion
+            else (target_exclusion, _scope_excerpt(chapter.body_markdown, "include"))
+        )
+        if target_excerpt is None or related_excerpt is None:
+            continue
+        findings.append(
+            _scope_finding(
+                category="cross_chapter_conflict",
+                chapter_ids=[target.chapter_id, chapter.chapter_id],
+                excerpts=[target_excerpt, related_excerpt],
+            )
+        )
+    return findings
+
+
+def _scope_excerpt(
+    body_markdown: str | None,
+    kind: Literal["include", "exclude", "late"],
+) -> str | None:
+    for sentence in _chapter_sentences(body_markdown):
+        if kind == "include" and _NEGATED_SCOPE.search(sentence):
+            continue
+        if _SCOPE_PATTERNS[kind].search(sentence):
+            return sentence
+    return None
+
+
+def _scope_finding(
+    *,
+    category: Literal["internal_conflict", "cross_chapter_conflict"],
+    chapter_ids: list[UUID],
+    excerpts: list[str],
+) -> ChapterValidationFinding:
+    internal = category == "internal_conflict"
+    return ChapterValidationFinding(
+        phase="consistency",
+        category=category,
+        severity="blocking",
+        message=(
+            _INTERNAL_SCOPE_CONFLICT_MESSAGE if internal else _SCOPE_CONFLICT_MESSAGE
+        ),
+        suggested_action=(
+            _INTERNAL_SCOPE_CONFLICT_ACTION if internal else _SCOPE_CONFLICT_ACTION
+        ),
+        involved_chapter_ids=chapter_ids,
+        excerpts=excerpts,
+    )
+
+
+def _chapter_sentences(body_markdown: str | None) -> list[str]:
+    """Split Markdown into concise sentence excerpts without altering meaning."""
+    if not body_markdown:
+        return []
+    sentences: list[str] = []
+    for part in re.split(r"(?<=[.!?])\s+|[\r\n]+", body_markdown):
+        sentence = " ".join(part.strip(" \t#>*_-").split())
+        if sentence:
+            sentences.append(sentence[:500])
+    return sentences
+
+
+def _public_finding(
+    finding: ChapterValidationFindingDraft,
+    *,
+    phase: Literal["completeness", "consistency", "evidence"],
+    severity: Literal["warning", "blocking"] | None = None,
+) -> ChapterValidationFinding:
+    """Attach the service-owned phase and any deterministic severity override."""
+    return ChapterValidationFinding(
+        phase=phase,
+        category=finding.category,
+        severity=severity or finding.severity,
+        message=finding.message,
+        suggested_action=finding.suggested_action,
+        involved_chapter_ids=finding.involved_chapter_ids,
+        excerpts=finding.excerpts,
+    )
+
+
+def _deduplicate_findings(
+    findings: list[ChapterValidationFinding],
+) -> list[ChapterValidationFinding]:
+    """Keep the first stable occurrence of repeated batched findings."""
+    unique: list[ChapterValidationFinding] = []
+    seen: set[tuple[object, ...]] = set()
+    for finding in findings:
+        key = (
+            finding.phase,
+            finding.category,
+            tuple(sorted(finding.involved_chapter_ids)),
+            _normalized_text(finding.message),
+        )
+        if key in seen or any(
+            _duplicates_scope_guard(finding, existing) for existing in unique
+        ):
+            continue
+        seen.add(key)
+        unique.append(finding)
+    return unique
+
+
+def _duplicates_scope_guard(
+    finding: ChapterValidationFinding,
+    existing: ChapterValidationFinding,
+) -> bool:
+    if set(finding.involved_chapter_ids) != set(existing.involved_chapter_ids):
+        return False
+    expected_categories = {
+        _SCOPE_CONFLICT_MESSAGE: {"cross_chapter_conflict"},
+        _INTERNAL_SCOPE_CONFLICT_MESSAGE: {"internal_conflict", "logic_error"},
+    }.get(existing.message)
+    if expected_categories is None or finding.category not in expected_categories:
+        return False
+
+    terms = set(
+        _normalized_text(f"{finding.message} {finding.suggested_action}").split()
+    )
+    return all(
+        terms & group
+        for group in (
+            {"construction", "commissioning", "works", "route"},
+            {"deliver", "delivery", "include", "includes", "measure", "scope"},
+            {"complete", "completed", "current", "exclude", "future", "ongoing"},
+        )
+    )
+
+
+def _aggregate_status(
+    findings: list[ChapterValidationFinding],
+) -> Literal["ready", "needs_review", "incomplete"]:
+    if any(finding.severity == "blocking" for finding in findings):
+        return "incomplete"
+    if findings:
+        return "needs_review"
+    return "ready"
+
+
+def _empty_chapter_decision(
+    request: ChapterValidationRequest,
+) -> ChapterValidationDecision:
+    """Return a deterministic missing-information result without model spend."""
+    target = next(
+        chapter
+        for chapter in request.chapters
+        if chapter.chapter_id == request.target_chapter_id
+    )
+    is_required = target.required
+    empty_finding = ChapterValidationFinding(
+        phase="completeness",
+        category="missing_information",
+        severity="blocking" if is_required else "warning",
+        message="The chapter has no content to validate.",
+        suggested_action=(
+            "Draft the chapter before marking it ready."
+            if is_required
+            else "Add content if it is relevant, or leave the optional chapter blank."
+        ),
+        involved_chapter_ids=[request.target_chapter_id],
+    )
+    findings = [empty_finding, *_deterministic_gap_findings(request)]
+    return ChapterValidationDecision(
+        target_chapter_id=request.target_chapter_id,
+        validated_revision_number=target.revision_number,
+        validation_input_fingerprint=request.validation_input_fingerprint,
+        status=_aggregate_status(findings),
+        findings=_deduplicate_findings(findings),
+    )

--- a/climate-advisor/service/app/services/cnb/chapter_validation.py
+++ b/climate-advisor/service/app/services/cnb/chapter_validation.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from collections.abc import Awaitable, Callable
 from typing import Any, Literal, cast
 from uuid import UUID
 
 from agents import Agent, ModelSettings, OpenAIChatCompletionsModel, Runner
+from app.config import Settings, get_settings
 from app.models.cnb.concept_note_application_context import ApplicationContextTemplate
 from app.models.cnb.concept_note_chapter_validation import (
     ChapterCompletenessValidationOutput,
@@ -29,8 +29,6 @@ from app.utils.prompt_budget import count_prompt_tokens
 from openai import AsyncOpenAI
 from pydantic import BaseModel, ValidationError
 
-from app.config import Settings, get_settings
-
 logger = logging.getLogger(__name__)
 
 ValidationPass = Literal["completeness", "consistency"]
@@ -44,47 +42,6 @@ ValidationPassRunner = Callable[
 
 
 _BLOCKING_GAP_SEVERITIES = {"missing_information", "critical", "blocking"}
-_SCOPE_CONFLICT_MESSAGE = (
-    "The target and related chapter define incompatible scope: one includes "
-    "delivery of current works while the other explicitly excludes completed or "
-    "current construction and commissioning works."
-)
-_SCOPE_CONFLICT_ACTION = (
-    "Align both chapters on one explicit future eligible scope and consistently "
-    "separate it from completed, construction, and commissioning works."
-)
-_INTERNAL_SCOPE_CONFLICT_MESSAGE = (
-    "The target defines the proposed measure as delivery of current works while "
-    "also stating that construction or commissioning is already at a late stage."
-)
-_INTERNAL_SCOPE_CONFLICT_ACTION = (
-    "Replace current works with a distinct future residual or follow-on scope, "
-    "schedule, and cost."
-)
-_SCOPE_PATTERNS = {
-    "include": re.compile(
-        r"\b(?:proposed measure|supported scope|funding scope|EUCF support)\b"
-        r".{0,160}\b(?:delivery|includes?|covers?|funds?)\b.{0,200}"
-        r"\b(?:route|construction|works?|infrastructure|building|installation)\b",
-        re.IGNORECASE,
-    ),
-    "exclude": re.compile(
-        r"\b(?:(?:must|will)\s+not\s+fund|exclud(?:e|es|ed|ing)|rather than)\b"
-        r".{0,260}\b(?:works?|construction|commissioning)\b",
-        re.IGNORECASE,
-    ),
-    "late": re.compile(
-        r"\b(?:late(?:-stage)?\s+construction\s+and\s+commissioning|"
-        r"construction\b.{0,120}(?:\d{1,3}\s*%\s+complete|almost complete|"
-        r"nearly complete).{0,160}\bcommissioning\b.{0,80}"
-        r"(?:underway|ongoing|continues?|continued|continuing|in progress))\b",
-        re.IGNORECASE,
-    ),
-}
-_NEGATED_SCOPE = re.compile(
-    r"\b(?:not|never)\s+(?:include|cover|fund)|\brather than\b|\bexclud(?:e|es|ed|ing)\b",
-    re.IGNORECASE,
-)
 
 
 class ChapterValidationError(Exception):
@@ -95,7 +52,7 @@ class ChapterValidationError(Exception):
 
 
 class ChapterValidationInputTooLargeError(ChapterValidationError):
-    """A complete target or comparison chapter cannot fit without truncation."""
+    """A complete output or document chapter cannot fit without truncation."""
 
     code = "chapter_validation_input_too_large"
     status_code = 422
@@ -160,7 +117,7 @@ def build_chapter_validation_request(
 
 
 class ConceptNoteChapterValidationService:
-    """Run completeness first, then target-versus-document consistency checks."""
+    """Run completeness first, then output-versus-document consistency checks."""
 
     def __init__(
         self,
@@ -194,12 +151,16 @@ class ConceptNoteChapterValidationService:
             for position, evidence in enumerate(request.evidence_links, start=1)
         ]
         completeness_payload = {
-            "target_chapter": target_payload,
-            "template": (
-                request.template.model_dump(mode="json") if request.template else None
-            ),
+            "document": {
+                "template": (
+                    request.template.model_dump(mode="json")
+                    if request.template
+                    else None
+                ),
+                "evidence_links": evidence_payload,
+            },
+            "output": target_payload,
             "open_gaps": [gap.model_dump(mode="json") for gap in request.open_gaps],
-            "evidence_links": evidence_payload,
         }
         prompts = self._settings.llm.prompts
         budget = self._settings.llm.generation.prompt_budget.cnb_validation
@@ -214,7 +175,7 @@ class ConceptNoteChapterValidationService:
             model=model_name,
             fallback_encoding=fallback_encoding,
             max_prompt_tokens=budget.max_prompt_tokens,
-            description="target chapter completeness input",
+            description="output completeness input",
         )
 
         logger.info(
@@ -315,9 +276,9 @@ class ConceptNoteChapterValidationService:
                 evidence_link_count=len(request.evidence_links),
             )
             batches = _build_consistency_batches(
-                target=target_payload,
+                output=target_payload,
                 completeness=completeness.model_dump(mode="json"),
-                other_chapters=[
+                document_chapters=[
                     chapter.model_dump(mode="json")
                     for chapter in sorted(
                         (
@@ -340,17 +301,19 @@ class ConceptNoteChapterValidationService:
                     run_pass,
                     "consistency",
                     {
-                        "target_chapter": target_payload,
+                        "document": {
+                            "chapters": batch,
+                            "evidence_links": evidence_payload,
+                        },
+                        "output": target_payload,
                         "completeness_result": completeness.model_dump(mode="json"),
-                        "compared_chapters": batch,
-                        "evidence_links": evidence_payload,
                     },
                     ChapterConsistencyValidationOutput,
                 )
                 _validate_consistency_findings(
                     output,
                     target_chapter_id=request.target_chapter_id,
-                    compared_chapter_ids={
+                    document_chapter_ids={
                         UUID(chapter["chapter_id"]) for chapter in batch
                     },
                     evidence_link_count=len(request.evidence_links),
@@ -426,9 +389,9 @@ async def _invoke_pass(
 
 def _build_consistency_batches(
     *,
-    target: dict[str, Any],
+    output: dict[str, Any],
     completeness: dict[str, Any],
-    other_chapters: list[dict[str, Any]],
+    document_chapters: list[dict[str, Any]],
     evidence_links: list[dict[str, Any]],
     prompt: str,
     model: str,
@@ -439,10 +402,12 @@ def _build_consistency_batches(
 
     def fits(chapters: list[dict[str, Any]]) -> bool:
         payload = {
-            "target_chapter": target,
+            "document": {
+                "chapters": chapters,
+                "evidence_links": evidence_links,
+            },
+            "output": output,
             "completeness_result": completeness,
-            "compared_chapters": chapters,
-            "evidence_links": evidence_links,
         }
         token_count = count_prompt_tokens(
             [
@@ -455,30 +420,30 @@ def _build_consistency_batches(
         )
         return token_count.tokens <= max_prompt_tokens
 
-    # The target and first-pass output must fit even for an empty document.
+    # The generated output and first-pass result must fit without document chapters.
     if not fits([]):
         raise ChapterValidationInputTooLargeError(
-            "Target chapter consistency input exceeds the configured prompt budget"
+            "Output consistency input exceeds the configured prompt budget"
         )
-    if not other_chapters:
+    if not document_chapters:
         return [[]]
 
     batches: list[list[dict[str, Any]]] = []
     current: list[dict[str, Any]] = []
-    for chapter in other_chapters:
+    for chapter in document_chapters:
         candidate = [*current, chapter]
         if fits(candidate):
             current = candidate
             continue
         if not current:
             raise ChapterValidationInputTooLargeError(
-                "A complete comparison chapter exceeds the configured prompt budget"
+                "A complete document chapter exceeds the configured prompt budget"
             )
         batches.append(current)
         current = [chapter]
         if not fits(current):
             raise ChapterValidationInputTooLargeError(
-                "A complete comparison chapter exceeds the configured prompt budget"
+                "A complete document chapter exceeds the configured prompt budget"
             )
     if current:
         batches.append(current)
@@ -529,11 +494,11 @@ def _validate_consistency_findings(
     output: ChapterConsistencyValidationOutput,
     *,
     target_chapter_id: UUID,
-    compared_chapter_ids: set[UUID],
+    document_chapter_ids: set[UUID],
     evidence_link_count: int,
 ) -> None:
-    """Reject hallucinated references and conflicts unrelated to the target."""
-    allowed_ids = {target_chapter_id} | compared_chapter_ids
+    """Reject hallucinated references and conflicts unrelated to the output."""
+    allowed_ids = {target_chapter_id} | document_chapter_ids
     for finding in output.findings:
         involved_ids = set(finding.involved_chapter_ids)
         if len(involved_ids) != len(finding.involved_chapter_ids):
@@ -547,7 +512,7 @@ def _validate_consistency_findings(
         if finding.category == "cross_chapter_conflict":
             if not (involved_ids - {target_chapter_id}):
                 raise ChapterValidationModelOutputError(
-                    "Cross-chapter finding did not reference a compared chapter"
+                    "Cross-chapter finding did not reference a document chapter"
                 )
         elif involved_ids != {target_chapter_id}:
             raise ChapterValidationModelOutputError(
@@ -597,7 +562,6 @@ def _merge_findings(
         if not _finding_is_covered_by_open_gaps(public_finding, request.open_gaps):
             merged.append(public_finding)
 
-    merged.extend(_deterministic_scope_findings(request))
     for output in consistency_outputs:
         merged.extend(
             _public_finding(
@@ -663,95 +627,6 @@ def _deterministic_gap_findings(
     return findings
 
 
-def _deterministic_scope_findings(
-    request: ChapterValidationRequest,
-) -> list[ChapterValidationFinding]:
-    """Find only explicit target-involved current-versus-future scope conflicts."""
-    target = next(
-        chapter
-        for chapter in request.chapters
-        if chapter.chapter_id == request.target_chapter_id
-    )
-    target_inclusion = _scope_excerpt(target.body_markdown, "include")
-    target_exclusion = _scope_excerpt(target.body_markdown, "exclude")
-    findings: list[ChapterValidationFinding] = []
-
-    late_works = _scope_excerpt(target.body_markdown, "late")
-    if target_inclusion is not None and late_works is not None:
-        findings.append(
-            _scope_finding(
-                category="internal_conflict",
-                chapter_ids=[target.chapter_id],
-                excerpts=[target_inclusion, late_works],
-            )
-        )
-
-    for chapter in request.chapters:
-        if chapter.chapter_id == target.chapter_id:
-            continue
-        target_excerpt, related_excerpt = (
-            (target_inclusion, _scope_excerpt(chapter.body_markdown, "exclude"))
-            if target_inclusion
-            else (target_exclusion, _scope_excerpt(chapter.body_markdown, "include"))
-        )
-        if target_excerpt is None or related_excerpt is None:
-            continue
-        findings.append(
-            _scope_finding(
-                category="cross_chapter_conflict",
-                chapter_ids=[target.chapter_id, chapter.chapter_id],
-                excerpts=[target_excerpt, related_excerpt],
-            )
-        )
-    return findings
-
-
-def _scope_excerpt(
-    body_markdown: str | None,
-    kind: Literal["include", "exclude", "late"],
-) -> str | None:
-    for sentence in _chapter_sentences(body_markdown):
-        if kind == "include" and _NEGATED_SCOPE.search(sentence):
-            continue
-        if _SCOPE_PATTERNS[kind].search(sentence):
-            return sentence
-    return None
-
-
-def _scope_finding(
-    *,
-    category: Literal["internal_conflict", "cross_chapter_conflict"],
-    chapter_ids: list[UUID],
-    excerpts: list[str],
-) -> ChapterValidationFinding:
-    internal = category == "internal_conflict"
-    return ChapterValidationFinding(
-        phase="consistency",
-        category=category,
-        severity="blocking",
-        message=(
-            _INTERNAL_SCOPE_CONFLICT_MESSAGE if internal else _SCOPE_CONFLICT_MESSAGE
-        ),
-        suggested_action=(
-            _INTERNAL_SCOPE_CONFLICT_ACTION if internal else _SCOPE_CONFLICT_ACTION
-        ),
-        involved_chapter_ids=chapter_ids,
-        excerpts=excerpts,
-    )
-
-
-def _chapter_sentences(body_markdown: str | None) -> list[str]:
-    """Split Markdown into concise sentence excerpts without altering meaning."""
-    if not body_markdown:
-        return []
-    sentences: list[str] = []
-    for part in re.split(r"(?<=[.!?])\s+|[\r\n]+", body_markdown):
-        sentence = " ".join(part.strip(" \t#>*_-").split())
-        if sentence:
-            sentences.append(sentence[:500])
-    return sentences
-
-
 def _public_finding(
     finding: ChapterValidationFindingDraft,
     *,
@@ -787,39 +662,11 @@ def _deduplicate_findings(
             tuple(sorted(finding.involved_chapter_ids)),
             _normalized_text(finding.message),
         )
-        if key in seen or any(
-            _duplicates_scope_guard(finding, existing) for existing in unique
-        ):
+        if key in seen:
             continue
         seen.add(key)
         unique.append(finding)
     return unique
-
-
-def _duplicates_scope_guard(
-    finding: ChapterValidationFinding,
-    existing: ChapterValidationFinding,
-) -> bool:
-    if set(finding.involved_chapter_ids) != set(existing.involved_chapter_ids):
-        return False
-    expected_categories = {
-        _SCOPE_CONFLICT_MESSAGE: {"cross_chapter_conflict"},
-        _INTERNAL_SCOPE_CONFLICT_MESSAGE: {"internal_conflict", "logic_error"},
-    }.get(existing.message)
-    if expected_categories is None or finding.category not in expected_categories:
-        return False
-
-    terms = set(
-        _normalized_text(f"{finding.message} {finding.suggested_action}").split()
-    )
-    return all(
-        terms & group
-        for group in (
-            {"construction", "commissioning", "works", "route"},
-            {"deliver", "delivery", "include", "includes", "measure", "scope"},
-            {"complete", "completed", "current", "exclude", "future", "ongoing"},
-        )
-    )
 
 
 def _aggregate_status(

--- a/climate-advisor/service/app/services/cnb/chapter_validation.py
+++ b/climate-advisor/service/app/services/cnb/chapter_validation.py
@@ -10,7 +10,6 @@ from typing import Any, Literal, cast
 from uuid import UUID
 
 from agents import Agent, ModelSettings, OpenAIChatCompletionsModel, Runner
-from app.config import Settings, get_settings
 from app.models.cnb.concept_note_application_context import ApplicationContextTemplate
 from app.models.cnb.concept_note_chapter_validation import (
     ChapterCompletenessValidationOutput,
@@ -29,6 +28,8 @@ from app.services.openrouter_client import build_openrouter_client_options
 from app.utils.prompt_budget import count_prompt_tokens
 from openai import AsyncOpenAI
 from pydantic import BaseModel, ValidationError
+
+from app.config import Settings, get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -185,16 +186,20 @@ class ConceptNoteChapterValidationService:
         if not (target.body_markdown or "").strip():
             return _empty_chapter_decision(request)
 
+        # Attach one-based positions so model output can cite existing evidence
+        # without copying or inventing source metadata.
         target_payload = target.model_dump(mode="json")
+        evidence_payload = [
+            {"position": position, **evidence.model_dump(mode="json")}
+            for position, evidence in enumerate(request.evidence_links, start=1)
+        ]
         completeness_payload = {
             "target_chapter": target_payload,
             "template": (
                 request.template.model_dump(mode="json") if request.template else None
             ),
             "open_gaps": [gap.model_dump(mode="json") for gap in request.open_gaps],
-            "evidence_links": [
-                evidence.model_dump(mode="json") for evidence in request.evidence_links
-            ],
+            "evidence_links": evidence_payload,
         }
         prompts = self._settings.llm.prompts
         budget = self._settings.llm.generation.prompt_budget.cnb_validation
@@ -226,6 +231,7 @@ class ConceptNoteChapterValidationService:
             request=request,
             target_payload=target_payload,
             completeness_payload=completeness_payload,
+            evidence_payload=evidence_payload,
             consistency_prompt=prompts.get_prompt("cnb_chapter_validation_consistency"),
             model_name=model_name,
             fallback_encoding=fallback_encoding,
@@ -261,6 +267,7 @@ class ConceptNoteChapterValidationService:
         request: ChapterValidationRequest,
         target_payload: dict[str, Any],
         completeness_payload: dict[str, Any],
+        evidence_payload: list[dict[str, Any]],
         consistency_prompt: str,
         model_name: str,
         fallback_encoding: str,
@@ -305,6 +312,7 @@ class ConceptNoteChapterValidationService:
             _validate_completeness_findings(
                 completeness,
                 target_chapter_id=request.target_chapter_id,
+                evidence_link_count=len(request.evidence_links),
             )
             batches = _build_consistency_batches(
                 target=target_payload,
@@ -320,6 +328,7 @@ class ConceptNoteChapterValidationService:
                         key=lambda chapter: (chapter.position, str(chapter.chapter_id)),
                     )
                 ],
+                evidence_links=evidence_payload,
                 prompt=consistency_prompt,
                 model=model_name,
                 fallback_encoding=fallback_encoding,
@@ -334,6 +343,7 @@ class ConceptNoteChapterValidationService:
                         "target_chapter": target_payload,
                         "completeness_result": completeness.model_dump(mode="json"),
                         "compared_chapters": batch,
+                        "evidence_links": evidence_payload,
                     },
                     ChapterConsistencyValidationOutput,
                 )
@@ -343,6 +353,7 @@ class ConceptNoteChapterValidationService:
                     compared_chapter_ids={
                         UUID(chapter["chapter_id"]) for chapter in batch
                     },
+                    evidence_link_count=len(request.evidence_links),
                 )
                 outputs.append(output)
             return completeness, outputs, len(batches)
@@ -418,6 +429,7 @@ def _build_consistency_batches(
     target: dict[str, Any],
     completeness: dict[str, Any],
     other_chapters: list[dict[str, Any]],
+    evidence_links: list[dict[str, Any]],
     prompt: str,
     model: str,
     fallback_encoding: str,
@@ -430,6 +442,7 @@ def _build_consistency_batches(
             "target_chapter": target,
             "completeness_result": completeness,
             "compared_chapters": chapters,
+            "evidence_links": evidence_links,
         }
         token_count = count_prompt_tokens(
             [
@@ -498,6 +511,7 @@ def _validate_completeness_findings(
     output: ChapterCompletenessValidationOutput,
     *,
     target_chapter_id: UUID,
+    evidence_link_count: int,
 ) -> None:
     """Reject pass-one findings that reference anything beyond the target."""
     for finding in output.findings:
@@ -508,6 +522,7 @@ def _validate_completeness_findings(
             raise ChapterValidationModelOutputError(
                 "Completeness finding referenced an invalid chapter"
             )
+    _validate_evidence_positions(output, evidence_link_count=evidence_link_count)
 
 
 def _validate_consistency_findings(
@@ -515,6 +530,7 @@ def _validate_consistency_findings(
     *,
     target_chapter_id: UUID,
     compared_chapter_ids: set[UUID],
+    evidence_link_count: int,
 ) -> None:
     """Reject hallucinated references and conflicts unrelated to the target."""
     allowed_ids = {target_chapter_id} | compared_chapter_ids
@@ -536,6 +552,23 @@ def _validate_consistency_findings(
         elif involved_ids != {target_chapter_id}:
             raise ChapterValidationModelOutputError(
                 "Internal consistency finding referenced another chapter"
+            )
+    _validate_evidence_positions(output, evidence_link_count=evidence_link_count)
+
+
+def _validate_evidence_positions(
+    output: ChapterCompletenessValidationOutput | ChapterConsistencyValidationOutput,
+    *,
+    evidence_link_count: int,
+) -> None:
+    """Reject duplicate or unavailable evidence references from model output."""
+    for finding in output.findings:
+        positions = finding.evidence_positions
+        if len(positions) != len(set(positions)) or any(
+            position > evidence_link_count for position in positions
+        ):
+            raise ChapterValidationModelOutputError(
+                "Validation finding referenced unavailable evidence"
             )
 
 
@@ -559,6 +592,7 @@ def _merge_findings(
             finding,
             phase="evidence" if finding.category == "evidence" else "completeness",
             severity=severity,
+            evidence_links=request.evidence_links,
         )
         if not _finding_is_covered_by_open_gaps(public_finding, request.open_gaps):
             merged.append(public_finding)
@@ -566,7 +600,12 @@ def _merge_findings(
     merged.extend(_deterministic_scope_findings(request))
     for output in consistency_outputs:
         merged.extend(
-            _public_finding(finding, phase="consistency") for finding in output.findings
+            _public_finding(
+                finding,
+                phase="consistency",
+                evidence_links=request.evidence_links,
+            )
+            for finding in output.findings
         )
 
     return _deduplicate_findings(merged)
@@ -584,10 +623,7 @@ def _finding_is_covered_by_open_gaps(
     }:
         return False
     finding_text = _normalized_text(f"{finding.message} {finding.suggested_action}")
-    return any(
-        _normalized_text(gap.reason) in finding_text
-        for gap in gaps
-    )
+    return any(_normalized_text(gap.reason) in finding_text for gap in gaps)
 
 
 def _normalized_text(value: str) -> str:
@@ -720,6 +756,7 @@ def _public_finding(
     finding: ChapterValidationFindingDraft,
     *,
     phase: Literal["completeness", "consistency", "evidence"],
+    evidence_links: list[ChapterValidationEvidenceLink],
     severity: Literal["warning", "blocking"] | None = None,
 ) -> ChapterValidationFinding:
     """Attach the service-owned phase and any deterministic severity override."""
@@ -731,6 +768,9 @@ def _public_finding(
         suggested_action=finding.suggested_action,
         involved_chapter_ids=finding.involved_chapter_ids,
         excerpts=finding.excerpts,
+        evidence=[
+            evidence_links[position - 1] for position in finding.evidence_positions
+        ],
     )
 
 

--- a/climate-advisor/service/app/services/cnb/chapter_validation.py
+++ b/climate-advisor/service/app/services/cnb/chapter_validation.py
@@ -20,14 +20,18 @@ from app.models.cnb.concept_note_chapter_validation import (
     ChapterValidationFinding,
     ChapterValidationFindingDraft,
     ChapterValidationGap,
+    ChapterValidationProfile,
     ChapterValidationRequest,
     ChapterValidationTemplate,
 )
-from app.persistence.concept_notes.workspace import WorkspaceValidationContext
+from app.persistence.concept_notes.workspace import (
+    WorkspaceValidationContext,
+    normalize_template_chapters,
+)
 from app.services.openrouter_client import build_openrouter_client_options
 from app.utils.prompt_budget import count_prompt_tokens
 from openai import AsyncOpenAI
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, TypeAdapter, ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +67,80 @@ class ChapterValidationModelOutputError(ChapterValidationError):
 
     code = "chapter_validation_model_output_invalid"
     status_code = 502
+
+
+class ChapterValidationTemplateError(ChapterValidationError):
+    """Template identity or field ownership needs correction before validation."""
+
+    code = "chapter_validation_template_invalid"
+    status_code = 409
+    public_message = (
+        "The application template needs review: ensure unique chapter references "
+        "and assign every required field to its applicable chapters."
+    )
+
+
+def select_chapter_validation_profile(
+    template: ChapterValidationTemplate | None,
+    target: ChapterValidationChapter,
+) -> ChapterValidationProfile | None:
+    """Select one chapter and reject ambiguous or unassigned template requirements.
+
+    Global required_fields remain an inventory, never model input. Every inventory
+    field must occur in at least one chapter's required_fields; shared requirements
+    are explicitly listed on each applicable chapter. No semantic mapping is inferred.
+    """
+    if template is None:
+        return None
+
+    # Reuse workspace normalization so generated chapter references match exactly.
+    try:
+        chapters = normalize_template_chapters(template.chapter_schema)
+    except ValueError as exc:
+        raise ChapterValidationTemplateError(
+            "Duplicate template chapter references"
+        ) from exc
+
+    selected: ChapterValidationProfile | None = None
+    assigned_fields: set[str] = set()
+    field_list = TypeAdapter(list[str])
+    for chapter, schema in zip(chapters, template.chapter_schema, strict=True):
+        try:
+            fields = field_list.validate_python(
+                schema.get("required_fields", []), strict=True
+            )
+        except ValidationError as exc:
+            raise ChapterValidationTemplateError(
+                "Invalid chapter required_fields"
+            ) from exc
+        if any(not field.strip() for field in fields):
+            raise ChapterValidationTemplateError("Empty chapter required field")
+        assigned_fields.update(fields)
+        if chapter.chapter_ref == target.template_section_id:
+            selected = ChapterValidationProfile(
+                name=template.name,
+                output_format=template.output_format,
+                chapter_schema={
+                    **{
+                        key: value
+                        for key, value in schema.items()
+                        if key not in {"chapter_ref", "required_fields"}
+                    },
+                    "title": chapter.title,
+                    "description": chapter.description,
+                    "required": chapter.required,
+                },
+                required_fields=fields,
+            )
+
+    # Older flat inventories must be reviewed rather than silently dropped.
+    if selected is None:
+        raise ChapterValidationTemplateError("No matching template chapter")
+    if set(template.required_fields) - assigned_fields:
+        raise ChapterValidationTemplateError(
+            "Template required fields lack chapter assignments"
+        )
+    return selected
 
 
 def build_chapter_validation_request(
@@ -140,6 +218,7 @@ class ConceptNoteChapterValidationService:
             for chapter in request.chapters
             if chapter.chapter_id == request.target_chapter_id
         )
+        profile = select_chapter_validation_profile(request.template, target)
         if not (target.body_markdown or "").strip():
             return _empty_chapter_decision(request)
 
@@ -152,11 +231,9 @@ class ConceptNoteChapterValidationService:
         ]
         completeness_payload = {
             "document": {
-                "template": (
-                    request.template.model_dump(mode="json")
-                    if request.template
-                    else None
-                ),
+                "validation_profile": profile.model_dump(mode="json")
+                if profile
+                else None,
                 "evidence_links": evidence_payload,
             },
             "output": target_payload,

--- a/climate-advisor/service/app/services/cnb/chapter_validation_workflow.py
+++ b/climate-advisor/service/app/services/cnb/chapter_validation_workflow.py
@@ -1,0 +1,294 @@
+"""Authorized persistence workflow for Concept Note chapter validation."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID
+
+from app.db.cnb_reference import get_cnb_reference_session_factory
+from app.models.cnb.concept_note_application_context import (
+    ApplicationContextTemplate,
+)
+from app.models.cnb.concept_note_chapter_validation import ChapterValidationDecision
+from app.models.cnb.concept_note_draft import (
+    ConceptNoteChapterValidationResponse,
+    ConceptNoteValidationCheckResponse,
+    ConceptNoteValidationFindingResponse,
+)
+from app.models.db.concept_note import ConceptNoteRun
+from app.persistence.concept_notes.workspace import (
+    ConceptNoteWorkspaceRepository,
+    WorkspaceValidationContext,
+    WorkspaceValidationInputChangedError,
+    WorkspaceValidationSnapshot,
+)
+from app.services.cnb.application_context import (
+    ConceptNoteApplicationContextService,
+    calculate_application_template_fingerprint,
+)
+from app.services.cnb.chapter_validation import (
+    ConceptNoteChapterValidationService,
+    build_chapter_validation_request,
+)
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_CHAPTER_VALIDATION_STEPS = frozenset({"drafting_document", "editing_document"})
+REVISION_CHANGED_MESSAGE = (
+    "The document or application template changed during validation; "
+    "run validation again"
+)
+STORAGE_UNAVAILABLE_MESSAGE = "Concept Note validation storage is unavailable"
+_CHECKS = (
+    ("required_content", "Required content", {"missing_information"}),
+    ("template_constraints", "Template constraints", {"template_constraint"}),
+    ("blocking_gaps", "Open gaps", {"unresolved_gap"}),
+    ("evidence_citations", "Evidence and citations", {"evidence"}),
+    (
+        "internal_consistency",
+        "Internal logic",
+        {"internal_conflict", "logic_error"},
+    ),
+    (
+        "cross_chapter_consistency",
+        "Cross-chapter consistency",
+        {"cross_chapter_conflict"},
+    ),
+)
+
+
+class ChapterValidationWorkflowError(Exception):
+    """Stable workflow failure exposed by the API and run-scoped agent tool."""
+
+    def __init__(self, code: str, status_code: int, message: str) -> None:
+        """Store the public error code, HTTP status, and safe message."""
+        super().__init__(message)
+        self.code = code
+        self.status_code = status_code
+
+
+class ConceptNoteChapterValidationWorkflowService:
+    """Load, evaluate, and atomically persist one authorized chapter result."""
+
+    def __init__(
+        self,
+        *,
+        workflow_session: AsyncSession,
+        workspace: ConceptNoteWorkspaceRepository | None = None,
+        validator: ConceptNoteChapterValidationService | None = None,
+        application_context: ConceptNoteApplicationContextService | None = None,
+    ) -> None:
+        """Store workflow and independently managed CNB persistence dependencies."""
+        self._workspace = workspace or ConceptNoteWorkspaceRepository(
+            get_cnb_reference_session_factory()
+        )
+        self._validator = validator or ConceptNoteChapterValidationService()
+        self._application_context = application_context or (
+            ConceptNoteApplicationContextService(workflow_session=workflow_session)
+        )
+
+    async def validate(
+        self,
+        *,
+        run: ConceptNoteRun,
+        chapter_id: UUID,
+    ) -> ConceptNoteChapterValidationResponse:
+        """Run both checks and persist the result when every input stays current.
+
+        Args:
+            run: Already authorized Concept Note run owned by the caller.
+            chapter_id: Active chapter within that run to evaluate and update.
+
+        Returns:
+            The fresh persisted validation result for the requested chapter.
+
+        Raises:
+            ChapterValidationWorkflowError: When workflow state, storage, chapter
+                identity, or concurrent input changes prevent a safe write.
+        """
+        # Step 1: authorize the workflow state and freeze the reviewed template.
+        if run.workflow_step not in ALLOWED_CHAPTER_VALIDATION_STEPS:
+            raise ChapterValidationWorkflowError(
+                "chapter_validation_not_allowed",
+                409,
+                "Chapter validation is available only while drafting or editing",
+            )
+        template = await self._load_template(run=run, chapter_id=chapter_id)
+        if template is None:
+            raise ChapterValidationWorkflowError(
+                "chapter_validation_template_unavailable",
+                409,
+                "The selected application template is unavailable",
+            )
+        template_fingerprint = calculate_application_template_fingerprint(template)
+
+        # Step 2: snapshot all remaining LLM and deterministic inputs.
+        context = await self._load_validation_context(
+            run=run,
+            chapter_id=chapter_id,
+            template_fingerprint=template_fingerprint,
+        )
+
+        # Step 3: run both LLM passes against the fingerprinted snapshot.
+        decision = await self._validator.validate(
+            build_chapter_validation_request(context, template=template)
+        )
+
+        # Step 4: recheck the independently stored template before publishing.
+        latest_template = await self._load_template(run=run, chapter_id=chapter_id)
+        if (
+            latest_template is None
+            or calculate_application_template_fingerprint(latest_template)
+            != template_fingerprint
+        ):
+            raise ChapterValidationWorkflowError(
+                "chapter_revision_changed",
+                409,
+                REVISION_CHANGED_MESSAGE,
+            )
+
+        # Step 5: recheck workspace inputs and publish result/status together.
+        stored = await self._persist_decision(
+            run=run,
+            chapter_id=chapter_id,
+            template_fingerprint=template_fingerprint,
+            decision=decision,
+        )
+        return chapter_validation_response(stored)
+
+    async def _load_validation_context(
+        self,
+        *,
+        run: ConceptNoteRun,
+        chapter_id: UUID,
+        template_fingerprint: str,
+    ) -> WorkspaceValidationContext:
+        """Load the fingerprinted workspace context with stable public errors."""
+        try:
+            return await self._workspace.load_validation_context(
+                run_id=run.run_id,
+                chapter_id=chapter_id,
+                template_fingerprint=template_fingerprint,
+            )
+        except ValueError as exc:
+            raise ChapterValidationWorkflowError(
+                "concept_note_chapter_not_found",
+                404,
+                "Concept Note chapter was not found",
+            ) from exc
+        except (OSError, SQLAlchemyError) as exc:
+            logger.exception(
+                "Failed to load chapter validation inputs run_id=%s chapter_id=%s",
+                run.run_id,
+                chapter_id,
+            )
+            raise ChapterValidationWorkflowError(
+                "cnb_storage_unavailable",
+                503,
+                STORAGE_UNAVAILABLE_MESSAGE,
+            ) from exc
+
+    async def _persist_decision(
+        self,
+        *,
+        run: ConceptNoteRun,
+        chapter_id: UUID,
+        template_fingerprint: str,
+        decision: ChapterValidationDecision,
+    ) -> WorkspaceValidationSnapshot:
+        """Atomically publish a decision if the workspace fingerprint is current."""
+        try:
+            return await self._workspace.upsert_validation(
+                run_id=run.run_id,
+                chapter_id=chapter_id,
+                template_fingerprint=template_fingerprint,
+                expected_fingerprint=decision.validation_input_fingerprint,
+                status=decision.status,
+                findings=[
+                    finding.model_dump(mode="json") for finding in decision.findings
+                ],
+            )
+        except WorkspaceValidationInputChangedError as exc:
+            raise ChapterValidationWorkflowError(
+                "chapter_revision_changed",
+                409,
+                REVISION_CHANGED_MESSAGE,
+            ) from exc
+        except (OSError, SQLAlchemyError) as exc:
+            logger.exception(
+                "Failed to persist chapter validation run_id=%s chapter_id=%s",
+                run.run_id,
+                chapter_id,
+            )
+            raise ChapterValidationWorkflowError(
+                "cnb_storage_unavailable",
+                503,
+                STORAGE_UNAVAILABLE_MESSAGE,
+            ) from exc
+
+    async def _load_template(
+        self,
+        *,
+        run: ConceptNoteRun,
+        chapter_id: UUID,
+    ) -> ApplicationContextTemplate | None:
+        """Load template state while preserving the workflow's stable storage error."""
+        try:
+            application_context = await self._application_context.load_for_run(run)
+        except (OSError, SQLAlchemyError) as exc:
+            logger.exception(
+                "Failed to load chapter validation template run_id=%s chapter_id=%s",
+                run.run_id,
+                chapter_id,
+            )
+            raise ChapterValidationWorkflowError(
+                "cnb_storage_unavailable",
+                503,
+                STORAGE_UNAVAILABLE_MESSAGE,
+            ) from exc
+        return application_context.template
+
+
+def chapter_validation_response(
+    snapshot: WorkspaceValidationSnapshot,
+) -> ConceptNoteChapterValidationResponse:
+    """Convert one detached persistence snapshot into the public contract."""
+    return ConceptNoteChapterValidationResponse(
+        status=snapshot.status,
+        is_stale=snapshot.is_stale,
+        validated_revision_number=snapshot.validated_revision_number,
+        validated_at=snapshot.validated_at,
+        checks=_validation_checks(snapshot.findings),
+        findings=[
+            ConceptNoteValidationFindingResponse.model_validate(finding)
+            for finding in snapshot.findings
+        ],
+    )
+
+
+def _validation_checks(
+    findings: list[dict[str, Any]],
+) -> list[ConceptNoteValidationCheckResponse]:
+    """Derive the stable public summary instead of persisting duplicate data."""
+    checks: list[ConceptNoteValidationCheckResponse] = []
+    for key, label, categories in _CHECKS:
+        matches = [item for item in findings if item.get("category") in categories]
+        status = (
+            "fail"
+            if any(item.get("severity") == "blocking" for item in matches)
+            else "warning"
+            if matches
+            else "pass"
+        )
+        checks.append(
+            ConceptNoteValidationCheckResponse(
+                key=key,
+                label=label,
+                status=status,
+                message=matches[0].get("message") if matches else None,
+            )
+        )
+    return checks

--- a/climate-advisor/service/app/services/concept_note_runs.py
+++ b/climate-advisor/service/app/services/concept_note_runs.py
@@ -15,7 +15,11 @@ from app.models.cnb.concept_note_runs import (
     ConceptNoteRunResponse,
     ConceptNoteStartRequest,
 )
-from app.models.db.concept_note import ConceptNoteRun
+from app.models.cnb.concept_note_markdown import (
+    ConceptNoteUploadStatusResponse,
+    source_format_from_filename,
+)
+from app.models.db.concept_note import ConceptNoteRun, ConceptNoteUpload
 from app.persistence.concept_notes.runs import ConceptNoteRunRepository
 from app.services.citycatalyst_client import (
     CityCatalystClient,
@@ -154,7 +158,11 @@ class ConceptNoteRunService:
             requested_user_id=requested_user_id,
             authorization=authorization,
         )
-        return _to_response(run, created=False)
+        uploads = await self.repository.list_uploads_for_run(
+            run_id=run.run_id,
+            user_id=run.user_id,
+        )
+        return _to_response(run, created=False, uploads=uploads)
 
     async def get_authorized_run(
         self,
@@ -334,14 +342,34 @@ def _to_response(
     run: ConceptNoteRun,
     *,
     created: bool,
+    uploads: list[ConceptNoteUpload] | None = None,
 ) -> ConceptNoteRunResponse:
     """Serialize one persisted run into the public API contract."""
     list_item = _to_list_item(run)
     return ConceptNoteRunResponse(
         **list_item.model_dump(),
         user_id=run.user_id,
+        uploads=[_to_upload_response(upload) for upload in uploads or []],
         created=created,
         trace_id=run.trace_id,
+    )
+
+
+def _to_upload_response(
+    upload: ConceptNoteUpload,
+) -> ConceptNoteUploadStatusResponse:
+    """Serialize persisted source metadata for workspace resume."""
+    return ConceptNoteUploadStatusResponse(
+        upload_id=upload.upload_id,
+        run_id=upload.run_id,
+        status=upload.ingest_status,
+        filename=upload.filename,
+        source_label=upload.source_label,
+        source_format=source_format_from_filename(upload.filename),
+        page_count=upload.page_count,
+        error_code=upload.ingest_error_code,
+        received_at=upload.received_at,
+        completed_at=upload.ingest_completed_at,
     )
 
 

--- a/climate-advisor/service/cnb_migrations/env.py
+++ b/climate-advisor/service/cnb_migrations/env.py
@@ -20,6 +20,7 @@ from app.models.db.cnb_reference import (  # noqa: F401
 from app.models.db.cnb_workspace import (  # noqa: F401
     ConceptNoteChapter,
     ConceptNoteChapterRevision,
+    ConceptNoteChapterValidation,
     ConceptNoteEvidenceLink,
     ConceptNoteExport,
     ConceptNoteGap,

--- a/climate-advisor/service/cnb_migrations/versions/20260828_120000_add_chapter_validations.py
+++ b/climate-advisor/service/cnb_migrations/versions/20260828_120000_add_chapter_validations.py
@@ -1,0 +1,82 @@
+"""Add latest-result persistence for chapter readiness validation.
+
+Revision ID: 20260828_120000
+Revises: 20260821_120000
+Create Date: 2026-08-28 12:00:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260828_120000"
+down_revision: str | Sequence[str] | None = "20260821_120000"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create one replaceable validation result per concept-note chapter."""
+    op.create_table(
+        "concept_note_chapter_validations",
+        sa.Column("validation_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("chapter_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "validated_revision_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "validation_input_fingerprint",
+            sa.String(length=64),
+            nullable=False,
+        ),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column(
+            "findings",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "validated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(
+            "status IN ('ready', 'needs_review', 'incomplete')",
+            name=op.f("ck_concept_note_chapter_validations_status_valid"),
+        ),
+        sa.CheckConstraint(
+            "length(validation_input_fingerprint) = 64",
+            name=op.f("ck_concept_note_chapter_validations_fingerprint_length"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["chapter_id"],
+            ["concept_note_chapters.chapter_id"],
+            name="fk_cnb_chapter_validations_chapter",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["validated_revision_id"],
+            ["concept_note_chapter_revisions.revision_id"],
+            name="fk_cnb_chapter_validations_revision",
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint(
+            "validation_id",
+            name="pk_concept_note_chapter_validations",
+        ),
+        sa.UniqueConstraint(
+            "chapter_id",
+            name="uq_concept_note_chapter_validations_chapter",
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Remove persisted chapter validation results."""
+    op.drop_table("concept_note_chapter_validations")

--- a/climate-advisor/service/tests/cnb/chapter_validation_helpers.py
+++ b/climate-advisor/service/tests/cnb/chapter_validation_helpers.py
@@ -1,0 +1,121 @@
+"""Small builders shared by chapter-validation tests."""
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+from uuid import UUID
+
+from app.config import get_settings
+from app.models.cnb.concept_note_chapter_validation import (
+    ChapterCompletenessValidationOutput,
+    ChapterConsistencyValidationOutput,
+    ChapterValidationChapter,
+    ChapterValidationEvidenceLink,
+    ChapterValidationFindingCategory,
+    ChapterValidationFindingDraft,
+    ChapterValidationGap,
+    ChapterValidationRequest,
+    ChapterValidationSeverity,
+    ChapterValidationTemplate,
+)
+from app.services.cnb.chapter_validation import ConceptNoteChapterValidationService
+
+TARGET_ID = UUID("11111111-1111-4111-8111-111111111111")
+OTHER_ID = UUID("22222222-2222-4222-8222-222222222222")
+THIRD_ID = UUID("33333333-3333-4333-8333-333333333333")
+UNKNOWN_ID = UUID("99999999-9999-4999-8999-999999999999")
+PassCallback = Callable[[str, dict[str, Any]], Awaitable[Any]]
+
+
+def chapter(
+    chapter_id: UUID,
+    *,
+    position: int,
+    body: str | None = "Complete chapter text.",
+    required: bool = True,
+) -> ChapterValidationChapter:
+    return ChapterValidationChapter(
+        chapter_id=chapter_id,
+        template_section_id=f"chapter-{position + 1}",
+        title=f"Chapter {position + 1}",
+        position=position,
+        required=required,
+        body_markdown=body,
+        revision_number=1 if body is not None else None,
+    )
+
+
+def request(
+    *,
+    chapters: list[ChapterValidationChapter] | None = None,
+    gaps: list[ChapterValidationGap] | None = None,
+    evidence: bool = True,
+    target_required: bool = True,
+) -> ChapterValidationRequest:
+    return ChapterValidationRequest(
+        target_chapter_id=TARGET_ID,
+        validation_input_fingerprint="a" * 64,
+        chapters=chapters or [chapter(TARGET_ID, position=0, required=target_required)],
+        template=ChapterValidationTemplate(
+            template_id=UUID("44444444-4444-4444-8444-444444444444"),
+            name="Application template",
+            chapter_schema=[{"chapter_ref": "chapter-1", "required": target_required}],
+            required_fields=["Implementation timetable"],
+        ),
+        open_gaps=gaps or [],
+        evidence_links=(
+            [ChapterValidationEvidenceLink(selected_source_label="City climate plan")]
+            if evidence
+            else []
+        ),
+    )
+
+
+def finding(
+    category: ChapterValidationFindingCategory,
+    message: str,
+    suggested_action: str,
+    *,
+    severity: ChapterValidationSeverity = "blocking",
+    chapter_ids: list[UUID] | None = None,
+) -> ChapterValidationFindingDraft:
+    return ChapterValidationFindingDraft(
+        category=category,
+        severity=severity,
+        message=message,
+        suggested_action=suggested_action,
+        involved_chapter_ids=chapter_ids or [TARGET_ID],
+    )
+
+
+def completeness(
+    *,
+    findings: list[ChapterValidationFindingDraft] | None = None,
+) -> ChapterCompletenessValidationOutput:
+    return ChapterCompletenessValidationOutput(findings=findings or [])
+
+
+def consistency(
+    *,
+    findings: list[ChapterValidationFindingDraft] | None = None,
+) -> ChapterConsistencyValidationOutput:
+    return ChapterConsistencyValidationOutput(findings=findings or [])
+
+
+def static_passes(
+    *,
+    completeness_result: ChapterCompletenessValidationOutput | None = None,
+    consistency_result: ChapterConsistencyValidationOutput | None = None,
+) -> PassCallback:
+    async def run_pass(phase: str, _: dict[str, Any]) -> Any:
+        if phase == "completeness":
+            return completeness_result or completeness()
+        return consistency_result or consistency()
+
+    return run_pass
+
+
+def service(run_pass: PassCallback) -> ConceptNoteChapterValidationService:
+    return ConceptNoteChapterValidationService(
+        settings=get_settings().model_copy(deep=True),
+        run_pass=run_pass,
+    )

--- a/climate-advisor/service/tests/cnb/chapter_validation_helpers.py
+++ b/climate-advisor/service/tests/cnb/chapter_validation_helpers.py
@@ -4,6 +4,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 from uuid import UUID
 
+from app.config import get_settings
 from app.models.cnb.concept_note_chapter_validation import (
     ChapterCompletenessValidationOutput,
     ChapterConsistencyValidationOutput,
@@ -17,8 +18,6 @@ from app.models.cnb.concept_note_chapter_validation import (
     ChapterValidationTemplate,
 )
 from app.services.cnb.chapter_validation import ConceptNoteChapterValidationService
-
-from app.config import get_settings
 
 TARGET_ID = UUID("11111111-1111-4111-8111-111111111111")
 OTHER_ID = UUID("22222222-2222-4222-8222-222222222222")
@@ -59,7 +58,13 @@ def request(
         template=ChapterValidationTemplate(
             template_id=UUID("44444444-4444-4444-8444-444444444444"),
             name="Application template",
-            chapter_schema=[{"chapter_ref": "chapter-1", "required": target_required}],
+            chapter_schema=[
+                {
+                    "chapter_ref": "chapter-1",
+                    "required": target_required,
+                    "required_fields": ["Implementation timetable"],
+                }
+            ],
             required_fields=["Implementation timetable"],
         ),
         open_gaps=gaps or [],

--- a/climate-advisor/service/tests/cnb/chapter_validation_helpers.py
+++ b/climate-advisor/service/tests/cnb/chapter_validation_helpers.py
@@ -4,7 +4,6 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 from uuid import UUID
 
-from app.config import get_settings
 from app.models.cnb.concept_note_chapter_validation import (
     ChapterCompletenessValidationOutput,
     ChapterConsistencyValidationOutput,
@@ -18,6 +17,8 @@ from app.models.cnb.concept_note_chapter_validation import (
     ChapterValidationTemplate,
 )
 from app.services.cnb.chapter_validation import ConceptNoteChapterValidationService
+
+from app.config import get_settings
 
 TARGET_ID = UUID("11111111-1111-4111-8111-111111111111")
 OTHER_ID = UUID("22222222-2222-4222-8222-222222222222")
@@ -77,6 +78,7 @@ def finding(
     *,
     severity: ChapterValidationSeverity = "blocking",
     chapter_ids: list[UUID] | None = None,
+    evidence_positions: list[int] | None = None,
 ) -> ChapterValidationFindingDraft:
     return ChapterValidationFindingDraft(
         category=category,
@@ -84,6 +86,7 @@ def finding(
         message=message,
         suggested_action=suggested_action,
         involved_chapter_ids=chapter_ids or [TARGET_ID],
+        evidence_positions=evidence_positions or [],
     )
 
 

--- a/climate-advisor/service/tests/cnb/test_application_context.py
+++ b/climate-advisor/service/tests/cnb/test_application_context.py
@@ -5,9 +5,11 @@ from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID
 
+from app.models.cnb.concept_note_application_context import ApplicationContextTemplate
 from app.models.db.concept_note import ConceptNoteRun
 from app.services.cnb.application_context import (
     ConceptNoteApplicationContextService,
+    calculate_application_template_fingerprint,
 )
 
 RUN_ID = UUID("10000000-0000-4000-8000-000000000001")
@@ -147,3 +149,41 @@ async def test_maps_selected_funder_programme_and_template() -> None:
             "hiap": False,
         },
     }
+
+
+async def test_loads_template_fingerprint_with_one_reference_query() -> None:
+    """Keep the frequently polled draft state independent of full context loading."""
+    template = SimpleNamespace(
+        template_id=TEMPLATE_ID,
+        template_name="EIB starter",
+        output_format="markdown",
+        chapter_schema=[{"chapter_ref": "summary", "title": "Summary"}],
+        required_fields=["project_summary"],
+    )
+    session = AsyncMock()
+    session.scalar.return_value = template
+    service = ConceptNoteApplicationContextService(
+        session_factory=_session_factory(session)
+    )
+    service._load_funder = AsyncMock()
+    service._load_opportunity = AsyncMock()
+    service._load_template = AsyncMock()
+
+    fingerprint = await service.load_template_fingerprint_for_run(
+        _run(with_funding=True)
+    )
+
+    expected_template = ApplicationContextTemplate(
+        id=TEMPLATE_ID,
+        name="EIB starter",
+        output_format="markdown",
+        chapter_schema=[{"chapter_ref": "summary", "title": "Summary"}],
+        required_fields=["project_summary"],
+    )
+    assert fingerprint == calculate_application_template_fingerprint(
+        expected_template
+    )
+    session.scalar.assert_awaited_once()
+    service._load_funder.assert_not_called()
+    service._load_opportunity.assert_not_called()
+    service._load_template.assert_not_called()

--- a/climate-advisor/service/tests/cnb/test_chapter_drafting.py
+++ b/climate-advisor/service/tests/cnb/test_chapter_drafting.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 
 import pytest
@@ -45,8 +45,14 @@ class FakeWorkspace:
     def __init__(self, chapters: list[WorkspaceChapterSnapshot]) -> None:
         self.chapters = chapters
 
-    async def list_chapters(self, *, run_id: UUID) -> list[WorkspaceChapterSnapshot]:
+    async def list_chapters(
+        self,
+        *,
+        run_id: UUID,
+        template_fingerprint: str | None = None,
+    ) -> list[WorkspaceChapterSnapshot]:
         assert run_id == RUN_ID
+        assert template_fingerprint is not None
         return list(self.chapters)
 
     async def save_generated_chapter(
@@ -69,6 +75,36 @@ class FakeWorkspace:
             revision_number=1,
         )
         return True
+
+
+async def test_load_state_uses_lightweight_template_fingerprint_lookup() -> None:
+    """Avoid loading full funder context for the frequently polled draft state."""
+    workspace = MagicMock()
+    workspace.list_chapters = AsyncMock(return_value=[])
+    application_context = MagicMock()
+    application_context.load_template_fingerprint_for_run = AsyncMock(
+        return_value="template-fingerprint"
+    )
+    application_context.load_for_run = AsyncMock()
+    service = cast(
+        ConceptNoteChapterDraftService,
+        object.__new__(ConceptNoteChapterDraftService),
+    )
+    service._workspace = workspace
+    service._application_context = application_context
+    run = cast(
+        ConceptNoteRun,
+        SimpleNamespace(run_id=RUN_ID, context_summary={}),
+    )
+
+    await service.load_state(run)
+
+    application_context.load_template_fingerprint_for_run.assert_awaited_once_with(run)
+    application_context.load_for_run.assert_not_called()
+    workspace.list_chapters.assert_awaited_once_with(
+        run_id=RUN_ID,
+        template_fingerprint="template-fingerprint",
+    )
 
 
 async def test_drafts_in_order_and_passes_every_previous_chapter() -> None:

--- a/climate-advisor/service/tests/cnb/test_chapter_validation.py
+++ b/climate-advisor/service/tests/cnb/test_chapter_validation.py
@@ -1,0 +1,231 @@
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+from app.models.cnb.concept_note_application_context import ApplicationContextTemplate
+from app.models.cnb.concept_note_chapter_validation import ChapterValidationGap
+from app.persistence.concept_notes.workspace import (
+    WorkspaceValidationChapter,
+    WorkspaceValidationContext,
+    WorkspaceValidationEvidence,
+    WorkspaceValidationGap,
+)
+from app.services.cnb.chapter_validation import (
+    ChapterValidationError,
+    ChapterValidationInputTooLargeError,
+    ChapterValidationModelOutputError,
+    build_chapter_validation_request,
+)
+from app.utils.prompt_budget import TokenCount
+from tests.cnb.chapter_validation_helpers import (
+    OTHER_ID,
+    TARGET_ID,
+    THIRD_ID,
+    UNKNOWN_ID,
+    chapter,
+    completeness,
+    consistency,
+    finding,
+    request,
+    service,
+    static_passes,
+)
+
+
+def test_builds_request_from_repository_snapshot() -> None:
+    target = WorkspaceValidationChapter(
+        chapter_id=TARGET_ID,
+        chapter_ref="chapter-1",
+        title="Chapter 1",
+        position=0,
+        status="draft",
+        required=True,
+        body_markdown="Draft body",
+        revision_id=UUID("55555555-5555-4555-8555-555555555555"),
+        revision_number=2,
+    )
+    context = WorkspaceValidationContext(
+        target=target,
+        chapters=[target],
+        open_gaps=[
+            WorkspaceValidationGap(
+                gap_id=UUID("66666666-6666-4666-8666-666666666666"),
+                field_key="budget",
+                severity="critical",
+                reason="Confirm the project budget.",
+            )
+        ],
+        evidence_links=[
+            WorkspaceValidationEvidence(
+                evidence_link_id=UUID("77777777-7777-4777-8777-777777777777"),
+                selected_source_label="Budget annex",
+                source_location="page 4",
+                claim_ref="project budget",
+                quote_or_summary="Confirmed total",
+            )
+        ],
+        fingerprint="b" * 64,
+    )
+    template = ApplicationContextTemplate(
+        id=UUID("88888888-8888-4888-8888-888888888888"),
+        name="Application",
+        chapter_schema=[{"chapter_ref": "chapter-1"}],
+        required_fields=["Budget"],
+    )
+
+    built = build_chapter_validation_request(context, template=template)
+
+    assert built.chapters[0].revision_number == 2
+    assert built.template and built.template.template_id == template.id
+    assert built.open_gaps[0].severity == "critical"
+    assert built.evidence_links[0].source_location == "page 4"
+
+
+async def test_runs_completeness_before_document_consistency() -> None:
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def run_pass(phase: str, payload: dict[str, Any]) -> Any:
+        calls.append((phase, payload))
+        return completeness() if phase == "completeness" else consistency()
+
+    decision = await service(run_pass).validate(
+        request(
+            chapters=[
+                chapter(TARGET_ID, position=0),
+                chapter(OTHER_ID, position=1),
+                chapter(THIRD_ID, position=2),
+            ]
+        )
+    )
+
+    assert [phase for phase, _ in calls] == ["completeness", "consistency"]
+    assert {item["chapter_id"] for item in calls[1][1]["compared_chapters"]} == {
+        str(OTHER_ID),
+        str(THIRD_ID),
+    }
+    assert decision.status == "ready"
+
+
+async def test_batches_complete_comparison_chapters_without_truncation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    batches: list[list[dict[str, Any]]] = []
+
+    def fake_count(parts: list[Any], **_: Any) -> TokenCount:
+        compared = parts[1].get("compared_chapters", [])
+        return TokenCount(
+            tokens=100 + sum(len(item["body_markdown"]) for item in compared),
+            tokenizer="test",
+        )
+
+    async def run_pass(phase: str, payload: dict[str, Any]) -> Any:
+        if phase == "completeness":
+            return completeness()
+        batches.append(payload["compared_chapters"])
+        return consistency()
+
+    monkeypatch.setattr(
+        "app.services.cnb.chapter_validation.count_prompt_tokens", fake_count
+    )
+    validation_service = service(run_pass)
+    budget = validation_service._settings.llm.generation.prompt_budget.cnb_validation
+    budget.max_prompt_tokens = 1000
+
+    await validation_service.validate(
+        request(
+            chapters=[
+                chapter(TARGET_ID, position=0),
+                chapter(OTHER_ID, position=1, body="A" * 600),
+                chapter(THIRD_ID, position=2, body="B" * 600),
+            ]
+        )
+    )
+
+    assert [[item["chapter_id"] for item in batch] for batch in batches] == [
+        [str(OTHER_ID)],
+        [str(THIRD_ID)],
+    ]
+
+
+async def test_rejects_hallucinated_chapter_ids() -> None:
+    model_result = consistency(
+        findings=[
+            finding(
+                "cross_chapter_conflict",
+                "The totals conflict.",
+                "Confirm the total.",
+                chapter_ids=[TARGET_ID, UNKNOWN_ID],
+            )
+        ],
+    )
+
+    with pytest.raises(ChapterValidationModelOutputError):
+        await service(static_passes(consistency_result=model_result)).validate(
+            request(
+                chapters=[
+                    chapter(TARGET_ID, position=0),
+                    chapter(OTHER_ID, position=1),
+                ]
+            )
+        )
+
+
+async def test_authoritative_gap_blocks_a_clean_model_result() -> None:
+    decision = await service(static_passes()).validate(
+        request(
+            gaps=[
+                ChapterValidationGap(
+                    severity="missing_information",
+                    reason="Confirm the co-financing amount.",
+                )
+            ],
+            evidence=False,
+        )
+    )
+
+    assert decision.status == "incomplete"
+    assert any(item.category == "missing_information" for item in decision.findings)
+
+
+async def test_rejects_oversized_input_before_calling_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_pass = AsyncMock(return_value=completeness())
+    monkeypatch.setattr(
+        "app.services.cnb.chapter_validation.count_prompt_tokens",
+        lambda *_args, **_kwargs: TokenCount(tokens=100_000, tokenizer="test"),
+    )
+
+    with pytest.raises(ChapterValidationInputTooLargeError):
+        await service(run_pass).validate(request())
+    run_pass.assert_not_awaited()
+
+
+async def test_provider_failure_returns_stable_error() -> None:
+    run_pass = AsyncMock(side_effect=RuntimeError("provider unavailable"))
+    with pytest.raises(ChapterValidationError) as exc_info:
+        await service(run_pass).validate(request())
+    assert exc_info.value.code == "chapter_validation_failed"
+
+
+@pytest.mark.parametrize(
+    ("required", "expected_status", "expected_severity"),
+    [(True, "incomplete", "blocking"), (False, "needs_review", "warning")],
+)
+async def test_empty_chapter_short_circuits_by_required_state(
+    required: bool,
+    expected_status: str,
+    expected_severity: str,
+) -> None:
+    run_pass = AsyncMock(return_value=completeness())
+    decision = await service(run_pass).validate(
+        request(
+            chapters=[chapter(TARGET_ID, position=0, body=None, required=required)],
+            target_required=required,
+        )
+    )
+
+    run_pass.assert_not_awaited()
+    assert decision.status == expected_status
+    assert decision.findings[0].severity == expected_severity

--- a/climate-advisor/service/tests/cnb/test_chapter_validation.py
+++ b/climate-advisor/service/tests/cnb/test_chapter_validation.py
@@ -100,12 +100,14 @@ async def test_runs_completeness_before_document_consistency() -> None:
     )
 
     assert [phase for phase, _ in calls] == ["completeness", "consistency"]
-    assert {item["chapter_id"] for item in calls[1][1]["compared_chapters"]} == {
+    assert {item["chapter_id"] for item in calls[1][1]["document"]["chapters"]} == {
         str(OTHER_ID),
         str(THIRD_ID),
     }
-    assert calls[0][1]["evidence_links"][0]["position"] == 1
-    assert calls[1][1]["evidence_links"][0]["position"] == 1
+    assert calls[0][1]["output"]["chapter_id"] == str(TARGET_ID)
+    assert calls[1][1]["output"]["chapter_id"] == str(TARGET_ID)
+    assert calls[0][1]["document"]["evidence_links"][0]["position"] == 1
+    assert calls[1][1]["document"]["evidence_links"][0]["position"] == 1
     assert decision.status == "ready"
 
 
@@ -161,22 +163,22 @@ async def test_rejects_model_reference_to_unavailable_evidence() -> None:
         )
 
 
-async def test_batches_complete_comparison_chapters_without_truncation(
+async def test_batches_complete_document_chapters_without_truncation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     batches: list[list[dict[str, Any]]] = []
 
     def fake_count(parts: list[Any], **_: Any) -> TokenCount:
-        compared = parts[1].get("compared_chapters", [])
+        document_chapters = parts[1].get("document", {}).get("chapters", [])
         return TokenCount(
-            tokens=100 + sum(len(item["body_markdown"]) for item in compared),
+            tokens=100 + sum(len(item["body_markdown"]) for item in document_chapters),
             tokenizer="test",
         )
 
     async def run_pass(phase: str, payload: dict[str, Any]) -> Any:
         if phase == "completeness":
             return completeness()
-        batches.append(payload["compared_chapters"])
+        batches.append(payload["document"]["chapters"])
         return consistency()
 
     monkeypatch.setattr(

--- a/climate-advisor/service/tests/cnb/test_chapter_validation.py
+++ b/climate-advisor/service/tests/cnb/test_chapter_validation.py
@@ -15,6 +15,7 @@ from app.services.cnb.chapter_validation import (
     ChapterValidationError,
     ChapterValidationInputTooLargeError,
     ChapterValidationModelOutputError,
+    ChapterValidationTemplateError,
     build_chapter_validation_request,
 )
 from app.utils.prompt_budget import TokenCount
@@ -70,7 +71,7 @@ def test_builds_request_from_repository_snapshot() -> None:
     template = ApplicationContextTemplate(
         id=UUID("88888888-8888-4888-8888-888888888888"),
         name="Application",
-        chapter_schema=[{"chapter_ref": "chapter-1"}],
+        chapter_schema=[{"chapter_ref": "chapter-1", "required_fields": ["Budget"]}],
         required_fields=["Budget"],
     )
 
@@ -78,6 +79,7 @@ def test_builds_request_from_repository_snapshot() -> None:
 
     assert built.chapters[0].revision_number == 2
     assert built.template and built.template.template_id == template.id
+    assert built.template.chapter_schema[0]["required_fields"] == ["Budget"]
     assert built.open_gaps[0].severity == "critical"
     assert built.evidence_links[0].source_location == "page 4"
 
@@ -109,6 +111,143 @@ async def test_runs_completeness_before_document_consistency() -> None:
     assert calls[0][1]["document"]["evidence_links"][0]["position"] == 1
     assert calls[1][1]["document"]["evidence_links"][0]["position"] == 1
     assert decision.status == "ready"
+
+
+async def test_completeness_receives_only_selected_schema_and_associated_fields() -> (
+    None
+):
+    validation_request = request()
+    template = validation_request.template
+    assert template is not None
+    template.chapter_schema = [
+        {
+            "chapter_ref": "other",
+            "title": "Chapter 1",
+            "required_fields": ["Budget", "Project name"],
+            "description": "Unrelated budget instructions",
+        },
+        {
+            "chapter_ref": "chapter-1",
+            "title": "Timetable",
+            "description": "Explain delivery milestones.",
+            "required": True,
+            "required_fields": ["Implementation timetable", "Project name"],
+            "word_limit": 200,
+        },
+    ]
+    template.required_fields = ["Budget", "Implementation timetable", "Project name"]
+    before = template.model_dump()
+    calls: list[dict[str, Any]] = []
+
+    async def run_pass(phase: str, payload: dict[str, Any]) -> Any:
+        if phase == "completeness":
+            calls.append(payload)
+            return completeness()
+        return consistency()
+
+    await service(run_pass).validate(validation_request)
+
+    assert calls[0]["document"]["validation_profile"] == {
+        "name": "Application template",
+        "output_format": None,
+        "chapter_schema": {
+            "title": "Timetable",
+            "description": "Explain delivery milestones.",
+            "required": True,
+            "word_limit": 200,
+        },
+        "required_fields": ["Implementation timetable", "Project name"],
+    }
+    assert "template" not in calls[0]["document"]
+    assert template.model_dump() == before
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        [],
+        [{"chapter_ref": "wrong", "required_fields": ["Implementation timetable"]}],
+        [{"chapter_ref": "chapter-1"}, {"chapter_ref": " chapter-1 "}],
+        [{"chapter_ref": "chapter-1"}],
+        [{"chapter_ref": "chapter-1", "required_fields": []}],
+        [{"chapter_ref": "chapter-1", "required_fields": None}],
+        [{"chapter_ref": "chapter-1", "required_fields": "Implementation timetable"}],
+        [{"chapter_ref": "chapter-1", "required_fields": [123]}],
+        [{"chapter_ref": "chapter-1", "required_fields": [" "]}],
+    ],
+    ids=[
+        "empty",
+        "no-match",
+        "duplicate",
+        "legacy-flat",
+        "unassigned",
+        "null",
+        "string",
+        "number",
+        "blank",
+    ],
+)
+async def test_invalid_template_never_calls_model(schema: list[dict[str, Any]]) -> None:
+    validation_request = request()
+    assert validation_request.template is not None
+    validation_request.template.chapter_schema = schema
+    run_pass = AsyncMock()
+
+    with pytest.raises(ChapterValidationTemplateError) as error:
+        await service(run_pass).validate(validation_request)
+
+    assert error.value.code == "chapter_validation_template_invalid"
+    assert error.value.status_code == 409
+    run_pass.assert_not_awaited()
+
+
+@pytest.mark.parametrize("chapter_ref", [None, " chapter-1 "])
+async def test_selection_uses_the_same_reference_normalization_as_workspace(
+    chapter_ref: str | None,
+) -> None:
+    validation_request = request()
+    assert validation_request.template is not None
+    schema = validation_request.template.chapter_schema[0]
+    if chapter_ref is None:
+        schema.pop("chapter_ref")
+    else:
+        schema["chapter_ref"] = chapter_ref
+
+    assert (
+        await service(static_passes()).validate(validation_request)
+    ).status == "ready"
+
+
+async def test_chapter_without_fields_does_not_inherit_other_chapters_requirements() -> (
+    None
+):
+    validation_request = request()
+    assert validation_request.template is not None
+    validation_request.template.chapter_schema = [
+        {"chapter_ref": "chapter-1", "required_fields": []},
+        {"chapter_ref": "other", "required_fields": ["Implementation timetable"]},
+    ]
+
+    async def run_pass(phase: str, payload: dict[str, Any]) -> Any:
+        if phase == "completeness":
+            assert payload["document"]["validation_profile"]["required_fields"] == []
+            return completeness()
+        return consistency()
+
+    await service(run_pass).validate(validation_request)
+
+
+async def test_no_template_preserves_template_free_validation() -> None:
+    validation_request = request()
+    validation_request.template = None
+
+    async def run_pass(phase: str, payload: dict[str, Any]) -> Any:
+        if phase == "completeness":
+            assert payload["document"]["validation_profile"] is None
+            return completeness()
+        return consistency()
+
+    await service(run_pass).validate(validation_request)
 
 
 async def test_resolves_model_evidence_positions_to_public_source_metadata() -> None:

--- a/climate-advisor/service/tests/cnb/test_chapter_validation.py
+++ b/climate-advisor/service/tests/cnb/test_chapter_validation.py
@@ -104,7 +104,61 @@ async def test_runs_completeness_before_document_consistency() -> None:
         str(OTHER_ID),
         str(THIRD_ID),
     }
+    assert calls[0][1]["evidence_links"][0]["position"] == 1
+    assert calls[1][1]["evidence_links"][0]["position"] == 1
     assert decision.status == "ready"
+
+
+async def test_resolves_model_evidence_positions_to_public_source_metadata() -> None:
+    model_result = completeness(
+        findings=[
+            finding(
+                "evidence",
+                "The stated start date conflicts with the delivery plan.",
+                "Confirm the approved start date.",
+                severity="warning",
+                evidence_positions=[1],
+            )
+        ]
+    )
+    validation_request = request()
+    validation_request.evidence_links[0] = validation_request.evidence_links[
+        0
+    ].model_copy(
+        update={
+            "source_location": "page 7",
+            "claim_ref": "implementation start date",
+            "quote_or_summary": "Works begin in March 2027.",
+        }
+    )
+
+    decision = await service(static_passes(completeness_result=model_result)).validate(
+        validation_request
+    )
+
+    assert decision.findings[0].phase == "evidence"
+    assert decision.findings[0].evidence[0].selected_source_label == "City climate plan"
+    assert decision.findings[0].evidence[0].source_location == "page 7"
+    assert decision.findings[0].evidence[0].claim_ref == "implementation start date"
+
+
+async def test_rejects_model_reference_to_unavailable_evidence() -> None:
+    model_result = completeness(
+        findings=[
+            finding(
+                "evidence",
+                "The date conflicts with a source.",
+                "Confirm the date.",
+                severity="warning",
+                evidence_positions=[2],
+            )
+        ]
+    )
+
+    with pytest.raises(ChapterValidationModelOutputError):
+        await service(static_passes(completeness_result=model_result)).validate(
+            request()
+        )
 
 
 async def test_batches_complete_comparison_chapters_without_truncation(

--- a/climate-advisor/service/tests/cnb/test_chapter_validation_consistency.py
+++ b/climate-advisor/service/tests/cnb/test_chapter_validation_consistency.py
@@ -1,0 +1,73 @@
+import pytest
+from tests.cnb.chapter_validation_helpers import (
+    OTHER_ID,
+    TARGET_ID,
+    chapter,
+    consistency,
+    finding,
+    request,
+    service,
+    static_passes,
+)
+
+INVESTMENT_BODY = (
+    "The proposed measure is the delivery of the 4.45 km tram route. Construction "
+    "is 97% complete and commissioning is underway."
+)
+EUCF_SUPPORT_BODY = (
+    "EUCF-supported work should focus on clearly defined remaining or follow-on "
+    "investment-concept activities rather than on works already completed, under "
+    "construction, or being commissioned."
+)
+
+
+@pytest.mark.parametrize(
+    ("target_body", "related_body", "expected_status"),
+    [
+        ("The project supports sustainable mobility.", INVESTMENT_BODY, "ready"),
+        (INVESTMENT_BODY, EUCF_SUPPORT_BODY, "incomplete"),
+    ],
+)
+async def test_scope_guard_requires_explicit_incompatible_claims(
+    target_body: str,
+    related_body: str,
+    expected_status: str,
+) -> None:
+    decision = await service(static_passes()).validate(
+        request(
+            chapters=[
+                chapter(TARGET_ID, position=0, body=target_body),
+                chapter(OTHER_ID, position=1, body=related_body),
+            ]
+        )
+    )
+
+    assert decision.status == expected_status
+
+
+async def test_deterministic_scope_conflict_deduplicates_model_paraphrase() -> None:
+    model_result = consistency(
+        findings=[
+            finding(
+                "cross_chapter_conflict",
+                "The target includes delivery of the current route while the related "
+                "chapter excludes construction works.",
+                "Align both chapters on one future residual scope.",
+                chapter_ids=[TARGET_ID, OTHER_ID],
+            )
+        ],
+    )
+    decision = await service(static_passes(consistency_result=model_result)).validate(
+        request(
+            chapters=[
+                chapter(TARGET_ID, position=0, body=INVESTMENT_BODY),
+                chapter(OTHER_ID, position=1, body=EUCF_SUPPORT_BODY),
+            ]
+        )
+    )
+
+    conflicts = [
+        item for item in decision.findings if item.category == "cross_chapter_conflict"
+    ]
+    assert len(conflicts) == 1
+    assert conflicts[0].excerpts

--- a/climate-advisor/service/tests/cnb/test_chapter_validation_consistency.py
+++ b/climate-advisor/service/tests/cnb/test_chapter_validation_consistency.py
@@ -1,8 +1,10 @@
-import pytest
+from typing import Any
+
 from tests.cnb.chapter_validation_helpers import (
     OTHER_ID,
     TARGET_ID,
     chapter,
+    completeness,
     consistency,
     finding,
     request,
@@ -10,64 +12,65 @@ from tests.cnb.chapter_validation_helpers import (
     static_passes,
 )
 
-INVESTMENT_BODY = (
-    "The proposed measure is the delivery of the 4.45 km tram route. Construction "
-    "is 97% complete and commissioning is underway."
-)
-EUCF_SUPPORT_BODY = (
-    "EUCF-supported work should focus on clearly defined remaining or follow-on "
-    "investment-concept activities rather than on works already completed, under "
-    "construction, or being commissioned."
-)
+OUTPUT_BODY = "The total project cost is EUR 4 million."
+DOCUMENT_BODY = "Total eligible expenditure: EUR 5 million."
 
 
-@pytest.mark.parametrize(
-    ("target_body", "related_body", "expected_status"),
-    [
-        ("The project supports sustainable mobility.", INVESTMENT_BODY, "ready"),
-        (INVESTMENT_BODY, EUCF_SUPPORT_BODY, "incomplete"),
-    ],
-)
-async def test_scope_guard_requires_explicit_incompatible_claims(
-    target_body: str,
-    related_body: str,
-    expected_status: str,
-) -> None:
+async def test_consistency_pass_verifies_output_against_document() -> None:
+    observed: dict[str, Any] = {}
+
+    async def run_pass(phase: str, payload: dict[str, Any]) -> Any:
+        if phase == "completeness":
+            return completeness()
+        observed.update(payload)
+        return consistency(
+            findings=[
+                finding(
+                    "cross_chapter_conflict",
+                    "The output total conflicts with the document budget.",
+                    "Confirm and use one approved total.",
+                    chapter_ids=[TARGET_ID, OTHER_ID],
+                )
+            ]
+        )
+
+    decision = await service(run_pass).validate(
+        request(
+            chapters=[
+                chapter(TARGET_ID, position=0, body=OUTPUT_BODY),
+                chapter(OTHER_ID, position=1, body=DOCUMENT_BODY),
+            ]
+        )
+    )
+
+    assert observed["output"]["body_markdown"] == OUTPUT_BODY
+    assert observed["document"]["chapters"][0]["body_markdown"] == DOCUMENT_BODY
+    assert decision.status == "incomplete"
+
+
+async def test_service_does_not_apply_program_specific_scope_rules() -> None:
     decision = await service(static_passes()).validate(
         request(
             chapters=[
-                chapter(TARGET_ID, position=0, body=target_body),
-                chapter(OTHER_ID, position=1, body=related_body),
+                chapter(
+                    TARGET_ID,
+                    position=0,
+                    body=(
+                        "The proposed measure is delivery of the route. Construction "
+                        "is 97% complete and commissioning is underway."
+                    ),
+                ),
+                chapter(
+                    OTHER_ID,
+                    position=1,
+                    body=(
+                        "The programme document excludes ongoing construction and "
+                        "commissioning."
+                    ),
+                ),
             ]
         )
     )
 
-    assert decision.status == expected_status
-
-
-async def test_deterministic_scope_conflict_deduplicates_model_paraphrase() -> None:
-    model_result = consistency(
-        findings=[
-            finding(
-                "cross_chapter_conflict",
-                "The target includes delivery of the current route while the related "
-                "chapter excludes construction works.",
-                "Align both chapters on one future residual scope.",
-                chapter_ids=[TARGET_ID, OTHER_ID],
-            )
-        ],
-    )
-    decision = await service(static_passes(consistency_result=model_result)).validate(
-        request(
-            chapters=[
-                chapter(TARGET_ID, position=0, body=INVESTMENT_BODY),
-                chapter(OTHER_ID, position=1, body=EUCF_SUPPORT_BODY),
-            ]
-        )
-    )
-
-    conflicts = [
-        item for item in decision.findings if item.category == "cross_chapter_conflict"
-    ]
-    assert len(conflicts) == 1
-    assert conflicts[0].excerpts
+    assert decision.status == "ready"
+    assert decision.findings == []

--- a/climate-advisor/service/tests/cnb/test_chapter_validation_persistence.py
+++ b/climate-advisor/service/tests/cnb/test_chapter_validation_persistence.py
@@ -1,0 +1,309 @@
+"""Persistence contracts for Concept Note chapter validation results."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from app.db.cnb import CnbBase
+from app.models.db.cnb_reference import CnbFundedProject, CnbFunder  # noqa: F401
+from app.models.db.cnb_workspace import (
+    ConceptNoteChapter,
+    ConceptNoteChapterRevision,
+    ConceptNoteChapterValidation,
+    ConceptNoteEvidenceLink,
+    ConceptNoteGap,
+)
+from app.persistence.concept_notes import workspace as workspace_module
+from app.persistence.concept_notes.workspace import (
+    ConceptNoteWorkspaceRepository,
+    WorkspaceValidationInputChangedError,
+)
+from sqlalchemy import DefaultClause, event, select, text, update
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+TEMPLATE_FINGERPRINT = "template-v1"
+
+
+@pytest.mark.asyncio
+async def test_final_fingerprint_locks_target_gap_and_evidence_rows() -> None:
+    """Prevent child-row updates from racing the final fingerprint write."""
+    session = MagicMock()
+    scalar_result = MagicMock()
+    scalar_result.all.return_value = []
+    session.scalars = AsyncMock(return_value=scalar_result)
+    chapter_id = uuid4()
+
+    await workspace_module._open_gaps_by_chapter(
+        session,
+        [chapter_id],
+        lock=True,
+    )
+    await workspace_module._evidence_by_chapter(
+        session,
+        [chapter_id],
+        lock=True,
+    )
+
+    statements = [call.args[0] for call in session.scalars.await_args_list]
+    rendered = [
+        str(statement.compile(dialect=postgresql.dialect())) for statement in statements
+    ]
+    assert len(rendered) == 2
+    assert all("FOR UPDATE" in statement for statement in rendered)
+
+
+@asynccontextmanager
+async def _validation_repository():
+    """Provide an isolated SQLite workspace with PostgreSQL JSON defaults adapted."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _enable_foreign_keys(dbapi_connection, _connection_record) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    session_factory: async_sessionmaker[AsyncSession] = async_sessionmaker(
+        engine,
+        expire_on_commit=False,
+    )
+    changed_defaults: list[tuple[object, object]] = []
+    for table in CnbBase.metadata.tables.values():
+        for column in table.columns:
+            default = column.server_default
+            if default is not None and "::jsonb" in str(default.arg):
+                changed_defaults.append((column, default))
+                column.server_default = DefaultClause(
+                    text(str(default.arg).replace("::jsonb", ""))
+                )
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(CnbBase.metadata.create_all)
+        yield ConceptNoteWorkspaceRepository(session_factory), session_factory
+    finally:
+        for column, default in changed_defaults:
+            column.server_default = default
+        await engine.dispose()
+
+
+async def _seed_document(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    run_id: UUID,
+) -> tuple[UUID, UUID]:
+    """Create two drafted chapters with target gaps and evidence."""
+    target_id = uuid4()
+    related_id = uuid4()
+    async with session_factory() as session, session.begin():
+        session.add_all(
+            [
+                ConceptNoteChapter(
+                    chapter_id=target_id,
+                    run_id=run_id,
+                    template_section_id="summary",
+                    title="Summary",
+                    position=0,
+                    status="draft",
+                    required=True,
+                ),
+                ConceptNoteChapter(
+                    chapter_id=related_id,
+                    run_id=run_id,
+                    template_section_id="budget",
+                    title="Budget",
+                    position=1,
+                    status="draft",
+                    required=True,
+                ),
+                ConceptNoteChapterRevision(
+                    chapter_id=target_id,
+                    revision_number=1,
+                    author_type="agent",
+                    change_type="draft",
+                    body_markdown="Target body",
+                ),
+                ConceptNoteChapterRevision(
+                    chapter_id=related_id,
+                    revision_number=1,
+                    author_type="agent",
+                    change_type="draft",
+                    body_markdown="Related body",
+                ),
+                ConceptNoteGap(
+                    run_id=run_id,
+                    chapter_id=target_id,
+                    field_key="beneficiaries",
+                    severity="missing_information",
+                    reason="Beneficiary count is missing",
+                    status="open",
+                ),
+                ConceptNoteEvidenceLink(
+                    chapter_id=target_id,
+                    selected_source_label="City plan",
+                    source_location="page 4",
+                    claim_ref="heat-risk",
+                    quote_or_summary="Heat exposure is increasing.",
+                ),
+            ]
+        )
+    return target_id, related_id
+
+
+async def test_validation_context_fingerprint_tracks_document_gap_and_evidence() -> (
+    None
+):
+    """Any planned validation input change must produce a new fingerprint."""
+    run_id = uuid4()
+    async with _validation_repository() as (repository, sessions):
+        target_id, _ = await _seed_document(sessions, run_id=run_id)
+
+        initial = await repository.load_validation_context(
+            run_id=run_id,
+            chapter_id=target_id,
+            template_fingerprint=TEMPLATE_FINGERPRINT,
+        )
+        async with sessions() as session, session.begin():
+            session.add(
+                ConceptNoteEvidenceLink(
+                    chapter_id=target_id,
+                    selected_source_label="Budget annex",
+                    source_location="table 2",
+                    claim_ref="cost",
+                    quote_or_summary="Estimated cost is EUR 2 million.",
+                )
+            )
+        evidence_changed = await repository.load_validation_context(
+            run_id=run_id,
+            chapter_id=target_id,
+            template_fingerprint=TEMPLATE_FINGERPRINT,
+        )
+        assert evidence_changed.fingerprint != initial.fingerprint
+
+        template_changed = await repository.load_validation_context(
+            run_id=run_id,
+            chapter_id=target_id,
+            template_fingerprint="template-v2",
+        )
+        assert template_changed.fingerprint != evidence_changed.fingerprint
+
+
+async def test_upsert_projects_staleness_and_rejects_an_old_fingerprint() -> None:
+    """Persist atomically and expose a stale ready result as needs review."""
+    run_id = uuid4()
+    async with _validation_repository() as (repository, sessions):
+        target_id, related_id = await _seed_document(sessions, run_id=run_id)
+        context = await repository.load_validation_context(
+            run_id=run_id,
+            chapter_id=target_id,
+            template_fingerprint=TEMPLATE_FINGERPRINT,
+        )
+        stored = await repository.upsert_validation(
+            run_id=run_id,
+            chapter_id=target_id,
+            template_fingerprint=TEMPLATE_FINGERPRINT,
+            expected_fingerprint=context.fingerprint,
+            status="ready",
+            findings=[],
+        )
+        assert stored.status == "ready"
+        assert stored.validated_revision_number == 1
+        assert not stored.is_stale
+
+        async with sessions() as session, session.begin():
+            session.add(
+                ConceptNoteChapterRevision(
+                    chapter_id=related_id,
+                    revision_number=2,
+                    author_type="user",
+                    change_type="edit_text",
+                    body_markdown="Conflicting related body",
+                )
+            )
+
+        stale_chapter = next(
+            chapter
+            for chapter in await repository.list_chapters(
+                run_id=run_id,
+                template_fingerprint=TEMPLATE_FINGERPRINT,
+            )
+            if chapter.chapter_id == target_id
+        )
+        assert stale_chapter.status == "needs_review"
+        assert stale_chapter.validation is not None
+        assert stale_chapter.validation.status == "ready"
+        assert stale_chapter.validation.is_stale
+
+        with pytest.raises(WorkspaceValidationInputChangedError):
+            await repository.upsert_validation(
+                run_id=run_id,
+                chapter_id=target_id,
+                template_fingerprint=TEMPLATE_FINGERPRINT,
+                expected_fingerprint=context.fingerprint,
+                status="ready",
+                findings=[],
+            )
+
+
+async def test_copy_omits_validation_and_delete_removes_source_result() -> None:
+    """A duplicate drops validation-derived states and dependent result rows."""
+    source_run_id = uuid4()
+    destination_run_id = uuid4()
+    async with _validation_repository() as (repository, sessions):
+        target_id, _ = await _seed_document(sessions, run_id=source_run_id)
+        async with sessions() as session, session.begin():
+            await session.execute(
+                update(ConceptNoteGap)
+                .where(ConceptNoteGap.run_id == source_run_id)
+                .values(status="resolved")
+            )
+        context = await repository.load_validation_context(
+            run_id=source_run_id,
+            chapter_id=target_id,
+            template_fingerprint=TEMPLATE_FINGERPRINT,
+        )
+        stored = await repository.upsert_validation(
+            run_id=source_run_id,
+            chapter_id=target_id,
+            template_fingerprint=TEMPLATE_FINGERPRINT,
+            expected_fingerprint=context.fingerprint,
+            status="ready",
+            findings=[],
+        )
+
+        await repository.copy_working_copy(
+            source_run_id=source_run_id,
+            destination_run_id=destination_run_id,
+        )
+        destination = await repository.list_chapters(run_id=destination_run_id)
+        copied_target = next(
+            chapter for chapter in destination if chapter.position == 0
+        )
+        assert copied_target.status == "draft"
+        assert copied_target.validation is None
+
+        async with sessions() as session:
+            all_validations = list(
+                (await session.scalars(select(ConceptNoteChapterValidation))).all()
+            )
+        assert [validation.validation_id for validation in all_validations] == [
+            stored.validation_id
+        ]
+
+        await repository.delete_run(run_id=source_run_id)
+        async with sessions() as session:
+            assert (
+                await session.get(
+                    ConceptNoteChapterValidation,
+                    stored.validation_id,
+                )
+                is None
+            )

--- a/climate-advisor/service/tests/cnb/test_chapter_validation_route.py
+++ b/climate-advisor/service/tests/cnb/test_chapter_validation_route.py
@@ -1,0 +1,99 @@
+"""HTTP contracts for explicit Concept Note chapter validation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from app.main import get_app
+from app.models.cnb.concept_note_draft import ConceptNoteChapterValidationResponse
+from app.routes.concept_note_chapter_validation import (
+    get_chapter_validation_workflow_service,
+)
+from app.services.cnb.chapter_validation_workflow import (
+    ChapterValidationWorkflowError,
+)
+from fastapi.testclient import TestClient
+
+
+def _post_validation(service: object) -> tuple[object, object, object]:
+    """Post one request with isolated authorization and validation services."""
+    app = get_app()
+    run_id = uuid4()
+    chapter_id = uuid4()
+    app.dependency_overrides[get_chapter_validation_workflow_service] = lambda: service
+    authorized_run = SimpleNamespace(
+        run_id=run_id,
+        user_id="owner",
+        workflow_step="editing_document",
+    )
+    try:
+        with (
+            patch(
+                "app.routes.concept_note_chapter_validation."
+                "ConceptNoteRunService.get_authorized_run",
+                AsyncMock(return_value=authorized_run),
+            ),
+            TestClient(app) as client,
+        ):
+            response = client.post(
+                f"/v1/concept-notes/{run_id}/chapters/{chapter_id}/validation",
+                params={"user_id": "owner"},
+                headers={"Authorization": "Bearer token"},
+            )
+    finally:
+        app.dependency_overrides.clear()
+    return response, run_id, chapter_id
+
+
+def test_validation_route_returns_persisted_result_with_chapter_id() -> None:
+    """Expose the fresh result through the stable public action contract."""
+    validated_at = datetime.now(UTC)
+    validation = ConceptNoteChapterValidationResponse(
+        status="needs_review",
+        is_stale=False,
+        validated_revision_number=3,
+        validated_at=validated_at,
+        findings=[],
+    )
+    service = SimpleNamespace(validate=AsyncMock(return_value=validation))
+
+    response, run_id, chapter_id = _post_validation(service)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["chapter_id"] == str(chapter_id)
+    assert payload["status"] == "needs_review"
+    assert payload["validated_revision_number"] == 3
+    service.validate.assert_awaited_once_with(
+        run=SimpleNamespace(
+            run_id=run_id,
+            user_id="owner",
+            workflow_step="editing_document",
+        ),
+        chapter_id=chapter_id,
+    )
+
+
+def test_validation_route_preserves_error_code_and_sanitizes_detail() -> None:
+    """Return a stable code without exposing the internal exception message."""
+    service = SimpleNamespace(
+        validate=AsyncMock(
+            side_effect=ChapterValidationWorkflowError(
+                "chapter_revision_changed",
+                409,
+                "The document changed during validation; run validation again",
+            )
+        )
+    )
+
+    response, _, _ = _post_validation(service)
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "code": "chapter_revision_changed",
+        "detail": "Unable to validate the requested chapter",
+        "status": 409,
+    }

--- a/climate-advisor/service/tests/cnb/test_chapter_validation_route.py
+++ b/climate-advisor/service/tests/cnb/test_chapter_validation_route.py
@@ -12,6 +12,7 @@ from app.models.cnb.concept_note_draft import ConceptNoteChapterValidationRespon
 from app.routes.concept_note_chapter_validation import (
     get_chapter_validation_workflow_service,
 )
+from app.services.cnb.chapter_validation import ChapterValidationTemplateError
 from app.services.cnb.chapter_validation_workflow import (
     ChapterValidationWorkflowError,
 )
@@ -95,5 +96,22 @@ def test_validation_route_preserves_error_code_and_sanitizes_detail() -> None:
     assert response.json() == {
         "code": "chapter_revision_changed",
         "detail": "Unable to validate the requested chapter",
+        "status": 409,
+    }
+
+
+def test_invalid_template_returns_actionable_safe_error() -> None:
+    service = SimpleNamespace(
+        validate=AsyncMock(
+            side_effect=ChapterValidationTemplateError("private source data")
+        )
+    )
+
+    response, _, _ = _post_validation(service)
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "code": "chapter_validation_template_invalid",
+        "detail": ChapterValidationTemplateError.public_message,
         "status": 409,
     }

--- a/climate-advisor/service/tests/cnb/test_chapter_validation_workflow.py
+++ b/climate-advisor/service/tests/cnb/test_chapter_validation_workflow.py
@@ -1,0 +1,225 @@
+"""Application workflow around validation and atomic persistence."""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, call
+from uuid import uuid4
+
+import pytest
+from app.models.cnb.concept_note_application_context import ApplicationContextTemplate
+from app.models.cnb.concept_note_chapter_validation import ChapterValidationDecision
+from app.persistence.concept_notes.workspace import (
+    WorkspaceValidationChapter,
+    WorkspaceValidationContext,
+    WorkspaceValidationInputChangedError,
+    WorkspaceValidationSnapshot,
+)
+from app.services.cnb.application_context import (
+    calculate_application_template_fingerprint,
+)
+from app.services.cnb.chapter_validation_workflow import (
+    ChapterValidationWorkflowError,
+    ConceptNoteChapterValidationWorkflowService,
+)
+from sqlalchemy.exc import SQLAlchemyError
+
+
+def _template() -> ApplicationContextTemplate:
+    return ApplicationContextTemplate(
+        id=uuid4(),
+        name="Application template",
+        chapter_schema=[{"chapter_ref": "budget", "required": True}],
+        required_fields=["Project budget"],
+    )
+
+
+def _context() -> WorkspaceValidationContext:
+    chapter = WorkspaceValidationChapter(
+        chapter_id=uuid4(),
+        chapter_ref="budget",
+        title="Budget",
+        position=0,
+        status="draft",
+        required=True,
+        body_markdown="The project costs EUR 2 million.",
+        revision_id=uuid4(),
+        revision_number=2,
+    )
+    return WorkspaceValidationContext(
+        target=chapter,
+        chapters=[chapter],
+        open_gaps=[],
+        evidence_links=[],
+        fingerprint="a" * 64,
+    )
+
+
+def _decision(context: WorkspaceValidationContext) -> ChapterValidationDecision:
+    return ChapterValidationDecision(
+        target_chapter_id=context.target.chapter_id,
+        validated_revision_number=2,
+        validation_input_fingerprint=context.fingerprint,
+        status="ready",
+        findings=[],
+    )
+
+
+def _workflow(
+    *,
+    context: WorkspaceValidationContext | None = None,
+    template_effect: object | None = None,
+    upsert_effect: Exception | None = None,
+):
+    context = context or _context()
+    workspace = MagicMock()
+    workspace.load_validation_context = AsyncMock(return_value=context)
+    workspace.upsert_validation = AsyncMock(side_effect=upsert_effect)
+    validator = MagicMock()
+    validator.validate = AsyncMock(return_value=_decision(context))
+    application_context = MagicMock()
+    if template_effect is None:
+        application_context.load_for_run = AsyncMock(
+            return_value=SimpleNamespace(template=_template())
+        )
+    else:
+        application_context.load_for_run = AsyncMock(side_effect=template_effect)
+    service = ConceptNoteChapterValidationWorkflowService(
+        workflow_session=MagicMock(),
+        workspace=workspace,
+        validator=validator,
+        application_context=application_context,
+    )
+    return service, workspace, validator, application_context, context
+
+
+@pytest.mark.asyncio
+async def test_workflow_persists_the_validated_fingerprint() -> None:
+    context = _context()
+    template = _template()
+    workflow, workspace, validator, app_context, _ = _workflow(
+        context=context,
+        template_effect=[
+            SimpleNamespace(template=template),
+            SimpleNamespace(template=template),
+        ],
+    )
+    workspace.upsert_validation.return_value = WorkspaceValidationSnapshot(
+        validation_id=uuid4(),
+        status="ready",
+        is_stale=False,
+        validated_revision_id=context.target.revision_id,
+        validated_revision_number=2,
+        validation_input_fingerprint=context.fingerprint,
+        validated_at=datetime.now(UTC),
+        findings=[],
+    )
+    run = SimpleNamespace(run_id=uuid4(), workflow_step="editing_document")
+
+    response = await workflow.validate(run=run, chapter_id=context.target.chapter_id)
+
+    assert response.status == "ready"
+    assert len(response.checks) == 6
+    app_context.load_for_run.assert_has_awaits([call(run), call(run)])
+    validator.validate.assert_awaited_once()
+    assert workspace.upsert_validation.await_args.kwargs["expected_fingerprint"] == (
+        context.fingerprint
+    )
+    assert workspace.upsert_validation.await_args.kwargs["template_fingerprint"] == (
+        calculate_application_template_fingerprint(template)
+    )
+
+
+@pytest.mark.asyncio
+async def test_workflow_maps_post_llm_fingerprint_race_to_409() -> None:
+    workflow, *_rest, context = _workflow(
+        upsert_effect=WorkspaceValidationInputChangedError()
+    )
+
+    with pytest.raises(ChapterValidationWorkflowError) as exc_info:
+        await workflow.validate(
+            run=SimpleNamespace(run_id=uuid4(), workflow_step="editing_document"),
+            chapter_id=context.target.chapter_id,
+        )
+
+    assert (exc_info.value.status_code, exc_info.value.code) == (
+        409,
+        "chapter_revision_changed",
+    )
+
+
+@pytest.mark.asyncio
+async def test_workflow_rejects_template_change_during_validation() -> None:
+    original = _template()
+    changed = original.model_copy(update={"required_fields": ["Changed field"]})
+    workflow, workspace, *_rest, context = _workflow(
+        template_effect=[
+            SimpleNamespace(template=original),
+            SimpleNamespace(template=changed),
+        ]
+    )
+
+    with pytest.raises(ChapterValidationWorkflowError) as exc_info:
+        await workflow.validate(
+            run=SimpleNamespace(run_id=uuid4(), workflow_step="editing_document"),
+            chapter_id=context.target.chapter_id,
+        )
+
+    assert exc_info.value.code == "chapter_revision_changed"
+    workspace.upsert_validation.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_workflow_rejects_disallowed_state() -> None:
+    workflow, workspace, *_ = _workflow()
+
+    with pytest.raises(ChapterValidationWorkflowError) as exc_info:
+        await workflow.validate(
+            run=SimpleNamespace(run_id=uuid4(), workflow_step="interviewing"),
+            chapter_id=uuid4(),
+        )
+
+    assert exc_info.value.code == "chapter_validation_not_allowed"
+    workspace.load_validation_context.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_workflow_requires_application_template() -> None:
+    workflow, workspace, validator, *_ = _workflow(
+        template_effect=[SimpleNamespace(template=None)]
+    )
+
+    with pytest.raises(ChapterValidationWorkflowError) as exc_info:
+        await workflow.validate(
+            run=SimpleNamespace(run_id=uuid4(), workflow_step="editing_document"),
+            chapter_id=uuid4(),
+        )
+
+    assert exc_info.value.code == "chapter_validation_template_unavailable"
+    workspace.load_validation_context.assert_not_called()
+    validator.validate.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "template_effect",
+    [
+        [OSError("offline")],
+        [SimpleNamespace(template=_template()), SQLAlchemyError("offline")],
+    ],
+)
+async def test_workflow_maps_template_storage_failures_to_503(
+    template_effect: list[object],
+) -> None:
+    workflow, workspace, *_ = _workflow(template_effect=template_effect)
+
+    with pytest.raises(ChapterValidationWorkflowError) as exc_info:
+        await workflow.validate(
+            run=SimpleNamespace(run_id=uuid4(), workflow_step="editing_document"),
+            chapter_id=uuid4(),
+        )
+
+    assert (exc_info.value.status_code, exc_info.value.code) == (
+        503,
+        "cnb_storage_unavailable",
+    )
+    workspace.upsert_validation.assert_not_called()

--- a/climate-advisor/service/tests/cnb/test_chapter_validation_workflow.py
+++ b/climate-advisor/service/tests/cnb/test_chapter_validation_workflow.py
@@ -20,6 +20,7 @@ from app.services.cnb.application_context import (
 from app.services.cnb.chapter_validation_workflow import (
     ChapterValidationWorkflowError,
     ConceptNoteChapterValidationWorkflowService,
+    chapter_validation_response,
 )
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -90,6 +91,42 @@ def _workflow(
         application_context=application_context,
     )
     return service, workspace, validator, application_context, context
+
+
+def test_public_response_preserves_validation_source_provenance() -> None:
+    snapshot = WorkspaceValidationSnapshot(
+        validation_id=uuid4(),
+        status="needs_review",
+        is_stale=False,
+        validated_revision_id=uuid4(),
+        validated_revision_number=2,
+        validation_input_fingerprint="a" * 64,
+        validated_at=datetime.now(UTC),
+        findings=[
+            {
+                "phase": "evidence",
+                "category": "evidence",
+                "severity": "warning",
+                "message": "The stated date conflicts with the delivery plan.",
+                "suggested_action": "Confirm the approved date.",
+                "involved_chapter_ids": [str(uuid4())],
+                "excerpts": ["Works begin in March 2028."],
+                "evidence": [
+                    {
+                        "selected_source_label": "Delivery plan",
+                        "source_location": "page 7",
+                        "claim_ref": "implementation start date",
+                        "quote_or_summary": "Works begin in March 2027.",
+                    }
+                ],
+            }
+        ],
+    )
+
+    response = chapter_validation_response(snapshot)
+
+    assert response.findings[0].evidence[0].selected_source_label == "Delivery plan"
+    assert response.findings[0].evidence[0].source_location == "page 7"
 
 
 @pytest.mark.asyncio

--- a/climate-advisor/service/tests/cnb/test_chapter_validation_workflow.py
+++ b/climate-advisor/service/tests/cnb/test_chapter_validation_workflow.py
@@ -17,6 +17,10 @@ from app.persistence.concept_notes.workspace import (
 from app.services.cnb.application_context import (
     calculate_application_template_fingerprint,
 )
+from app.services.cnb.chapter_validation import (
+    ChapterValidationTemplateError,
+    ConceptNoteChapterValidationService,
+)
 from app.services.cnb.chapter_validation_workflow import (
     ChapterValidationWorkflowError,
     ConceptNoteChapterValidationWorkflowService,
@@ -29,7 +33,13 @@ def _template() -> ApplicationContextTemplate:
     return ApplicationContextTemplate(
         id=uuid4(),
         name="Application template",
-        chapter_schema=[{"chapter_ref": "budget", "required": True}],
+        chapter_schema=[
+            {
+                "chapter_ref": "budget",
+                "required": True,
+                "required_fields": ["Project budget"],
+            }
+        ],
         required_fields=["Project budget"],
     )
 
@@ -187,7 +197,8 @@ async def test_workflow_maps_post_llm_fingerprint_race_to_409() -> None:
 @pytest.mark.asyncio
 async def test_workflow_rejects_template_change_during_validation() -> None:
     original = _template()
-    changed = original.model_copy(update={"required_fields": ["Changed field"]})
+    changed = original.model_copy(deep=True)
+    changed.chapter_schema[0]["required_fields"] = ["Project budget", "Currency"]
     workflow, workspace, *_rest, context = _workflow(
         template_effect=[
             SimpleNamespace(template=original),
@@ -202,6 +213,25 @@ async def test_workflow_rejects_template_change_during_validation() -> None:
         )
 
     assert exc_info.value.code == "chapter_revision_changed"
+    workspace.upsert_validation.assert_not_called()
+
+
+async def test_invalid_assignments_never_persist_a_validation_result() -> None:
+    template = _template()
+    template.chapter_schema[0].pop("required_fields")
+    workflow, workspace, _, _, context = _workflow(
+        template_effect=[SimpleNamespace(template=template)]
+    )
+    run_pass = AsyncMock()
+    workflow._validator = ConceptNoteChapterValidationService(run_pass=run_pass)
+
+    with pytest.raises(ChapterValidationTemplateError):
+        await workflow.validate(
+            run=SimpleNamespace(run_id=uuid4(), workflow_step="editing_document"),
+            chapter_id=context.target.chapter_id,
+        )
+
+    run_pass.assert_not_awaited()
     workspace.upsert_validation.assert_not_called()
 
 

--- a/climate-advisor/service/tests/cnb/test_chat_runtime_context.py
+++ b/climate-advisor/service/tests/cnb/test_chat_runtime_context.py
@@ -7,11 +7,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
-from app.config import get_settings
 from app.models.requests import MessageCreateRequest
 from app.utils.chat_workflow_context import ChatWorkflowContext
 from app.utils.concept_note_context import clean_cnb_history
 from app.utils.streaming_handler import StreamingHandler
+
+from app.config import get_settings
 
 
 @pytest.mark.parametrize("current_already_saved", [False, True])
@@ -125,6 +126,44 @@ async def test_cnb_unavailable_bundle_is_runtime_data() -> None:
         "CONCEPT_NOTE_CONTEXT_BUNDLE_UNAVAILABLE\n"
     )
     assert messages[1] == {"role": "user", "content": payload.content}
+
+
+@pytest.mark.parametrize(
+    "content",
+    ["Help me", "What should I do next?", "Work on my concept note"],
+)
+async def test_vague_cnb_request_uses_the_bound_run_context(content: str) -> None:
+    run_id = uuid4()
+    context_loader = AsyncMock(
+        return_value={
+            "workflow_step": "editing_document",
+            "document_context": {"chapters": ["Summary", "Budget"]},
+        }
+    )
+    handler = StreamingHandler(
+        thread_id=str(uuid4()), user_id="owner", session_factory=MagicMock()
+    )
+    handler.workflow_context = ChatWorkflowContext(concept_note_run_id=str(run_id))
+    payload = MessageCreateRequest(user_id="owner", content=content)
+
+    with (
+        patch(
+            "app.utils.streaming_handler.load_conversation_history",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch("app.utils.streaming_handler.load_agent_context", new=context_loader),
+    ):
+        messages = await handler._load_conversation_history(get_settings(), payload)
+
+    context = json.loads(messages[0]["content"].split("\n", 1)[1])
+    assert context["workflow_step"] == "editing_document"
+    assert context["document_context"]["chapters"] == ["Summary", "Budget"]
+    assert messages[-1] == {"role": "user", "content": content}
+    context_loader.assert_awaited_once_with(
+        session_factory=handler.session_factory,
+        user_id="owner",
+        run_id=run_id,
+    )
 
 
 async def test_general_chat_history_roles_are_unchanged() -> None:

--- a/climate-advisor/service/tests/cnb/test_concept_note_agent_scope.py
+++ b/climate-advisor/service/tests/cnb/test_concept_note_agent_scope.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
 from app.config import get_settings
 from app.db import Base
 from app.models.cnb.context_bundle import ConceptNoteContextBundle
@@ -11,7 +13,6 @@ from app.models.db.concept_note import (
 )
 from app.models.db.concept_note import ConceptNoteRun
 from app.services.agent_service import AgentService
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 
 @pytest.mark.asyncio
@@ -74,7 +75,24 @@ async def test_source_query_registration_requires_ready_bundle_and_allowed_step(
         )
         agent = await service.create_agent()
         assert [tool.name for tool in agent.tools] == ["concept_note_sources_query"]
-        assert service.active_instructions == settings.llm.prompts.compose_prompt("cnb_chat")
+        assert service.active_instructions == settings.llm.prompts.compose_prompt(
+            "cnb_chat"
+        )
+        await service.close()
+
+        async with session_factory() as session, session.begin():
+            run = await session.get(ConceptNoteRun, run_id)
+            assert run is not None
+            run.workflow_step = "editing_document"
+        service = AgentService(
+            cc_access_token="token",
+            cc_thread_id=uuid4(),
+            cc_user_id="owner",
+            session_factory=session_factory,
+            concept_note_run_id=run_id,
+        )
+        agent = await service.create_agent()
+        assert [tool.name for tool in agent.tools] == ["concept_note_sources_query"]
         await service.close()
 
         async with session_factory() as session, session.begin():

--- a/climate-advisor/service/tests/cnb/test_prompt_projection.py
+++ b/climate-advisor/service/tests/cnb/test_prompt_projection.py
@@ -65,7 +65,11 @@ def populated_state():
             template_name="Application",
             chapter_schema=[
                 TemplateChapterDraft(chapter_ref="chapter-private-1", title="Summary"),
-                TemplateChapterDraft(chapter_ref="chapter-private-2", title="Budget"),
+                TemplateChapterDraft(
+                    chapter_ref="chapter-private-2",
+                    title="Budget",
+                    required_fields=["Total cost", "Funding requested"],
+                ),
             ],
         )
     ]
@@ -101,6 +105,10 @@ def test_research_projection_round_trip_keeps_identity_only_in_backend():
     assert "project-private" not in json.dumps(payload)
     assert payload["evidence"][1]["project_position"] == 0
     assert payload["evidence"][1]["field"] == "funded_projects[0].summary"
+    assert payload["funder_templates"][0]["chapter_schema"][1]["required_fields"] == [
+        "Total cost",
+        "Funding requested",
+    ]
     assert payload["conflicts"][0]["evidence_positions"] == [1]
     restored = restore_research_state(public, state, sources)
     assert restored.funded_projects[0].funded_project_ref == "project-private"
@@ -109,6 +117,10 @@ def test_research_projection_round_trip_keeps_identity_only_in_backend():
         == "chapter-private-2"
     )
     assert restored.evidence[1].source_ref == "source-002"
+    assert restored.funder_templates[0].chapter_schema[1].required_fields == [
+        "Total cost",
+        "Funding requested",
+    ]
     assert restored.evidence[1].funded_project_ref == "project-private"
     assert restored.conflicts[0].evidence_refs == [restored.evidence[1].evidence_ref]
     assert state.model_dump(mode="json") == original

--- a/climate-advisor/service/tests/cnb/test_research_bundle.py
+++ b/climate-advisor/service/tests/cnb/test_research_bundle.py
@@ -1,12 +1,12 @@
 """Tests for CNB funder research bundle conversion and material paths."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from app.models.cnb.research import (
     FieldEvidence,
+    FundedProjectResearchResult,
     FunderCriterionResearchResult,
     FunderTemplateResearchResult,
-    FundedProjectResearchResult,
     ResearchConflictResult,
     ResearchRunMetadata,
     TemplateChapterDraft,
@@ -65,6 +65,7 @@ def test_material_paths_use_criterion_template_and_chapter_references() -> None:
                         TemplateChapterDraft(
                             chapter_ref="chapter-001",
                             title="Project summary",
+                            required_fields=["Objectives"],
                         )
                     ],
                 )
@@ -93,9 +94,14 @@ def test_material_paths_use_criterion_template_and_chapter_references() -> None:
     )
 
     assert "funder_templates[template-001].template_name" in paths
+    assert templates[0].model_dump()["chapter_schema"][0]["required_fields"] == [
+        "Objectives"
+    ]
     assert (
-        "funder_templates[template-001].chapter_schema[chapter-001].title" in paths
+        "funder_templates[template-001].chapter_schema[chapter-001].required_fields"
+        in paths
     )
+    assert "funder_templates[template-001].chapter_schema[chapter-001].title" in paths
     assert "funder_criteria[selection-002].label" in paths
     assert not any("funder_criteria[opportunity-001]" in path for path in paths)
 
@@ -117,7 +123,7 @@ def test_bundle_drops_prior_run_evidence_and_its_conflict_links() -> None:
     result = build_result().model_copy(
         update={"evidence": [evidence], "conflicts": [conflict]}
     )
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     metadata = ResearchRunMetadata(
         pipeline_version="3.0",
         model_name="test-model",

--- a/climate-advisor/service/tests/cnb/test_research_service.py
+++ b/climate-advisor/service/tests/cnb/test_research_service.py
@@ -93,7 +93,7 @@ def test_service_writes_pending_review_artifacts_on_final_turn(
             ),
             models=SimpleNamespace(
                 funding_research=SimpleNamespace(
-                    name="openai/gpt-5.4",
+                    name="openai/gpt-5.6-sol",
                     reasoning_effort="medium",
                 )
             ),
@@ -200,10 +200,10 @@ def test_service_writes_pending_review_artifacts_on_final_turn(
         (run_directory / "research_bundle.json").read_text(encoding="utf-8")
     )
     assert saved_bundle["request"]["program_name"] == "Example Program"
-    assert saved_bundle["run_metadata"]["model_name"] == "openai/gpt-5.4"
+    assert saved_bundle["run_metadata"]["model_name"] == "openai/gpt-5.6-sol"
     assert (run_directory / "review.md").exists()
     assert (run_directory / "agent_trace.jsonl").exists()
-    assert fake_openai.responses.calls[0]["model"] == "openai/gpt-5.4"
+    assert fake_openai.responses.calls[0]["model"] == "openai/gpt-5.6-sol"
     assert fake_openai.responses.calls[0]["reasoning"] == {"effort": "medium"}
     assert "tools" not in fake_openai.responses.calls[0]
     model_input = json.loads(fake_openai.responses.calls[0]["input"])
@@ -213,7 +213,7 @@ def test_service_writes_pending_review_artifacts_on_final_turn(
     assert "current_filled_object" not in model_input["research_request"]
     assert model_input["missing_data"]
     assert model_input["turn_budget"]["final_audit"] is True
-    assert bundle.run_metadata.model_name == "openai/gpt-5.4"
+    assert bundle.run_metadata.model_name == "openai/gpt-5.6-sol"
     assert bundle.run_metadata.reasoning_effort == "medium"
     assert bundle.run_metadata.mlflow_run_id == "mlflow-001"
     assert bundle.run_metadata.prompt_sha256

--- a/climate-advisor/service/tests/test_agent_service.py
+++ b/climate-advisor/service/tests/test_agent_service.py
@@ -27,7 +27,7 @@ def build_mock_settings(
     base_url: str = "https://openrouter.ai/api/v1",
     prompt: str = "You are helpful",
     temperature: float = 0.0,
-    default_model: str = "openai/gpt-5.4-mini",
+    default_model: str = "openai/gpt-5.6-terra",
     agentic_flow_model: str | None = None,
     agentic_flow_temperature: float | None = None,
 ):
@@ -96,7 +96,7 @@ class AgentServiceInitializationTests(unittest.TestCase):
         with patch("app.services.agent_service.AsyncOpenAI"):
             service = AgentService()
             self.assertIsNotNone(service)
-            self.assertEqual(service.default_model, "openai/gpt-5.4-mini")
+            self.assertEqual(service.default_model, "openai/gpt-5.6-terra")
             self.assertEqual(service.default_temperature, 0.0)
 
     @patch("app.services.agent_service.get_settings")
@@ -108,7 +108,7 @@ class AgentServiceInitializationTests(unittest.TestCase):
         mock_settings = build_mock_settings(
             base_url="https://api.openai.com/v1",
             default_model="openai/gpt-4.1",
-            agentic_flow_model="openai/gpt-5.4",
+            agentic_flow_model="openai/gpt-5.6-sol",
         )
         mock_get_settings.return_value = mock_settings
 
@@ -116,7 +116,7 @@ class AgentServiceInitializationTests(unittest.TestCase):
             service = AgentService()
 
         self.assertEqual(service.default_model, "gpt-4.1")
-        self.assertEqual(service.agentic_flow_model, "gpt-5.4")
+        self.assertEqual(service.agentic_flow_model, "gpt-5.6-sol")
 
     @patch("app.services.agent_service.get_settings")
     def test_agent_service_keeps_provider_prefix_for_openrouter_base_url(
@@ -144,7 +144,7 @@ class AgentServiceInitializationTests(unittest.TestCase):
         mock_settings = build_mock_settings(
             base_url="https://api.openai.com/v1",
             default_model="openai/gpt-4.1",
-            agentic_flow_model="openai/gpt-5.4",
+            agentic_flow_model="openai/gpt-5.6-sol",
         )
         mock_get_settings.return_value = mock_settings
 
@@ -154,7 +154,7 @@ class AgentServiceInitializationTests(unittest.TestCase):
             with patch("app.services.agent_service.AsyncOpenAI"):
                 service = AgentService()
 
-        self.assertEqual(service.agentic_flow_model, "gpt-5.4")
+        self.assertEqual(service.agentic_flow_model, "gpt-5.6-sol")
 
     @patch("app.services.agent_service.get_settings")
     def test_agent_service_raises_without_api_key(self, mock_get_settings) -> None:
@@ -321,7 +321,7 @@ class AgentCreationTests(unittest.IsolatedAsyncioTestCase):
                     # Verify agent was created
                     mock_agent_class.assert_called_once()
                     call_kwargs = mock_agent_class.call_args[1]
-                    self.assertEqual(call_kwargs["model"].model, "openai/gpt-5.4-mini")
+                    self.assertEqual(call_kwargs["model"].model, "openai/gpt-5.6-terra")
                     self.assertEqual(call_kwargs["model_settings"].temperature, 0.0)
 
     async def test_create_agent_with_model_override(self) -> None:
@@ -361,7 +361,7 @@ class AgentCreationTests(unittest.IsolatedAsyncioTestCase):
     async def test_create_agent_uses_agentic_flow_temperature(self) -> None:
         """Test agent creation uses agentic-flow temperature for that configured model."""
         mock_settings = build_mock_settings(
-            agentic_flow_model="openai/gpt-5.4",
+            agentic_flow_model="openai/gpt-5.6-sol",
             agentic_flow_temperature=0.3,
         )
 
@@ -371,10 +371,10 @@ class AgentCreationTests(unittest.IsolatedAsyncioTestCase):
             with patch("app.services.agent_service.AsyncOpenAI"):
                 with patch("app.services.agent_service.Agent") as mock_agent_class:
                     service = AgentService()
-                    await service.create_agent(model="openai/gpt-5.4")
+                    await service.create_agent(model="openai/gpt-5.6-sol")
 
                     call_kwargs = mock_agent_class.call_args[1]
-                    self.assertEqual(call_kwargs["model"].model, "openai/gpt-5.4")
+                    self.assertEqual(call_kwargs["model"].model, "openai/gpt-5.6-sol")
                     self.assertEqual(call_kwargs["model_settings"].temperature, 0.3)
 
     async def test_create_agent_includes_system_prompt(self) -> None:

--- a/climate-advisor/service/tests/test_ca_model_migration.py
+++ b/climate-advisor/service/tests/test_ca_model_migration.py
@@ -19,8 +19,8 @@ from openai import AsyncOpenAI
 def test_all_active_ca_model_defaults_use_the_requested_family():
     models = get_settings().llm.models
     expected = {
-        "orchestrator": ("openai/gpt-5.6-luna", "none"),
-        "agentic_flow": ("openai/gpt-5.6-sol", "none"),
+        "orchestrator": ("openai/gpt-5.6-luna", "medium"),
+        "agentic_flow": ("openai/gpt-5.6-sol", "medium"),
         "funding_research": ("openai/gpt-5.6-sol", "medium"),
         "funder_identity": ("openai/gpt-5.6-luna", "low"),
         "cnb_source_reader": ("openai/gpt-5.6-luna", "low"),
@@ -51,7 +51,7 @@ def completion(model, *, content=None, tool_calls=None, finish_reason="stop"):
 
 @pytest.mark.parametrize("mode", ["general", "cnb", "stationary_energy", "custom"])
 @pytest.mark.asyncio
-async def test_chat_modes_round_trip_function_tools_with_explicit_none(
+async def test_chat_modes_round_trip_function_tools_with_medium_reasoning(
     monkeypatch, mode
 ):
     requests = []
@@ -124,7 +124,7 @@ async def test_chat_modes_round_trip_function_tools_with_explicit_none(
         if mode == "custom":
             assert "reasoning_effort" not in body
         else:
-            assert body["reasoning_effort"] == "none"
+            assert body["reasoning_effort"] == "medium"
         assert "temperature" not in body
         assert body["tools"][0]["function"]["name"] == "lookup_evidence"
     assert any(

--- a/climate-advisor/service/tests/test_cnb_migrations.py
+++ b/climate-advisor/service/tests/test_cnb_migrations.py
@@ -17,6 +17,7 @@ CNB_DATABASE_URL = os.getenv("CNB_TEST_DATABASE_URL")
 CNB_TABLES = {
     "concept_note_chapters",
     "concept_note_chapter_revisions",
+    "concept_note_chapter_validations",
     "concept_note_evidence_links",
     "concept_note_gaps",
     "concept_note_matched_projects",
@@ -107,9 +108,11 @@ def test_cnb_offline_migration_preserves_explicit_constraint_names() -> None:
     assert "ck_funding_evidence_ck_funding_evidence" not in sql
     assert "DROP CONSTRAINT uq_funder_templates_opportunity_name" in sql
     assert "CONSTRAINT uq_funder_templates_opportunity UNIQUE" in sql
+    assert "CREATE TABLE concept_note_chapter_validations" in sql
+    assert "ck_concept_note_chapter_validations_status_valid" in sql
 
 
-def test_cnb_metadata_contains_only_the_thirteen_owned_tables() -> None:
+def test_cnb_metadata_contains_only_the_fourteen_owned_tables() -> None:
     """Keep CA-owned run, context-bundle, and upload tables out of CNB metadata."""
     assert set(CnbBase.metadata.tables) == CNB_TABLES
     assert not {
@@ -208,6 +211,13 @@ def test_cnb_upgrade_downgrade_and_chain_isolation() -> None:
     assert "uq_source_documents_content_hash_url" in source_uniques
     assert "uq_concept_note_chapter_revisions_number" in revision_uniques
     assert "uq_concept_note_matched_projects_run_project" in match_uniques
+    validation_uniques = {
+        item["name"]
+        for item in inspector.get_unique_constraints(
+            "concept_note_chapter_validations"
+        )
+    }
+    assert "uq_concept_note_chapter_validations_chapter" in validation_uniques
     template_uniques = {
         item["name"] for item in inspector.get_unique_constraints("funder_templates")
     }
@@ -228,6 +238,10 @@ def test_cnb_upgrade_downgrade_and_chain_isolation() -> None:
             ("source_document_id",): "RESTRICT",
         },
         "concept_note_chapter_revisions": {("chapter_id",): "CASCADE"},
+        "concept_note_chapter_validations": {
+            ("chapter_id",): "CASCADE",
+            ("validated_revision_id",): "SET NULL",
+        },
         "concept_note_evidence_links": {("chapter_id",): "CASCADE"},
         "concept_note_gaps": {("chapter_id",): "SET NULL"},
         "concept_note_matched_projects": {("funded_project_id",): "RESTRICT"},
@@ -293,6 +307,10 @@ def test_cnb_upgrade_downgrade_and_chain_isolation() -> None:
             "patch_summary",
             "created_at",
         },
+        "concept_note_chapter_validations": {
+            "findings",
+            "validated_at",
+        },
         "concept_note_gaps": {"status", "created_at"},
         "concept_note_matched_projects": {"matched_tags", "evidence", "caveats"},
     }
@@ -306,7 +324,7 @@ def test_cnb_upgrade_downgrade_and_chain_isolation() -> None:
         revision = connection.execute(
             text("SELECT version_num FROM cnb_alembic_version")
         ).scalar_one()
-    assert revision == "20260821_120000"
+    assert revision == "20260828_120000"
 
     _run_alembic(
         config="cnb-alembic.ini",

--- a/climate-advisor/service/tests/test_concept_note_runs.py
+++ b/climate-advisor/service/tests/test_concept_note_runs.py
@@ -11,7 +11,7 @@ from app.models.cnb.concept_note_runs import (
     ConceptNoteRunListResponse,
     ConceptNoteStartRequest,
 )
-from app.models.db.concept_note import ConceptNoteRun
+from app.models.db.concept_note import ConceptNoteRun, ConceptNoteUpload
 from app.models.db.thread import Thread
 from app.persistence.concept_notes.runs import ConceptNoteRunRepository
 from app.services.citycatalyst_client import (
@@ -92,6 +92,7 @@ def _run_service(
         funding_reference_validator=funding_validator,
     )
     service.repository = repository
+    repository.list_uploads_for_run.return_value = []
     return service, repository, cc_client, funding_validator
 
 
@@ -263,6 +264,39 @@ async def test_get_run_revalidates_city_access_owned_by_citycatalyst() -> None:
         token="token",
         user_id=payload.user_id,
     )
+
+
+async def test_get_run_returns_owned_upload_metadata() -> None:
+    """Keep uploaded filenames visible when the workspace is resumed."""
+    payload = _start_request()
+    run = _persisted_run(
+        payload,
+        request_fingerprint=_request_fingerprint(payload),
+    )
+    upload = ConceptNoteUpload(
+        upload_id=uuid4(),
+        run_id=run.run_id,
+        uploaded_by_user_id=payload.user_id,
+        filename="Richfield_FloodRiskPrioritization.pdf",
+        source_label="Richfield Flood Risk Prioritization",
+        ingest_status="ready",
+        page_count=55,
+        received_at=datetime.now(timezone.utc),
+        ingest_completed_at=datetime.now(timezone.utc),
+    )
+    service, repository, _, _ = _run_service()
+    repository.get_for_user.return_value = run
+    repository.list_uploads_for_run.return_value = [upload]
+
+    response = await service.get_run(
+        run_id=run.run_id,
+        requested_user_id=payload.user_id,
+        authorization="Bearer token",
+    )
+
+    assert response.uploads[0].filename == upload.filename
+    assert response.uploads[0].status == "ready"
+    assert response.uploads[0].page_count == 55
 
 
 async def test_list_runs_rejects_authenticated_user_mismatch() -> None:

--- a/climate-advisor/service/tests/test_message_token_refresh.py
+++ b/climate-advisor/service/tests/test_message_token_refresh.py
@@ -1,0 +1,101 @@
+"""Contracts for refreshing CityCatalyst authorization on reopened chats."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from uuid import uuid4
+
+import pytest
+from app.db import Base
+from app.models.db.thread import Thread
+from app.models.requests import MessageCreateRequest
+from app.routes import messages as messages_route
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+
+class _StreamingHandlerStub:
+    """Capture the token selected by the message route without running an agent."""
+
+    selected_token: str | None = None
+
+    def __init__(self, **kwargs: object) -> None:
+        token = kwargs.get("cc_access_token")
+        type(self).selected_token = token if isinstance(token, str) else None
+
+    async def stream_response(
+        self,
+        _payload: MessageCreateRequest,
+        _history_warning: str | None,
+    ) -> AsyncIterator[bytes]:
+        yield b""
+
+
+@pytest.mark.asyncio
+async def test_reopened_thread_uses_and_persists_current_message_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A current payload token must replace the expired token stored on the thread."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    session_factory: async_sessionmaker[AsyncSession] = async_sessionmaker(
+        engine,
+        expire_on_commit=False,
+    )
+    thread_id = uuid4()
+    run_id = str(uuid4())
+
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all)
+        async with session_factory() as session:
+            session.add(
+                Thread(
+                    thread_id=thread_id,
+                    user_id="owner-1",
+                    context={
+                        "access_token": "expired-thread-token",
+                        "concept_note_run_id": run_id,
+                    },
+                )
+            )
+            await session.commit()
+
+        monkeypatch.setattr(messages_route, "StreamingHandler", _StreamingHandlerStub)
+
+        async def skip_message_insert(
+            _service: object,
+            **_kwargs: object,
+        ) -> None:
+            return None
+
+        monkeypatch.setattr(
+            messages_route.MessageService,
+            "create_user_message",
+            skip_message_insert,
+        )
+        response = await messages_route.post_message(
+            MessageCreateRequest(
+                user_id="owner-1",
+                thread_id=str(thread_id),
+                content="Mark the final chapter ready",
+                context={"access_token": "current-message-token"},
+            ),
+            session=None,
+            session_factory=session_factory,
+        )
+
+        assert response.status_code == 200
+        assert _StreamingHandlerStub.selected_token == "current-message-token"
+        async with session_factory() as session:
+            thread = await session.get(Thread, thread_id)
+            assert thread is not None
+            assert thread.context == {
+                "access_token": "current-message-token",
+                "concept_note_run_id": run_id,
+            }
+    finally:
+        await engine.dispose()

--- a/climate-advisor/service/tests/test_prompt_budget.py
+++ b/climate-advisor/service/tests/test_prompt_budget.py
@@ -20,10 +20,17 @@ def test_stationary_energy_prompt_budget_loads_from_llm_config() -> None:
     assert chat_budget.max_normalized_rows_per_candidate == 3
 
 
-def test_count_prompt_tokens_falls_back_for_openrouter_gpt_5_4_slug() -> None:
+def test_cnb_validation_prompt_budget_loads_from_llm_config() -> None:
+    config = _load_llm_config()
+
+    assert config.generation.prompt_budget.tokenizer_encoding == "o200k_base"
+    assert config.generation.prompt_budget.cnb_validation.max_prompt_tokens == 50000
+
+
+def test_count_prompt_tokens_falls_back_for_openrouter_gpt_5_6_sol_slug() -> None:
     token_count = count_prompt_tokens(
         ["Stationary Energy prompt"],
-        model="openai/gpt-5.4",
+        model="openai/gpt-5.6-sol",
         fallback_encoding="o200k_base",
     )
 
@@ -113,7 +120,7 @@ def test_trim_messages_to_budget_preserves_stationary_context_and_current_user()
     trimmed, token_count, removed = trim_messages_to_budget(
         messages,
         instruction_text="system prompt",
-        model="openai/gpt-5.4",
+        model="openai/gpt-5.6-sol",
         budget=StationaryEnergyPromptBudget(max_prompt_tokens=80),
     )
 
@@ -141,7 +148,7 @@ def test_trim_messages_to_budget_preserves_embedded_stationary_context() -> None
     trimmed, token_count, removed = trim_messages_to_budget(
         messages,
         instruction_text="",
-        model="openai/gpt-5.4",
+        model="openai/gpt-5.6-sol",
         budget=StationaryEnergyPromptBudget(max_prompt_tokens=80),
     )
 

--- a/climate-advisor/service/tests/test_prompt_config.py
+++ b/climate-advisor/service/tests/test_prompt_config.py
@@ -50,6 +50,12 @@ def test_configured_prompt_files_use_required_schema_blocks() -> None:
         "cnb_source_summary_synthesis": prompts.cnb_source_summary_synthesis,
         "cnb_source_question_reading": prompts.cnb_source_question_reading,
         "cnb_chapter_drafting": prompts.cnb_chapter_drafting,
+        "cnb_chapter_validation_completeness": (
+            prompts.cnb_chapter_validation_completeness
+        ),
+        "cnb_chapter_validation_consistency": (
+            prompts.cnb_chapter_validation_consistency
+        ),
     }
 
     for prompt_name, prompt_path in prompt_entries.items():
@@ -184,7 +190,9 @@ def test_compose_prompt_wraps_core_and_stationary_energy_review() -> None:
     assert "Stationary Energy review tool argument contracts:" not in composed_prompt
 
 
-def test_compose_prompt_wraps_core_and_cnb_chat_without_general_inventory_policy() -> None:
+def test_compose_prompt_wraps_core_and_cnb_chat_without_general_inventory_policy() -> (
+    None
+):
     prompts = _load_llm_config().prompts
     composed = prompts.compose_prompt("cnb_chat")
 
@@ -228,7 +236,17 @@ def test_cnb_source_configuration_matches_pdf_first_contract() -> None:
     prompt = config.prompts.get_prompt("cnb_source_summary_synthesis")
     assert '"page":3' in prompt
     assert '"heading":' in prompt
-    assert "covered_segment_ids" not in config.prompts.get_prompt("cnb_source_document_mapping")
+    assert "covered_segment_ids" not in config.prompts.get_prompt(
+        "cnb_source_document_mapping"
+    )
+
+
+def test_cnb_chapter_validation_configuration_matches_two_pass_contract() -> None:
+    config = _load_llm_config()
+
+    assert config.models.cnb_chapter_validator.name == "openai/gpt-5.6-terra"
+    assert config.models.cnb_chapter_validator.reasoning_effort == "medium"
+    assert config.generation.prompt_budget.cnb_validation.max_prompt_tokens == 50000
 
 
 def test_cnb_source_prompts_define_grounding_and_caveat_contracts() -> None:

--- a/climate-advisor/service/tests/test_prompt_config.py
+++ b/climate-advisor/service/tests/test_prompt_config.py
@@ -208,6 +208,11 @@ def test_compose_prompt_wraps_core_and_cnb_chat_without_general_inventory_policy
     assert "data, not user requests" in composed
     assert "INTERNAL_TOOL_OUTPUT_JSON" in composed
     assert "does not persist" in composed
+    assert "Assume the user has no knowledge of internal run context" in composed
+    assert 'A short or vague request such as "Help me"' in composed
+    assert "available template or document order" in composed
+    assert "automatically" in composed
+    assert 'require the user to say "use only this"' in composed
     assert "inventory_list_accessible" not in composed
     assert "general CityCatalyst climate and inventory chat" not in composed
 
@@ -247,6 +252,13 @@ def test_cnb_chapter_validation_configuration_matches_two_pass_contract() -> Non
     assert config.models.cnb_chapter_validator.name == "openai/gpt-5.6-terra"
     assert config.models.cnb_chapter_validator.reasoning_effort == "medium"
     assert config.generation.prompt_budget.cnb_validation.max_prompt_tokens == 50000
+    for prompt_name in (
+        "cnb_chapter_validation_completeness",
+        "cnb_chapter_validation_consistency",
+    ):
+        prompt = config.prompts.get_prompt(prompt_name)
+        assert "`evidence_positions`" in prompt
+        assert "one-based" in prompt
 
 
 def test_cnb_source_prompts_define_grounding_and_caveat_contracts() -> None:

--- a/climate-advisor/service/tests/test_prompt_config.py
+++ b/climate-advisor/service/tests/test_prompt_config.py
@@ -266,6 +266,9 @@ def test_cnb_chapter_validation_configuration_matches_two_pass_contract() -> Non
     consistency_prompt = config.prompts.get_prompt("cnb_chapter_validation_consistency")
     assert "`document`" in completeness_prompt
     assert "`output`" in completeness_prompt
+    assert "`document.validation_profile.required_fields`" in completeness_prompt
+    assert "backend has already selected" in completeness_prompt
+    assert "document.template" not in completeness_prompt
     assert "`document`" in consistency_prompt
     assert "`output`" in consistency_prompt
     assert "programme-specific eligibility rules" in consistency_prompt

--- a/climate-advisor/service/tests/test_prompt_config.py
+++ b/climate-advisor/service/tests/test_prompt_config.py
@@ -260,6 +260,17 @@ def test_cnb_chapter_validation_configuration_matches_two_pass_contract() -> Non
         assert "`evidence_positions`" in prompt
         assert "one-based" in prompt
 
+    completeness_prompt = config.prompts.get_prompt(
+        "cnb_chapter_validation_completeness"
+    )
+    consistency_prompt = config.prompts.get_prompt("cnb_chapter_validation_consistency")
+    assert "`document`" in completeness_prompt
+    assert "`output`" in completeness_prompt
+    assert "`document`" in consistency_prompt
+    assert "`output`" in consistency_prompt
+    assert "programme-specific eligibility rules" in consistency_prompt
+    assert "EUCF" not in consistency_prompt
+
 
 def test_cnb_source_prompts_define_grounding_and_caveat_contracts() -> None:
     prompts = _load_llm_config().prompts

--- a/docs/ConceptNoteBuilderArchitecture.md
+++ b/docs/ConceptNoteBuilderArchitecture.md
@@ -1412,12 +1412,67 @@ How it works:
   API. This makes provenance available to the workspace UI without allowing the
   model to supply source identity metadata.
 - Both validation passes use an explicit `document` and generated `output`
-  contract. Completeness compares the output with supplied template and evidence
-  material; consistency compares it with the remaining document chapters. The
+  contract. Completeness compares the output with a code-selected
+  `document.validation_profile` and evidence material; consistency compares it
+  with the remaining document chapters. The profile contains exactly one
+  chapter schema and its chapter-specific required fields. The
   generic service applies no programme-name or programme-specific text matcher,
   so a conflict must be grounded in the supplied document and output.
 - A five-minute reconciler marks chapter-drafting leases left `running` for more
   than one hour as failed and retryable, without discarding completed chapters.
+
+#### Chapter template requirement assignments
+
+Each `funder_templates.chapter_schema` entry has its own `required_fields` string
+array. The template-level `required_fields` remains the document-wide inventory;
+it is retained in storage and fingerprints but is not sent to completeness.
+For example, after reviewing the original application instructions, a template
+may contain:
+
+```json
+{
+  "chapter_schema": [
+    {
+      "chapter_ref": "summary",
+      "title": "Project summary",
+      "required": true,
+      "required_fields": ["Project name", "Objectives"]
+    },
+    {
+      "chapter_ref": "budget",
+      "title": "Budget",
+      "required": true,
+      "required_fields": ["Project name", "Total cost"]
+    }
+  ],
+  "required_fields": ["Project name", "Objectives", "Total cost"]
+}
+```
+
+Validation uses the same chapter-reference normalization as workspace creation,
+including positional references for entries without an explicit `chapter_ref`.
+It rejects duplicate references and missing target matches. It preserves other
+selected chapter constraints (such as word limits), excludes the internal
+chapter reference from the profile, and sends only that chapter's field list.
+Every field in the global inventory must have an exact-text assignment to at
+least one chapter. A shared requirement must be assigned to every applicable
+chapter; an empty array means that chapter has no required fields.
+
+Before deploying against existing reference data, review the source template,
+add these arrays to its stored chapter entries, and preserve chapter references
+and the global inventory. Ambiguous assignments require source review, not an
+automatic migration based on titles or field names. No database column migration
+is needed because the schema is JSONB. The funded-project import CLI does not
+update managed application templates. Changes to the nested assignments affect
+the existing template fingerprint, invalidating prior chapter-validation results.
+
+Invalid or incomplete assignments return `chapter_validation_template_invalid`
+(HTTP 409) before a model call or result write, with a fixed public message asking
+for template review. The offline research contract carries the nested fields
+through model projection, review artifacts, and serialization, and instructs the
+researcher to retain an explicit gap when source material cannot establish
+ownership. A template-free core validation request still uses a null profile;
+the public workflow continues to require a selected application template.
 
 Chapter fields should support the editable document surface:
 

--- a/docs/ConceptNoteBuilderArchitecture.md
+++ b/docs/ConceptNoteBuilderArchitecture.md
@@ -1411,6 +1411,11 @@ How it works:
   source label, location, claim reference, and summary before findings reach the
   API. This makes provenance available to the workspace UI without allowing the
   model to supply source identity metadata.
+- Both validation passes use an explicit `document` and generated `output`
+  contract. Completeness compares the output with supplied template and evidence
+  material; consistency compares it with the remaining document chapters. The
+  generic service applies no programme-name or programme-specific text matcher,
+  so a conflict must be grounded in the supplied document and output.
 - A five-minute reconciler marks chapter-drafting leases left `running` for more
   than one hour as failed and retryable, without discarding completed chapters.
 

--- a/docs/ConceptNoteBuilderArchitecture.md
+++ b/docs/ConceptNoteBuilderArchitecture.md
@@ -1406,6 +1406,11 @@ How it works:
   They do not create chapters by themselves.
 - Evidence links are shown to the user to explain why a claim was grounded.
   They are review/audit UI only and are ignored by DOCX/PDF export.
+- Chapter-validation prompts reference evidence by one-based list position.
+  Service code validates those positions and resolves them to the persisted
+  source label, location, claim reference, and summary before findings reach the
+  API. This makes provenance available to the workspace UI without allowing the
+  model to supply source identity metadata.
 - A five-minute reconciler marks chapter-drafting leases left `running` for more
   than one hour as failed and retryable, without discarding completed chapters.
 

--- a/docs/ConceptNoteBuilderArchitecture.md
+++ b/docs/ConceptNoteBuilderArchitecture.md
@@ -2243,7 +2243,7 @@ prompts:
 ```
 
 The main CNB chat uses `models.agentic_flow` (`openai/gpt-5.6-sol`) with explicit
-`reasoning_effort: none` for its Chat Completions function-tool loop. Funding
+`reasoning_effort: medium` for its Chat Completions function-tool loop. Funding
 research and similar-project selection use Sol with medium reasoning on the
 existing Responses API path; canonical-funder identity matching uses Luna with
 low reasoning. Chapter drafting remains GPT-5.6 Terra with medium reasoning.


### PR DESCRIPTION
## Layer scope

This existing PR is now the bottom Climate Advisor layer of a two-PR stack. It contains only `climate-advisor/**`: validation models, persistence, migration, prompts, service orchestration, route, configuration, documentation, and their tests. The CityCatalyst proxy and UI moved to #3090; the original combined-change context below is retained for review history.

## Problem

Concept Note Builder needed a reliable review-before-export workflow. Real source-backed runs also exposed connected resilience and usability problems: uploaded PDF metadata disappeared after navigation, polling could exhaust the shared API rate limit, transient refresh failures looked like missing runs, missing-information prompts were repeated across the workspace, and export showed the same missing facts as both prompts and validation blockers.

## What this PR changes

- Adds persisted, two-pass chapter validation for completeness, evidence, internal logic, and cross-chapter consistency, with bounded concurrency, latest-result persistence, stale-result detection, retry behavior, and a dedicated CNB migration.
- Adds the guided **Review & export** journey: missing information, conflicts and logic, export decision, explicit export-anyway confirmation, and DOCX/PDF selection.
- Preserves uploaded-source metadata in run responses, supports the real 19.4 MiB Richfield PDF through the Next.js proxy, and restores upload details after refresh or resume.
- Reduces workspace polling pressure, stops polling terminal uploads, and keeps the last valid run visible through transient API failures.
- Simplifies the draft workspace with inline missing-information popovers, a collapsible chapter panel that fully returns document width, and removal of duplicated chapter summaries and framing.
- Unifies unanswered prompts and validation blockers into one **Missing information** count and one fix action while keeping warnings separate.
- Routes active Climate Advisor generation through GPT-5.6 Terra or Sol and updates model-contract tests and documentation.
- Keeps the CodeQL exception-exposure fix while preserving stable machine-readable validation error codes.

## Resulting behavior

Users can upload evidence, leave and reopen a run, draft every template chapter, inspect missing facts directly in the text, collapse the chapter navigation without leaving an empty rail, run or reuse saved validation, and make one clear export decision. The export screen presents one missing-information count instead of reporting the same items twice.

## Migration

Run the CNB migration chain through revision `20260828_120000` before using chapter validation.

https://github.com/user-attachments/assets/472b9836-40cd-4dac-8999-0d9c91c04557

## Stack

1. **#3081 - Climate Advisor chapter validation** (this PR)
2. #3090 - CityCatalyst guided review and export