### PR TITLE
fix(CC-657): update csv-download e2e test for checkbox download modal

### DIFF
--- a/app/e2e/csv-download.spec.ts
+++ b/app/e2e/csv-download.spec.ts
@@ -41,12 +41,24 @@ async function openDownloadModal(page: Page) {
   });
 }
 
-async function downloadCsv(page: Page): Promise<Download> {
+/** Chakra v3 / Ark checkbox: click the control part rather than the root. */
+async function selectDownloadFormat(page: Page, format: string) {
+  const checkbox = page.getByTestId(`download-${format}-checkbox`);
+  await expect(checkbox).toBeVisible();
+  await checkbox.locator('[data-part="control"]').click();
+}
+
+async function confirmDownload(page: Page): Promise<Download> {
   const downloadPromise = page.waitForEvent("download");
-  const csvDownloadButton = page.getByTestId("download-csv-button");
-  await expect(csvDownloadButton).toBeVisible();
-  await csvDownloadButton.click();
+  const confirmButton = page.getByTestId("download-confirm-button");
+  await expect(confirmButton).toBeEnabled();
+  await confirmButton.click();
   return downloadPromise;
+}
+
+async function downloadCsv(page: Page): Promise<Download> {
+  await selectDownloadFormat(page, "csv");
+  return confirmDownload(page);
 }
 
 async function saveDownload(
@@ -280,7 +292,8 @@ test.describe("CSV Download", () => {
     });
 
     await openDownloadModal(page);
-    await page.getByTestId("download-csv-button").click();
+    await selectDownloadFormat(page, "csv");
+    await page.getByTestId("download-confirm-button").click();
 
     await expect(
       page.getByText(/There was an error during download|Download failed/i).first(),
@@ -290,25 +303,32 @@ test.describe("CSV Download", () => {
   test("Multiple format downloads work correctly", async ({ page }, testInfo) => {
     await openDownloadModal(page);
 
-    const csvDownload = await downloadCsv(page);
+    await selectDownloadFormat(page, "csv");
+    await selectDownloadFormat(page, "ecrf");
+
+    // Confirming with both formats selected fires both downloads together,
+    // so match by filename rather than event order.
+    const csvDownloadPromise = page.waitForEvent("download", {
+      predicate: (download) => download.suggestedFilename().endsWith(".csv"),
+    });
+    const ecrfDownloadPromise = page.waitForEvent("download", {
+      predicate: (download) => /\.xlsx?$/.test(download.suggestedFilename()),
+      timeout: 90000,
+    });
+
+    await page.getByTestId("download-confirm-button").click();
+
+    const [csvDownload, ecrfDownload] = await Promise.all([
+      csvDownloadPromise,
+      ecrfDownloadPromise,
+    ]);
+
     expect(csvDownload.suggestedFilename()).toContain(".csv");
+    expect(ecrfDownload.suggestedFilename()).toMatch(/\.xlsx?$/);
 
     const csvPath = testInfo.outputPath("inventory-multi-format.csv");
     const csvContent = await saveDownload(csvDownload, csvPath);
     expect(csvContent).toContain("GPC Reference Number");
-
-    await dismissToasts(page);
-
-    const ecrfDownloadButton = page.getByTestId("download-ecrf-button");
-    await expect(ecrfDownloadButton).toBeVisible();
-
-    const ecrfDownloadPromise = page.waitForEvent("download", {
-      timeout: 90000,
-    });
-    await ecrfDownloadButton.click();
-
-    const ecrfDownload = await ecrfDownloadPromise;
-    expect(ecrfDownload.suggestedFilename()).toMatch(/\.xlsx?$/);
 
     await csvDownload.delete();
     await ecrfDownload.delete();


### PR DESCRIPTION
## Summary
- The GHGI download modal was redesigned to use checkbox format selection with a single confirm button (`redesign(CC-657): rework GHGI download modal with checkbox format selection`), but `e2e/csv-download.spec.ts` still targeted the removed per-format buttons (`download-csv-button`, `download-ecrf-button`), causing CI to fail: https://github.com/Open-Earth-Foundation/CityCatalyst/actions/runs/33532927691/job/99940231632
- Updated the spec to check the relevant format checkbox(es) and click the shared `download-confirm-button`, following the existing Chakra/Ark checkbox click convention from `signup.spec.ts`
- Reworked the "Multiple format downloads" test to select both formats and confirm once (since confirming now triggers all selected downloads together and closes the modal), matching each `Download` by filename instead of assuming event order

## Test plan
- [x] `npx tsc --noEmit` passes for the changed file
- [x] `npx eslint e2e/csv-download.spec.ts` passes
- [x] CI e2e run passes on this PR