### PR TITLE
feat(api): CC-762 implement remaining service API endpoints for MEED

### DIFF
--- a/app/migrations/20260903120451-create-meed-rank-snapshot.cjs
+++ b/app/migrations/20260903120451-create-meed-rank-snapshot.cjs
@@ -1,0 +1,49 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable("MeedRankSnapshot", {
+      id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        primaryKey: true,
+        defaultValue: Sequelize.UUIDV4,
+      },
+      inventory_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: "Inventory",
+          key: "inventory_id",
+        },
+        onUpdate: "CASCADE",
+        onDelete: "CASCADE",
+      },
+      request: {
+        type: Sequelize.JSONB,
+        defaultValue: {},
+        allowNull: false,
+      },
+      response: {
+        type: Sequelize.JSONB,
+        defaultValue: {},
+        allowNull: false,
+      },
+      created: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+      last_updated: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable("MeedActionReport");
+  },
+};

--- a/app/migrations/20260903120451-create-meed-rank-snapshot.cjs
+++ b/app/migrations/20260903120451-create-meed-rank-snapshot.cjs
@@ -44,6 +44,6 @@ module.exports = {
   },
 
   async down(queryInterface) {
-    await queryInterface.dropTable("MeedActionReport");
+    await queryInterface.dropTable("MeedRankSnapshot");
   },
 };

--- a/app/migrations/20260903120517-create-meed-action-report.cjs
+++ b/app/migrations/20260903120517-create-meed-action-report.cjs
@@ -1,0 +1,53 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable("MeedActionReport", {
+      id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        primaryKey: true,
+        defaultValue: Sequelize.UUIDV4,
+      },
+      inventory_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: "Inventory",
+          key: "inventory_id",
+        },
+        onUpdate: "CASCADE",
+        onDelete: "CASCADE",
+      },
+      action_id: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      languages: {
+        type: Sequelize.ARRAY(Sequelize.TEXT),
+        allowNull: false,
+        defaultValue: [],
+      },
+      chapters: {
+        type: Sequelize.JSONB,
+        allowNull: false,
+        defaultValue: {},
+      },
+      created: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+      last_updated: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable("MeedActionReport");
+  },
+};

--- a/app/scripts/build-swagger-doc.ts
+++ b/app/scripts/build-swagger-doc.ts
@@ -162,6 +162,10 @@ function generateOpenAPISpec() {
             description: "Bulk location operations",
           },
           {
+            name: "meed",
+            description: "HIAP MEED module operations",
+          },
+          {
             name: "mock",
             description: "Mock data endpoints",
           },

--- a/app/src/app/api/v1/city/[city]/meed/actions/translate/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/actions/translate/route.ts
@@ -49,8 +49,8 @@ import z from "zod";
 const translateActionsRequest = z.object({
   inventoryId: z.string().uuid(),
   sourceLanguage: z.string().min(2),
-  targetLanguages: z.array(z.string().min(2)),
-  actionIds: z.array(z.string().min(1)),
+  targetLanguages: z.array(z.string().min(2)).min(1),
+  actionIds: z.array(z.string().min(1)).min(1),
 });
 
 export const POST = apiHandler(async (req, { session }) => {

--- a/app/src/app/api/v1/city/[city]/meed/actions/translate/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/actions/translate/route.ts
@@ -1,0 +1,67 @@
+import MeedApiService from "@/backend/MeedApiService";
+import { PermissionService } from "@/backend/permissions/PermissionService";
+import { apiHandler } from "@/util/api";
+import { NextResponse } from "next/server";
+import z from "zod";
+
+/**
+ * @swagger
+ * /api/v1/city/{city}/meed/actions/translate:
+ *   post:
+ *     tags:
+ *       - meed
+ *       - city
+ *     operationId: translateMeedActions
+ *     summary: Translates explanations for given list of actions to other languages
+ *     description: Translates explanations into other languages, saves them to the database and returns translated actions
+ *     parameters:
+ *       - in: path
+ *         name: city
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               inventoryId:
+ *                 type: string
+ *                 format: uuid
+ *               sourceLanguage:
+ *                 type: string
+ *               targetLanguages:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *               actionIds:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *     responses:
+ *       200:
+ *         description: Actions translated, returned in result body
+ */
+
+const translateActionsRequest = z.object({
+  inventoryId: z.string().uuid(),
+  sourceLanguage: z.string().min(2),
+  targetLanguages: z.array(z.string().min(2)),
+  actionIds: z.array(z.string().min(1)),
+});
+
+export const POST = apiHandler(async (req, { session }) => {
+  const body = translateActionsRequest.parse(await req.json());
+  await PermissionService.canAccessInventory(session, body.inventoryId);
+
+  const result = await MeedApiService.translateExplanations(
+    body.inventoryId,
+    body.sourceLanguage,
+    body.targetLanguages,
+    body.actionIds,
+  );
+  return NextResponse.json({ data: result });
+});

--- a/app/src/app/api/v1/city/[city]/meed/exclusions-preview/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/exclusions-preview/route.ts
@@ -1,0 +1,121 @@
+import MeedApiService from "@/backend/MeedApiService";
+import { PermissionService } from "@/backend/permissions";
+import { apiHandler } from "@/util/api";
+import { NextResponse } from "next/server";
+import z from "zod";
+
+/**
+ * @swagger
+ * /api/v1/city/{city}/meed/exclusions-preview:
+ *   post:
+ *     tags:
+ *       - meed
+ *       - city
+ *     operationId: getMeedExclusionsPreview
+ *     summary: Fetches preview of exclusions from prioritization
+ *     description: Fetches preview of actions excluded before the prioritization process runs
+ *     parameters:
+ *       - in: path
+ *         name: city
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               cityDataList:
+ *                 type: array
+ *                 items:
+ *                   type: object
+ *                   properties:
+ *                     locode:
+ *                       type: string
+ *                     excludedSectorTags:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                     excludedCoBenefitKeys:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                     excludedActionsFreeText:
+ *                       type: string
+ *     responses:
+ *       200:
+ *         description: Prioritization exclusions retrieved
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       locode:
+ *                         type: string
+ *                       proposedExcludedActions:
+ *                         type: array
+ *                         items:
+ *                           type: object
+ *                           properties:
+ *                             actionId:
+ *                               type: string
+ *                             actionName:
+ *                               type: string
+ *                             reasons:
+ *                               type: array
+ *                               items:
+ *                                 type: string
+ *                             matchedBy:
+ *                               type: array
+ *                               items:
+ *                                 type: string
+ *                       exclusionSummary:
+ *                         type: object
+ *                         properties:
+ *                           totalProposed:
+ *                             type: number
+ *                           byReasonType:
+ *                             type: object
+ *                             additionalProperties:
+ *                               type: object
+ *                               properties:
+ *                                 count:
+ *                                   type: number
+ *                                 actionIds:
+ *                                   type: array
+ *                                   items:
+ *                                     type: string
+ *                       warnings:
+ *                         type: array
+ *                         items:
+ *                           type: string
+ */
+const getExclusionsPreviewParams = z.object({
+  city: z.string().uuid(),
+});
+const getExclusionsPreviewRequest = z.object({
+  cityDataList: z.array(
+    z.object({
+      locode: z.string().min(1),
+      excludedSectorTags: z.array(z.string()),
+      excludedCoBenefitKeys: z.array(z.string()),
+      excludedActionsFreeText: z.string(),
+    }),
+  ),
+});
+
+export const POST = apiHandler(async (req, { session, params }) => {
+  const { city: cityId } = getExclusionsPreviewParams.parse(params);
+  const body = getExclusionsPreviewRequest.parse(await req.json());
+  await PermissionService.canAccessCity(session, cityId);
+  const result = await MeedApiService.getExclusionsPreview(body);
+  return NextResponse.json({ data: result });
+});

--- a/app/src/app/api/v1/city/[city]/meed/feasibility-scores/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/feasibility-scores/route.ts
@@ -1,0 +1,63 @@
+import MeedApiService from "@/backend/MeedApiService";
+import { PermissionService } from "@/backend/permissions";
+import { apiHandler } from "@/util/api";
+import { NextResponse } from "next/server";
+import z from "zod";
+
+/**
+ * @swagger
+ * /api/v1/city/{city}/meed/feasibility-scores:
+ *   get:
+ *     tags:
+ *       - meed
+ *       - city
+ *     operationId: getMeedFeasibilityScores
+ *     summary: Fetches MEED+ action mitigation feasibility scores
+ *     description: Fetches MEED+ action mitigation feasibility scores for the given city via the MEED service from the global API
+ *     parameters:
+ *       - in: path
+ *         name: city
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Feasibility scores retrieved
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     locode:
+ *                       type: string
+ *                     country_code:
+ *                       type: string
+ *                     scores:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           action_id:
+ *                             type: string
+ *                           action_score:
+ *                             type: number
+ *                           rank_within_city:
+ *                             type: number
+ *                           dimension_scores:
+ *                             type: object
+ *                             additionalProperties:
+ *                               type: number
+ */
+const getFeasibilityScoresParams = z.object({
+  city: z.string().uuid(),
+});
+export const GET = apiHandler(async (_req, { session, params }) => {
+  const { city: cityId } = getFeasibilityScoresParams.parse(params);
+  await PermissionService.canAccessCity(session, cityId);
+  const result = await MeedApiService.getFeasibilityScores(cityId);
+  return NextResponse.json({ data: result });
+});

--- a/app/src/app/api/v1/city/[city]/meed/generate-plan/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/generate-plan/route.ts
@@ -1,0 +1,66 @@
+import MeedApiService from "@/backend/MeedApiService";
+import { PermissionService } from "@/backend/permissions/PermissionService";
+import { apiHandler } from "@/util/api";
+import { NextResponse } from "next/server";
+import z from "zod";
+
+/**
+ * @swagger
+ * /api/v1/city/{city}/meed/generate-plan:
+ *   post:
+ *     tags:
+ *       - meed
+ *       - city
+ *     operationId: generateMeedPlan
+ *     summary: Generates an report plan output
+ *     description: Uses the MEED service to create a plan output in structured markdown format
+ *     parameters:
+ *       - in: path
+ *         name: city
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               inventoryId:
+ *                 type: string
+ *                 format: uuid
+ *               languages:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *               actionId:
+ *                 type: string
+ *               debugContextOnly:
+ *                 type: boolean
+ *                 required: false
+ *     responses:
+ *       200:
+ *         description: Output plan generated
+ */
+
+const generatePlanRequest = z.object({
+  inventoryId: z.string().uuid(),
+  languages: z.array(z.string().min(2)),
+  actionId: z.string().min(1),
+  debugContextOnly: z.boolean().default(false),
+});
+
+export const POST = apiHandler(async (req, { session }) => {
+  const body = generatePlanRequest.parse(await req.json());
+  await PermissionService.canAccessInventory(session, body.inventoryId);
+
+  const result = await MeedApiService.generatePlan(
+    body.inventoryId,
+    body.languages,
+    body.actionId,
+    body.debugContextOnly,
+  );
+  return NextResponse.json({ data: result });
+});

--- a/app/src/app/api/v1/city/[city]/meed/generate-plan/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/generate-plan/route.ts
@@ -64,3 +64,47 @@ export const POST = apiHandler(async (req, { session }) => {
   );
   return NextResponse.json({ data: result });
 });
+
+/**
+ * @swagger
+ * /api/v1/city/{city}/meed/generate-plan:
+ *   get:
+ *     tags:
+ *       - meed
+ *       - city
+ *     operationId: getMeedPlan
+ *     summary: Fetches saved MEED+ city action report for a given inventory from the database
+ *     description: Fetches saved MEED+ city action report for a given inventory from the database
+ *     parameters:
+ *       - in: path
+ *         name: city
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: query
+ *         name: inventoryId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: query
+ *         name: actionId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Plan retrieved
+ */
+const getRankingQuery = z.object({
+  inventoryId: z.string().uuid(),
+  actionId: z.string().min(1),
+});
+export const GET = apiHandler(async (_req, { session, searchParams }) => {
+  const { inventoryId, actionId } = getRankingQuery.parse(searchParams);
+  await PermissionService.canAccessInventory(session, inventoryId);
+
+  const result = await MeedApiService.getPlan(inventoryId, actionId);
+  return NextResponse.json({ data: result });
+});

--- a/app/src/app/api/v1/city/[city]/meed/generate-plan/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/generate-plan/route.ts
@@ -27,6 +27,7 @@ import z from "zod";
  *         application/json:
  *           schema:
  *             type: object
+ *             required: [inventoryId, languages, actionId]
  *             properties:
  *               inventoryId:
  *                 type: string
@@ -39,7 +40,6 @@ import z from "zod";
  *                 type: string
  *               debugContextOnly:
  *                 type: boolean
- *                 required: false
  *     responses:
  *       200:
  *         description: Output plan generated

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -513,9 +513,11 @@ export default class MeedApiService {
       },
       debugContextOnly,
     };
-    console.log("DATA", JSON.stringify(data, null, 2));
     const result = await this.makeRequest("reports/output-plan", data);
-    console.log(result);
+    logger.info(
+      { inventoryId, languages, actionId, result, data },
+      "MEED output plan route finished",
+    );
 
     // save result to database
     const report = await db.models.MeedActionReport.create({

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -519,14 +519,26 @@ export default class MeedApiService {
       "MEED output plan route finished",
     );
 
-    // save result to database
-    const report = await db.models.MeedActionReport.create({
-      id: randomUUID(),
-      inventoryId,
-      actionId: result.action_id,
-      languages: result.language,
-      chapters: result.chapters,
+    // save result to database, update existing report if it exists
+    let report = await db.models.MeedActionReport.findOne({
+      where: { inventoryId, actionId: result.action_id },
     });
+    if (report) {
+      await report.update({
+        inventoryId,
+        actionId: result.action_id,
+        languages: result.language,
+        chapters: result.chapters,
+      });
+    } else {
+      report = await db.models.MeedActionReport.create({
+        id: randomUUID(),
+        inventoryId,
+        actionId: result.action_id,
+        languages: result.language,
+        chapters: result.chapters,
+      });
+    }
 
     return report;
   }

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -4,6 +4,8 @@ import PopulationService from "./PopulationService";
 import createHttpError from "http-errors";
 import { InventoryService } from "./InventoryService";
 import { randomUUID } from "node:crypto";
+import { Op } from "sequelize";
+import { logger } from "@/services/logger";
 
 const MEED_API_URL = process.env.HIAP_MEED_API_URL + "/v1/";
 
@@ -341,6 +343,83 @@ export default class MeedApiService {
       `climate-finance/projects?country_code=${countryLocode}&action_id=${actionId}`,
     );
     return result;
+  }
+
+  public static async translateExplanations(
+    inventoryId: string,
+    sourceLanguage: string,
+    targetLanguages: string[],
+    rankedActionIds: string[],
+  ) {
+    const actions = await db.models.MeedActionRanked.findAll({
+      where: { inventoryId, actionId: { [Op.in]: rankedActionIds } },
+    });
+    const rankedActions = actions
+      .map((action) => {
+        const canonicalExplanation = action.explanations?.[sourceLanguage];
+        if (!canonicalExplanation) {
+          logger.error(
+            {
+              id: action.id,
+              inventoryId: action.inventoryId,
+              actionId: action.actionId,
+              sourceLanguage,
+            },
+            "MEED: Explanation missing in source language for translation, skipping translation",
+          );
+        }
+        return {
+          actionId: action.actionId,
+          canonicalExplanation,
+        };
+      })
+      .filter((rankedAction) => !!rankedAction.canonicalExplanation);
+
+    const result = await this.makeRequest("explanations/translate", {
+      sourceLanguage,
+      targetLanguages,
+      rankedActions,
+    });
+
+    if (!result.translations) {
+      logger.error(
+        {
+          inventoryId,
+          sourceLanguage,
+          result,
+        },
+        "MEED: Translation failed",
+      );
+      return null;
+    }
+
+    // save to database
+    await db.sequelize?.transaction(async (transaction) => {
+      for (const translation of result.translations) {
+        const action = actions.find(
+          (action) => action.actionId == translation.actionId,
+        );
+        if (!action) {
+          logger.error(
+            {
+              inventoryId,
+              sourceLanguage,
+              result,
+              actionId: translation.actionId,
+            },
+            "MEED: Failed to find action for translation result",
+          );
+          continue;
+        }
+        action.explanations = {
+          ...action.explanations,
+          ...translation.explanations,
+        };
+        await action.save({ transaction });
+      }
+    });
+
+    return actions;
   }
 
   private static async makeRequest(route: string, data: object | null = null) {

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -507,6 +507,7 @@ export default class MeedApiService {
       },
       debugContextOnly,
     };
+    console.log("DATA", JSON.stringify(data, null, 2));
     const result = await this.makeRequest("reports/output-plan", data);
     console.log(result);
 
@@ -520,6 +521,21 @@ export default class MeedApiService {
     });
 
     return report;
+  }
+
+  public static async getPlan(inventoryId: string, actionId: string) {
+    const plan = await db.models.MeedActionReport.findOne({
+      where: {
+        inventoryId,
+        actionId,
+      },
+    });
+
+    if (!plan) {
+      throw new createHttpError.NotFound("Plan not found");
+    }
+
+    return plan;
   }
 
   private static async makeRequest(

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -206,9 +206,11 @@ export default class MeedApiService {
     });
 
     // make API request to MEED API
+    const requestId = randomUUID(); // to be able to save it to snapshot later
     const result: MeedRankResponse = await this.makeRequest(
       "prioritize",
       fullRequest,
+      requestId,
     );
 
     const rankedActionsRaw: MeedResponseActionRanked[] =
@@ -228,6 +230,26 @@ export default class MeedApiService {
         where: { inventoryId },
         transaction,
       });
+
+      // delete existing rank snapshots so there's only one per inventory
+      await db.models.MeedRankSnapshot.destroy({
+        where: { inventoryId },
+        transaction,
+      });
+
+      // store snapshot of ranking request and response so it can be used to generate a report
+      await db.models.MeedRankSnapshot.create(
+        {
+          id: randomUUID(),
+          inventoryId,
+          request: {
+            meta: { requestId },
+            requestData: fullRequest,
+          },
+          response: result,
+        },
+        { transaction },
+      );
 
       const rankedActions = await db.models.MeedActionRanked.bulkCreate(
         rankedActionsRaw.map((action) => ({
@@ -483,23 +505,37 @@ export default class MeedApiService {
         request: rankSnapshot.request,
         response: rankSnapshot.response,
       },
-      debugContextOnly, // TODO disable after testing
+      debugContextOnly,
     };
     const result = await this.makeRequest("reports/output-plan", data);
     console.log(result);
-    // TODO save result to DB
-    return result;
+
+    // save result to database
+    const report = await db.models.MeedActionReport.create({
+      id: randomUUID(),
+      inventoryId,
+      actionId: result.action_id,
+      languages: result.language,
+      chapters: result.chapters,
+    });
+
+    return report;
   }
 
-  private static async makeRequest(route: string, data: object | null = null) {
+  private static async makeRequest(
+    route: string,
+    data: object | null = null,
+    requestId: string | undefined = undefined,
+  ) {
     const method = data == null ? "GET" : "POST";
+    requestId = requestId ?? randomUUID();
     const body =
       data == null
         ? undefined
         : JSON.stringify({
             requestData: data,
             meta: {
-              requestId: randomUUID(),
+              requestId,
             },
           });
     const response = await fetch(MEED_API_URL + route, {

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -427,6 +427,12 @@ export default class MeedApiService {
       })
       .filter((rankedAction) => !!rankedAction.canonicalExplanation);
 
+    if (rankedActions.length === 0) {
+      throw new createHttpError.BadRequest(
+        "Missing action explanations in source language",
+      );
+    }
+
     const result = await this.makeRequest("explanations/translate", {
       sourceLanguage,
       targetLanguages,

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -362,6 +362,19 @@ export default class MeedApiService {
     return result.results;
   }
 
+  public static async getFeasibilityScores(cityId: string) {
+    const city = await db.models.City.findOne({ where: { cityId } });
+    if (!city) {
+      throw new createHttpError.NotFound("City not found");
+    }
+    const cityLocode = city.locode;
+    const countryLocode = city.countryLocode;
+    const result = await this.makeRequest(
+      `cities/${cityLocode}/action-mitigation-feasibility-scores?country_code=${countryLocode}`,
+    );
+    return result;
+  }
+
   public static async translateExplanations(
     inventoryId: string,
     sourceLanguage: string,

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -452,6 +452,45 @@ export default class MeedApiService {
     return actions;
   }
 
+  public static async generatePlan(
+    inventoryId: string,
+    languages: string[],
+    actionId: string,
+    debugContextOnly: boolean,
+  ) {
+    const inventory = await db.models.Inventory.findOne({
+      where: { inventoryId },
+      include: [{ model: db.models.City, as: "city" }],
+    });
+    if (!inventory) {
+      throw new createHttpError.NotFound("Inventory not found");
+    }
+
+    const rankSnapshot = await db.models.MeedRankSnapshot.findOne({
+      where: { inventoryId },
+    });
+    if (!rankSnapshot) {
+      throw new createHttpError.NotFound(
+        "Rank snapshot not found - run ranking first",
+      );
+    }
+
+    const data = {
+      locode: inventory.city.locode,
+      actionId,
+      language: languages,
+      prioritizationSnapshot: {
+        request: rankSnapshot.request,
+        response: rankSnapshot.response,
+      },
+      debugContextOnly, // TODO disable after testing
+    };
+    const result = await this.makeRequest("reports/output-plan", data);
+    console.log(result);
+    // TODO save result to DB
+    return result;
+  }
+
   private static async makeRequest(route: string, data: object | null = null) {
     const method = data == null ? "GET" : "POST";
     const body =

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -89,6 +89,15 @@ type MeedResponseActionRemoved = {
   };
 };
 
+type ExclusionsPreviewRequest = {
+  cityDataList: {
+    locode: string;
+    excludedSectorTags: string[];
+    excludedCoBenefitKeys: string[];
+    excludedActionsFreeText: string;
+  }[];
+};
+
 export default class MeedApiService {
   public static async runRanking(
     inventoryId: string,
@@ -343,6 +352,14 @@ export default class MeedApiService {
       `climate-finance/projects?country_code=${countryLocode}&action_id=${actionId}`,
     );
     return result;
+  }
+
+  public static async getExclusionsPreview(data: ExclusionsPreviewRequest) {
+    const result = await this.makeRequest(
+      "prioritize/exclusions/preview",
+      data,
+    );
+    return result.results;
   }
 
   public static async translateExplanations(

--- a/app/src/models/MeedActionReport.ts
+++ b/app/src/models/MeedActionReport.ts
@@ -1,0 +1,106 @@
+import * as Sequelize from "sequelize";
+import { DataTypes, Model, Optional } from "sequelize";
+import type { Inventory, InventoryId } from "./Inventory";
+
+export interface MeedActionReportAttributes {
+  id: string;
+  inventoryId?: string;
+  actionId?: string;
+  languages?: string[];
+  chapters?: object;
+  created?: Date;
+  lastUpdated?: Date;
+}
+
+export type MeedActionReportPk = "id";
+export type MeedActionReportId = MeedActionReport[MeedActionReportPk];
+export type MeedActionReportOptionalAttributes =
+  "actionId" | "languages" | "chapters" | "created" | "lastUpdated";
+export type MeedActionReportCreationAttributes = Optional<
+  MeedActionReportAttributes,
+  MeedActionReportOptionalAttributes
+>;
+
+export class MeedActionReport
+  extends Model<MeedActionReportAttributes, MeedActionReportCreationAttributes>
+  implements MeedActionReportAttributes
+{
+  declare id: string;
+  declare inventoryId?: string;
+  declare actionId?: string;
+  declare languages?: string[];
+  declare chapters?: object;
+  declare created?: Date;
+  declare lastUpdated?: Date;
+
+  // MeedActionReport belongsTo Inventory via inventoryId
+  declare inventory: Inventory;
+  declare getInventory: Sequelize.BelongsToGetAssociationMixin<Inventory>;
+  declare setInventory: Sequelize.BelongsToSetAssociationMixin<
+    Inventory,
+    InventoryId
+  >;
+  declare createInventory: Sequelize.BelongsToCreateAssociationMixin<Inventory>;
+
+  static initModel(sequelize: Sequelize.Sequelize): typeof MeedActionReport {
+    return MeedActionReport.init(
+      {
+        id: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          primaryKey: true,
+        },
+        inventoryId: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          references: {
+            model: "Inventory",
+            key: "inventory_id",
+          },
+          field: "inventory_id",
+        },
+        actionId: {
+          type: DataTypes.TEXT,
+          field: "action_id",
+          allowNull: false,
+        },
+        languages: {
+          type: DataTypes.ARRAY(DataTypes.TEXT),
+          allowNull: false,
+          defaultValue: [],
+        },
+        chapters: {
+          type: DataTypes.JSONB,
+          allowNull: false,
+          defaultValue: {},
+        },
+        created: {
+          type: DataTypes.DATE,
+          allowNull: false,
+          defaultValue: DataTypes.NOW,
+        },
+        lastUpdated: {
+          field: "last_updated",
+          type: DataTypes.DATE,
+          allowNull: false,
+          defaultValue: DataTypes.NOW,
+        },
+      },
+      {
+        sequelize,
+        tableName: "MeedActionReport",
+        schema: "public",
+        timestamps: true,
+        createdAt: "created",
+        updatedAt: "last_updated",
+        indexes: [
+          {
+            name: "MeedActionReport_pkey",
+            unique: true,
+            fields: [{ name: "id" }],
+          },
+        ],
+      },
+    );
+  }
+}

--- a/app/src/models/MeedRankSnapshot.ts
+++ b/app/src/models/MeedRankSnapshot.ts
@@ -1,0 +1,99 @@
+import * as Sequelize from "sequelize";
+import { DataTypes, Model, Optional } from "sequelize";
+import type { Inventory, InventoryId } from "./Inventory";
+
+export interface MeedRankSnapshotAttributes {
+  id: string;
+  inventoryId?: string;
+  request?: object;
+  response?: object;
+  created?: Date;
+  lastUpdated?: Date;
+}
+
+export type MeedRankSnapshotPk = "id";
+export type MeedRankSnapshotId = MeedRankSnapshot[MeedRankSnapshotPk];
+export type MeedRankSnapshotOptionalAttributes =
+  "request" | "response" | "created" | "lastUpdated";
+export type MeedRankSnapshotCreationAttributes = Optional<
+  MeedRankSnapshotAttributes,
+  MeedRankSnapshotOptionalAttributes
+>;
+
+export class MeedRankSnapshot
+  extends Model<MeedRankSnapshotAttributes, MeedRankSnapshotCreationAttributes>
+  implements MeedRankSnapshotAttributes
+{
+  declare id: string;
+  declare inventoryId?: string;
+  declare request?: object;
+  declare response?: object;
+  declare created?: Date;
+  declare lastUpdated?: Date;
+
+  // MeedRankSnapshot belongsTo Inventory via inventoryId
+  declare inventory: Inventory;
+  declare getInventory: Sequelize.BelongsToGetAssociationMixin<Inventory>;
+  declare setInventory: Sequelize.BelongsToSetAssociationMixin<
+    Inventory,
+    InventoryId
+  >;
+  declare createInventory: Sequelize.BelongsToCreateAssociationMixin<Inventory>;
+
+  static initModel(sequelize: Sequelize.Sequelize): typeof MeedRankSnapshot {
+    return MeedRankSnapshot.init(
+      {
+        id: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          primaryKey: true,
+        },
+        inventoryId: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          references: {
+            model: "Inventory",
+            key: "inventory_id",
+          },
+          field: "inventory_id",
+        },
+        request: {
+          type: DataTypes.JSONB,
+          allowNull: false,
+          defaultValue: {},
+        },
+        response: {
+          type: DataTypes.JSONB,
+          allowNull: false,
+          defaultValue: {},
+        },
+        created: {
+          type: DataTypes.DATE,
+          allowNull: false,
+          defaultValue: DataTypes.NOW,
+        },
+        lastUpdated: {
+          field: "last_updated",
+          type: DataTypes.DATE,
+          allowNull: false,
+          defaultValue: DataTypes.NOW,
+        },
+      },
+      {
+        sequelize,
+        tableName: "MeedRankSnapshot",
+        schema: "public",
+        timestamps: true,
+        createdAt: "created",
+        updatedAt: "last_updated",
+        indexes: [
+          {
+            name: "MeedRankSnapshot_pkey",
+            unique: true,
+            fields: [{ name: "id" }],
+          },
+        ],
+      },
+    );
+  }
+}

--- a/app/src/models/init-models.ts
+++ b/app/src/models/init-models.ts
@@ -136,6 +136,16 @@ import type {
   MeedActionRemovedCreationAttributes,
 } from "./MeedActionRemoved";
 import type {
+  MeedActionReportAttributes,
+  MeedActionReportCreationAttributes,
+} from "./MeedActionReport";
+import { MeedActionReport as _MeedActionReport } from "./MeedActionReport";
+import type {
+  MeedRankSnapshotAttributes,
+  MeedRankSnapshotCreationAttributes,
+} from "./MeedRankSnapshot";
+import { MeedRankSnapshot as _MeedRankSnapshot } from "./MeedRankSnapshot";
+import type {
   MethodologyAttributes,
   MethodologyCreationAttributes,
 } from "./Methodology";
@@ -306,6 +316,8 @@ export {
   _ImportMappingFeedback as ImportMappingFeedback,
   _MeedActionRanked as MeedActionRanked,
   _MeedActionRemoved as MeedActionRemoved,
+  _MeedActionReport as MeedActionReport,
+  _MeedRankSnapshot as MeedRankSnapshot,
   _Methodology as Methodology,
   _Organization as Organization,
   _Project as Project,
@@ -397,6 +409,10 @@ export type {
   MeedActionRankedCreationAttributes,
   MeedActionRemovedAttributes,
   MeedActionRemovedCreationAttributes,
+  MeedActionReportAttributes,
+  MeedActionReportCreationAttributes,
+  MeedRankSnapshotAttributes,
+  MeedRankSnapshotCreationAttributes,
   MethodologyAttributes,
   MethodologyCreationAttributes,
   OrganizationAttributes,
@@ -497,6 +513,8 @@ export function initModels(sequelize: Sequelize) {
   const ImportMappingFeedback = _ImportMappingFeedback.initModel(sequelize);
   const MeedActionRanked = _MeedActionRanked.initModel(sequelize);
   const MeedActionRemoved = _MeedActionRemoved.initModel(sequelize);
+  const MeedActionReport = _MeedActionReport.initModel(sequelize);
+  const MeedRankSnapshot = _MeedRankSnapshot.initModel(sequelize);
   const Methodology = _Methodology.initModel(sequelize);
   const Organization = _Organization.initModel(sequelize);
   const Project = _Project.initModel(sequelize);
@@ -1198,6 +1216,24 @@ export function initModels(sequelize: Sequelize) {
     foreignKey: "inventoryId",
   });
 
+  // Associations for MeedActionReport and MeedRankSnapshot
+  MeedActionReport.belongsTo(Inventory, {
+    as: "inventory",
+    foreignKey: "inventoryId",
+  });
+  Inventory.hasMany(MeedActionReport, {
+    as: "meedActionReports",
+    foreignKey: "inventoryId",
+  });
+  MeedRankSnapshot.belongsTo(Inventory, {
+    as: "inventory",
+    foreignKey: "inventoryId",
+  });
+  Inventory.hasMany(MeedRankSnapshot, {
+    as: "meedRankSnapshots",
+    foreignKey: "inventoryId",
+  });
+
   // Associations for UnrankedActionSelection
   UnrankedActionSelectionModel.belongsTo(Inventory, {
     as: "inventory",
@@ -1321,6 +1357,8 @@ export function initModels(sequelize: Sequelize) {
     ImportMappingFeedback: ImportMappingFeedback,
     MeedActionRanked: MeedActionRanked,
     MeedActionRemoved: MeedActionRemoved,
+    MeedActionReport: MeedActionReport,
+    MeedRankSnapshot: MeedRankSnapshot,
     Methodology: Methodology,
     Organization: Organization,
     Project: Project,


### PR DESCRIPTION
Implements the 4 remaining API routes needed to communicate with the HIAP MEED service:

- [x] POST /api/v1/city/[city]/meed/actions/translate
- [x] POST /api/v1/city/[city]/meed/exclusions-preview
- [x] GET /api/v1/city/[city]/meed/feasibility-scores
- [x] POST /api/v1/city/[city]/meed/generate-plan

It also adds this route to re-fetch created plan (action report) from the database, similar to how the ranking works
- [x] GET /api/v1/city/[city]/meed/generate-plan

For the generate plan route there is the new table MeedActionReport, which stores the results of the call so it can be retrieved at a later date without re-running the plan generation.
It also stores the full request and response context of the ranking run in the new table MeedRankSnapshot.

TODO:
- [x] Test all routes extensively with the service