### PR TITLE
feat: CC-763 create model, migration and API for MeedState

### DIFF
--- a/app/migrations/20260910121932-create-meed-state.cjs
+++ b/app/migrations/20260910121932-create-meed-state.cjs
@@ -1,0 +1,84 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable("MeedState", {
+      id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        primaryKey: true,
+        defaultValue: Sequelize.UUIDV4,
+      },
+      inventory_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: "Inventory",
+          key: "inventory_id",
+        },
+        onUpdate: "CASCADE",
+        onDelete: "CASCADE",
+      },
+
+      exclusions: {
+        type: Sequelize.ARRAY(Sequelize.TEXT),
+        allowNull: false,
+        defaultValue: [],
+      },
+      sectors: {
+        type: Sequelize.ARRAY(Sequelize.TEXT),
+        allowNull: false,
+        defaultValue: [],
+      },
+      strategic_priorities: {
+        type: Sequelize.ARRAY(Sequelize.TEXT),
+        allowNull: false,
+        defaultValue: [],
+      },
+      timeline: {
+        type: Sequelize.ARRAY(Sequelize.TEXT),
+        allowNull: false,
+        defaultValue: [],
+      },
+
+      // weights
+      impact_weight: {
+        type: Sequelize.FLOAT,
+        allowNull: true,
+      },
+      alignment_weight: {
+        type: Sequelize.FLOAT,
+        allowNull: true,
+      },
+      feasibility_weight: {
+        type: Sequelize.FLOAT,
+        allowNull: true,
+      },
+
+      excluded_sectors: {
+        type: Sequelize.ARRAY(Sequelize.TEXT),
+        allowNull: false,
+        defaultValue: [],
+      },
+      excluded_co_benefits: {
+        type: Sequelize.ARRAY(Sequelize.TEXT),
+        allowNull: false,
+        defaultValue: [],
+      },
+      exclude_text: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+    });
+    await queryInterface.addIndex("MeedState", {
+      fields: ["inventory_id"],
+      unique: true,
+      name: "MeedState_unique",
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable("MeedState");
+  },
+};

--- a/app/src/app/api/v1/city/[city]/meed/state/route.ts
+++ b/app/src/app/api/v1/city/[city]/meed/state/route.ts
@@ -1,0 +1,174 @@
+import MeedApiService from "@/backend/MeedApiService";
+import { PermissionService } from "@/backend/permissions/PermissionService";
+import { apiHandler } from "@/util/api";
+import { NextResponse } from "next/server";
+import z from "zod";
+
+/**
+ * @swagger
+ * /api/v1/city/{city}/meed/state:
+ *   get:
+ *     tags:
+ *       - meed
+ *       - city
+ *     operationId: getMeedState
+ *     summary: Fetches MEED+ module state for a given inventory
+ *     description: Fetches MEED+ module state (user settings) for the inventory passed in the search parameter 'inventoryId'
+ *     parameters:
+ *       - in: path
+ *         name: city
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: State retrieved
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       format: uuid
+ *                     inventoryId:
+ *                       type: string
+ *                       format: uuid
+ *                     exclusions:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                     sectors:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                     strategicPriorities:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                     timeline:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                     impactWeight:
+ *                       type: number
+ *                     alignmentWeight:
+ *                       type: number
+ *                     feasibilityWeight:
+ *                       type: number
+ *                     excludedSectors:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                     excludedCoBenefits:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                     excludeText:
+ *                       type: string
+ *                     created:
+ *                       type: string
+ *                       format: date-time
+ *                     lastUpdated:
+ *                       type: string
+ *                       format: date-time
+ */
+export const GET = apiHandler(async (_req, { session, searchParams }) => {
+  const { inventoryId } = searchParams;
+  await PermissionService.canAccessInventory(session, inventoryId);
+
+  const result = await MeedApiService.getState(inventoryId);
+  return NextResponse.json({ data: result });
+});
+
+/**
+ * @swagger
+ * /api/v1/city/{city}/meed/state:
+ *   post:
+ *     tags:
+ *       - meed
+ *       - city
+ *     operationId: setMeedState
+ *     summary: Updates the MEED+ module state for a given inventory
+ *     description: Changes supplied state properties for the inventory passed in the request body field 'inventoryId'
+ *     parameters:
+ *       - in: path
+ *         name: city
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               inventoryId:
+ *                 type: string
+ *                 format: uuid
+ *               exclusions:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *               sectors:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *               strategicPriorities:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *               timeline:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *               impactWeight:
+ *                 type: number
+ *               alignmentWeight:
+ *                 type: number
+ *               feasibilityWeight:
+ *                 type: number
+ *               excludedSectors:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *               excludedCoBenefits:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *               excludeText:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: State updated, returned in response
+ */
+
+const setMeedStateRequest = z.object({
+  inventoryId: z.string().uuid(),
+  exclusions: z.array(z.string().min(1)).optional(),
+  sectors: z.array(z.string().min(1)).optional(),
+  strategicPriorities: z.array(z.string().min(1)).optional(),
+  timeline: z.array(z.string().min(1)).optional(),
+
+  impactWeight: z.number().gte(0).lte(1).optional(),
+  alignmentWeight: z.number().gte(0).lte(1).optional(),
+  feasibilityWeight: z.number().gte(0).lte(1).optional(),
+
+  excludedSectors: z.array(z.string().min(1)).optional(),
+  excludedCoBenefits: z.array(z.string().min(1)).optional(),
+  excludeText: z.string().min(1).optional(),
+});
+
+export const POST = apiHandler(async (req, { session }) => {
+  const body = setMeedStateRequest.parse(await req.json());
+  await PermissionService.canAccessInventory(session, body.inventoryId);
+
+  const result = await MeedApiService.setState(body);
+  return NextResponse.json({ data: result });
+});

--- a/app/src/backend/MeedApiService.ts
+++ b/app/src/backend/MeedApiService.ts
@@ -6,6 +6,10 @@ import { InventoryService } from "./InventoryService";
 import { randomUUID } from "node:crypto";
 import { Op } from "sequelize";
 import { logger } from "@/services/logger";
+import {
+  MeedStateAttributes,
+  MeedStateCreationAttributes,
+} from "@/models/MeedState";
 
 const MEED_API_URL = process.env.HIAP_MEED_API_URL + "/v1/";
 
@@ -556,6 +560,29 @@ export default class MeedApiService {
     }
 
     return plan;
+  }
+
+  public static async getState(inventoryId: string) {
+    const state = await db.models.MeedState.findOne({ where: { inventoryId } });
+    return state;
+  }
+
+  public static async setState(
+    updatedState: Omit<MeedStateCreationAttributes, "id">,
+  ) {
+    let state = await db.models.MeedState.findOne({
+      where: { inventoryId: updatedState.inventoryId },
+    });
+    if (!state) {
+      state = await db.models.MeedState.create({
+        ...updatedState,
+        id: randomUUID(),
+      });
+    } else {
+      await state.update(updatedState);
+    }
+
+    return state;
   }
 
   private static async makeRequest(

--- a/app/src/models/MeedState.ts
+++ b/app/src/models/MeedState.ts
@@ -1,0 +1,168 @@
+import * as Sequelize from "sequelize";
+import { DataTypes, Model, Optional } from "sequelize";
+import type { Inventory, InventoryId } from "./Inventory";
+
+export interface MeedStateAttributes {
+  id: string;
+  inventoryId?: string;
+
+  exclusions: string[];
+  sectors: string[];
+  strategicPriorities: string[];
+  timeline: string[];
+
+  impactWeight?: number;
+  alignmentWeight?: number;
+  feasibilityWeight?: number;
+
+  excludedSectors: string[];
+  excludedCoBenefits: string[];
+  excludeText: string;
+
+  created?: Date;
+  lastUpdated?: Date;
+}
+
+export type MeedStatePk = "id";
+export type MeedStateId = MeedState[MeedStatePk];
+export type MeedStateOptionalAttributes =
+  | "exclusions"
+  | "sectors"
+  | "strategicPriorities"
+  | "timeline"
+  | "impactWeight"
+  | "alignmentWeight"
+  | "feasibilityWeight"
+  | "excludedSectors"
+  | "excludedCoBenefits"
+  | "excludeText"
+  | "created"
+  | "lastUpdated";
+export type MeedStateCreationAttributes = Optional<
+  MeedStateAttributes,
+  MeedStateOptionalAttributes
+>;
+
+export class MeedState
+  extends Model<MeedStateAttributes, MeedStateCreationAttributes>
+  implements MeedStateAttributes
+{
+  declare id: string;
+  declare inventoryId?: string;
+
+  declare exclusions: string[];
+  declare sectors: string[];
+  declare strategicPriorities: string[];
+  declare timeline: string[];
+
+  declare impactWeight?: number;
+  declare alignmentWeight?: number;
+  declare feasibilityWeight?: number;
+
+  declare excludedSectors: string[];
+  declare excludedCoBenefits: string[];
+  declare excludeText: string;
+
+  declare created?: Date;
+  declare lastUpdated?: Date;
+
+  // MeedState belongsTo Inventory via inventoryId
+  declare inventory: Inventory;
+  declare getInventory: Sequelize.BelongsToGetAssociationMixin<Inventory>;
+  declare setInventory: Sequelize.BelongsToSetAssociationMixin<
+    Inventory,
+    InventoryId
+  >;
+  declare createInventory: Sequelize.BelongsToCreateAssociationMixin<Inventory>;
+
+  static initModel(sequelize: Sequelize.Sequelize): typeof MeedState {
+    return MeedState.init(
+      {
+        id: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          primaryKey: true,
+        },
+        inventoryId: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          references: {
+            model: "Inventory",
+            key: "inventory_id",
+          },
+          field: "inventory_id",
+        },
+
+        exclusions: { type: DataTypes.ARRAY(DataTypes.TEXT), allowNull: false },
+        sectors: { type: DataTypes.ARRAY(DataTypes.TEXT), allowNull: false },
+        strategicPriorities: {
+          type: DataTypes.ARRAY(DataTypes.TEXT),
+          allowNull: false,
+          field: "strategic_priorities",
+        },
+        timeline: { type: DataTypes.ARRAY(DataTypes.TEXT), allowNull: false },
+        impactWeight: {
+          type: DataTypes.FLOAT,
+          allowNull: true,
+          field: "impact_weight",
+        },
+        alignmentWeight: {
+          type: DataTypes.FLOAT,
+          allowNull: true,
+          field: "alignment_weight",
+        },
+        feasibilityWeight: {
+          type: DataTypes.FLOAT,
+          allowNull: true,
+          field: "feasibility_weight",
+        },
+
+        excludedSectors: {
+          type: DataTypes.ARRAY(DataTypes.TEXT),
+          allowNull: false,
+        },
+        excludedCoBenefits: {
+          type: DataTypes.ARRAY(DataTypes.TEXT),
+          allowNull: false,
+        },
+        excludeText: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+          field: "exclude_text",
+        },
+
+        created: {
+          type: DataTypes.DATE,
+          allowNull: false,
+          defaultValue: DataTypes.NOW,
+        },
+        lastUpdated: {
+          field: "last_updated",
+          type: DataTypes.DATE,
+          allowNull: false,
+          defaultValue: DataTypes.NOW,
+        },
+      },
+      {
+        sequelize,
+        tableName: "MeedState",
+        schema: "public",
+        timestamps: true,
+        createdAt: "created",
+        updatedAt: "last_updated",
+        indexes: [
+          {
+            name: "MeedState_pkey",
+            unique: true,
+            fields: [{ name: "id" }],
+          },
+          {
+            name: "MeedState_unique",
+            unique: true,
+            fields: [{ name: "inventory_id" }],
+          },
+        ],
+      },
+    );
+  }
+}

--- a/app/src/models/init-models.ts
+++ b/app/src/models/init-models.ts
@@ -146,6 +146,11 @@ import type {
 } from "./MeedRankSnapshot";
 import { MeedRankSnapshot as _MeedRankSnapshot } from "./MeedRankSnapshot";
 import type {
+  MeedStateAttributes,
+  MeedStateCreationAttributes,
+} from "./MeedState";
+import { MeedState as _MeedState } from "./MeedState";
+import type {
   MethodologyAttributes,
   MethodologyCreationAttributes,
 } from "./Methodology";
@@ -308,6 +313,7 @@ export {
   _MeedActionRemoved as MeedActionRemoved,
   _MeedActionReport as MeedActionReport,
   _MeedRankSnapshot as MeedRankSnapshot,
+  _MeedState as MeedState,
   _Methodology as Methodology,
   _Organization as Organization,
   _Project as Project,
@@ -401,6 +407,8 @@ export type {
   MeedActionReportCreationAttributes,
   MeedRankSnapshotAttributes,
   MeedRankSnapshotCreationAttributes,
+  MeedStateAttributes,
+  MeedStateCreationAttributes,
   MethodologyAttributes,
   MethodologyCreationAttributes,
   OrganizationAttributes,
@@ -499,6 +507,7 @@ export function initModels(sequelize: Sequelize) {
   const MeedActionRemoved = _MeedActionRemoved.initModel(sequelize);
   const MeedActionReport = _MeedActionReport.initModel(sequelize);
   const MeedRankSnapshot = _MeedRankSnapshot.initModel(sequelize);
+  const MeedState = _MeedState.initModel(sequelize);
   const Methodology = _Methodology.initModel(sequelize);
   const Organization = _Organization.initModel(sequelize);
   const Project = _Project.initModel(sequelize);
@@ -1190,7 +1199,7 @@ export function initModels(sequelize: Sequelize) {
     foreignKey: "inventoryId",
   });
 
-  // Associations for MeedActionReport and MeedRankSnapshot
+  // Associations for MeedActionReport, MeedRankSnapshot and MeedState
   MeedActionReport.belongsTo(Inventory, {
     as: "inventory",
     foreignKey: "inventoryId",
@@ -1205,6 +1214,14 @@ export function initModels(sequelize: Sequelize) {
   });
   Inventory.hasMany(MeedRankSnapshot, {
     as: "meedRankSnapshots",
+    foreignKey: "inventoryId",
+  });
+  MeedState.belongsTo(Inventory, {
+    as: "inventory",
+    foreignKey: "inventoryId",
+  });
+  Inventory.hasMany(MeedState, {
+    as: "meedStates",
     foreignKey: "inventoryId",
   });
 
@@ -1333,6 +1350,7 @@ export function initModels(sequelize: Sequelize) {
     MeedActionRemoved: MeedActionRemoved,
     MeedActionReport: MeedActionReport,
     MeedRankSnapshot: MeedRankSnapshot,
+    MeedState: MeedState,
     Methodology: Methodology,
     Organization: Organization,
     Project: Project,


### PR DESCRIPTION
## Summary

Creates database model `MeedState` and the corresponding table for it via database migration.

Adds the following API routes to read and write the state for a specific inventory (with access control):
- `GET /api/v1/city/{city}/meed/state`
- `POST /api/v1/city/{city}/meed/state`

## Ticket
CC-763