### PR TITLE
Refine agent workflow and skill guidance

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -12,3 +12,12 @@ alwaysApply: true
 - In non-trivial functions, add short `#` comments for logical blocks/steps when it improves readability.
 - Prefer intent/why comments over obvious line-by-line descriptions.
 - Do not integrate needles backwards compatibility logic.
+
+## Task scope and completion
+
+- For review, diagnosis, explanation, or planning requests, inspect and report; implement only when requested. For change/build/fix requests, complete the authorized work and relevant local validation without repeatedly asking for permission.
+- Resolve routine implementation choices from repository context. Ask a focused question only when the missing answer materially changes scope, correctness, or an authorization boundary; continue independent authorized work meanwhile.
+- Preserve unrelated user changes. Keep refactors, formatting, and fixes scoped to the task.
+- Treat skills as workflows within the user's requested scope, not as permission for external writes or additional work. Honor authorization already given; prepare a concrete result before seeking any still-required approval.
+- Apply required post-change inspections once to the final diff. A successful inspection may require no edits. Repeat only for subsequent relevant changes or unresolved findings.
+- Run checks appropriate to the change and required gates. After they pass, broaden testing only for a concrete remaining risk; report pre-existing failures separately.

--- a/.cursor/rules/python-fastapi.mdc
+++ b/.cursor/rules/python-fastapi.mdc
@@ -29,7 +29,7 @@ alwaysApply: false
 - **Vector store**: pgvector (PostgreSQL extension)
 - **Auth**: JWT validation + service-to-service via `X-Service-Name`/`X-Service-Key`
 - **Streaming**: SSE (Server-Sent Events)
-- **Deps**: `climate-advisor/service/requirements.txt`
+- **Deps**: `climate-advisor/pyproject.toml` with `climate-advisor/uv.lock`; use `uv` from `climate-advisor/`.
 
 ## hiap / hiap-meed Conventions
 

--- a/.cursor/skills/create-migration/SKILL.md
+++ b/.cursor/skills/create-migration/SKILL.md
@@ -98,11 +98,15 @@ _Inventory.hasMany(_MyEntity, { as: "myEntities", foreignKey: "inventoryId" });
 
 ### Step 5: Run Migration
 
+Before executing a migration, identify the effective database target from the selected environment and Sequelize configuration without printing credentials. Prefer a disposable local/test database. A request to create a migration does not authorize applying it to a shared or production database; use such a target only when that execution is explicitly authorized. If no suitable target is available, finish the migration files and report that execution was not verified.
+
 ```bash
 cd app && npm run db:migrate
 ```
 
 ### Step 6: Verify
+
+Exercise rollback/re-apply only on the disposable test database, confirming the migration being undone is the one introduced by this task. Do not use an unqualified rollback against a shared database or undo a pre-existing migration. If the change includes several migrations, verify each intended migration in order.
 
 ```bash
 cd app && npm run db:migrate:undo   # Test rollback

--- a/.cursor/skills/create-migration/SKILL.md
+++ b/.cursor/skills/create-migration/SKILL.md
@@ -9,6 +9,8 @@ description: Create a Sequelize database migration and model for CityCatalyst. U
 
 ### Step 1: Generate Migration File
 
+Create exactly one migration file per PR by default. Combine the PR's schema changes in that file unless the user explicitly requests otherwise.
+
 ```bash
 cd app && npm run db:gen-migration -- --name add-my-entity
 ```
@@ -115,6 +117,7 @@ cd app && npm run db:migrate        # Re-apply
 
 ## Checklist
 
+- [ ] The PR creates one migration file unless the user explicitly requested otherwise
 - [ ] Migration file is `.cjs` (CommonJS)
 - [ ] `up` and `down` are both implemented (reversible)
 - [ ] UUIDs use `Sequelize.UUIDV4` as default

--- a/.cursor/skills/full-feature/SKILL.md
+++ b/.cursor/skills/full-feature/SKILL.md
@@ -7,7 +7,7 @@ description: End-to-end feature development workflow for CityCatalyst covering d
 
 ## Overview
 
-A complete feature in CityCatalyst touches up to 7 layers. Follow this order to avoid dependency issues.
+A feature may touch several layers. First identify the layers required by the request and existing code, then follow their dependency order. Skip phases that do not apply; do not create a migration, API endpoint, RTK hook, or UI merely to complete this list.
 
 ## Workflow
 
@@ -16,7 +16,7 @@ A complete feature in CityCatalyst touches up to 7 layers. Follow this order to 
 1. **Migration**: Create migration file in `app/migrations/` (see [create-migration skill](../create-migration/SKILL.md))
 2. **Model**: Create Sequelize model in `app/src/models/`
 3. **Register**: Add to `app/src/models/init-models.ts`
-4. **Run**: `cd app && npm run db:migrate`
+4. **Validate**: Follow the migration skill's database-target checks. Run migrations only against a verified disposable local/test database, or an explicitly authorized target. Creating a migration does not authorize applying it to a shared database.
 
 ### Phase 2: Backend API
 
@@ -44,9 +44,11 @@ A complete feature in CityCatalyst touches up to 7 layers. Follow this order to 
 ### Phase 5: Quality
 
 16. **Types**: Ensure all types are in `app/src/util/types.ts` or co-located
-17. **Lint**: `cd app && npm run lint`
-18. **Format**: `cd app && npm run prettier`
-19. **Test**: `cd app && npm run jest`
+17. **Lint**: From `app/`, run ESLint on the changed supported files. Complete any broader required CI checks when available.
+18. **Format**: From `app/`, run `npx prettier --write <changed-file> ...` with explicit paths. `npm run prettier` formats the entire app; reserve it for an explicitly requested formatting task.
+19. **Test**: Run the relevant Jest tests and add regression coverage for changed behavior where practical. Run broader suites when required by CI or justified by shared-code impact, failures, or an unresolved risk. Once the necessary checks pass, finish; do not repeatedly broaden testing without new evidence.
+
+Distinguish failures introduced by this change from pre-existing failures. Report unrelated blockers rather than expanding the feature to repair them. Apply each required post-change skill once to the final diff, revisiting only later edits.
 
 ## File Mapping
 

--- a/.cursor/skills/non-tech-contribute/SKILL.md
+++ b/.cursor/skills/non-tech-contribute/SKILL.md
@@ -1,140 +1,63 @@
 ---
 name: non-tech-contribute
-description: Guide non-technical contributors through making safe code changes to CityCatalyst. Use when someone without coding experience wants to update text, translations, colors, copy, or small UI details, and needs the agent to handle git, verification, and PR creation for them.
+description: Help a contributor who explicitly wants non-technical assistance make a small CityCatalyst text, translation, or UI change, including git and PR handling when authorized. Do not infer coding experience from omitted git terminology.
 ---
 
 # Non-Tech Contribute
 
-Help non-technical team members (product, design, business, data) ship real changes to CityCatalyst. You handle git, verification, and PR creation for them — they only describe the change in plain language.
+Turn a plain-language request into a small, reviewable change. Handle the technical work; explain decisions and results in language the contributor can assess.
 
-## When to use
+## Scope and authorization
 
-- The user is not an engineer and asks to change something visible: text, translation, color, copy, tooltip, spacing, image, link.
-- The user says "I want to change/fix/update…" and does not mention git, branches, or commits.
-- The change is small in scope (typically ≤ 5 files). If it grows beyond that or requires architecture decisions, flag it for engineering review.
-
-## Golden rules
-
-- The user never types git commands. You run them.
-- Never commit to `develop` or `main` directly — always a new branch.
-- One PR per logical change.
-- Always run the TypeScript check before committing.
-- If the change requires new dependencies, migrations, or architecture decisions, stop and flag it.
+- Use this workflow when the user identifies as non-technical or explicitly asks for help handling the contribution process. A request that omits branches or commits is not enough to select it.
+- Keep one logical change per branch/PR. Never commit directly to `develop` or `main`.
+- A request to edit authorizes the scoped local edit and relevant validation. Commit, push, or create/update a PR only when those actions are requested or already authorized. A request to implement a change and open its PR includes publishing the necessary feature branch.
+- If publication is not authorized, finish the local change and verification, then present the concrete diff before asking about publishing. Do not ask again for authorization already given.
+- Treat more than roughly five affected files as a reason to reassess scope, not an automatic failure. For new dependencies, migrations, architecture decisions, or critical auth/payment/export behavior, explain the engineering decision needed and complete any independent authorized work first.
 
 ## Workflow
 
-### Phase 1 — Understand the change
+### 1. Understand the requested outcome
 
-Ask, in plain language:
+Infer what, where, and the desired result from the request and available screenshots or repository context. Ask only for missing information that would materially change the result. Do not repeat questions already answered or require confirmation of a complete request before inspecting files.
 
-1. **What** do you want to change? (text, color, behavior, layout)
-2. **Where** in the app is it? (which page, section, button — a screenshot or Jam link helps a lot)
-3. **What should it look like after?** (new text, new color hex, new behavior)
+### 2. Prepare an isolated branch
 
-Confirm your understanding in one sentence before touching anything.
+1. Inspect `git status --short`, the current branch, and any existing task branch or PR.
+2. Reuse an appropriate task branch when continuing the same change. Otherwise fetch `origin develop` and create a feature branch from it.
+3. If the working tree contains unrelated edits, preserve them. Use a separate worktree for the new branch; do not switch the dirty checkout, stash, reset, or stage someone else's work. If user changes overlap the requested edit and isolation would omit needed work, ask how to combine them.
+4. Use `<username>/<type>-<short-description>` when the username is known, or a descriptive `<type>/<short-description>` branch. A missing display name is not a reason to block the edit.
 
-### Phase 2 — Git setup (automatic)
+### 3. Make the scoped edit
 
-1. Run `git status` and `git branch --show-current`.
-2. If not on a clean branch off `develop`, run:
+Locate the actual implementation before editing:
 
-```bash
-git checkout develop && git pull
-git checkout -b <username>/<type>-<short-description>
-```
+| Change | Starting point |
+| --- | --- |
+| Text or translation | `app/src/i18n/locales/<lang>/` |
+| Page or component | `app/src/app/` or `app/src/components/` |
+| Colors | `app/src/lib/theme/` and the component's semantic tokens |
+| Client data or API | `app/src/services/` or `app/src/app/api/` |
 
-**Branch naming:** `<username>/<type>-<short-description>`
+Follow `app/AGENTS.md`. Add new translation keys in English for CI translation; an explicitly requested correction to an existing locale may edit that locale's value. Use semantic color tokens and project UI wrappers. Explain the changed behavior briefly.
 
-- `<username>`: run `git config user.name` and slugify (lowercase, no spaces). If empty, ask the user's first name.
-- `<type>`: `fix` (bug/typo), `feat` (new feature/content), `style` (visual), `i18n` (translation), `docs` (documentation), `hotfix` (urgent prod fix).
+### 4. Verify the change
 
-Examples:
+- For TypeScript changes, run `npx tsc --noEmit` from `app/`; preserve the exit status and inspect the useful error output.
+- For supported changed files, run targeted ESLint/Prettier checks with explicit paths. Do not format the entire app for a small edit.
+- For translation-only edits, validate JSON and preserve key/interpolation contracts. For visible UI changes, inspect the affected screen when a preview is available.
+- Run additional tests when affected behavior or required CI checks justify them.
+- Fix errors introduced by this change. Compare with the base when needed to distinguish pre-existing failures; do not repair unrelated failures just to get a green run. Report missing dependencies or unavailable checks accurately.
+- Finish once the relevant checks and required post-change inspections are complete. Inspect the final diff for unintended files or hunks.
 
-- `brian/fix-spanish-translation-help-button`
-- `amanda/feat-add-tooltip-emissions-chart`
-- `greta/style-update-sidebar-color`
+### 5. Publish when authorized
 
-### Phase 3 — Find and modify
+1. Stage only the intended files/hunks using explicit paths or selective staging. Do not use `git add -A`.
+2. Review `git diff --cached` to confirm that the commit contains only this task's change.
+3. Commit with a concise Conventional Commit subject, such as `i18n: correct onboarding button translation`.
+4. Push only the task branch when authorized. Do not force-push.
+5. Use [pull-request-standards](../pull-request-standards/SKILL.md) to create or update the PR. Preserve a requested draft state and use the repository template. Include a concrete screen/language/click path in **How to test** when useful.
 
-1. Locate the right file(s):
-   - **Text / translations:** `app/src/i18n/locales/<lang>/*.json`
-   - **Pages / components:** `app/src/app/` (routes) or `app/src/components/`
-   - **Colors / theme:** Chakra UI theme in `app/src/lib/theme.ts` (or component-level styles)
-   - **API / data:** `app/src/services/` or `app/src/app/api/`
-2. Make a minimal, focused edit.
-3. Explain the diff in plain language, e.g. *"I changed the button text from 'Need Help' to '¿Necesitas Ayuda?' in the Spanish translation file."*
+### 6. Hand off
 
-### Phase 4 — Verify
-
-Quick sanity checks:
-
-```bash
-cd app && npx tsc --noEmit 2>&1 | tail -20
-git diff --stat
-```
-
-For visible changes (translations, colors, copy), also run a lint pass if it is fast:
-
-```bash
-cd app && npm run lint -- --quiet 2>&1 | tail -20
-```
-
-Fix any errors before proceeding. If you cannot fix them, stop and explain what is blocking.
-
-### Phase 5 — Commit, push, and open the PR (automatic)
-
-Do not ask the user to type git commands.
-
-1. Commit with a Conventional-Commit style subject:
-
-   ```bash
-   git add -A
-   git commit -m "<type>: <short imperative description>"
-   ```
-
-   Types: `fix:`, `feat:`, `style:`, `i18n:`, `docs:`.
-
-2. Push the branch:
-
-   ```bash
-   git push -u origin <branch-name>
-   ```
-
-3. Open the PR by **delegating to the [pull-request-standards skill](../pull-request-standards/SKILL.md)**. Do not hand-roll a title or body here — that skill owns the format, uses `.github/PULL_REQUEST_TEMPLATE.md`, and picks the right GitHub tool. Give it the plain-language description you got from the user so it can fill:
-
-   - **Summary** — the outcome in the user's own words (1–3 sentences).
-   - **Changes** — the minimal bullet list of what was touched.
-   - **How to test** — the exact click-path a reviewer can follow (e.g. *"Open `/onboarding` in Spanish and check the header button says 'EDITAR'."*).
-   - **Ticket** — only if the user gave you a ticket ID (e.g. `ON-1234`); otherwise omit the section.
-   - **Notes** — only for screenshots or callouts the reviewer needs.
-
-### Phase 6 — Hand off
-
-Once the PR is open, tell the user:
-
-- The PR URL.
-- Who or which team is expected to review (usually within 24h).
-- Where to watch status (GitHub PR page, CI checks).
-- Where to ask for help if CI fails (Slack channel).
-
-## Escalate to engineering when
-
-- The change touches more than ~5 files or crosses backend + frontend.
-- The change requires a new dependency, migration, environment variable, or feature flag.
-- Verification (`tsc`, lint) fails and the fix is not obvious.
-- The change is user-facing on a critical path (auth, payments, data export) — even if small.
-
-## Examples
-
-**Input:** "I want the onboarding 'EDIT' button to show 'EDITAR' in Spanish."
-**Action:** Find the key in `app/src/i18n/locales/es/*.json`, update the value, `tsc`, commit `i18n: translate onboarding edit button to Spanish`, push, delegate PR creation with a How-to-test that names the page and button.
-
----
-
-**Input:** "The sidebar color should be darker, like #1a1a2e instead of the current blue."
-**Action:** Find the sidebar component or theme token, update the color, `tsc` + lint, commit `style: darken sidebar background`, push, delegate PR creation with a screenshot request in Notes if the user has one.
-
----
-
-**Input:** "I want to add a tooltip that says 'Values shown in tCO2e' next to the emissions chart."
-**Action:** Locate the chart component, wrap the label with a Chakra `Tooltip`, add an i18n key if the copy is user-facing, `tsc`, commit `feat: add tCO2e tooltip on emissions chart`, push, delegate PR creation with a How-to-test pointing to the chart page.
+Return the PR URL when published, summarize the visible change and validation, and identify any remaining blocker. Name a reviewer, review timeframe, or support channel only when repository or user context actually establishes it.

--- a/.cursor/skills/prompt-schema-authoring/SKILL.md
+++ b/.cursor/skills/prompt-schema-authoring/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: prompt-schema-authoring
-description: Create or update any LLM-related prompt file in this repository using the required `<role>`, `<task>`, `<input>`, and `<output>` structure, with optional `<tools>` when tool policy is needed, and explicit model-aligned field contracts. Use for prompts stored in markdown, Python prompt templates, YAML/JSON config prompts, and any other runtime prompt definitions for large language models (LLMs).
+description: Create or update runtime LLM prompts and reusable prompt fragments, keeping their structure and field contracts aligned with the calling code and consuming models.
 ---
 
 # prompt-schema-authoring
 
 Use this skill to keep prompts explicit, contract-driven, and context-efficient.
+
+## Full prompts and include fragments
+
+Identify how the prompt is loaded before choosing its structure. Full prompt entries configured in `llm_config.yaml` require the schema below. Reusable include fragments, such as `climate-advisor/prompts/tools/*.md`, may contain only focused tool policy or argument-contract text; do not add standalone role/task/input/output blocks or examples unless the fragment becomes a directly configured full prompt.
+
+Runtime prompt text is application data for the coding agent, not a replacement for contribution instructions. Follow the relevant package `AGENTS.md` when editing it.
 
 ## Workflow
 
@@ -14,14 +20,14 @@ Use this skill to keep prompts explicit, contract-driven, and context-efficient.
 - Open the target prompt in `*/prompts/`.
 - Open the corresponding model in `app/modules/*/models.py` or any other schema we are using for the LLM input/output definitions
 
-2. Write prompt sections in this order.
+2. For a full prompt, write sections in this order. For an include fragment, keep only its focused contract.
 
 - `<role>`
 - `<task>`
 - `<input>`
 - `<tools>` (optional but preferred when tools are available)
 - `<output>`
-- Add `<example_output>` whenever possible.
+- Add `<example_output>` when it usefully clarifies the full prompt's contract.
 
 3. Define `<input>` from real runtime payload only.
 
@@ -31,7 +37,7 @@ Use this skill to keep prompts explicit, contract-driven, and context-efficient.
 
 4. Define `<tools>` when tool selection/policy exists.
 
-- Add `<tools>` for tool-capable prompts.
+- Add `<tools>` for full tool-capable prompts; keep include fragments focused as described above.
 - List each tool and when to use it.
 - List when not to use it.
 - Keep user-facing formatting rules in `<output>`, not `<tools>`.
@@ -46,7 +52,7 @@ Use this skill to keep prompts explicit, contract-driven, and context-efficient.
 - Explain field behavior clearly.
 - Exclude internal/auto fields that should not come from the LLM (for example `created_at`).
 
-6. Add one valid `<example_output>` that conforms to the model.
+6. For a full prompt, add one valid `<example_output>` when it clarifies the contract or corrects a demonstrated failure. Do not duplicate large schemas or obvious examples solely to fill a section.
 
 7. Keep contracts aligned end-to-end.
 
@@ -56,8 +62,8 @@ Use this skill to keep prompts explicit, contract-driven, and context-efficient.
 
 - Keep instructions explicit and operational.
 - Keep output contract field-by-field and typed.
-- Keep required prompt blocks: `<role>`, `<task>`, `<input>`, `<output>`.
-- Add `<tools>` for tool-capable prompts, and use it for tool usage policy.
+- Keep required full-prompt blocks: `<role>`, `<task>`, `<input>`, `<output>`. Apply the include-fragment exception above.
+- Add `<tools>` for full tool-capable prompts, and use it for tool usage policy.
 - Avoid asking for wrappers/status/error fields unless the model requires them.
 - Avoid asking for timestamps from the LLM.
 - Avoid meta phrasing requirements that conflict with downstream synthesis.

--- a/.cursor/skills/pull-request-standards/SKILL.md
+++ b/.cursor/skills/pull-request-standards/SKILL.md
@@ -109,10 +109,11 @@ ON-1234
 - For creation, pass derived `owner`, `repo`, `head`, `base`, `title`, `body`, and draft mode when requested.
 - For updates, first identify the existing PR by branch or user-provided PR number, then update only the requested or generated metadata.
 - Preserve existing PR body sections that are clearly hand-authored and still relevant. Replace stale generated summaries, changes, or commit lists.
-- If the branch is missing remotely, report that clearly and ask whether to push unless the user already requested a push.
+- If the branch is missing remotely, use the authorization rules below. Ask whether to publish only if the request does not already authorize it.
 
 ## Push Policy
 
-- Assume the branch is already pushed when the user only asks to create or update PR metadata.
-- Do not run `git push` or `git push -u` unless the user explicitly asks.
-- When push is explicitly requested, use the minimal push needed and continue the PR operation after push succeeds.
+- For PR-metadata-only requests, use the existing remote branch; do not publish unrelated local commits.
+- A request to implement changes and open a PR (including a draft PR) authorizes committing the scoped changes and publishing the necessary feature branch. An explicit push request or prior authorization also suffices.
+- For a local-edit-only request, prepare and verify the change before asking whether to publish it.
+- Publish only the intended task commits, use a normal non-force push, and continue the PR operation after it succeeds. Preserve the requested draft state.

--- a/.cursor/skills/simplify-after-change/SKILL.md
+++ b/.cursor/skills/simplify-after-change/SKILL.md
@@ -1,17 +1,19 @@
+---
+name: simplify-after-change
+description: Review code changed in the current task for unnecessary complexity and make small behavior-preserving simplifications only where they improve readability.
+---
+
 # simplify-after-change
 
 ## Purpose
 
-After any code change, simplify the changed code so it is boring, readable, and minimal while preserving behavior.
+After code changes, inspect the final diff for unnecessary complexity. The review is required when the package calls for it; edits are not. Leave already clear code unchanged.
 
 ## Default scope
 
-Operate only on:
+Review the code changed by the current task. Inspect nearby code and direct callers only when needed to understand behavior; an open or previously modified file is not automatically in scope.
 
-1. files edited in this change, or
-2. the currently open file(s)
-
-Do not refactor unrelated modules unless requested.
+Do not refactor unrelated code or include pre-existing user changes. Expand edits only when necessary to complete the requested change and explain that dependency.
 
 ## Non-negotiables
 
@@ -65,12 +67,13 @@ Do not refactor unrelated modules unless requested.
 
 ## Process
 
-1. Identify complexity smells in the scoped files.
-2. Simplify in-place with minimal, safe edits.
-3. Ensure no unused imports or dead code remain.
-4. If anything is uncertain, leave a TODO and explain the risk.
+1. Review the final diff once for complexity introduced or directly affected by the task.
+2. Make a small simplification only when its benefit and behavior preservation are clear. No edits is a valid result.
+3. Remove unused imports or dead code introduced by the change.
+4. If behavior preservation is uncertain, leave the code unchanged and report the specific unresolved concern; do not add speculative TODOs.
+5. Validate any simplification with checks appropriate to the affected behavior. Revisit only code changed after this review or a concrete unresolved concern, rather than restarting the whole pass.
 
 ## Output
 
-- Provide a short bullet list of what was simplified and why.
-- Apply edits directly in the files.
+- Include meaningful simplifications in the task's existing change summary. If no edits were needed, a brief statement is sufficient.
+- Report relevant validation or an unresolved concern without adding a separate checklist for each pass.

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md — CityCatalyst
 
-> Comprehensive reference for AI coding agents working on the CityCatalyst web application.
-> This file covers architecture, patterns, conventions, and the full codebase map.
+> Essential contribution rules for the CityCatalyst web application.
+> Read [the codebase map](docs/AGENT_CODEBASE_MAP.md) only when you need service, hook, model, or domain navigation. Verify details against the current code.
 
 ---
 
@@ -14,7 +14,7 @@ npm run build                   # Production build
 
 # Quality
 npm run lint                    # ESLint (Next.js core-web-vitals + i18next)
-npm run prettier                # Prettier --write (semi: true)
+npx prettier --write <file> ...  # Format explicit changed files (semi: true)
 npm run openapi:lint            # Spectral lint for OpenAPI spec
 
 # Testing
@@ -31,158 +31,17 @@ npm run db:seed                 # Run all seeders
 npm run sync-catalogue          # Sync GPC catalogue from Global API
 
 # i18n
-npm run i18n:update             # Auto-translate EN keys to de, es, pt
+npm run i18n:update             # Auto-translate EN keys to de, es, pt, fr
 ```
 
 ---
 
-## Architecture
+## Task scope
 
-```
-app/src/
-├── app/                        # Next.js 15 App Router
-│   ├── [lng]/                  # Locale-prefixed pages (en, de, es, fr, pt)
-│   │   ├── auth/               # Login, signup, password reset, invite acceptance
-│   │   ├── admin/              # OEF admin panel
-│   │   ├── cities/[cityId]/    # City pages: GHGI inventory, dashboard, settings
-│   │   ├── onboarding/         # City/org onboarding flows
-│   │   ├── organization/       # Org management, projects, billing
-│   │   └── public/             # Public dashboards (unauthenticated)
-│   ├── api/v1/                 # REST API (all routes use apiHandler wrapper)
-│   └── docs/                   # Swagger UI (auto-generated OpenAPI)
-│
-├── backend/                    # Server-side business logic (services)
-│   ├── permissions/            # Permission system (PermissionService, RoleChecker)
-│   ├── hiap/                   # HIAP prioritization orchestration
-│   ├── ccra/                   # Climate risk assessment services
-│   └── llm/                    # LLM abstraction (OpenAI adapter, config)
-│
-├── components/                 # React components (Chakra UI v3)
-│   ├── ui/                     # Design system primitives (button, dialog, field, data-table)
-│   ├── Navigation/             # Navbar, sidebar, breadcrumbs
-│   ├── Tabs/                   # Tab views (Activity, SubSector)
-│   ├── Modals/                 # Dialogs (activity-modal, invite, delete)
-│   ├── Sections/               # Page sections
-│   ├── Skeletons/              # Loading states
-│   ├── steps/                  # Multi-step wizards (GHGI, JourneyNavigator)
-│   ├── shared/                 # Cross-feature shared components
-│   ├── ChatBot/                # AI chat interface
-│   ├── PublicDashboard/        # Public-facing dashboards
-│   └── admin/                  # Admin-specific components
-│
-├── features/                   # Redux slices
-│   └── city/                   # citySlice, openClimateCitySlice, inventoryDataSlice
-│
-├── hooks/                      # Custom React hooks (see list below)
-├── i18n/                       # i18next config + locales/{en,de,es,fr,pt}/*.json
-│
-├── lib/                        # Core infrastructure
-│   ├── auth.ts                 # NextAuth config (credentials, JWT, AppSession)
-│   ├── auth/                   # PAT validator
-│   ├── theme/                  # Chakra v3 theme system (recipes, custom-colors)
-│   ├── custom-errors/          # ManualInputValidationError, CustomOrganizationError, CustomInviteError
-│   ├── emails/                 # React Email templates (registration, invites, HIAP, etc.)
-│   ├── mcp/                    # MCP server + tools (cities, emissions, action-plans, risk-assessment)
-│   └── highlight.ts            # Highlight.io integration
-│
-├── models/                     # Sequelize v6 models (PostgreSQL)
-│   ├── init-models.ts          # Model registration + associations
-│   ├── index.ts                # DB connection (DATABASE_* env vars)
-│   └── *.ts                    # Individual model files
-│
-├── services/                   # Client-side services
-│   ├── api.ts                  # RTK Query API (createApi, ~2000 lines, main data layer)
-│   ├── logger.ts               # Pino logger
-│   ├── chatService.ts          # Chat SSE service
-│   └── PDFExportService.ts     # PDF generation
-│
-└── util/                       # Shared utilities
-    ├── api.ts                  # apiHandler, errorHandler, auth resolution, rate limiter
-    ├── types.ts                # Central TypeScript types/interfaces for API contracts
-    ├── validation.ts           # Zod schemas for request validation
-    ├── enums.ts                # InventoryTypeEnum, GlobalWarmingPotentialTypeEnum, ImportStatusEnum
-    ├── constants.ts            # Sector definitions, GPC config
-    ├── feature-flags.ts        # FeatureFlags enum + hasFeatureFlag/hasServerFeatureFlag
-    ├── helpers.ts              # General helpers
-    ├── routes.ts               # Route path utilities
-    ├── translate.ts            # Translation helpers
-    ├── geojson.ts              # GeoJSON utilities
-    ├── csv.ts                  # CSV export helpers
-    ├── rate-limiter.ts         # In-memory rate limiter (200 req/min)
-    ├── permission-errors.ts    # Permission error utilities
-    ├── check-user-session.ts   # Session check helpers
-    ├── big_int.ts              # BigInt utilities
-    ├── ccra-constants.ts       # CCRA scoring constants
-    ├── form-schema/            # Activity form schema definitions
-    └── GHGI/                   # GPC reference resolver + data tables
-```
-
----
-
-## Key Backend Services (`src/backend/`)
-
-| Service                      | Responsibility                                                 |
-| ---------------------------- | -------------------------------------------------------------- |
-| `UserService`                | User CRUD, invites, org/project scoping                        |
-| `InventoryService`           | Inventory lookups by city, locode, permissions                 |
-| `ActivityService`            | Activity/gas value CRUD, emissions factors, versioning         |
-| `CalculationService`         | Emissions math using methodology-specific formulas             |
-| `DataSourceService`          | Data source management per inventory                           |
-| `GPCService`                 | Resolves GPC reference numbers to sector/subsector/subcategory |
-| `PermissionService`          | `canAccessInventory`, `canCreateCity`, role-based checks       |
-| `EmailService`               | All email flows (invites, password, projects) via React Email  |
-| `NotificationService`        | Nodemailer singleton, admin notifications                      |
-| `AdminService`               | Bulk inventory creation, OpenClimate wiring                    |
-| `ResultsService`             | Emissions results aggregation, forecasts                       |
-| `PopulationService`          | Population data for city/year                                  |
-| `HiapService`                | HIAP orchestration (S3, rankings, bulk jobs)                   |
-| `HiapApiService`             | HTTP client to external HIAP API                               |
-| `ActionPlanService`          | Action plan creation and management                            |
-| `CcraService`                | Climate risk normalization and scoring                         |
-| `CcraApiService`             | CCRA API client (Global API)                                   |
-| `ECRFDownloadService`        | eCRF Excel template export                                     |
-| `ECRFImportService`          | eCRF import parsing                                            |
-| `FileParserService`          | XLSX/CSV parsing                                               |
-| `FileUploadService`          | Generic file upload (S3 provider)                              |
-| `FileValidatorService`       | Import validation (size, format, CIRIS)                        |
-| `AIInterpretationService`    | LLM column mapping for tabular imports                         |
-| `InventoryExtractionService` | LLM extraction from PDF documents                              |
-| `CDPService`                 | CDP Green Star API client                                      |
-| `CityBoundaryService`        | City GeoJSON from Global API                                   |
-| `UnitConversionService`      | Unit conversion tables                                         |
-| `VersionHistoryService`      | Inventory version diff/history                                 |
-| `ModuleService`              | Module access management                                       |
-| `ModuleDashboardService`     | Dashboard aggregation (GHGI/HIAP/CCRA)                         |
-
----
-
-## Custom Hooks (`src/hooks/`)
-
-| Hook                         | Purpose                                                     |
-| ---------------------------- | ----------------------------------------------------------- |
-| `useLogin`                   | Wraps NextAuth `signIn("credentials")`, analytics, redirect |
-| `useUserPermissions`         | Check user permissions for resources                        |
-| `useAdminGuard`              | Redirect non-admin users                                    |
-| `useModuleAccess`            | Check if current project has a module enabled               |
-| `useModuleAccessLayout`      | Module access for layout gating                             |
-| `useRouteParams`             | Extract typed route params                                  |
-| `use-latest-inventory`       | Get the latest inventory for a city                         |
-| `use-inventory-organization` | Get org context for an inventory                            |
-| `use-organizational-context` | Org context provider (Context + localStorage)               |
-| `useChat`                    | Chat with AI assistant                                      |
-| `useSSEStream`               | Server-Sent Events streaming                                |
-| `useFuzzySearch`             | Client-side fuzzy search                                    |
-| `usePollUntil`               | Polling with stop condition                                 |
-| `useScrollSpy`               | Scroll position tracking                                    |
-| `useEnterSubmit`             | Submit form on Enter                                        |
-| `use-copy-to-clipboard`      | Clipboard copy helper                                       |
-| `use-action-plan`            | Action plan management                                      |
-| `use-activity-form`          | Complex activity value form (react-hook-form wrapper)       |
-| `use-activity-validation`    | Activity data validation                                    |
-| `use-emission-factors`       | Emission factor fetching for forms                          |
-| `Toasts`                     | Toast notification helpers                                  |
-
----
+- Complete the requested change and relevant validation. For review or planning requests, inspect and report without implementing unrequested changes.
+- Preserve unrelated edits. Keep formatting and refactors within the task's scope.
+- Resolve routine implementation choices from repository context; ask only when a missing answer materially changes scope, correctness, or authorization.
+- Follow applicable skills without treating them as permission for additional work. Honor authorization already given and prepare a concrete result before seeking any still-required approval.
 
 ## API Route Pattern (Critical)
 
@@ -247,18 +106,6 @@ Add `@swagger` comments above imports for OpenAPI generation:
 
 Main client-side data layer. Uses `fetchBaseQuery` with `baseUrl: "/api/v1/"` and `credentials: "include"`.
 
-### Existing Tag Types
-
-```
-UserInfo, UserPermissions, InventoryProgress, UserInventories, SubSectorValue,
-InventoryValue, ActivityValue, UserData, FileData, CityData, ReportResults,
-YearlyReportResults, SectorBreakdown, Inventory, CitiesAndInventories, Inventories,
-Invites, Organizations, OrganizationInvite, Projects, Organization, Project,
-ProjectUsers, UserAccessStatus, Cities, Hiap, HiapJobs, Themes, Client,
-CityDashboard, Modules, GHGIDashboard, HiapDashboard, Authz, CCRADashboard,
-ProjectModules, ActionPlan, VersionHistory, PersonalAccessToken, AdminModules
-```
-
 ### Pattern for Adding Endpoints
 
 ```typescript
@@ -282,18 +129,6 @@ Most API responses wrap data in `{ data: ... }` — use `transformResponse` to u
 
 ## Database (Sequelize v6 + PostgreSQL)
 
-### Core Models
-
-**Tenancy**: `Organization` → `Project` → `City` → `Inventory`
-**Users**: `User`, `CityUser`, `CityInvite`, `OrganizationAdmin`, `ProjectAdmin`, `OrganizationInvite`, `ProjectInvite`
-**GPC Hierarchy**: `Sector` → `SubSector` → `SubCategory` → `Scope`, `ReportingLevel`
-**Emissions Data**: `InventoryValue`, `ActivityValue`, `GasValue`, `ActivityData`, `EmissionsFactor`, `FormulaInput`
-**Data Sources**: `DataSource` (DataSourceI18n), `DataSourceActivityData`, `DataSourceEmissionsFactor`, `DataSourceGHGs`, `DataSourceMethodology`, `DataSourceReportingLevel`, `DataSourceFormulaInput`
-**Catalogue**: `Catalogue`, `Methodology`, `GHGs`, `GasToCO2Eq`
-**Planning**: `ActionPlan`, `HighImpactActionRanking`, `HighImpactActionRanked`, `UnrankedActionSelection`
-**Product**: `Module`, `ProjectModules`, `Version`, `ImportedInventoryFile`, `UserFile`, `Theme`
-**OAuth**: `OAuthClient`, `OAuthClientI18N`, `OAuthClientAuthz`, `PersonalAccessToken`
-
 ### Conventions
 
 - Primary keys: UUIDs with `DataTypes.UUIDV4` default
@@ -308,7 +143,7 @@ Most API responses wrap data in `{ data: ... }` — use `transformResponse` to u
 - Client hook: `useTranslation` from `@/i18n/client` (not raw `react-i18next`)
 - Always pass `lng` from the `[lng]` route param
 - Namespaces map to JSON files: `src/i18n/locales/en/<namespace>.json`
-- Only add keys to the **English** file — CI auto-translates to de, es, fr, pt
+- Add new keys to the **English** file — CI auto-translates to de, es, fr, pt. Explicitly requested corrections to existing locale values may edit that locale directly.
 - All user-facing strings must use `t()` (ESLint `i18next` rule enforced)
 - Key format: kebab-case (`"inventory-not-found"`, `"save-changes"`)
 
@@ -354,6 +189,8 @@ with an empty env from the Docker build.
 
 ## Testing
 
+Run checks appropriate to changed behavior and required gates. Use targeted tests first; broaden only for shared-code impact, failures, or a concrete unresolved risk. Once sufficient checks pass, finish. Distinguish pre-existing failures from regressions introduced by the task. Documentation-only edits need link/content validation rather than application test suites.
+
 ### Jest (API + Unit)
 
 - File naming: `*.jest.ts` (NOT `*.test.ts`)
@@ -390,43 +227,6 @@ with an empty env from the Docker build.
 - **Logging**: `import { logger } from "@/services/logger"` (Pino)
 - **Styling**: Chakra v3 semantic tokens (never raw colors)
 - **Strings**: All user-facing text via `t()` from i18next
-
----
-
-## Domain Glossary
-
-| Term            | Meaning                                                                        |
-| --------------- | ------------------------------------------------------------------------------ |
-| GPC             | Global Protocol for Community-Scale Greenhouse Gas Emissions                   |
-| GHGI            | Greenhouse Gas Inventory — a city's emissions profile                          |
-| Inventory       | A specific city's emissions data for a given year                              |
-| Sector          | Top-level GPC category (Stationary Energy, Transportation, Waste, IPPU, AFOLU) |
-| SubSector       | Second-level GPC category within a sector                                      |
-| SubCategory     | Third-level GPC category (most granular)                                       |
-| Scope           | Emissions scope (1: direct, 2: indirect energy, 3: other indirect)             |
-| ActivityValue   | An individual emissions data entry (e.g., fuel consumption)                    |
-| GasValue        | Gas-specific emissions for an activity (CO2, CH4, N2O, etc.)                   |
-| InventoryValue  | Aggregated emissions per sub-category                                          |
-| EmissionsFactor | Factor to convert activity data to emissions                                   |
-| DataSource      | External data provider for emissions factors/activity data                     |
-| HIAP            | High Impact Action Prioritization — ranking climate actions                    |
-| CCRA            | Climate Change Risk Assessment                                                 |
-| Locode          | UN/LOCODE city identifier (e.g., "BR RIO")                                     |
-| eCRF            | Electronic Common Reporting Framework (GPC Excel format)                       |
-| AR5/AR6         | IPCC Assessment Report versions for Global Warming Potential values            |
-| GWP             | Global Warming Potential — converts gases to CO2 equivalent                    |
-
----
-
-## Sibling Services (same monorepo, different stacks)
-
-| Service         | Path               | Stack                                 | Purpose                  |
-| --------------- | ------------------ | ------------------------------------- | ------------------------ |
-| global-api      | `global-api/`      | Python FastAPI + SQLAlchemy + Alembic | Data services, GIS       |
-| climate-advisor | `climate-advisor/` | Python FastAPI + LangChain + pgvector | RAG chat agent           |
-| hiap            | `hiap/`            | Python FastAPI + XGBoost + ChromaDB   | Action prioritization ML |
-| hiap-meed       | `hiap-meed/`       | Python FastAPI                        | MEED scoring pipeline    |
-| api-demo        | `api-demo/`        | Static HTML + nginx                   | OAuth demo SPA           |
 
 ---
 

--- a/app/docs/AGENT_CODEBASE_MAP.md
+++ b/app/docs/AGENT_CODEBASE_MAP.md
@@ -1,0 +1,229 @@
+# CityCatalyst app codebase map
+
+Navigation reference for [app/AGENTS.md](../AGENTS.md). Read only the sections relevant to the task. These lists are discovery aids, not exhaustive contracts: verify paths, exports, tags, and versions in the current code before relying on them. `../package.json` defines the app dependencies (currently Next.js `^16.3.0`).
+
+## Contents
+
+- [Architecture](#architecture)
+- [Backend services](#key-backend-services-srcbackend)
+- [Custom hooks](#custom-hooks-srchooks)
+- [RTK Query tags](#rtk-query-tag-reference)
+- [Database models](#database-model-reference)
+- [Domain glossary](#domain-glossary)
+- [Sibling services](#sibling-services-same-monorepo-different-stacks)
+
+## Architecture
+
+```
+app/src/
+├── app/                        # Next.js App Router
+│   ├── [lng]/                  # Locale-prefixed pages (en, de, es, fr, pt)
+│   │   ├── auth/               # Login, signup, password reset, invite acceptance
+│   │   ├── admin/              # OEF admin panel
+│   │   ├── cities/[cityId]/    # City pages: GHGI inventory, dashboard, settings
+│   │   ├── onboarding/         # City/org onboarding flows
+│   │   ├── organization/       # Org management, projects, billing
+│   │   └── public/             # Public dashboards (unauthenticated)
+│   ├── api/v1/                 # REST API (all routes use apiHandler wrapper)
+│   └── docs/                   # Swagger UI (auto-generated OpenAPI)
+│
+├── backend/                    # Server-side business logic (services)
+│   ├── permissions/            # Permission system (PermissionService, RoleChecker)
+│   ├── hiap/                   # HIAP prioritization orchestration
+│   ├── ccra/                   # Climate risk assessment services
+│   └── llm/                    # LLM abstraction (OpenAI adapter, config)
+│
+├── components/                 # React components (Chakra UI v3)
+│   ├── ui/                     # Design system primitives (button, dialog, field, data-table)
+│   ├── Navigation/             # Navbar, sidebar, breadcrumbs
+│   ├── Tabs/                   # Tab views (Activity, SubSector)
+│   ├── Modals/                 # Dialogs (activity-modal, invite, delete)
+│   ├── Sections/               # Page sections
+│   ├── Skeletons/              # Loading states
+│   ├── steps/                  # Multi-step wizards (GHGI, JourneyNavigator)
+│   ├── shared/                 # Cross-feature shared components
+│   ├── ChatBot/                # AI chat interface
+│   ├── PublicDashboard/        # Public-facing dashboards
+│   └── admin/                  # Admin-specific components
+│
+├── features/                   # Redux slices
+│   └── city/                   # citySlice, openClimateCitySlice, inventoryDataSlice
+│
+├── hooks/                      # Custom React hooks (see list below)
+├── i18n/                       # i18next config + locales/{en,de,es,fr,pt}/*.json
+│
+├── lib/                        # Core infrastructure
+│   ├── auth.ts                 # NextAuth config (credentials, JWT, AppSession)
+│   ├── auth/                   # PAT validator
+│   ├── theme/                  # Chakra v3 theme system (recipes, custom-colors)
+│   ├── custom-errors/          # ManualInputValidationError, CustomOrganizationError, CustomInviteError
+│   ├── emails/                 # React Email templates (registration, invites, HIAP, etc.)
+│   ├── mcp/                    # MCP server + tools (cities, emissions, action-plans, risk-assessment)
+│   └── highlight.ts            # Highlight.io integration
+│
+├── models/                     # Sequelize v6 models (PostgreSQL)
+│   ├── init-models.ts          # Model registration + associations
+│   ├── index.ts                # DB connection (DATABASE_* env vars)
+│   └── *.ts                    # Individual model files
+│
+├── services/                   # Client-side services
+│   ├── api.ts                  # RTK Query API (createApi, ~2000 lines, main data layer)
+│   ├── logger.ts               # Pino logger
+│   ├── chatService.ts          # Chat SSE service
+│   └── PDFExportService.ts     # PDF generation
+│
+└── util/                       # Shared utilities
+    ├── api.ts                  # apiHandler, errorHandler, auth resolution, rate limiter
+    ├── types.ts                # Central TypeScript types/interfaces for API contracts
+    ├── validation.ts           # Zod schemas for request validation
+    ├── enums.ts                # InventoryTypeEnum, GlobalWarmingPotentialTypeEnum, ImportStatusEnum
+    ├── constants.ts            # Sector definitions, GPC config
+    ├── feature-flags.ts        # FeatureFlags enum + hasFeatureFlag/hasServerFeatureFlag
+    ├── helpers.ts              # General helpers
+    ├── routes.ts               # Route path utilities
+    ├── translate.ts            # Translation helpers
+    ├── geojson.ts              # GeoJSON utilities
+    ├── csv.ts                  # CSV export helpers
+    ├── rate-limiter.ts         # In-memory rate limiter (200 req/min)
+    ├── permission-errors.ts    # Permission error utilities
+    ├── check-user-session.ts   # Session check helpers
+    ├── big_int.ts              # BigInt utilities
+    ├── ccra-constants.ts       # CCRA scoring constants
+    ├── form-schema/            # Activity form schema definitions
+    └── GHGI/                   # GPC reference resolver + data tables
+```
+
+---
+
+## Key Backend Services (`src/backend/`)
+
+| Service                      | Responsibility                                                 |
+| ---------------------------- | -------------------------------------------------------------- |
+| `UserService`                | User CRUD, invites, org/project scoping                        |
+| `InventoryService`           | Inventory lookups by city, locode, permissions                 |
+| `ActivityService`            | Activity/gas value CRUD, emissions factors, versioning         |
+| `CalculationService`         | Emissions math using methodology-specific formulas             |
+| `DataSourceService`          | Data source management per inventory                           |
+| `GPCService`                 | Resolves GPC reference numbers to sector/subsector/subcategory |
+| `PermissionService`          | `canAccessInventory`, `canCreateCity`, role-based checks       |
+| `EmailService`               | All email flows (invites, password, projects) via React Email  |
+| `NotificationService`        | Nodemailer singleton, admin notifications                      |
+| `AdminService`               | Bulk inventory creation, OpenClimate wiring                    |
+| `ResultsService`             | Emissions results aggregation, forecasts                       |
+| `PopulationService`          | Population data for city/year                                  |
+| `HiapService`                | HIAP orchestration (S3, rankings, bulk jobs)                   |
+| `HiapApiService`             | HTTP client to external HIAP API                               |
+| `ActionPlanService`          | Action plan creation and management                            |
+| `CcraService`                | Climate risk normalization and scoring                         |
+| `CcraApiService`             | CCRA API client (Global API)                                   |
+| `ECRFDownloadService`        | eCRF Excel template export                                     |
+| `ECRFImportService`          | eCRF import parsing                                            |
+| `FileParserService`          | XLSX/CSV parsing                                               |
+| `FileUploadService`          | Generic file upload (S3 provider)                              |
+| `FileValidatorService`       | Import validation (size, format, CIRIS)                        |
+| `AIInterpretationService`    | LLM column mapping for tabular imports                         |
+| `InventoryExtractionService` | LLM extraction from PDF documents                              |
+| `CDPService`                 | CDP Green Star API client                                      |
+| `CityBoundaryService`        | City GeoJSON from Global API                                   |
+| `UnitConversionService`      | Unit conversion tables                                         |
+| `VersionHistoryService`      | Inventory version diff/history                                 |
+| `ModuleService`              | Module access management                                       |
+| `ModuleDashboardService`     | Dashboard aggregation (GHGI/HIAP/CCRA)                         |
+
+---
+
+## Custom Hooks (`src/hooks/`)
+
+| Hook                         | Purpose                                                     |
+| ---------------------------- | ----------------------------------------------------------- |
+| `useLogin`                   | Wraps NextAuth `signIn("credentials")`, analytics, redirect |
+| `useUserPermissions`         | Check user permissions for resources                        |
+| `useAdminGuard`              | Redirect non-admin users                                    |
+| `useModuleAccess`            | Check if current project has a module enabled               |
+| `useModuleAccessLayout`      | Module access for layout gating                             |
+| `useRouteParams`             | Extract typed route params                                  |
+| `use-latest-inventory`       | Get the latest inventory for a city                         |
+| `use-inventory-organization` | Get org context for an inventory                            |
+| `use-organizational-context` | Org context provider (Context + localStorage)               |
+| `useChat`                    | Chat with AI assistant                                      |
+| `useSSEStream`               | Server-Sent Events streaming                                |
+| `useFuzzySearch`             | Client-side fuzzy search                                    |
+| `usePollUntil`               | Polling with stop condition                                 |
+| `useScrollSpy`               | Scroll position tracking                                    |
+| `useEnterSubmit`             | Submit form on Enter                                        |
+| `use-copy-to-clipboard`      | Clipboard copy helper                                       |
+| `use-action-plan`            | Action plan management                                      |
+| `use-activity-form`          | Complex activity value form (react-hook-form wrapper)       |
+| `use-activity-validation`    | Activity data validation                                    |
+| `use-emission-factors`       | Emission factor fetching for forms                          |
+| `Toasts`                     | Toast notification helpers                                  |
+
+---
+
+
+## RTK Query tag reference
+
+### Existing Tag Types
+
+```
+UserInfo, UserPermissions, InventoryProgress, UserInventories, SubSectorValue,
+InventoryValue, ActivityValue, UserData, FileData, CityData, ReportResults,
+YearlyReportResults, SectorBreakdown, Inventory, CitiesAndInventories, Inventories,
+Invites, Organizations, OrganizationInvite, Projects, Organization, Project,
+ProjectUsers, UserAccessStatus, Cities, Hiap, HiapJobs, Themes, Client,
+CityDashboard, Modules, GHGIDashboard, HiapDashboard, Authz, CCRADashboard,
+ProjectModules, ActionPlan, VersionHistory, PersonalAccessToken, AdminModules
+```
+
+
+## Database model reference
+
+### Core Models
+
+**Tenancy**: `Organization` → `Project` → `City` → `Inventory`
+**Users**: `User`, `CityUser`, `CityInvite`, `OrganizationAdmin`, `ProjectAdmin`, `OrganizationInvite`, `ProjectInvite`
+**GPC Hierarchy**: `Sector` → `SubSector` → `SubCategory` → `Scope`, `ReportingLevel`
+**Emissions Data**: `InventoryValue`, `ActivityValue`, `GasValue`, `ActivityData`, `EmissionsFactor`, `FormulaInput`
+**Data Sources**: `DataSource` (DataSourceI18n), `DataSourceActivityData`, `DataSourceEmissionsFactor`, `DataSourceGHGs`, `DataSourceMethodology`, `DataSourceReportingLevel`, `DataSourceFormulaInput`
+**Catalogue**: `Catalogue`, `Methodology`, `GHGs`, `GasToCO2Eq`
+**Planning**: `ActionPlan`, `HighImpactActionRanking`, `HighImpactActionRanked`, `UnrankedActionSelection`
+**Product**: `Module`, `ProjectModules`, `Version`, `ImportedInventoryFile`, `UserFile`, `Theme`
+**OAuth**: `OAuthClient`, `OAuthClientI18N`, `OAuthClientAuthz`, `PersonalAccessToken`
+
+
+## Domain Glossary
+
+| Term            | Meaning                                                                        |
+| --------------- | ------------------------------------------------------------------------------ |
+| GPC             | Global Protocol for Community-Scale Greenhouse Gas Emissions                   |
+| GHGI            | Greenhouse Gas Inventory — a city's emissions profile                          |
+| Inventory       | A specific city's emissions data for a given year                              |
+| Sector          | Top-level GPC category (Stationary Energy, Transportation, Waste, IPPU, AFOLU) |
+| SubSector       | Second-level GPC category within a sector                                      |
+| SubCategory     | Third-level GPC category (most granular)                                       |
+| Scope           | Emissions scope (1: direct, 2: indirect energy, 3: other indirect)             |
+| ActivityValue   | An individual emissions data entry (e.g., fuel consumption)                    |
+| GasValue        | Gas-specific emissions for an activity (CO2, CH4, N2O, etc.)                   |
+| InventoryValue  | Aggregated emissions per sub-category                                          |
+| EmissionsFactor | Factor to convert activity data to emissions                                   |
+| DataSource      | External data provider for emissions factors/activity data                     |
+| HIAP            | High Impact Action Prioritization — ranking climate actions                    |
+| CCRA            | Climate Change Risk Assessment                                                 |
+| Locode          | UN/LOCODE city identifier (e.g., "BR RIO")                                     |
+| eCRF            | Electronic Common Reporting Framework (GPC Excel format)                       |
+| AR5/AR6         | IPCC Assessment Report versions for Global Warming Potential values            |
+| GWP             | Global Warming Potential — converts gases to CO2 equivalent                    |
+
+---
+
+## Sibling Services (same monorepo, different stacks)
+
+| Service         | Path               | Stack                                 | Purpose                  |
+| --------------- | ------------------ | ------------------------------------- | ------------------------ |
+| global-api      | `global-api/`      | Python FastAPI + SQLAlchemy + Alembic | Data services, GIS       |
+| climate-advisor | `climate-advisor/` | Python FastAPI + LangChain + pgvector | RAG chat agent           |
+| hiap            | `hiap/`            | Python FastAPI + XGBoost + ChromaDB   | Action prioritization ML |
+| hiap-meed       | `hiap-meed/`       | Python FastAPI                        | MEED scoring pipeline    |
+| api-demo        | `api-demo/`        | Static HTML + nginx                   | OAuth demo SPA           |
+
+---

--- a/climate-advisor/AGENTS.md
+++ b/climate-advisor/AGENTS.md
@@ -16,20 +16,20 @@ This repo includes **project-level Cursor skills** under `../.cursor/skills/` fr
 
 Skills included:
 
-- `simplify-after-change`: **Mandatory** after any code change. Simplifies the changed code, removes unnecessary complexity, and keeps behavior identical.
-- `docs-after-change`: **Mandatory** after any code change. Keeps docstrings, README, and architecture docs accurate.
+- `simplify-after-change`: Reviews changed code for unnecessary complexity while preserving behavior.
+- `docs-after-change`: Checks docstrings, README, and architecture docs for changes to documented contracts.
 - `script-quality-gate`: Use when adding or changing a runnable script or CLI entrypoint.
 - `repo-doc-audit`: One-off full repo documentation audit (**manual** via `/repo-doc-audit`).
 - `prompt-schema-authoring`: Use when creating or updating prompt files under `prompts/`.
 
 ### Mandatory after code changes
 
-After **any code change** (add/edit/delete/rename), you must apply BOTH skills before ending your turn:
+After a task changes code, apply both inspections once to the final diff, in this order:
 
 1. `simplify-after-change`
 2. `docs-after-change`
 
-If you intentionally skip a mandatory skill, leave a one-line justification in your response message.
+Inspections are mandatory; edits are not. Already clear code and accurate documentation may remain unchanged. For runtime-configuration-only changes, apply `docs-after-change`. Revisit only subsequent relevant edits or unresolved findings, not the entire workflow. Combine meaningful results in the task summary. If an inspection cannot be completed, explain the specific limitation in one line.
 
 ---
 
@@ -72,7 +72,7 @@ Every script intended to be executed must include a **top-level docstring** desc
 
 ### Folder placement must follow the existing hierarchy
 
-All directories containing code must include an `__init__.py` file to ensure proper package resolution. These files must be **empty or contain only a module-level docstring** - do not add imports or re-exports. Because the project uses absolute imports exclusively, convenience re-exports in `__init__.py` are unnecessary and risk introducing circular imports.
+Python directories that must be importable packages must include an `__init__.py` file; this does not apply to non-Python code, data, or deployment directories. These files must be **empty or contain only a module-level docstring** - do not add imports or re-exports. Because the project uses absolute imports exclusively, convenience re-exports in `__init__.py` are unnecessary and risk introducing circular imports.
 
 Use the established Climate Advisor layout:
 
@@ -244,6 +244,7 @@ Use `script-quality-gate` when you add or change one.
 - New features should include tests where practical.
 - Bug fixes should include a regression test whenever feasible.
 - If you change prompts, tool outputs, or workflow contracts, update or add tests that exercise those paths.
+- Run tests appropriate to the changed behavior and required gates. Once those pass, broaden or repeat validation only for subsequent changes, failures, or a concrete unresolved risk. Report unrelated pre-existing failures separately.
 
 ---
 
@@ -270,7 +271,7 @@ When making changes:
 ## Quick checklist for contributions
 
 - [ ] Docs updated if setup, prompts, or run behavior changed
-- [ ] `__init__.py` present in all code folders (empty or docstring-only - no imports or re-exports)
+- [ ] Required Python packages have `__init__.py` (empty or docstring-only - no imports or re-exports)
 - [ ] No module-level `__all__` export lists
 - [ ] Prompt files remain aligned with runtime payloads and output parsers
 - [ ] Scripts follow docstring and CLI rules
@@ -278,6 +279,6 @@ When making changes:
 - [ ] Clear separation of concerns (services vs utils vs scripts)
 - [ ] Logging used instead of print
 - [ ] pytest coverage added or updated when feasible
-- [ ] Type hints present in all function signatures
+- [ ] Production signatures typed; test helpers typed where practical
 - [ ] `pyproject.toml` and `uv.lock` stay consistent
 - [ ] Relevant tests run, or inability to run explained

--- a/hiap/AGENTS.md
+++ b/hiap/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This repository contains a single AI project. All contributions must optimize for:
+This repository subtree contains the HIAP AI project. All contributions must optimize for:
 
 - **Readability**: clear docs, clean structure, no dead or unused code, and a logical separation of concerns.
 - **Maintainability**: reusable utilities, configuration-driven behavior, proper logging, minimal duplication.
@@ -12,15 +12,15 @@ This repository contains a single AI project. All contributions must optimize fo
 
 ## Cursor Agent Skills (project-level)
 
-This repo includes **project-level Cursor skills** under `.cursor/skills/` (version-controlled). These skills are available to anyone who checks out the repository and opens it in Cursor. See [Cursor Skills docs](https://cursor.com/docs/context/skills).
+This monorepo includes **project-level Cursor skills** under `../.cursor/skills/` from this subtree (the repository-root `.cursor/skills/` directory). These skills are available to anyone who checks out the repository and opens it in Cursor. See [Cursor Skills docs](https://cursor.com/docs/context/skills).
 
 ### Mandatory after code changes
 
-After **any code change** (add/edit/delete/rename), you must apply the `docs-after-change` skill before ending your turn.
+After a task changes code or runtime configuration, apply `docs-after-change` once to the final diff. The inspection is mandatory; documentation edits are needed only when the documented contract changed. Revisit only subsequent relevant changes or unresolved findings.
 
 Skills included:
 
-- `docs-after-change`: **Mandatory** after any code change. Keeps docstrings/README/architecture accurate.
+- `docs-after-change`: Checks documentation impact as required above.
 - `script-quality-gate`: Use when adding/changing a runnable script or CLI entrypoint.
 - `repo-doc-audit`: One-off full repo documentation audit (**manual** via `/repo-doc-audit`).
 
@@ -81,7 +81,7 @@ Usage (from project root):
 
 ### Folder placement must follow the hierarchy
 
-All directories containing code must include an `__init__.py` file to ensure proper package resolution.
+Python directories that must be importable packages must include an `__init__.py` file. This does not apply to non-Python code, data, or deployment directories.
 
 Use this structure:
 
@@ -192,13 +192,15 @@ if __name__ == "__main__":
 
 ### Docstrings are required (functions and methods)
 
-- Every Python **function and method** must have a docstring.
+- Every production Python **function and method** must have a docstring.
   - **Trivial** functions/methods: a minimal **one-liner** is enough.
   - **Non-trivial** or side-effecting functions/methods: docstring must describe:
     - inputs/parameters (expected types/shape and any constraints)
     - return value (and what it represents)
     - side effects (filesystem/DB/network, mutations, logging, caching)
     - raised exceptions (when non-obvious)
+
+- Tests should use descriptive names. Add test docstrings only when the setup or intent is not obvious from the name and assertions.
 
 ### Logging is required
 
@@ -235,7 +237,7 @@ __all__ = ["setup_logger"]
 
 ### Type hints
 
-- All function signatures must have Python type hints.
+- All production function signatures must have Python type hints. Type reusable test helpers and fixtures where practical; avoid noisy annotations for decorator-injected mocks.
 - Prefer returning concrete types, avoid `Any` unless you have a good reason.
 
 ### Path handling
@@ -284,6 +286,7 @@ __all__ = ["setup_logger"]
 - Use `pytest` for tests.
 - New features should include tests where practical.
 - Bug fixes should include a regression test whenever feasible.
+- Run tests appropriate to the changed behavior and required gates. Once those pass, broaden or repeat validation only for subsequent changes, failures, or a concrete unresolved risk. Report unrelated pre-existing failures separately.
 
 ---
 
@@ -308,7 +311,7 @@ docker run -it --rm -p 8000:8000 --env-file .env my-great-app
 When making changes:
 
 - Keep changes minimal and scoped to the task.
-- Respect the existing folder structure and move files if they are in the wrong place.
+- Respect the existing folder structure. Move files only when needed for the requested change; report unrelated layout issues instead of reorganizing them.
 - Update `README.md` if setup or run behavior changes.
 - If you add a runnable script, ensure it follows the standalone script rules.
 - If you add dependencies, update `pyproject.toml` accordingly.
@@ -317,11 +320,11 @@ When making changes:
 
 ## Quick checklist for contributions
 
-- [ ] `__init__.py` present in all code folders
+- [ ] `__init__.py` present where Python package imports require it
 - [ ] No duplication (helpers in utils where appropriate)
 - [ ] Clear separation of concerns (services vs utils vs scripts)
 - [ ] Runnable scripts: docstring, argparse, `__main__`
 - [ ] README updated if install, run, or other documentation changed
 - [ ] Logging used instead of print
 - [ ] pytest coverage added or updated when feasible
-- [ ] Type hints present in all function signatures
+- [ ] Production signatures typed; test helpers typed where practical


### PR DESCRIPTION
## Summary

Refines CityCatalyst agent rules and Cursor skills so task scope, authorization boundaries, validation depth, and documentation checks are clearer and more consistent. It also moves the detailed web-app codebase inventory into a separate navigation document to keep app guidance focused.

## Changes

- clarify task authorization, safe migration execution, targeted validation, and post-change inspection guidance
- tighten the non-technical contribution, prompt authoring, PR, and simplification workflows
- align app, Climate Advisor, and HIAP agent guidance with the updated workflow
- move the detailed app architecture map to app/docs/AGENT_CODEBASE_MAP.md

## How to test

1. Review the changed Markdown and MDC files for the intended workflow guidance.
2. Confirm links between AGENTS.md files, skills, and the new codebase map resolve.
3. Run git diff --check against develop.

## Notes

Documentation and agent-workflow guidance only; no application runtime behavior is changed.