### PR TITLE
fix(meed): call hiap-meed's /v1/prioritize, not /v1/rank

### DIFF
--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -189,8 +189,6 @@ export default class MeedApiService {
     });
 
     // make API request to MEED API
-    // hiap-meed calls this operation `prioritize`; `rank` is the CityCatalyst
-    // route's own name and does not exist upstream.
     const result: MeedRankResponse = await this.makeRequest(
       "prioritize",
       fullRequest,

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -189,8 +189,10 @@ export default class MeedApiService {
     });
 
     // make API request to MEED API
+    // hiap-meed calls this operation `prioritize`; `rank` is the CityCatalyst
+    // route's own name and does not exist upstream.
     const result: MeedRankResponse = await this.makeRequest(
-      "rank",
+      "prioritize",
       fullRequest,
     );
 


### PR DESCRIPTION
Running a prioritization on dev fails. `POST /api/v1/city/{city}/meed/rank/` returns **400**:

```json
{"error":{"message":"MEED API error: {\n  \"detail\": \"Not Found\"\n}"}}
```

## What is happening

`{"detail": "Not Found"}` is FastAPI's stock response for a path it does not route — not a business error from the pipeline. Nothing in the ranking ever ran; the request never reached a handler.

`MeedApiService.runRanking` posts to:

```ts
await this.makeRequest("rank", fullRequest);
// MEED_API_URL = process.env.HIAP_MEED_API_URL + "/v1/"
// → POST http://hiap-meed-service-dev/v1/rank
```

hiap-meed registers eleven routes and none of them is `rank`. The operation is **`/v1/prioritize`** (`hiap-meed/app/modules/prioritizer/api.py:416`, mounted with no router prefix).

## Why it reads as correct

`rank` is the name of the **CityCatalyst** route that wraps this call — `city/{city}/meed/rank`. That name has leaked into the outbound call, where the service calls the same operation `prioritize`.

Every other call in this file already uses the upstream spelling, which is why only this one fails:

| `makeRequest(...)` | hiap-meed route | |
|---|---|---|
| `"prioritize"` | `/v1/prioritize` | ← this PR |
| `"action-pathways"` | `/v1/action-pathways` | ✅ |
| `` `cities/${locode}/attributes` `` | `/v1/cities/{locode}/attributes` | ✅ |
| `` `cities/${locode}/action-policy-scores` `` | `/v1/cities/{locode}/action-policy-scores` | ✅ |
| `` `cities/${locode}/climate-finance/feasibility` `` | same | ✅ |
| `"climate-finance/opportunities"` | `/v1/climate-finance/opportunities` | ✅ |
| `"climate-finance/projects"` | `/v1/climate-finance/projects` | ✅ |

## The change

One string, plus a comment so the next reader does not "correct" it back to match the CityCatalyst route name.

## Separate suggestion, not in this PR

The status code sent us the wrong way. `makeRequest` collapses every non-200 into `BadRequest`:

```ts
if (response.status != 200 || result.detail) {
  throw new createHttpError.BadRequest("MEED API error: " + resultString);
}
```

So a **404 from a wrong path** presents as **400 Bad Request** — telling the reader their payload was malformed when it was never inspected. The same flattening hides a **503** from the fail-closed legal S3 fetch and a **429** when the output-plan queue is saturated, both of which need different handling by the caller.

Preserving the upstream status, or at least distinguishing "upstream rejected this" from "your request is invalid", would turn this class of bug into a five-second diagnosis. Happy to do that in a follow-up if you agree.

## Testing

There is no test harness around `MeedApiService`, so this is unverified beyond typecheck and the route comparison above — the real guard would be an integration test against a running hiap-meed. Worth a look after merge on dev, where the failing request is easy to repeat.