### PR TITLE
fix(meed): tolerate removed actions that carry no legal evidence

### DIFF
--- a/app/migrations/20260831210000-meed-removed-legal-nullable.cjs
+++ b/app/migrations/20260831210000-meed-removed-legal-nullable.cjs
@@ -1,0 +1,57 @@
+"use strict";
+
+/**
+ * Allows a removed action to carry no legal verdict.
+ *
+ * `MeedActionRemoved` was created when every row came from the legal hard
+ * filter, so the three verdict columns were `NOT NULL` with no default. That
+ * assumption stopped holding once exclusions confirmed on the pre-flight screen
+ * began reaching the ranking: hiap-meed returns those with
+ * `removal_source: "user_exclusion"` and `legal: null`, because no legal
+ * assessment was involved.
+ *
+ * The JSONB and array columns already default to `{}` / `[]`, so they accept
+ * such a row as-is. These three had no default and would reject it.
+ *
+ * NULL here means "no legal assessment applies to this removal", which is
+ * distinct from an assessment that ran and returned nothing.
+ */
+const COLUMNS = [
+  "verdict_category",
+  "ownership_category",
+  "restrictions_category",
+];
+
+/** @type {import("sequelize-cli").Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      for (const column of COLUMNS) {
+        await queryInterface.changeColumn(
+          "MeedActionRemoved",
+          column,
+          { type: Sequelize.TEXT, allowNull: true },
+          { transaction },
+        );
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      // Rows added while the columns were nullable would block the constraint.
+      for (const column of COLUMNS) {
+        await queryInterface.sequelize.query(
+          `DELETE FROM "MeedActionRemoved" WHERE "${column}" IS NULL`,
+          { transaction },
+        );
+        await queryInterface.changeColumn(
+          "MeedActionRemoved",
+          column,
+          { type: Sequelize.TEXT, allowNull: false },
+          { transaction },
+        );
+      }
+    });
+  },
+};

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -68,7 +68,13 @@ type MeedResponseActionRemoved = {
   action_name: string;
   removal_reason?: string;
   removal_source?: string;
-  legal: {
+  /**
+   * Only populated for legal hard-filter removals. hiap-meed declares it
+   * `RemovedActionLegalEvidence | None` with `default=None`, so an action
+   * removed for any other reason — a user exclusion, for instance — arrives
+   * with `legal: null`.
+   */
+  legal?: {
     verdict_category?: string;
     ownership_category?: string;
     restrictions_category?: string;
@@ -237,13 +243,13 @@ export default class MeedApiService {
             actionName: action.action_name,
             removalReason: action.removal_reason,
             removalSource: action.removal_source,
-            verdictCategory: action.legal.verdict_category,
-            ownershipCategory: action.legal.ownership_category,
-            restrictionsCategory: action.legal.restrictions_category,
-            ownershipDescription: action.legal.ownership_description,
-            restrictionsDescription: action.legal.restrictions_description,
-            legalJustification: action.legal.legal_justification,
-            legalReferences: action.legal.legal_references,
+            verdictCategory: action.legal?.verdict_category,
+            ownershipCategory: action.legal?.ownership_category,
+            restrictionsCategory: action.legal?.restrictions_category,
+            ownershipDescription: action.legal?.ownership_description,
+            restrictionsDescription: action.legal?.restrictions_description,
+            legalJustification: action.legal?.legal_justification,
+            legalReferences: action.legal?.legal_references,
           }),
           { transaction },
         ),


### PR DESCRIPTION
Follows #3084. With that path fix deployed the prioritizer now runs — the request spends ~30 s doing real work — and then fails at the point where the result is written to the database:

```
500 {"error":{"message":"Internal server error",
     "error":"Cannot read properties of null (reading 'verdict_category')"}}
```

## Cause

hiap-meed attaches legal evidence **only** to removals made by the legal hard filter:

```python
legal: RemovedActionLegalEvidence | None = Field(
    default=None,
    description="Legal evidence for legal hard-filter removals.",
)
```

`MeedResponseActionRemoved` declares `legal` as required, and the mapping into `MeedActionRemoved` dereferences it for every removed action:

```ts
verdictCategory: action.legal.verdict_category,   // throws when legal is null
```

An action removed for any other reason — a **user exclusion** — arrives with `legal: null` and throws on the first field. That aborts the whole `bulkCreate` transaction, so a run that spent thirty seconds in the prioritizer persists nothing.

## Why it appears now and not before

It needs a non-legal removal to exist, which means the user has to have confirmed exclusions on the pre-flight screen. With an empty `excludedActionIds`, every removed action comes from the legal filter and carries evidence.

The failing request had ten:

```json
"excludedActionIds": ["icare_0031","icare_0064","c40_0034","c40_0037",
                      "c40_0040","c40_0035","icare_0110","icare_0111",
                      "icare_0053","c40_0036"]
```

So this surfaced the first time the exclusion flow was used end to end.

## The change

`legal` becomes optional on the type, matching the service, and the seven reads are optional-chained. The columns are already nullable, so a user exclusion now stores its `removal_reason` and `removal_source` with empty legal fields — which is the correct record of what happened.

Ranked actions are unaffected: that mapping reads flat fields with no nested access.

## Worth a look while you are here

Both this and #3084 come from `MeedResponseActionRemoved` being written against an example response rather than hiap-meed's schema, so optionality was lost in transcription. `RemovedActionSummary` marks both `removal_reason` and `legal` nullable. If those types were generated from the service's OpenAPI schema, or checked against it in CI, both bugs would have been compile-time errors instead of production 500s.

Also still open from #3084: `makeRequest` collapses every non-200 into `BadRequest`, so upstream 404s, 503s and 429s all reach the browser as 400.

## Testing

Typecheck and prettier pass. Not verified against a running service — the check is repeating the failing request on dev after merge: run a prioritization with at least one confirmed exclusion and it should complete and persist rather than 500.