### PR TITLE
CC-818: Fix org logo rendering as broken image in navbar

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -17,5 +17,8 @@ RUN npm ci --omit=dev
 COPY --from=full-build /app/.next ./.next
 COPY --from=full-build /app/public ./public
 COPY --from=full-build /app/templates ./templates
+# next start reloads this file at runtime. Without it, images.remotePatterns
+# is empty and org logos (S3 via /_next/image) return 400.
+COPY --from=full-build /app/next.config.mjs ./next.config.mjs
 EXPOSE 3000
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
## Summary

Org logos uploaded in brand settings were stored correctly in S3 but rendered as broken images in the navbar. The production image did not include `next.config.mjs`, so `next start` ran with empty `images.remotePatterns` and `/_next/image` rejected the S3 URL.

## Changes

- Copy `next.config.mjs` into the production Docker image so the S3 allowlist is available at runtime.

## How to test

1. Confirm the production image contains `/app/next.config.mjs`.
2. After deploy to dev, open an org with a branding logo and check the navbar (not only the brand-settings preview).
3. The optimizer URL should return an image instead of 400 `url parameter is not allowed`. Direct S3 URLs already work, for example https://citycatalyst-files.s3.us-east-1.amazonaws.com/1788976914928_Microsoft-Word-Logo-2019-present.jpg

## Ticket

https://linear.app/openearth/issue/CC-818/fix-org-logo-rendering-as-broken-image-in-navbar-after-brand-settings

Made with [Cursor](https://cursor.com)