### PR TITLE
CC-757: Fix transient Climate Advisor token issuance failures

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -120,6 +120,38 @@ both `CA_SERVICE_INTEGRATION` and `CONCEPT_NOTE_BUILDER` and sets
 `CA_BASE_URL` to that address. Climate Advisor must also have its independent
 `CNB_DATABASE_URL` configured and migrated.
 
+### CityCatalyst-to-Climate-Advisor user tokens
+
+CNB, chat, PDF OCR delivery, and Stationary Energy use the shared server-side
+`src/backend/climate-advisor-token.ts` client. It caches validated user tokens
+until 60 seconds before expiry and shares one pending issuance (including retries)
+between concurrent calls for the same user. Tokens are user-scoped; inventory IDs
+remain request context. Returned `expires_in` is the remaining lifetime, including
+when a cached token is attached to a new chat thread.
+
+The cache holds at most 1,000 tokens per process, evicts least-recently-used entries,
+and resets when `HOST`, `CC_SERVICE_API_KEY`, or `VERIFICATION_TOKEN_SECRET` changes.
+Expired entries are removed on access or insertion. Tokens are not written to the
+Next.js fetch cache. New processes and different pods start cold independently;
+no sticky sessions or distributed cache are required. Identity and resource
+permissions are still checked by the existing authorization boundaries.
+
+Cold-cache issuance retries transport failures, timeouts, and HTTP 502/503/504 at
+most twice after the initial attempt. Each attempt has a three-second deadline
+covering headers and body reading. Backoff is 200 ms then 400 ms, each with 0–100 ms
+jitter, for a maximum configured budget of 9.8 seconds. Other HTTP failures and
+malformed token responses are not retried or cached. Actual CA operations are
+not replayed by this client; OCR retains its separate durable delivery retries.
+
+Exhausted issuance preserves its final upstream HTTP status; network failures map
+to 502 and timeouts to 504. JSON routes use the existing API error envelope with a
+sanitized message. Chat messages retain their SSE error-event contract. Logs
+include attempt, status, failure category, duration, and whether another retry
+will follow, without tokens, service keys, headers, or upstream response bodies.
+After deployment, compare token issuance volume and exhausted-retry logs during
+workspace refreshes, including after a pod restart. Rollback requires only a code
+revert, with no database migration.
+
 ## Running
 
 ### Development

--- a/app/src/app/api/v1/chat/messages/route.ts
+++ b/app/src/app/api/v1/chat/messages/route.ts
@@ -53,9 +53,9 @@ import { NextResponse } from "next/server";
 import {
   callClimateAdvisorChat,
   extractClimateAdvisorErrorMessage,
-  issueClimateAdvisorUserToken,
   readClimateAdvisorResponsePayload,
 } from "@/backend/chat/climate-advisor";
+import { issueClimateAdvisorUserToken } from "@/backend/climate-advisor-token";
 import { buildClimateAdvisorMessagePayload } from "@/backend/chat/message-payload";
 import { logger } from "@/services/logger";
 import { apiHandler } from "@/util/api";

--- a/app/src/app/api/v1/chat/messages/route.ts
+++ b/app/src/app/api/v1/chat/messages/route.ts
@@ -50,6 +50,7 @@
  */
 
 import { NextResponse } from "next/server";
+import { requireExistingChatUser } from "@/backend/chat/authorization";
 import {
   callClimateAdvisorChat,
   extractClimateAdvisorErrorMessage,
@@ -77,6 +78,8 @@ export const POST = apiHandler(async (req, { session }) => {
         { status: 400 },
       );
     }
+
+    await requireExistingChatUser(session.user.id);
 
     logger.info(
       {

--- a/app/src/app/api/v1/chat/threads/route.ts
+++ b/app/src/app/api/v1/chat/threads/route.ts
@@ -40,6 +40,7 @@
 
 import createHttpError from "http-errors";
 import { NextResponse } from "next/server";
+import { requireExistingChatUser } from "@/backend/chat/authorization";
 import { createClimateAdvisorThread } from "@/backend/chat/climate-advisor";
 import { logger } from "@/services/logger";
 import { apiHandler } from "@/util/api";
@@ -52,6 +53,7 @@ export const POST = apiHandler(async (req, { session }) => {
 
   const requestBody = await req.json().catch(() => ({}));
   const { title, inventory_id } = createChatThreadRequest.parse(requestBody);
+  await requireExistingChatUser(session.user.id);
 
   logger.info(
     {

--- a/app/src/backend/PdfOcrDeliveryService.ts
+++ b/app/src/backend/PdfOcrDeliveryService.ts
@@ -2,7 +2,7 @@ import { Op } from "sequelize";
 
 import { db } from "@/models";
 import type { PdfOcrJob } from "@/models/PdfOcrJob";
-import { issueClimateAdvisorUserToken } from "@/backend/chat/climate-advisor";
+import { issueClimateAdvisorUserToken } from "@/backend/climate-advisor-token";
 import {
   getConceptNoteSourceFormat,
   type ConceptNoteSourceFormat,

--- a/app/src/backend/agentic/ghgi/stationary-energy/ca.ts
+++ b/app/src/backend/agentic/ghgi/stationary-energy/ca.ts
@@ -1,11 +1,11 @@
 import createHttpError from "http-errors";
 
 import {
-  type ClimateAdvisorTokenResponse,
   joinServiceUrl,
-  readClimateAdvisorTokenResponse,
   requireServiceEnv,
 } from "@/backend/climate-advisor-connection";
+
+import { issueClimateAdvisorUserToken } from "@/backend/climate-advisor-token";
 
 /**
  * Read a required Climate Advisor proxy environment variable.
@@ -28,109 +28,6 @@ export function getClimateAdvisorRequestId(req: Request): string | undefined {
   return req.headers.get("x-request-id")?.trim() || undefined;
 }
 
-/**
- * Extract the most useful error message from a Climate Advisor JSON payload.
- */
-function climateAdvisorErrorMessage(
-  payload: unknown,
-  fallback: string,
-): string {
-  if (payload && typeof payload === "object") {
-    const problem = payload as Record<string, unknown>;
-    if (typeof problem.detail === "string" && problem.detail.trim()) {
-      return problem.detail;
-    }
-    if (typeof problem.title === "string" && problem.title.trim()) {
-      return problem.title;
-    }
-    const error = problem.error;
-    if (error && typeof error === "object") {
-      const message = (error as Record<string, unknown>).message;
-      if (typeof message === "string" && message.trim()) {
-        return message;
-      }
-    }
-  }
-
-  return fallback;
-}
-
-/**
- * Read a CA error payload as JSON when available.
- */
-async function readClimateAdvisorErrorPayload(
-  response: Response,
-): Promise<unknown> {
-  try {
-    return await response.json();
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Build an HTTP error that preserves an upstream JSON payload when present.
- */
-function createClimateAdvisorHttpError(
-  status: number,
-  payload: unknown,
-  fallback: string,
-) {
-  const message = climateAdvisorErrorMessage(payload, fallback);
-  if (payload && typeof payload === "object") {
-    return createHttpError(status, message, { data: payload });
-  }
-  return createHttpError(status, message);
-}
-
-/**
- * Re-throw a CA proxy failure with the upstream HTTP status and payload.
- */
-async function throwClimateAdvisorProxyError(
-  response: Response,
-  fallback: string,
-): Promise<never> {
-  const payload = await readClimateAdvisorErrorPayload(response);
-  throw createClimateAdvisorHttpError(response.status, payload, fallback);
-}
-
-export async function issueCaUserToken(params: {
-  tokenUserID: string;
-  inventoryId?: string;
-}): Promise<ClimateAdvisorTokenResponse> {
-  const serviceKey = requireEnv("CC_SERVICE_API_KEY");
-  const host = requireEnv("HOST");
-  let response: Response;
-  try {
-    response = await fetch(
-      joinServiceUrl(host, "/api/v1/internal/ca/user-token/"),
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-CA-Service-Key": serviceKey,
-        },
-        body: JSON.stringify({
-          user_id: params.tokenUserID,
-          inventory_id: params.inventoryId,
-        }),
-      },
-    );
-  } catch (error) {
-    throw new createHttpError.BadGateway(
-      error instanceof Error
-        ? error.message
-        : "CA token issuance request failed",
-    );
-  }
-
-  if (!response.ok) {
-    await throwClimateAdvisorProxyError(response, "CA token issuance failed");
-  }
-
-  return readClimateAdvisorTokenResponse(response);
-}
-
 export async function callClimateAdvisor(params: {
   path: string;
   tokenUserID: string;
@@ -139,8 +36,8 @@ export async function callClimateAdvisor(params: {
   body?: Record<string, unknown>;
   requestId?: string;
 }): Promise<Response> {
-  const token = await issueCaUserToken({
-    tokenUserID: params.tokenUserID,
+  const token = await issueClimateAdvisorUserToken({
+    userId: params.tokenUserID,
     inventoryId: params.inventoryId,
   });
   const caBaseUrl = requireEnv("CA_BASE_URL");

--- a/app/src/backend/chat/authorization.ts
+++ b/app/src/backend/chat/authorization.ts
@@ -1,0 +1,13 @@
+import createHttpError from "http-errors";
+
+import { db } from "@/models";
+
+/** Cached service tokens do not establish that a session's user still exists. */
+export async function requireExistingChatUser(userId: string): Promise<void> {
+  const user = await db.models.User.findByPk(userId, {
+    attributes: ["userId"],
+  });
+  if (!user) {
+    throw new createHttpError.NotFound("User not found");
+  }
+}

--- a/app/src/backend/chat/climate-advisor.ts
+++ b/app/src/backend/chat/climate-advisor.ts
@@ -1,11 +1,11 @@
 import createHttpError from "http-errors";
 
 import {
-  type ClimateAdvisorTokenResponse,
   joinServiceUrl,
-  readClimateAdvisorTokenResponse,
   requireServiceEnv,
 } from "@/backend/climate-advisor-connection";
+
+import { issueClimateAdvisorUserToken } from "@/backend/climate-advisor-token";
 
 type QueryValue = string | number | boolean | null | undefined;
 
@@ -89,51 +89,6 @@ function buildClimateAdvisorUrl(
   }
 
   return url.toString();
-}
-
-/**
- * Issue a short-lived CA user token through the internal service endpoint.
- */
-export async function issueClimateAdvisorUserToken(params: {
-  userId: string;
-  inventoryId?: string;
-}): Promise<ClimateAdvisorTokenResponse> {
-  const serviceKey = requireEnv("CC_SERVICE_API_KEY");
-  const host = requireEnv("HOST");
-  let response: Response;
-  try {
-    response = await fetch(
-      joinServiceUrl(host, "/api/v1/internal/ca/user-token/"),
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-CA-Service-Key": serviceKey,
-        },
-        body: JSON.stringify({
-          user_id: params.userId,
-          inventory_id: params.inventoryId,
-        }),
-      },
-    );
-  } catch (error) {
-    throw new createHttpError.BadGateway(
-      error instanceof Error
-        ? error.message
-        : "CA token issuance request failed",
-    );
-  }
-
-  if (!response.ok) {
-    const payload = await readClimateAdvisorResponsePayload(response);
-    throw createClimateAdvisorHttpError(
-      response.status,
-      payload,
-      "CA token issuance failed",
-    );
-  }
-
-  return readClimateAdvisorTokenResponse(response);
 }
 
 /**

--- a/app/src/backend/climate-advisor-token.ts
+++ b/app/src/backend/climate-advisor-token.ts
@@ -1,0 +1,224 @@
+import { createHash } from "node:crypto";
+import createHttpError from "http-errors";
+
+import {
+  type ClimateAdvisorTokenResponse,
+  joinServiceUrl,
+  readClimateAdvisorTokenResponse,
+  requireServiceEnv,
+} from "@/backend/climate-advisor-connection";
+import { logger } from "@/services/logger";
+
+const EXPIRY_MARGIN_MS = 60_000;
+const MAX_CACHED_TOKENS = 1_000;
+const ATTEMPT_TIMEOUT_MS = 3_000;
+const MAX_ATTEMPTS = 3;
+const TRANSIENT_STATUSES = new Set([502, 503, 504]);
+const STATE_KEY = Symbol.for("citycatalyst.ca-user-token-cache.v1");
+
+type TokenParams = { userId: string; inventoryId?: string };
+type CachedToken = { accessToken: string; expiresAt: number };
+type TokenState = {
+  fingerprint: string;
+  tokens: Map<string, CachedToken>;
+  inFlight: Map<string, Promise<CachedToken>>;
+};
+const processState = globalThis as typeof globalThis & {
+  [STATE_KEY]?: TokenState;
+};
+
+/** Keep only safe failure metadata; upstream bodies and errors may contain secrets. */
+class TokenIssuanceFailure extends Error {
+  constructor(
+    readonly status: number,
+    readonly retryable: boolean,
+    readonly category: "http" | "transport" | "timeout" | "invalid_response",
+  ) {
+    super(
+      category === "invalid_response"
+        ? "Invalid CA token response"
+        : "Unable to obtain Climate Advisor access token",
+    );
+  }
+}
+
+/** Share state across Next.js route bundles, replacing it after credential rotation. */
+function getState(host: string, serviceKey: string): TokenState {
+  const fingerprint = createHash("sha256")
+    .update(
+      JSON.stringify([host, serviceKey, process.env.VERIFICATION_TOKEN_SECRET]),
+    )
+    .digest("hex");
+  if (processState[STATE_KEY]?.fingerprint !== fingerprint) {
+    processState[STATE_KEY] = {
+      fingerprint,
+      tokens: new Map(),
+      inFlight: new Map(),
+    };
+  }
+  return processState[STATE_KEY];
+}
+
+/** Bound the entire attempt, including reading a stalled response body. */
+async function fetchToken(
+  host: string,
+  serviceKey: string,
+  params: TokenParams,
+): Promise<CachedToken> {
+  const controller = new AbortController();
+  const startedAt = Date.now();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      (async () => {
+        const response = await fetch(
+          joinServiceUrl(host, "/api/v1/internal/ca/user-token/"),
+          {
+            method: "POST",
+            cache: "no-store",
+            signal: controller.signal,
+            headers: {
+              "Content-Type": "application/json",
+              "X-CA-Service-Key": serviceKey,
+            },
+            body: JSON.stringify({
+              user_id: params.userId,
+              inventory_id: params.inventoryId,
+            }),
+          },
+        );
+        if (!response.ok) {
+          void response.body?.cancel().catch(() => {});
+          throw new TokenIssuanceFailure(
+            response.status,
+            TRANSIENT_STATUSES.has(response.status),
+            "http",
+          );
+        }
+
+        // Read transport bytes separately so a broken stream is retryable, whereas
+        // a complete but malformed JSON/token payload is not.
+        const body = await response.text();
+        let token: ClimateAdvisorTokenResponse;
+        try {
+          token = await readClimateAdvisorTokenResponse(new Response(body));
+        } catch {
+          throw new TokenIssuanceFailure(502, false, "invalid_response");
+        }
+        // Start before the request to avoid overstating the issuer's lifetime.
+        const expiresAt = startedAt + token.expires_in * 1_000;
+        if (!Number.isFinite(expiresAt) || expiresAt - Date.now() < 1_000) {
+          throw new TokenIssuanceFailure(502, false, "invalid_response");
+        }
+        return { accessToken: token.access_token, expiresAt };
+      })(),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          controller.abort();
+          reject(new TokenIssuanceFailure(504, true, "timeout"));
+        }, ATTEMPT_TIMEOUT_MS);
+      }),
+    ]);
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new TokenIssuanceFailure(504, true, "timeout");
+    }
+    if (error instanceof TokenIssuanceFailure) throw error;
+    throw new TokenIssuanceFailure(502, true, "transport");
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/** Retry only issuance, keeping the full retry sequence inside the shared promise. */
+async function issueWithRetry(
+  host: string,
+  serviceKey: string,
+  params: TokenParams,
+): Promise<CachedToken> {
+  const startedAt = Date.now();
+  for (let attempt = 1; ; attempt++) {
+    try {
+      const token = await fetchToken(host, serviceKey, params);
+      logger.debug(
+        { attempt, duration_ms: Date.now() - startedAt },
+        "CA user token issued",
+      );
+      return token;
+    } catch (error) {
+      const failure = error as TokenIssuanceFailure;
+      const retrying = failure.retryable && attempt < MAX_ATTEMPTS;
+      logger.warn(
+        {
+          attempt,
+          status: failure.status,
+          category: failure.category,
+          duration_ms: Date.now() - startedAt,
+          retrying,
+        },
+        "CA user token issuance failed",
+      );
+      if (!retrying) {
+        throw createHttpError(failure.status, failure.message, {
+          expose: true,
+        });
+      }
+      const delay = 200 * 2 ** (attempt - 1) + Math.floor(Math.random() * 101);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+}
+
+/** Reuse a user-scoped token; inventory is request context, not JWT permission scope. */
+export async function issueClimateAdvisorUserToken(
+  params: TokenParams,
+): Promise<ClimateAdvisorTokenResponse> {
+  const host = requireServiceEnv("HOST");
+  const serviceKey = requireServiceEnv("CC_SERVICE_API_KEY");
+  const state = getState(host, serviceKey);
+  let token = state.tokens.get(params.userId);
+  state.tokens.delete(params.userId);
+  if (token && token.expiresAt > Date.now() + EXPIRY_MARGIN_MS) {
+    state.tokens.set(params.userId, token); // Most recently used.
+  } else {
+    let pending = state.inFlight.get(params.userId);
+    if (!pending) {
+      pending = issueWithRetry(host, serviceKey, params)
+        .then((issued) => {
+          // A request started before rotation must not populate the new cache.
+          if (processState[STATE_KEY] === state) {
+            for (const [userId, cached] of state.tokens) {
+              if (cached.expiresAt <= Date.now() + EXPIRY_MARGIN_MS) {
+                state.tokens.delete(userId);
+              }
+            }
+            if (issued.expiresAt > Date.now() + EXPIRY_MARGIN_MS) {
+              state.tokens.set(params.userId, issued);
+              while (state.tokens.size > MAX_CACHED_TOKENS) {
+                state.tokens.delete(state.tokens.keys().next().value!);
+              }
+            }
+          }
+          return issued;
+        })
+        .finally(() => state.inFlight.delete(params.userId));
+      state.inFlight.set(params.userId, pending);
+    }
+    token = await pending;
+  }
+  const expiresIn = Math.floor((token.expiresAt - Date.now()) / 1_000);
+  if (expiresIn <= 0) {
+    throw createHttpError(
+      502,
+      "Unable to obtain Climate Advisor access token",
+      {
+        expose: true,
+      },
+    );
+  }
+  return {
+    access_token: token.accessToken,
+    expires_in: expiresIn,
+    token_type: "Bearer",
+  };
+}

--- a/app/src/backend/concept-notes.ts
+++ b/app/src/backend/concept-notes.ts
@@ -4,29 +4,13 @@ import createHttpError from "http-errors";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
-import {
-  callClimateAdvisorChat,
-  issueClimateAdvisorUserToken,
-} from "@/backend/chat/climate-advisor";
-import type { ClimateAdvisorTokenResponse } from "@/backend/climate-advisor-connection";
+import { callClimateAdvisorChat } from "@/backend/chat/climate-advisor";
+import { issueClimateAdvisorUserToken } from "@/backend/climate-advisor-token";
 import { PermissionService } from "@/backend/permissions/PermissionService";
 import type { AppSession } from "@/lib/auth";
 import { logger } from "@/services/logger";
 
 const upstreamRunSchema = z.object({ city_id: z.string().uuid() });
-const tokenRefreshMarginMs = 60_000;
-const tokenCacheMaxEntries = 1_000;
-
-type CachedUserToken = {
-  token: ClimateAdvisorTokenResponse;
-  expiresAt: number;
-};
-
-const userTokenCache = new Map<string, CachedUserToken>();
-const userTokenIssuance = new Map<
-  string,
-  Promise<ClimateAdvisorTokenResponse>
->();
 
 type ConceptNoteApiRequest = {
   path: string;
@@ -49,7 +33,9 @@ type AuthorizedConceptNoteApiRequest = Omit<ConceptNoteApiRequest, "userId"> & {
 export async function callConceptNoteApi(
   request: ConceptNoteApiRequest,
 ): Promise<Response> {
-  const token = await getConceptNoteUserToken(request.userId);
+  const token = await issueClimateAdvisorUserToken({
+    userId: request.userId,
+  });
 
   return callClimateAdvisorChat({
     path: request.path,
@@ -62,72 +48,6 @@ export async function callConceptNoteApi(
       "X-Request-ID": request.requestId ?? `cc-${randomUUID()}`,
     },
   });
-}
-
-/**
- * Reuse one valid CA token per user and coalesce concurrent token issuance.
- */
-async function getConceptNoteUserToken(
-  userId: string,
-): Promise<ClimateAdvisorTokenResponse> {
-  const now = Date.now();
-  const cached = userTokenCache.get(userId);
-  if (cached && cached.expiresAt > now) {
-    userTokenCache.delete(userId);
-    userTokenCache.set(userId, cached);
-    return cached.token;
-  }
-  userTokenCache.delete(userId);
-
-  const pending = userTokenIssuance.get(userId);
-  if (pending) {
-    return pending;
-  }
-
-  const issuance = issueClimateAdvisorUserToken({ userId }).then((token) => {
-    cacheConceptNoteUserToken(userId, token);
-    return token;
-  });
-  userTokenIssuance.set(userId, issuance);
-  try {
-    return await issuance;
-  } finally {
-    if (userTokenIssuance.get(userId) === issuance) {
-      userTokenIssuance.delete(userId);
-    }
-  }
-}
-
-/** Retain a valid token until shortly before its reported expiry. */
-function cacheConceptNoteUserToken(
-  userId: string,
-  token: ClimateAdvisorTokenResponse,
-): void {
-  const now = Date.now();
-  const ttlMs = token.expires_in * 1_000 - tokenRefreshMarginMs;
-  if (ttlMs <= 0) {
-    return;
-  }
-
-  for (const [cachedUserId, cached] of userTokenCache) {
-    if (cached.expiresAt <= now) {
-      userTokenCache.delete(cachedUserId);
-    }
-  }
-  userTokenCache.set(userId, { token, expiresAt: now + ttlMs });
-  while (userTokenCache.size > tokenCacheMaxEntries) {
-    const oldestUserId = userTokenCache.keys().next().value;
-    if (oldestUserId === undefined) {
-      break;
-    }
-    userTokenCache.delete(oldestUserId);
-  }
-}
-
-/** Reset process-local token state between isolated unit tests. */
-export function resetConceptNoteUserTokenCacheForTests(): void {
-  userTokenCache.clear();
-  userTokenIssuance.clear();
 }
 
 /** Check city access before calling an authenticated Concept Note endpoint. */

--- a/app/tests/api/chat-routes.jest.ts
+++ b/app/tests/api/chat-routes.jest.ts
@@ -14,6 +14,8 @@ import { GET as getThreadMessages } from "@/app/api/v1/chat/threads/[threadId]/m
 import { POST as postChatThread } from "@/app/api/v1/chat/threads/route";
 import { Auth, type AppSession } from "@/lib/auth";
 import { db } from "@/models";
+import type { User } from "@/models/User";
+import { issueClimateAdvisorUserToken } from "@/backend/climate-advisor-token";
 import { Roles } from "@/util/types";
 
 const testUserID = "beb9634a-b68c-4c1b-a20b-2ab0ced5e3c2";
@@ -50,8 +52,10 @@ describe("Chat routes", () => {
   const originalHost = process.env.HOST;
   const originalDbInitialized = db.initialized;
   let sessionSpy: ReturnType<typeof jest.spyOn>;
+  let userLookup: jest.SpiedFunction<typeof db.models.User.findByPk>;
 
   beforeAll(() => {
+    userLookup = jest.spyOn(db.models.User, "findByPk");
     const expires = new Date();
     expires.setDate(expires.getDate() + 1);
 
@@ -76,6 +80,7 @@ describe("Chat routes", () => {
     process.env.CC_SERVICE_API_KEY = "cc-service-key";
     process.env.HOST = "http://cc.example";
     db.initialized = true;
+    userLookup.mockReset().mockResolvedValue({ userId: testUserID } as User);
     global.fetch = jest.fn() as unknown as typeof fetch;
   });
 
@@ -90,6 +95,129 @@ describe("Chat routes", () => {
     process.env.CC_SERVICE_API_KEY = originalServiceKey;
     process.env.HOST = originalHost;
     sessionSpy.mockRestore();
+    userLookup.mockRestore();
+  });
+
+  it.each(["cold", "warm"])(
+    "rejects a deleted user's thread creation with a %s token cache",
+    async (cache) => {
+      const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>;
+      if (cache === "warm") {
+        fetchMock.mockResolvedValueOnce(
+          jsonResponse({
+            access_token: "cached-token",
+            expires_in: 3600,
+            token_type: "Bearer",
+          }),
+        );
+        await issueClimateAdvisorUserToken({ userId: testUserID });
+        fetchMock.mockReset();
+      }
+      userLookup.mockResolvedValue(null);
+      fetchMock.mockImplementation(async (url) =>
+        String(url).includes("user-token")
+          ? jsonResponse({
+              access_token: "token",
+              expires_in: 3600,
+              token_type: "Bearer",
+            })
+          : jsonResponse({ thread_id: "unexpected-thread" }),
+      );
+
+      const response = await postChatThread(
+        makeRequest("http://localhost:3000/api/v1/chat/threads", "POST", {}),
+        { params: Promise.resolve({}) },
+      );
+      expect(response.status).toBe(404);
+      await expect(response.json()).resolves.toEqual({
+        error: { message: "User not found" },
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["cold", "warm"])(
+    "rejects a deleted user's message with a %s token cache using SSE errors",
+    async (cache) => {
+      const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>;
+      if (cache === "warm") {
+        fetchMock.mockResolvedValueOnce(
+          jsonResponse({
+            access_token: "cached-token",
+            expires_in: 3600,
+            token_type: "Bearer",
+          }),
+        );
+        await issueClimateAdvisorUserToken({ userId: testUserID });
+        fetchMock.mockReset();
+      }
+      userLookup.mockResolvedValue(null);
+      fetchMock.mockImplementation(async (url) =>
+        String(url).includes("user-token")
+          ? jsonResponse({
+              access_token: "token",
+              expires_in: 3600,
+              token_type: "Bearer",
+            })
+          : new Response('event: done\ndata: {"ok":true}\n\n'),
+      );
+
+      const response = await postChatMessage(
+        makeRequest("http://localhost:3000/api/v1/chat/messages", "POST", {
+          threadId: "existing-thread",
+          content: "Hello",
+        }),
+        { params: Promise.resolve({}) },
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+      const body = await response.text();
+      expect(body).toContain("event: error");
+      expect(body).toContain('"message":"User not found"');
+      expect(body).toContain('"ok":false');
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rechecks the user while sharing a cached token across threads and messages", async () => {
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>;
+    fetchMock.mockImplementation(async (url) => {
+      if (String(url).includes("user-token")) {
+        return jsonResponse({
+          access_token: "shared-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        });
+      }
+      return String(url).endsWith("/threads")
+        ? jsonResponse({ thread_id: "thread-1" })
+        : new Response('event: done\ndata: {"ok":true}\n\n');
+    });
+    const createThread = () =>
+      postChatThread(
+        makeRequest("http://localhost:3000/api/v1/chat/threads", "POST", {}),
+        { params: Promise.resolve({}) },
+      );
+    expect((await createThread()).status).toBe(200);
+    expect((await createThread()).status).toBe(200);
+    const response = await postChatMessage(
+      makeRequest("http://localhost:3000/api/v1/chat/messages", "POST", {
+        threadId: "thread-1",
+        content: "Hello",
+      }),
+      { params: Promise.resolve({}) },
+    );
+    await expect(response.text()).resolves.toContain('"ok":true');
+    expect(userLookup).toHaveBeenCalledTimes(3);
+    expect(
+      userLookup.mock.calls.every(([userId]) => userId === testUserID),
+    ).toBe(true);
+    expect(
+      fetchMock.mock.calls.filter(([url]) =>
+        String(url).includes("user-token"),
+      ),
+    ).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
   it("creates a CA thread through the shared backend helper", async () => {

--- a/app/tests/api/chat-routes.jest.ts
+++ b/app/tests/api/chat-routes.jest.ts
@@ -68,6 +68,10 @@ describe("Chat routes", () => {
   });
 
   beforeEach(() => {
+    Reflect.deleteProperty(
+      globalThis,
+      Symbol.for("citycatalyst.ca-user-token-cache.v1"),
+    );
     process.env.CA_BASE_URL = "http://ca.example";
     process.env.CC_SERVICE_API_KEY = "cc-service-key";
     process.env.HOST = "http://cc.example";
@@ -140,7 +144,7 @@ describe("Chat routes", () => {
       inventory_id: testInventoryId,
       context: expect.objectContaining({
         access_token: "token-123",
-        expires_in: 3600,
+        expires_in: expect.any(Number),
         token_type: "Bearer",
         issued_at: expect.any(String),
       }),
@@ -273,7 +277,7 @@ describe("Chat routes", () => {
     }
   });
 
-  it("preserves JSON token-issuance errors when creating a CA thread", async () => {
+  it("preserves token-issuance status with a sanitized message", async () => {
     const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>;
     fetchMock.mockResolvedValueOnce(
       jsonResponse(
@@ -295,15 +299,42 @@ describe("Chat routes", () => {
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({
       error: {
-        message: "service token rejected",
-        code: undefined,
-        data: {
-          detail: "service token rejected",
-        },
+        message: "Unable to obtain Climate Advisor access token",
       },
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it.each([502, 503, 504])(
+    "returns exhausted token status %s through apiHandler",
+    async (status) => {
+      jest.useFakeTimers();
+      try {
+        const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>;
+        fetchMock.mockImplementation(async () =>
+          jsonResponse({ detail: "private upstream diagnostics" }, { status }),
+        );
+        const pending = postChatThread(
+          makeRequest("http://localhost:3000/api/v1/chat/threads", "POST", {}),
+          { params: Promise.resolve({}) },
+        );
+        await jest.runAllTimersAsync();
+        const response = await pending;
+        expect(response.status).toBe(status);
+        await expect(response.json()).resolves.toEqual({
+          error: { message: "Unable to obtain Climate Advisor access token" },
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(
+          fetchMock.mock.calls.every(([url]) =>
+            String(url).includes("user-token"),
+          ),
+        ).toBe(true);
+      } finally {
+        jest.useRealTimers();
+      }
+    },
+  );
 
   it("preserves JSON CA thread creation errors from the shared backend helper", async () => {
     const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>;

--- a/app/tests/api/internal-ca-service-auth.jest.ts
+++ b/app/tests/api/internal-ca-service-auth.jest.ts
@@ -18,6 +18,7 @@ import { NextRequest } from "next/server";
 import { POST as postAllowedCapabilities } from "@/app/api/v1/internal/ca/capabilities/allowed-capabilities/route";
 import { POST as postUserToken } from "@/app/api/v1/internal/ca/user-token/route";
 import { PermissionService } from "@/backend/permissions/PermissionService";
+import { issueClimateAdvisorUserToken } from "@/backend/climate-advisor-token";
 import { db } from "@/models";
 import { Roles, UserRole } from "@/util/types";
 import { WhereOptions } from "sequelize";
@@ -65,18 +66,14 @@ let postListNotationKeys: typeof import("@/app/api/v1/internal/ca/capabilities/g
 let postCommitNotationKeys: typeof import("@/app/api/v1/internal/ca/capabilities/ghgi/stationary-energy/commit-notation-keys/route").POST;
 
 beforeAll(async () => {
-  ({ POST: postLoadContext } = await import(
-    "@/app/api/v1/internal/ca/capabilities/ghgi/stationary-energy/load-context/route"
-  ));
-  ({ POST: postCommitAccepted } = await import(
-    "@/app/api/v1/internal/ca/capabilities/ghgi/stationary-energy/commit-accepted/route"
-  ));
-  ({ POST: postListNotationKeys } = await import(
-    "@/app/api/v1/internal/ca/capabilities/ghgi/stationary-energy/list-notation-keys/route"
-  ));
-  ({ POST: postCommitNotationKeys } = await import(
-    "@/app/api/v1/internal/ca/capabilities/ghgi/stationary-energy/commit-notation-keys/route"
-  ));
+  ({ POST: postLoadContext } =
+    await import("@/app/api/v1/internal/ca/capabilities/ghgi/stationary-energy/load-context/route"));
+  ({ POST: postCommitAccepted } =
+    await import("@/app/api/v1/internal/ca/capabilities/ghgi/stationary-energy/commit-accepted/route"));
+  ({ POST: postListNotationKeys } =
+    await import("@/app/api/v1/internal/ca/capabilities/ghgi/stationary-energy/list-notation-keys/route"));
+  ({ POST: postCommitNotationKeys } =
+    await import("@/app/api/v1/internal/ca/capabilities/ghgi/stationary-energy/commit-notation-keys/route"));
 });
 
 const USER_ID = "11111111-1111-4111-8111-111111111111";
@@ -233,6 +230,10 @@ describe("internal CA service auth contract", () => {
   });
 
   beforeEach(() => {
+    Reflect.deleteProperty(
+      globalThis,
+      Symbol.for("citycatalyst.ca-user-token-cache.v1"),
+    );
     process.env.CC_SERVICE_API_KEY = "ci-shared-service-key";
     process.env.HOST = "http://localhost:3000";
     process.env.NEXT_PUBLIC_FEATURE_FLAGS =
@@ -291,6 +292,10 @@ describe("internal CA service auth contract", () => {
   });
 
   afterEach(() => {
+    Reflect.deleteProperty(
+      globalThis,
+      Symbol.for("citycatalyst.ca-user-token-cache.v1"),
+    );
     jest.restoreAllMocks();
     mockBuildStationaryEnergyContext.mockReset();
     mockCommitAcceptedStationaryEnergyRows.mockReset();
@@ -326,6 +331,55 @@ describe("internal CA service auth contract", () => {
 
     expect(missingResponse.status).toBe(401);
     expect(wrongResponse.status).toBe(401);
+  });
+
+  it("rechecks live role, permissions, and user existence with a cached token", async () => {
+    jest
+      .mocked(db.models.User.findByPk)
+      .mockResolvedValueOnce(
+        db.models.User.build({
+          userId: USER_ID,
+          email: "user@example.test",
+          role: Roles.Admin,
+        }),
+      );
+    const fetchSpy = jest
+      .spyOn(global, "fetch")
+      .mockImplementation(async (_, init) =>
+        postUserToken(
+          makeRequest(
+            "/api/v1/internal/ca/user-token",
+            JSON.parse(String(init?.body)),
+            init?.headers,
+          ),
+        ),
+      );
+    const token = await issueClimateAdvisorUserToken({ userId: USER_ID });
+    const request = () =>
+      postAllowedCapabilities(
+        makeRequest(
+          "/api/v1/internal/ca/capabilities/allowed-capabilities",
+          allowedBody(),
+          serviceHeaders(token.access_token),
+        ),
+        { params: Promise.resolve({}) },
+      );
+    expect((await request()).status).toBe(200);
+    expect(
+      jest.mocked(PermissionService.canEditInventory).mock.calls.at(-1)?.[0]
+        .user.role,
+    ).toBe(Roles.User);
+
+    jest
+      .mocked(PermissionService.canEditInventory)
+      .mockRejectedValueOnce(new createHttpError.Forbidden("Access revoked"));
+    expect((await request()).status).toBe(403);
+    jest.mocked(db.models.User.findOne).mockResolvedValueOnce(null);
+    expect((await request()).status).toBe(401);
+    expect(
+      (await issueClimateAdvisorUserToken({ userId: USER_ID })).access_token,
+    ).toBe(token.access_token);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it("rejects token exchange for nonexistent users", async () => {

--- a/app/tests/api/stationary-energy-draft-routes.jest.ts
+++ b/app/tests/api/stationary-energy-draft-routes.jest.ts
@@ -79,6 +79,10 @@ describe("Stationary Energy draft routes", () => {
   });
 
   beforeEach(() => {
+    Reflect.deleteProperty(
+      globalThis,
+      Symbol.for("citycatalyst.ca-user-token-cache.v1"),
+    );
     process.env.NEXT_PUBLIC_FEATURE_FLAGS =
       "CA_SERVICE_INTEGRATION,STATIONARY_ENERGY_AGENTIC";
     process.env.CA_BASE_URL = "http://ca.example";
@@ -449,7 +453,7 @@ describe("Stationary Energy draft routes", () => {
     }
   });
 
-  it("preserves JSON token-issuance errors from the shared CA helper", async () => {
+  it("preserves sanitized token-issuance errors from the shared CA helper", async () => {
     const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>;
     fetchMock.mockResolvedValueOnce(
       jsonResponse(
@@ -475,11 +479,7 @@ describe("Stationary Energy draft routes", () => {
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({
       error: {
-        message: "service token rejected",
-        code: undefined,
-        data: {
-          detail: "service token rejected",
-        },
+        message: "Unable to obtain Climate Advisor access token",
       },
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);

--- a/app/tests/climate-advisor-token.jest.ts
+++ b/app/tests/climate-advisor-token.jest.ts
@@ -1,0 +1,388 @@
+/** Regression coverage for CC-757's shared issuance, lifetime, and failure boundary. */
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import { issueClimateAdvisorUserToken } from "@/backend/climate-advisor-token";
+import { callConceptNoteApi } from "@/backend/concept-notes";
+import { callClimateAdvisor } from "@/backend/agentic/ghgi/stationary-energy/ca";
+import { createClimateAdvisorThread } from "@/backend/chat/climate-advisor";
+import { logger } from "@/services/logger";
+
+const originalFetch = global.fetch;
+const originalEnv = { ...process.env };
+const stateKey = Symbol.for("citycatalyst.ca-user-token-cache.v1");
+const user = { userId: "user-a" };
+let fetchMock: jest.MockedFunction<typeof fetch>;
+
+/** Build fresh responses because each real fetch body can only be consumed once. */
+function tokenResponse(accessToken = "user-a-token", expiresIn = 3600) {
+  return Response.json({
+    access_token: accessToken,
+    expires_in: expiresIn,
+    token_type: "Bearer",
+  });
+}
+
+beforeEach(() => {
+  Reflect.deleteProperty(globalThis, stateKey);
+  process.env.HOST = "http://cc.example";
+  process.env.CA_BASE_URL = "http://ca.example";
+  process.env.CC_SERVICE_API_KEY = "secret-service-key";
+  process.env.VERIFICATION_TOKEN_SECRET = "signing-secret";
+  jest.useFakeTimers({ now: new Date("2026-09-09T12:00:00Z") });
+  jest.spyOn(Math, "random").mockReturnValue(0.5);
+  jest.spyOn(logger, "warn").mockImplementation(() => {});
+  jest.spyOn(logger, "debug").mockImplementation(() => {});
+  fetchMock = jest.fn<typeof fetch>();
+  global.fetch = fetchMock;
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, stateKey);
+  global.fetch = originalFetch;
+  process.env = { ...originalEnv };
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+describe("CA token reuse", () => {
+  it("coalesces a burst and reports remaining lifetime without exposing cache objects", async () => {
+    fetchMock.mockImplementation(async () => tokenResponse());
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => issueClimateAdvisorUserToken(user)),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(
+      results.every((token) => token.access_token === "user-a-token"),
+    ).toBe(true);
+    results[0].access_token = "tampered";
+    jest.setSystemTime(Date.now() + 120_000);
+    expect(await issueClimateAdvisorUserToken(user)).toEqual({
+      access_token: "user-a-token",
+      expires_in: 3480,
+      token_type: "Bearer",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ cache: "no-store" });
+  });
+
+  it("keeps users isolated while inventory remains context", async () => {
+    fetchMock.mockImplementation(async (_, init) =>
+      tokenResponse(JSON.parse(String(init?.body)).user_id),
+    );
+    const [a, b, aOtherInventory] = await Promise.all([
+      issueClimateAdvisorUserToken({ ...user, inventoryId: "inventory-a" }),
+      issueClimateAdvisorUserToken({ userId: "user-b" }),
+      issueClimateAdvisorUserToken({ ...user, inventoryId: "inventory-b" }),
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect([
+      a.access_token,
+      b.access_token,
+      aOtherInventory.access_token,
+    ]).toEqual(["user-a", "user-b", "user-a"]);
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toEqual({
+      user_id: "user-a",
+      inventory_id: "inventory-a",
+    });
+  });
+
+  it("refreshes at the 60-second boundary, coalescing the refresh", async () => {
+    fetchMock.mockImplementation(async () => tokenResponse());
+    await issueClimateAdvisorUserToken(user);
+    jest.setSystemTime(Date.now() + 3_539_000);
+    expect((await issueClimateAdvisorUserToken(user)).expires_in).toBe(61);
+    jest.setSystemTime(Date.now() + 1_000);
+    await Promise.all([
+      issueClimateAdvisorUserToken(user),
+      issueClimateAdvisorUserToken(user),
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("accounts for issuance latency and does not cache short-lived tokens", async () => {
+    fetchMock.mockImplementation(async () => {
+      jest.setSystemTime(Date.now() + 1_500);
+      return tokenResponse("short", 60);
+    });
+    expect((await issueClimateAdvisorUserToken(user)).expires_in).toBe(58);
+    await issueClimateAdvisorUserToken(user);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts the least recently used token after 1,000 users", async () => {
+    fetchMock.mockImplementation(async () => tokenResponse());
+    for (let id = 0; id < 1000; id++)
+      await issueClimateAdvisorUserToken({ userId: String(id) });
+    await issueClimateAdvisorUserToken({ userId: "0" });
+    await issueClimateAdvisorUserToken({ userId: "1000" });
+    await issueClimateAdvisorUserToken({ userId: "0" });
+    expect(fetchMock).toHaveBeenCalledTimes(1001);
+    await issueClimateAdvisorUserToken({ userId: "1" });
+    expect(fetchMock).toHaveBeenCalledTimes(1002);
+  });
+
+  it.each(["HOST", "CC_SERVICE_API_KEY", "VERIFICATION_TOKEN_SECRET"])(
+    "invalidates cached tokens when %s changes",
+    async (key) => {
+      fetchMock.mockImplementation(async () => tokenResponse());
+      await issueClimateAdvisorUserToken(user);
+      process.env[key] += "-changed";
+      await issueClimateAdvisorUserToken(user);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("does not join an old in-flight request or cache its result after rotation", async () => {
+    let completeOld!: (response: Response) => void;
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          completeOld = resolve;
+        }),
+    );
+    const oldRequest = issueClimateAdvisorUserToken(user);
+    process.env.CC_SERVICE_API_KEY = "rotated-key";
+    fetchMock.mockResolvedValueOnce(tokenResponse("new-token"));
+    await issueClimateAdvisorUserToken(user);
+    completeOld(tokenResponse("old-token"));
+    await oldRequest;
+    expect((await issueClimateAdvisorUserToken(user)).access_token).toBe(
+      "new-token",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares state across module reloads and starts cold after a process-state reset", async () => {
+    fetchMock.mockImplementation(async () => tokenResponse());
+    await issueClimateAdvisorUserToken(user);
+    await jest.isolateModulesAsync(async () => {
+      const anotherBundle = await import("@/backend/climate-advisor-token");
+      await anotherBundle.issueClimateAdvisorUserToken(user);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    Reflect.deleteProperty(globalThis, stateKey);
+    await issueClimateAdvisorUserToken(user);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("CA issuance retries", () => {
+  it.each([502, 503, 504])(
+    "shares recovery from a cold-cache %s",
+    async (status) => {
+      fetchMock.mockResolvedValueOnce(
+        new Response("private gateway body", { status }),
+      );
+      fetchMock.mockImplementation(async () => tokenResponse());
+      const requests = Promise.all([
+        issueClimateAdvisorUserToken(user),
+        issueClimateAdvisorUserToken(user),
+      ]);
+      await jest.advanceTimersByTimeAsync(249);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      await jest.advanceTimersByTimeAsync(1);
+      await requests;
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each([502, 503, 504])(
+    "preserves exhausted %s and allows a later fresh attempt",
+    async (status) => {
+      fetchMock.mockImplementation(
+        async () => new Response("secret-service-key", { status }),
+      );
+      const failure = expect(
+        issueClimateAdvisorUserToken(user),
+      ).rejects.toMatchObject({
+        statusCode: status,
+        expose: true,
+        message: "Unable to obtain Climate Advisor access token",
+      });
+      await jest.advanceTimersByTimeAsync(700);
+      await failure;
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(JSON.stringify(jest.mocked(logger.warn).mock.calls)).not.toContain(
+        "secret-service-key",
+      );
+      fetchMock.mockResolvedValueOnce(tokenResponse());
+      await issueClimateAdvisorUserToken(user);
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    },
+  );
+
+  it("preserves the final status when failures differ", async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error("secret network diagnostics"))
+      .mockResolvedValueOnce(new Response(null, { status: 502 }))
+      .mockResolvedValueOnce(new Response(null, { status: 503 }));
+    const failure = expect(
+      issueClimateAdvisorUserToken(user),
+    ).rejects.toMatchObject({ statusCode: 503 });
+    await jest.runAllTimersAsync();
+    await failure;
+    expect(JSON.stringify(jest.mocked(logger.warn).mock.calls)).not.toContain(
+      "secret network diagnostics",
+    );
+  });
+
+  it("maps exhausted transport errors to 502", async () => {
+    fetchMock.mockRejectedValue(new Error("private connection information"));
+    const failure = expect(
+      issueClimateAdvisorUserToken(user),
+    ).rejects.toMatchObject({ statusCode: 502 });
+    await jest.runAllTimersAsync();
+    await failure;
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("recovers from a broken response stream", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.error(new Error("connection reset"));
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(tokenResponse());
+    const result = issueClimateAdvisorUserToken(user);
+    await jest.runAllTimersAsync();
+    await expect(result).resolves.toMatchObject({
+      access_token: "user-a-token",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["headers", "body"])(
+    "bounds stalled %s and exhausts as 504 within ten seconds",
+    async (stage) => {
+      fetchMock.mockImplementation(() =>
+        stage === "headers"
+          ? new Promise<Response>(() => {})
+          : Promise.resolve(new Response(new ReadableStream())),
+      );
+      const started = Date.now();
+      const failure = expect(
+        issueClimateAdvisorUserToken(user),
+      ).rejects.toMatchObject({ statusCode: 504 });
+      await jest.runAllTimersAsync();
+      await failure;
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(Date.now() - started).toBe(9700);
+      expect(
+        fetchMock.mock.calls.every(([, init]) => init?.signal?.aborted),
+      ).toBe(true);
+    },
+  );
+
+  it("recovers after a timeout", async () => {
+    fetchMock
+      .mockImplementationOnce(() => new Promise<Response>(() => {}))
+      .mockResolvedValueOnce(tokenResponse());
+    const result = issueClimateAdvisorUserToken(user);
+    await jest.runAllTimersAsync();
+    await expect(result).resolves.toMatchObject({
+      access_token: "user-a-token",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([400, 401, 403, 404, 429, 500])(
+    "does not retry HTTP %s",
+    async (status) => {
+      fetchMock.mockResolvedValueOnce(
+        new Response("private error", { status }),
+      );
+      await expect(issueClimateAdvisorUserToken(user)).rejects.toMatchObject({
+        statusCode: status,
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([
+    "not json",
+    "null",
+    JSON.stringify({ access_token: "" }),
+    JSON.stringify({
+      access_token: "token",
+      expires_in: -1,
+      token_type: "Bearer",
+    }),
+    JSON.stringify({
+      access_token: "token",
+      expires_in: 3600,
+      token_type: "Basic",
+    }),
+  ])("does not retry or cache malformed response %s", async (body) => {
+    fetchMock.mockResolvedValueOnce(new Response(body));
+    await expect(issueClimateAdvisorUserToken(user)).rejects.toMatchObject({
+      statusCode: 502,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    fetchMock.mockResolvedValueOnce(tokenResponse());
+    await issueClimateAdvisorUserToken(user);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("shared caller integration", () => {
+  it("coalesces CNB and Stationary Energy without replaying downstream mutations", async () => {
+    fetchMock.mockImplementation(async (url) =>
+      String(url).includes("user-token")
+        ? tokenResponse()
+        : new Response(null, { status: 503 }),
+    );
+    const responses = await Promise.all([
+      callConceptNoteApi({
+        ...user,
+        path: "/v1/concept-notes/start",
+        method: "POST",
+        body: { city_id: "city" },
+      }),
+      callClimateAdvisor({
+        tokenUserID: user.userId,
+        inventoryId: "inventory",
+        path: "/v1/stationary-energy-drafts/start",
+        method: "POST",
+        requestId: "request-123",
+        body: { inventory_id: "inventory" },
+      }),
+    ]);
+    expect(responses.map((response) => response.status)).toEqual([503, 503]);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const stationary = fetchMock.mock.calls.find(([url]) =>
+      String(url).includes("stationary-energy"),
+    );
+    expect(stationary?.[1]).toMatchObject({
+      headers: {
+        Authorization: "Bearer user-a-token",
+        "X-Request-ID": "request-123",
+      },
+    });
+  });
+
+  it("passes remaining token lifetime to a newly created chat thread", async () => {
+    fetchMock.mockResolvedValueOnce(tokenResponse());
+    await issueClimateAdvisorUserToken(user);
+    jest.setSystemTime(Date.now() + 120_000);
+    fetchMock.mockResolvedValueOnce(Response.json({ thread_id: "thread" }));
+    await createClimateAdvisorThread(user);
+    const body = JSON.parse(String(fetchMock.mock.calls[1][1]?.body));
+    expect(body.context).toMatchObject({
+      access_token: "user-a-token",
+      expires_in: 3480,
+      issued_at: new Date().toISOString(),
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/tests/concept-note-api.jest.ts
+++ b/app/tests/concept-note-api.jest.ts
@@ -8,7 +8,6 @@ import {
 } from "@jest/globals";
 import createHttpError from "http-errors";
 
-import type { ClimateAdvisorTokenResponse } from "@/backend/climate-advisor-connection";
 import type { AppSession } from "@/lib/auth";
 import { Roles } from "@/util/types";
 
@@ -34,6 +33,8 @@ const loggerError = jest.fn();
 
 jest.unstable_mockModule("@/backend/chat/climate-advisor", () => ({
   callClimateAdvisorChat,
+}));
+jest.unstable_mockModule("@/backend/climate-advisor-token", () => ({
   issueClimateAdvisorUserToken,
 }));
 jest.unstable_mockModule("@/backend/permissions/PermissionService", () => ({
@@ -49,23 +50,16 @@ const session: AppSession = {
 };
 
 let callAuthorizedConceptNoteApi: typeof import("@/backend/concept-notes").callAuthorizedConceptNoteApi;
-let callConceptNoteApi: typeof import("@/backend/concept-notes").callConceptNoteApi;
 let conceptNoteRunResponse: typeof import("@/backend/concept-notes").conceptNoteRunResponse;
-let resetConceptNoteUserTokenCacheForTests: typeof import("@/backend/concept-notes").resetConceptNoteUserTokenCacheForTests;
 
 beforeAll(async () => {
-  ({
-    callAuthorizedConceptNoteApi,
-    callConceptNoteApi,
-    conceptNoteRunResponse,
-    resetConceptNoteUserTokenCacheForTests,
-  } = await import("@/backend/concept-notes"));
+  ({ callAuthorizedConceptNoteApi, conceptNoteRunResponse } =
+    await import("@/backend/concept-notes"));
 });
 
 describe("Concept Note API authorization", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    resetConceptNoteUserTokenCacheForTests();
     canAccessCity.mockResolvedValue(undefined);
     issueClimateAdvisorUserToken.mockResolvedValue({
       access_token: "ca-token",
@@ -124,102 +118,6 @@ describe("Concept Note API authorization", () => {
 
     expect(issueClimateAdvisorUserToken).not.toHaveBeenCalled();
     expect(callClimateAdvisorChat).not.toHaveBeenCalled();
-  });
-
-  it("reuses one user token across sequential Concept Note requests", async () => {
-    await callConceptNoteApi({
-      path: "/v1/concept-notes/run-1",
-      userId: ownerId,
-    });
-    await callConceptNoteApi({
-      path: "/v1/concept-notes/run-1",
-      userId: ownerId,
-    });
-
-    expect(issueClimateAdvisorUserToken).toHaveBeenCalledTimes(1);
-    expect(callClimateAdvisorChat).toHaveBeenCalledTimes(2);
-  });
-
-  it("coalesces concurrent user-token issuance", async () => {
-    let resolveToken:
-      ((token: ClimateAdvisorTokenResponse) => void) | undefined;
-    issueClimateAdvisorUserToken.mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolveToken = resolve;
-      }),
-    );
-
-    const first = callConceptNoteApi({
-      path: "/v1/concept-notes/run-1",
-      userId: ownerId,
-    });
-    const second = callConceptNoteApi({
-      path: "/v1/concept-notes/run-1/draft",
-      userId: ownerId,
-    });
-    expect(issueClimateAdvisorUserToken).toHaveBeenCalledTimes(1);
-
-    resolveToken?.({
-      access_token: "shared-token",
-      expires_in: 300,
-      token_type: "Bearer",
-    });
-    await Promise.all([first, second]);
-
-    expect(issueClimateAdvisorUserToken).toHaveBeenCalledTimes(1);
-    expect(callClimateAdvisorChat).toHaveBeenCalledTimes(2);
-  });
-
-  it("does not cache failed token issuance", async () => {
-    issueClimateAdvisorUserToken
-      .mockRejectedValueOnce(new Error("token service unavailable"))
-      .mockResolvedValueOnce({
-        access_token: "recovered-token",
-        expires_in: 300,
-        token_type: "Bearer",
-      });
-
-    await expect(
-      callConceptNoteApi({ path: "/v1/concept-notes/run-1", userId: ownerId }),
-    ).rejects.toThrow("token service unavailable");
-    await callConceptNoteApi({
-      path: "/v1/concept-notes/run-1",
-      userId: ownerId,
-    });
-
-    expect(issueClimateAdvisorUserToken).toHaveBeenCalledTimes(2);
-  });
-
-  it("does not reuse tokens inside the refresh margin", async () => {
-    issueClimateAdvisorUserToken.mockResolvedValue({
-      access_token: "short-token",
-      expires_in: 30,
-      token_type: "Bearer",
-    });
-
-    await callConceptNoteApi({
-      path: "/v1/concept-notes/run-1",
-      userId: ownerId,
-    });
-    await callConceptNoteApi({
-      path: "/v1/concept-notes/run-1",
-      userId: ownerId,
-    });
-
-    expect(issueClimateAdvisorUserToken).toHaveBeenCalledTimes(2);
-  });
-
-  it("keeps cached tokens isolated by user", async () => {
-    await callConceptNoteApi({
-      path: "/v1/concept-notes/run-1",
-      userId: ownerId,
-    });
-    await callConceptNoteApi({
-      path: "/v1/concept-notes/run-2",
-      userId: "other-owner",
-    });
-
-    expect(issueClimateAdvisorUserToken).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/app/tests/pdf-ocr-delivery.jest.ts
+++ b/app/tests/pdf-ocr-delivery.jest.ts
@@ -15,7 +15,7 @@ const getSourceFormat = jest.fn<() => "pdf" | "markdown">();
 jest.unstable_mockModule("@/models", () => ({
   db: { models: { PdfOcrJob: { findAll: jest.fn() } } },
 }));
-jest.unstable_mockModule("@/backend/chat/climate-advisor", () => ({
+jest.unstable_mockModule("@/backend/climate-advisor-token", () => ({
   issueClimateAdvisorUserToken: issueToken,
 }));
 jest.unstable_mockModule("@/backend/PdfOcrService", () => ({


### PR DESCRIPTION
## Summary

Concept Note Builder refreshes can fail before reaching Climate Advisor when user-token issuance encounters a transient gateway error. Share validated tokens across CNB, chat, OCR delivery, and Stationary Energy, retry transient issuance failures, and preserve sanitized failure statuses instead of turning gateway errors into generic 500s.

## Changes

- Replace the CNB-only cache introduced by CC-815 and both token issuers with one process-wide client: per-user isolation, shared in-flight issuance, a 1,000-entry LRU limit, configuration invalidation, and refresh 60 seconds before expiry.
- Return remaining token lifetime when attaching cached tokens to chat threads.
- Limit issuance to three attempts, each with a three-second deadline, and short backoff with jitter. Retry transport errors/timeouts and 502/503/504 only; do not replay downstream CA operations.
- Add cache, retry, caller-integration, sanitized-error, and live-permission regression coverage; document operation across cold processes and pods.

## How to test

From `app`, with local database settings available:

```sh
npm run jest:windows -- --runInBand --runTestsByPath tests/climate-advisor-token.jest.ts tests/concept-note-api.jest.ts tests/pdf-ocr-delivery.jest.ts tests/api/chat-routes.jest.ts tests/api/stationary-energy-draft-routes.jest.ts tests/api/internal-ca-service-auth.jest.ts --coverage=false
npx tsc --noEmit --incremental false
```

Validated **83 tests across six suites**, TypeScript, and ESLint on touched files after rebasing onto current `develop`.

Local browser verification with real CC/CA services and an injected token-endpoint fault confirmed:
- A warmed cache refreshes the workspace without issuing another token.
- A fresh process recovers from 502 followed by 200; workspace, draft, and run-list requests complete successfully.
- Exhausted retries reach the browser as 503 with sanitized diagnostics.

The temporary fixture and fault proxy were removed, and restored services returned healthy responses.

## Ticket

CC-757

## Notes

No migrations or infrastructure changes. The cache is process-local and does not require sticky sessions. Existing authorization, Python token refresh, chat SSE errors, and OCR delivery retries retain their contracts.

